### PR TITLE
fix(agent-core): carry title provenance on the rename notification

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2415,27 +2415,6 @@ function createAcpSessionStoreMock(records: AcpSessionMetadata[]) {
   };
 }
 
-/**
- * Empty the thread-list cache without touching any title state, so a
- * `getCachedThreadSummary` read falls through to the information store. Every
- * thread mutation does this in the running app, which is the whole reason the
- * second tier exists — a test that reads while the cache is warm is measuring
- * the provider row, not the store, and will agree with itself either way.
- */
-async function coldenThreadListCache(
-  registry: DesktopBackendRegistry,
-  backend: AppServerBackendKind,
-  parentThreadId: string,
-): Promise<void> {
-  await registry.publishLocalEvent({
-    backend,
-    notification: {
-      method: "thread/subthreadsCollapsed/updated",
-      params: { parentThreadId, collapsed: true },
-    },
-  });
-}
-
 function createKimiAgentRecord(
   backendId: AcpBackendId = "acp:kimi" as AcpBackendId,
   runtimeCapabilities?: BackendAcpRuntimeCapabilities,
@@ -6827,7 +6806,7 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("records a generated ACP title as derived once the cache goes cold", async () => {
+  it("records a generated ACP title as derived", async () => {
     const acpBackendId = "acp:kimi" as AcpBackendId;
     const { registry } = createKimiAcpRegistry({
       acpBackendId,
@@ -6861,13 +6840,12 @@ describe("DesktopBackendRegistry", () => {
       threadId: "session-1",
       title: "Investigate the flaky federation handshake test",
     });
-    await coldenThreadListCache(registry, acpBackendId, "session-1");
 
-    // The information-store tier — the one this read exists to serve, since a
-    // warm thread-list cache answers first and every mutation empties it.
-    // Nothing lists again after the rename on purpose: a later listing row
-    // outranks the notification's own record, so the assertion would hold
-    // whatever the notification carried.
+    // This reads the information store, not the thread-list cache: the
+    // rename's own notification empties that cache on the way out. Nothing
+    // lists again afterwards on purpose — a later listing row outranks the
+    // notification's own record, so the assertion would hold whatever the
+    // notification carried.
     expect(
       registry.getCachedThreadSummary({
         backend: acpBackendId,
@@ -6879,8 +6857,73 @@ describe("DesktopBackendRegistry", () => {
     });
   });
 
-  it("keeps a fallback-sourced ACP rename's title on a cold-cache read", async () => {
+  it("records a generated Codex title as derived", async () => {
+    // The same generated title on the other backend. Codex stores no
+    // provenance of its own, so PwrAgent's generator is the only thing that
+    // knows — and if it stays silent the recorders read the title as an
+    // operator rename, which is the defect this provenance exists to stop.
+    // Leaving that to the ACP branch alone would make the answer depend on
+    // which backend a thread happens to run.
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    onTestFinished(async () => {
+      await registry.close();
+    });
+
+    await registry.listThreads({ backend: "codex" });
+    await (registry as unknown as {
+      applyGeneratedThreadTitle(params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+        title: string;
+      }): Promise<void>;
+    }).applyGeneratedThreadTitle({
+      backend: "codex",
+      threadId: "thread-1",
+      title: "Ship the release runbook",
+    });
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toMatchObject({
+      title: "Ship the release runbook",
+      titleSource: "derived",
+    });
+    // This mock never echoes the rename, so the provider keeps serving the
+    // placeholder — the unacknowledged-rename state `withObservedThreadName`
+    // exists for. It must carry the rename's own provenance onto the row:
+    // stamping `explicit` here would leave a listing and a store read
+    // disagreeing about the same thread for the life of the process.
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Ship the release runbook",
+        titleSource: "derived",
+      }),
+    ]);
+  });
+
+  it("never announces a rename as a fallback title", async () => {
     const acpBackendId = "acp:kimi" as AcpBackendId;
+    const events: AgentEvent[] = [];
     const { registry } = createKimiAcpRegistry({
       acpBackendId,
       sessions: [
@@ -6901,11 +6944,20 @@ describe("DesktopBackendRegistry", () => {
       await registry.close();
     });
 
+    const unsubscribe = registry.onEvent((event) => {
+      events.push(event);
+    });
+    onTestFinished(() => {
+      unsubscribe();
+    });
     await registry.listThreads({ backend: acpBackendId });
     // The stopgap `applyPromptDerivedAcpThreadTitle` applies when no title
-    // generator is available: a real prompt-derived name carrying the
-    // "still replaceable" fallback marker. Forwarding that marker into the
-    // information store would make `isUsableTitle` refuse the name outright.
+    // generator is available: a real prompt-derived name stored against the
+    // session as "still replaceable by a better one". That marker answers a
+    // question only the session store asks. On the wire the same word means
+    // "this thread has no name", and every consumer — thread chips, the quit
+    // dialog, the federated summary cache — would discard the name being
+    // announced.
     await (registry as unknown as {
       renameAcpSession(
         backend: AcpBackendId,
@@ -6919,8 +6971,25 @@ describe("DesktopBackendRegistry", () => {
       "Investigate the flaky federation handshake test",
       { titleSource: "fallback" },
     );
-    await coldenThreadListCache(registry, acpBackendId, "session-1");
 
+    expect(
+      events.filter(
+        (event) => event.notification.method === "thread/name/updated",
+      ),
+    ).toEqual([
+      {
+        backend: acpBackendId,
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "session-1",
+            threadName: "Investigate the flaky federation handshake test",
+          },
+        },
+      },
+    ]);
+    // The session keeps the marker it was given; only the announcement drops
+    // it.
     expect(
       registry.getCachedThreadSummary({
         backend: acpBackendId,
@@ -7014,15 +7083,6 @@ describe("DesktopBackendRegistry", () => {
         titleSource: "explicit",
       }),
     ]);
-    expect(
-      registry.getCachedThreadSummary({
-        backend: "codex",
-        threadId: "thread-1",
-      }),
-    ).toMatchObject({
-      title: "Ship the release runbook",
-      titleSource: "explicit",
-    });
   });
 
   it("exposes live Codex thread names while thread/list still returns the placeholder", async () => {
@@ -20001,6 +20061,10 @@ command = "pnpm dev"
         params: {
           threadId: "thread-title",
           threadName: "Leopard tea button",
+          // PwrAgent generated this name, and says so on the wire. Codex
+          // stores no provenance of its own, so silence here would make the
+          // recorders read a generated title as an operator rename.
+          titleSource: "derived",
         },
       },
     });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2415,6 +2415,27 @@ function createAcpSessionStoreMock(records: AcpSessionMetadata[]) {
   };
 }
 
+/**
+ * Empty the thread-list cache without touching any title state, so a
+ * `getCachedThreadSummary` read falls through to the information store. Every
+ * thread mutation does this in the running app, which is the whole reason the
+ * second tier exists — a test that reads while the cache is warm is measuring
+ * the provider row, not the store, and will agree with itself either way.
+ */
+async function coldenThreadListCache(
+  registry: DesktopBackendRegistry,
+  backend: AppServerBackendKind,
+  parentThreadId: string,
+): Promise<void> {
+  await registry.publishLocalEvent({
+    backend,
+    notification: {
+      method: "thread/subthreadsCollapsed/updated",
+      params: { parentThreadId, collapsed: true },
+    },
+  });
+}
+
 function createKimiAgentRecord(
   backendId: AcpBackendId = "acp:kimi" as AcpBackendId,
   runtimeCapabilities?: BackendAcpRuntimeCapabilities,
@@ -6806,45 +6827,29 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
-  it("keeps a generated ACP title marked derived for cached-summary readers", async () => {
-    const acpBackendId = "acp:gemini" as AcpBackendId;
-    const sessions: AcpSessionMetadata[] = [
-      {
-        backendId: acpBackendId,
-        sessionId: "session-1",
-        title: "ACP session",
-        titleSource: "fallback",
-        cwd: "/repo/project",
-        createdAt: 1000,
-        updatedAt: 1000,
-        executionMode: "default",
-        status: "idle",
-      },
-    ];
-    const sessionStore = createAcpSessionStoreMock(sessions);
-    const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
-      acpAgentStore: createAcpAgentStoreMock([
+  it("records a generated ACP title as derived once the cache goes cold", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessions: [
         {
           backendId: acpBackendId,
-          registryId: "gemini",
-          name: "Gemini CLI",
-          distributionKind: "local",
-          distributionSource: "gemini --acp --skip-trust",
-          installStatus: "installed",
-          authStatus: "not-required",
-          verificationStatus: "not-applicable",
-          allowlistRuleId: "local-gemini-cli",
-          installedAt: 1000,
+          sessionId: "session-1",
+          title: "ACP session",
+          titleSource: "fallback",
+          cwd: "/repo/project",
+          createdAt: 1000,
           updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
         },
-      ]),
-      acpSessionStore: sessionStore,
+      ],
+    });
+    onTestFinished(async () => {
+      await registry.close();
     });
 
     await registry.listThreads({ backend: acpBackendId });
-
     await (registry as unknown as {
       applyGeneratedThreadTitle(params: {
         backend: AppServerBackendKind;
@@ -6856,13 +6861,13 @@ describe("DesktopBackendRegistry", () => {
       threadId: "session-1",
       title: "Investigate the flaky federation handshake test",
     });
+    await coldenThreadListCache(registry, acpBackendId, "session-1");
 
-    // The session store is PwrAgent's own durable record of the provenance,
-    // and it is what `listThreads` reports. A cached-summary reader must not
-    // contradict it and call a generated title an operator rename.
-    expect(sessionStore.getSession(acpBackendId, "session-1")).toMatchObject({
-      titleSource: "derived",
-    });
+    // The information-store tier — the one this read exists to serve, since a
+    // warm thread-list cache answers first and every mutation empties it.
+    // Nothing lists again after the rename on purpose: a later listing row
+    // outranks the notification's own record, so the assertion would hold
+    // whatever the notification carried.
     expect(
       registry.getCachedThreadSummary({
         backend: acpBackendId,
@@ -6872,52 +6877,35 @@ describe("DesktopBackendRegistry", () => {
       title: "Investigate the flaky federation handshake test",
       titleSource: "derived",
     });
-
-    await registry.close();
   });
 
-  it("records an ACP prompt-derived stopgap title without a fallback source", async () => {
-    const acpBackendId = "acp:gemini" as AcpBackendId;
-    const sessions: AcpSessionMetadata[] = [
-      {
-        backendId: acpBackendId,
-        sessionId: "session-1",
-        title: "ACP session",
-        titleSource: "fallback",
-        cwd: "/repo/project",
-        createdAt: 1000,
-        updatedAt: 1000,
-        executionMode: "default",
-        status: "idle",
-      },
-    ];
-    const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
-      acpAgentStore: createAcpAgentStoreMock([
+  it("keeps a fallback-sourced ACP rename's title on a cold-cache read", async () => {
+    const acpBackendId = "acp:kimi" as AcpBackendId;
+    const { registry } = createKimiAcpRegistry({
+      acpBackendId,
+      sessions: [
         {
           backendId: acpBackendId,
-          registryId: "gemini",
-          name: "Gemini CLI",
-          distributionKind: "local",
-          distributionSource: "gemini --acp --skip-trust",
-          installStatus: "installed",
-          authStatus: "not-required",
-          verificationStatus: "not-applicable",
-          allowlistRuleId: "local-gemini-cli",
-          installedAt: 1000,
+          sessionId: "session-1",
+          title: "ACP session",
+          titleSource: "fallback",
+          cwd: "/repo/project",
+          createdAt: 1000,
           updatedAt: 1000,
+          executionMode: "default",
+          status: "idle",
         },
-      ]),
-      acpSessionStore: createAcpSessionStoreMock(sessions),
+      ],
+    });
+    onTestFinished(async () => {
+      await registry.close();
     });
 
     await registry.listThreads({ backend: acpBackendId });
-
-    // The stopgap the title helper applies when generation is unavailable. Its
-    // `fallback` source keeps the thread eligible for a real generated title,
-    // but the information store refuses a fallback-sourced title outright --
-    // so forwarding that source would strand the "ACP session" placeholder.
+    // The stopgap `applyPromptDerivedAcpThreadTitle` applies when no title
+    // generator is available: a real prompt-derived name carrying the
+    // "still replaceable" fallback marker. Forwarding that marker into the
+    // information store would make `isUsableTitle` refuse the name outright.
     await (registry as unknown as {
       renameAcpSession(
         backend: AcpBackendId,
@@ -6931,6 +6919,7 @@ describe("DesktopBackendRegistry", () => {
       "Investigate the flaky federation handshake test",
       { titleSource: "fallback" },
     );
+    await coldenThreadListCache(registry, acpBackendId, "session-1");
 
     expect(
       registry.getCachedThreadSummary({
@@ -6939,13 +6928,11 @@ describe("DesktopBackendRegistry", () => {
       }),
     ).toMatchObject({
       title: "Investigate the flaky federation handshake test",
-      titleSource: "derived",
+      titleSource: "explicit",
     });
-
-    await registry.close();
   });
 
-  it("leaves a generated Codex title explicit, matching what the provider reports", async () => {
+  it("treats a rename that states no source as an operator rename", async () => {
     const codexClient = new MockBackendClient({
       threads: [
         {
@@ -6961,36 +6948,34 @@ describe("DesktopBackendRegistry", () => {
       codexClient,
       overlayStore: createOverlayStoreMock(),
     });
-
-    await registry.listThreads({ backend: "codex" });
-    await (registry as unknown as {
-      applyGeneratedThreadTitle(params: {
-        backend: AppServerBackendKind;
-        threadId: string;
-        title: string;
-      }): Promise<void>;
-    }).applyGeneratedThreadTitle({
-      backend: "codex",
-      threadId: "thread-1",
-      title: "Investigate the flaky federation handshake test",
+    onTestFinished(async () => {
+      await registry.close();
     });
 
-    // Deliberate, not an oversight. Codex infers provenance from record shape
-    // rather than storing it, so a generated title -- which never matches the
-    // thread preview -- comes back `explicit` on the next listing, and the
-    // rename invalidates the list cache so that listing is the next one.
-    // Reporting `derived` here would be true for one listing and then flip.
+    await registry.listThreads({ backend: "codex" });
+    // A Codex rename and a federated one both arrive with no provenance, and
+    // the default has to stay what every consumer assumed before the field
+    // existed.
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/name/updated",
+        params: {
+          threadId: "thread-1",
+          threadName: "Ship the release runbook",
+        },
+      },
+    });
+
     expect(
       registry.getCachedThreadSummary({
         backend: "codex",
         threadId: "thread-1",
       }),
     ).toMatchObject({
-      title: "Investigate the flaky federation handshake test",
+      title: "Ship the release runbook",
       titleSource: "explicit",
     });
-
-    await registry.close();
   });
 
   it("still reports an operator rename as an explicit title", async () => {
@@ -7009,6 +6994,9 @@ describe("DesktopBackendRegistry", () => {
       codexClient,
       overlayStore: createOverlayStoreMock(),
     });
+    onTestFinished(async () => {
+      await registry.close();
+    });
 
     await registry.listThreads({ backend: "codex" });
     await registry.renameThread({
@@ -7026,7 +7014,6 @@ describe("DesktopBackendRegistry", () => {
         titleSource: "explicit",
       }),
     ]);
-
     expect(
       registry.getCachedThreadSummary({
         backend: "codex",
@@ -7036,64 +7023,6 @@ describe("DesktopBackendRegistry", () => {
       title: "Ship the release runbook",
       titleSource: "explicit",
     });
-
-    await registry.close();
-  });
-
-  it("keeps an ACP operator rename explicit", async () => {
-    const acpBackendId = "acp:gemini" as AcpBackendId;
-    const sessions: AcpSessionMetadata[] = [
-      {
-        backendId: acpBackendId,
-        sessionId: "session-1",
-        title: "ACP session",
-        titleSource: "fallback",
-        cwd: "/repo/project",
-        createdAt: 1000,
-        updatedAt: 1000,
-        executionMode: "default",
-        status: "idle",
-      },
-    ];
-    const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({ threads: [] }),
-      overlayStore: createOverlayStoreMock(),
-      acpAgentStore: createAcpAgentStoreMock([
-        {
-          backendId: acpBackendId,
-          registryId: "gemini",
-          name: "Gemini CLI",
-          distributionKind: "local",
-          distributionSource: "gemini --acp --skip-trust",
-          installStatus: "installed",
-          authStatus: "not-required",
-          verificationStatus: "not-applicable",
-          allowlistRuleId: "local-gemini-cli",
-          installedAt: 1000,
-          updatedAt: 1000,
-        },
-      ]),
-      acpSessionStore: createAcpSessionStoreMock(sessions),
-    });
-
-    await registry.listThreads({ backend: acpBackendId });
-    await registry.renameThread({
-      backend: acpBackendId,
-      threadId: "session-1",
-      name: "Ship the release runbook",
-    });
-
-    expect(
-      registry.getCachedThreadSummary({
-        backend: acpBackendId,
-        threadId: "session-1",
-      }),
-    ).toMatchObject({
-      title: "Ship the release runbook",
-      titleSource: "explicit",
-    });
-
-    await registry.close();
   });
 
   it("exposes live Codex thread names while thread/list still returns the placeholder", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -38,6 +38,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadMessageOrigin,
   AppServerThreadSummary,
+  AppServerThreadTitleSource,
   AppServerReviewTarget,
   AppServerTurnInputItem,
   AttachThreadPullRequestToolArgs,
@@ -6801,6 +6802,296 @@ describe("DesktopBackendRegistry", () => {
         title: "Exploring PwrSnap Project",
       }),
     ]);
+
+    await registry.close();
+  });
+
+  it("keeps a generated ACP title marked derived for cached-summary readers", async () => {
+    const acpBackendId = "acp:gemini" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "session-1",
+        title: "ACP session",
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        status: "idle",
+      },
+    ];
+    const sessionStore = createAcpSessionStoreMock(sessions);
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "gemini",
+          name: "Gemini CLI",
+          distributionKind: "local",
+          distributionSource: "gemini --acp --skip-trust",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-gemini-cli",
+          installedAt: 1000,
+          updatedAt: 1000,
+        },
+      ]),
+      acpSessionStore: sessionStore,
+    });
+
+    await registry.listThreads({ backend: acpBackendId });
+
+    await (registry as unknown as {
+      applyGeneratedThreadTitle(params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+        title: string;
+      }): Promise<void>;
+    }).applyGeneratedThreadTitle({
+      backend: acpBackendId,
+      threadId: "session-1",
+      title: "Investigate the flaky federation handshake test",
+    });
+
+    // The session store is PwrAgent's own durable record of the provenance,
+    // and it is what `listThreads` reports. A cached-summary reader must not
+    // contradict it and call a generated title an operator rename.
+    expect(sessionStore.getSession(acpBackendId, "session-1")).toMatchObject({
+      titleSource: "derived",
+    });
+    expect(
+      registry.getCachedThreadSummary({
+        backend: acpBackendId,
+        threadId: "session-1",
+      }),
+    ).toMatchObject({
+      title: "Investigate the flaky federation handshake test",
+      titleSource: "derived",
+    });
+
+    await registry.close();
+  });
+
+  it("records an ACP prompt-derived stopgap title without a fallback source", async () => {
+    const acpBackendId = "acp:gemini" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "session-1",
+        title: "ACP session",
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        status: "idle",
+      },
+    ];
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "gemini",
+          name: "Gemini CLI",
+          distributionKind: "local",
+          distributionSource: "gemini --acp --skip-trust",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-gemini-cli",
+          installedAt: 1000,
+          updatedAt: 1000,
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+    });
+
+    await registry.listThreads({ backend: acpBackendId });
+
+    // The stopgap the title helper applies when generation is unavailable. Its
+    // `fallback` source keeps the thread eligible for a real generated title,
+    // but the information store refuses a fallback-sourced title outright --
+    // so forwarding that source would strand the "ACP session" placeholder.
+    await (registry as unknown as {
+      renameAcpSession(
+        backend: AcpBackendId,
+        threadId: string,
+        name: string,
+        options?: { titleSource?: AppServerThreadTitleSource },
+      ): Promise<{ threadId: string }>;
+    }).renameAcpSession(
+      acpBackendId,
+      "session-1",
+      "Investigate the flaky federation handshake test",
+      { titleSource: "fallback" },
+    );
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: acpBackendId,
+        threadId: "session-1",
+      }),
+    ).toMatchObject({
+      title: "Investigate the flaky federation handshake test",
+      titleSource: "derived",
+    });
+
+    await registry.close();
+  });
+
+  it("leaves a generated Codex title explicit, matching what the provider reports", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({ backend: "codex" });
+    await (registry as unknown as {
+      applyGeneratedThreadTitle(params: {
+        backend: AppServerBackendKind;
+        threadId: string;
+        title: string;
+      }): Promise<void>;
+    }).applyGeneratedThreadTitle({
+      backend: "codex",
+      threadId: "thread-1",
+      title: "Investigate the flaky federation handshake test",
+    });
+
+    // Deliberate, not an oversight. Codex infers provenance from record shape
+    // rather than storing it, so a generated title -- which never matches the
+    // thread preview -- comes back `explicit` on the next listing, and the
+    // rename invalidates the list cache so that listing is the next one.
+    // Reporting `derived` here would be true for one listing and then flip.
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toMatchObject({
+      title: "Investigate the flaky federation handshake test",
+      titleSource: "explicit",
+    });
+
+    await registry.close();
+  });
+
+  it("still reports an operator rename as an explicit title", async () => {
+    const codexClient = new MockBackendClient({
+      threads: [
+        {
+          id: "thread-1",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          linkedDirectories: [],
+          source: "codex",
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.listThreads({ backend: "codex" });
+    await registry.renameThread({
+      backend: "codex",
+      threadId: "thread-1",
+      name: "Ship the release runbook",
+    });
+
+    await expect(
+      registry.listThreads({ backend: "codex" }),
+    ).resolves.toEqual([
+      expect.objectContaining({
+        id: "thread-1",
+        title: "Ship the release runbook",
+        titleSource: "explicit",
+      }),
+    ]);
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toMatchObject({
+      title: "Ship the release runbook",
+      titleSource: "explicit",
+    });
+
+    await registry.close();
+  });
+
+  it("keeps an ACP operator rename explicit", async () => {
+    const acpBackendId = "acp:gemini" as AcpBackendId;
+    const sessions: AcpSessionMetadata[] = [
+      {
+        backendId: acpBackendId,
+        sessionId: "session-1",
+        title: "ACP session",
+        titleSource: "fallback",
+        cwd: "/repo/project",
+        createdAt: 1000,
+        updatedAt: 1000,
+        executionMode: "default",
+        status: "idle",
+      },
+    ];
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([
+        {
+          backendId: acpBackendId,
+          registryId: "gemini",
+          name: "Gemini CLI",
+          distributionKind: "local",
+          distributionSource: "gemini --acp --skip-trust",
+          installStatus: "installed",
+          authStatus: "not-required",
+          verificationStatus: "not-applicable",
+          allowlistRuleId: "local-gemini-cli",
+          installedAt: 1000,
+          updatedAt: 1000,
+        },
+      ]),
+      acpSessionStore: createAcpSessionStoreMock(sessions),
+    });
+
+    await registry.listThreads({ backend: acpBackendId });
+    await registry.renameThread({
+      backend: acpBackendId,
+      threadId: "session-1",
+      name: "Ship the release runbook",
+    });
+
+    expect(
+      registry.getCachedThreadSummary({
+        backend: acpBackendId,
+        threadId: "session-1",
+      }),
+    ).toMatchObject({
+      title: "Ship the release runbook",
+      titleSource: "explicit",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -2342,6 +2342,11 @@ export class AcpBackendAdapter {
               params: {
                 threadId: sessionId,
                 threadName: title,
+                // The agent named its own session. `title` is only non-empty
+                // when `updateSessionTitleFromAcpUpdate` accepted a topic
+                // update, and that writes `derived` unconditionally, so this
+                // is the source it just recorded rather than a guess.
+                titleSource: "derived",
               },
             },
           });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6278,6 +6278,33 @@ function buildPromptHash(prompt: string): string {
   return prompt.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
+/**
+ * Where the name on a `thread/name/updated` came from.
+ *
+ * The notification did not always carry provenance, and this recorder assumed
+ * `explicit` for every rename — which called each generated title an operator
+ * rename. The emitters that know now say so, so this only has to decide what
+ * silence means.
+ *
+ * Silence means `explicit`, which is what every consumer assumed before the
+ * field existed. A Codex rename and a federated one both arrive without it and
+ * neither has anything better to offer: Codex stores no provenance, and
+ * `withObservedThreadName` force-stamps `explicit` on any Codex row it
+ * patches — so PwrAgent, not the provider, is what makes a generated Codex
+ * title read as an operator rename. Changing that needs durable
+ * PwrAgent-owned provenance for Codex, which is a design change and not this.
+ *
+ * `fallback` is deliberately not honored. It reaches here only from the ACP
+ * prompt-derived stopgap, whose title is a real name that the information
+ * store would refuse outright (`isUsableTitle`), stranding the placeholder it
+ * replaced. The stopgap's own label is the thing that is wrong; recording
+ * `explicit` keeps today's behavior instead of trading one wrong answer for a
+ * worse one.
+ */
+function renamedThreadTitleSource(value: unknown): AppServerThreadTitleSource {
+  return value === "derived" || value === "explicit" ? value : "explicit";
+}
+
 function isEligibleForGeneratedTitle(
   thread: AppServerThreadSummary | undefined,
   prompt: string,
@@ -11767,10 +11794,11 @@ export class DesktopBackendRegistry {
       throw new Error("Selected ACP thread was not found.");
     }
     const updatedAt = Date.now();
+    const titleSource = options?.titleSource ?? "explicit";
     this.acpBackend.upsertSession({
       ...session,
       title: nextName,
-      titleSource: options?.titleSource ?? "explicit",
+      titleSource,
       updatedAt: Math.max(session.updatedAt, updatedAt),
     });
     await this.emit({
@@ -11780,6 +11808,7 @@ export class DesktopBackendRegistry {
         params: {
           threadId,
           threadName: nextName,
+          titleSource,
         },
       },
     });
@@ -34783,6 +34812,7 @@ export class DesktopBackendRegistry {
       const params = event.notification.params as {
         threadId?: unknown;
         threadName?: unknown;
+        titleSource?: unknown;
       };
       const threadId = params.threadId;
       const threadName = params.threadName;
@@ -34790,16 +34820,12 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
-          const titleSource = this.renamedThreadTitleSource(
-            event.backend,
-            threadId,
-          );
           this.threadInfoStore.observe({
             identity: { backend: event.backend, threadId },
             observationSequence: this.reserveThreadInfoObservation(),
             source: "lifecycle-notification",
             title: trimmed,
-            ...(titleSource ? { titleSource } : {}),
+            titleSource: renamedThreadTitleSource(params.titleSource),
           });
           this.observedThreadNames.set(key, trimmed);
         }
@@ -34822,49 +34848,6 @@ export class DesktopBackendRegistry {
         this.reserveThreadInfoObservation(),
       );
     }
-  }
-
-  /**
-   * Where the name on a `thread/name/updated` came from.
-   *
-   * The notification carries `{ threadId, threadName }` and no provenance, so
-   * this used to record every rename as `explicit`. Three of the four emitters
-   * are not operators: `applyGeneratedThreadTitle` renames with `derived`, its
-   * prompt-derived stopgap renames with `fallback`, and the ACP adapter
-   * forwards an agent's own session summary. For an ACP backend the session
-   * store is PwrAgent's own durable record of which one it was — it is
-   * written before the notification is emitted, and it is what `listThreads`
-   * reports — so read it instead of guessing, and the two readers agree by
-   * construction rather than until the next listing.
-   *
-   * Codex is deliberately left alone. Its provenance is not stored but
-   * inferred from record shape (`getThreadTitleInfo`): a title that differs
-   * from the thread preview reads as `explicit`, which a generated title
-   * always does. The provider therefore reports `explicit` on the very next
-   * listing, and the rename invalidates the list cache, so overriding it here
-   * would buy one listing of accuracy and then flip a status card from
-   * shortened back to full length. Making Codex honest needs durable
-   * PwrAgent-owned provenance that outranks the provider, which is a design
-   * change and not this.
-   *
-   * `fallback` is returned as `undefined` on purpose: the information store
-   * refuses a fallback-sourced title (`isUsableTitle`), so passing it through
-   * would drop a real prompt-derived name and strand the placeholder it
-   * replaced. Recording the title without a source lets the store apply its
-   * own rule and report the name as `derived`, which is what it is.
-   */
-  private renamedThreadTitleSource(
-    backend: AppServerBackendKind,
-    threadId: string,
-  ): AppServerThreadTitleSource | undefined {
-    if (!isAcpBackendId(backend)) {
-      return "explicit";
-    }
-    const titleSource = this.acpBackend.getSession(
-      backend,
-      threadId,
-    )?.titleSource;
-    return titleSource === "fallback" ? undefined : titleSource;
   }
 
   private withObservedThreadName(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -34790,12 +34790,16 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
+          const titleSource = this.renamedThreadTitleSource(
+            event.backend,
+            threadId,
+          );
           this.threadInfoStore.observe({
             identity: { backend: event.backend, threadId },
             observationSequence: this.reserveThreadInfoObservation(),
             source: "lifecycle-notification",
             title: trimmed,
-            titleSource: "explicit",
+            ...(titleSource ? { titleSource } : {}),
           });
           this.observedThreadNames.set(key, trimmed);
         }
@@ -34818,6 +34822,49 @@ export class DesktopBackendRegistry {
         this.reserveThreadInfoObservation(),
       );
     }
+  }
+
+  /**
+   * Where the name on a `thread/name/updated` came from.
+   *
+   * The notification carries `{ threadId, threadName }` and no provenance, so
+   * this used to record every rename as `explicit`. Three of the four emitters
+   * are not operators: `applyGeneratedThreadTitle` renames with `derived`, its
+   * prompt-derived stopgap renames with `fallback`, and the ACP adapter
+   * forwards an agent's own session summary. For an ACP backend the session
+   * store is PwrAgent's own durable record of which one it was — it is
+   * written before the notification is emitted, and it is what `listThreads`
+   * reports — so read it instead of guessing, and the two readers agree by
+   * construction rather than until the next listing.
+   *
+   * Codex is deliberately left alone. Its provenance is not stored but
+   * inferred from record shape (`getThreadTitleInfo`): a title that differs
+   * from the thread preview reads as `explicit`, which a generated title
+   * always does. The provider therefore reports `explicit` on the very next
+   * listing, and the rename invalidates the list cache, so overriding it here
+   * would buy one listing of accuracy and then flip a status card from
+   * shortened back to full length. Making Codex honest needs durable
+   * PwrAgent-owned provenance that outranks the provider, which is a design
+   * change and not this.
+   *
+   * `fallback` is returned as `undefined` on purpose: the information store
+   * refuses a fallback-sourced title (`isUsableTitle`), so passing it through
+   * would drop a real prompt-derived name and strand the placeholder it
+   * replaced. Recording the title without a source lets the store apply its
+   * own rule and report the name as `derived`, which is what it is.
+   */
+  private renamedThreadTitleSource(
+    backend: AppServerBackendKind,
+    threadId: string,
+  ): AppServerThreadTitleSource | undefined {
+    if (!isAcpBackendId(backend)) {
+      return "explicit";
+    }
+    const titleSource = this.acpBackend.getSession(
+      backend,
+      threadId,
+    )?.titleSource;
+    return titleSource === "fallback" ? undefined : titleSource;
   }
 
   private withObservedThreadName(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -74,6 +74,7 @@ import {
   estimateTokenUsageCost,
   formatTokenUsageUsd,
   isToolManagedWorktreePath,
+  normalizeRenamedTitleSource,
   resolveOpenAiPricingServiceTier,
   shortenDerivedThreadTitle,
   type AgentEvent,
@@ -95,6 +96,7 @@ import {
   type AppServerThreadReviewEntry,
   type AppServerToolRequestUserInputResponse,
   type AppServerThreadReplay,
+  type AppServerRenamedTitleSource,
   type AppServerThreadStatus,
   type AppServerThreadSummary,
   type AppServerThreadTitleSource,
@@ -6278,33 +6280,6 @@ function buildPromptHash(prompt: string): string {
   return prompt.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
-/**
- * Where the name on a `thread/name/updated` came from.
- *
- * The notification did not always carry provenance, and this recorder assumed
- * `explicit` for every rename — which called each generated title an operator
- * rename. The emitters that know now say so, so this only has to decide what
- * silence means.
- *
- * Silence means `explicit`, which is what every consumer assumed before the
- * field existed. A Codex rename and a federated one both arrive without it and
- * neither has anything better to offer: Codex stores no provenance, and
- * `withObservedThreadName` force-stamps `explicit` on any Codex row it
- * patches — so PwrAgent, not the provider, is what makes a generated Codex
- * title read as an operator rename. Changing that needs durable
- * PwrAgent-owned provenance for Codex, which is a design change and not this.
- *
- * `fallback` is deliberately not honored. It reaches here only from the ACP
- * prompt-derived stopgap, whose title is a real name that the information
- * store would refuse outright (`isUsableTitle`), stranding the placeholder it
- * replaced. The stopgap's own label is the thing that is wrong; recording
- * `explicit` keeps today's behavior instead of trading one wrong answer for a
- * worse one.
- */
-function renamedThreadTitleSource(value: unknown): AppServerThreadTitleSource {
-  return value === "derived" || value === "explicit" ? value : "explicit";
-}
-
 function isEligibleForGeneratedTitle(
   thread: AppServerThreadSummary | undefined,
   prompt: string,
@@ -7880,8 +7855,16 @@ export class DesktopBackendRegistry {
    * thread list during an active turn. Reconcile list rows through this map so
    * federation snapshots and remote search do not regress to a placeholder
    * after the local renderer has already received the generated name.
+   *
+   * The provenance travels with the name. Re-stating it as `explicit` on the
+   * way out would undo what the rename recorded, and every reader here writes
+   * at a newer sequence than the rename did — so the guess, not the rename,
+   * would be what the store keeps.
    */
-  private readonly observedThreadNames = new Map<string, string>();
+  private readonly observedThreadNames = new Map<
+    string,
+    { title: string; titleSource: AppServerRenamedTitleSource }
+  >();
   private hasLoggedNotificationsEnabledError = false;
   private readonly threadTurnQueue: ThreadTurnQueue;
   private automationInspectionHandler?: AutomationInspectionHandler;
@@ -11726,6 +11709,10 @@ export class DesktopBackendRegistry {
 
   async renameThread(
     request: RenameThreadRequest,
+    // Not on `RenameThreadRequest`: that type crosses IPC, and an operator
+    // rename must never be able to claim it was generated. Only this class's
+    // own title generator supplies a source.
+    options?: { titleSource?: AppServerRenamedTitleSource },
   ): Promise<RenameThreadResponse> {
     const backend = request.backend ?? "codex";
     // A rename supersedes PwrAgent's launch placeholder. Clear this before the
@@ -11736,7 +11723,12 @@ export class DesktopBackendRegistry {
     );
     let result: { threadId: string };
     if (isAcpBackendId(backend)) {
-      result = await this.renameAcpSession(backend, request.threadId, request.name);
+      result = await this.renameAcpSession(
+        backend,
+        request.threadId,
+        request.name,
+        options,
+      );
     } else if (backend === "codex") {
       result = await this.withCodexThreadClient(request.threadId, async (client) =>
         await this.renameWithClient(client, request.threadId, request.name),
@@ -11767,6 +11759,7 @@ export class DesktopBackendRegistry {
           params: {
             threadId: result.threadId,
             threadName: request.name.trim(),
+            ...(options?.titleSource ? { titleSource: options.titleSource } : {}),
           },
         },
       });
@@ -11801,6 +11794,15 @@ export class DesktopBackendRegistry {
       titleSource,
       updatedAt: Math.max(session.updatedAt, updatedAt),
     });
+    // The session store and the notification ask different questions of the
+    // same word. `fallback` there means "a better title may still replace
+    // this", which is how the prompt-derived stopgap keeps its name open to
+    // the agent's own (see updateSessionTitleFromAcpUpdate). On the wire it
+    // would mean "this thread has no name", and every consumer would discard
+    // the name being announced. The stopgap's title is real, so the rename
+    // announces the only two things a rename can be.
+    const announcedTitleSource: AppServerRenamedTitleSource | undefined =
+      titleSource === "fallback" ? undefined : titleSource;
     await this.emit({
       backend,
       notification: {
@@ -11808,7 +11810,7 @@ export class DesktopBackendRegistry {
         params: {
           threadId,
           threadName: nextName,
-          titleSource,
+          ...(announcedTitleSource ? { titleSource: announcedTitleSource } : {}),
         },
       },
     });
@@ -28529,16 +28531,24 @@ export class DesktopBackendRegistry {
     threadId: string;
     title: string;
   }): Promise<void> {
+    // Both backends announce the same provenance. PwrAgent generated this
+    // title and knows that; the branch is only about which rename path stores
+    // it. Letting the Codex side stay silent would make it read as an operator
+    // rename, which is what this provenance exists to stop — and would make
+    // the behavior depend on the backend.
     if (isAcpBackendId(params.backend)) {
       await this.renameAcpSession(params.backend, params.threadId, params.title, {
         titleSource: "derived",
       });
     } else {
-      await this.renameThread({
-        backend: params.backend,
-        threadId: params.threadId,
-        name: params.title,
-      });
+      await this.renameThread(
+        {
+          backend: params.backend,
+          threadId: params.threadId,
+          name: params.title,
+        },
+        { titleSource: "derived" },
+      );
     }
   }
 
@@ -34820,14 +34830,24 @@ export class DesktopBackendRegistry {
         const trimmed = threadName.trim();
         if (trimmed) {
           const key = buildThreadIdentityKey(event.backend, threadId);
+          const titleSource = normalizeRenamedTitleSource(params.titleSource);
           this.threadInfoStore.observe({
             identity: { backend: event.backend, threadId },
             observationSequence: this.reserveThreadInfoObservation(),
             source: "lifecycle-notification",
             title: trimmed,
-            titleSource: renamedThreadTitleSource(params.titleSource),
+            titleSource,
           });
-          this.observedThreadNames.set(key, trimmed);
+          // Only where a provider can still contradict us. This map is the
+          // "provider has not echoed our rename back yet" set, and every
+          // reader of it is Codex-facing; the sole path that removes an entry
+          // is the Codex listing. An ACP rename has no such window — it wrote
+          // the session store on its way here, and that store is what ACP
+          // listings read — so remembering one only leaks an entry that
+          // nothing can ever retire.
+          if (!isAcpBackendId(event.backend)) {
+            this.observedThreadNames.set(key, { title: trimmed, titleSource });
+          }
         }
       }
       return;
@@ -34854,21 +34874,25 @@ export class DesktopBackendRegistry {
     thread: AppServerThreadSummary,
   ): AppServerThreadSummary {
     const key = buildThreadIdentityKey(thread.source, thread.id);
-    const observedName = this.observedThreadNames.get(key);
-    if (!observedName) {
+    const observed = this.observedThreadNames.get(key);
+    if (!observed) {
       return thread;
     }
-    if (thread.titleSource === "explicit") {
-      // Matching explicit text means the provider acknowledged our event.
-      // Different explicit text is durable provider truth from a rename this
-      // process may not have observed (profiles can be shared by processes).
+    if (thread.titleSource === observed.titleSource) {
+      // Matching provenance means the provider acknowledged our event. Text
+      // that differs under the same source is durable provider truth from a
+      // rename this process may not have observed (profiles can be shared by
+      // processes). Comparing against the recorded source rather than a
+      // hardcoded `explicit` is what lets a generated title retire: stamping
+      // `explicit` here would also overwrite the `derived` the rename set,
+      // leaving listThreads and getThreadInfo permanently disagreeing.
       this.observedThreadNames.delete(key);
       return thread;
     }
     return {
       ...thread,
-      title: observedName,
-      titleSource: "explicit",
+      title: observed.title,
+      titleSource: observed.titleSource,
     };
   }
 
@@ -34879,10 +34903,10 @@ export class DesktopBackendRegistry {
       return threadIds;
     }
     const keyPrefix = buildThreadIdentityKey("codex", "");
-    for (const [key, observedName] of this.observedThreadNames) {
+    for (const [key, observed] of this.observedThreadNames) {
       if (
         key.startsWith(keyPrefix)
-        && observedName.toLowerCase().includes(normalizedFilter)
+        && observed.title.toLowerCase().includes(normalizedFilter)
       ) {
         threadIds.add(key.slice(keyPrefix.length));
       }
@@ -34919,14 +34943,17 @@ export class DesktopBackendRegistry {
     const unacknowledgedRename = this.observedThreadNames.get(
       buildThreadIdentityKey(backend, threadId),
     );
-    const title = unacknowledgedRename ?? candidate;
+    const title = unacknowledgedRename?.title ?? candidate;
     this.threadInfoStore.observe({
       identity: { backend, threadId },
       observationSequence: displayMetadataObservationSequence,
       source: "lifecycle-notification",
       ...(title !== undefined ? { title } : {}),
+      // The rename's own provenance, not a fresh guess. This observation takes
+      // a newer sequence than the rename did, so asserting `explicit` here
+      // would silently revert a generated title on the next resume replay.
       ...(unacknowledgedRename !== undefined
-        ? { titleSource: "explicit" as const }
+        ? { titleSource: unacknowledgedRename.titleSource }
         : titleSource !== undefined
           ? { titleSource }
           : {}),

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -12,6 +12,7 @@ import {
   isAcpBackendId,
   isAppServerBackendKind,
   isMessagingBindingTargetKind,
+  normalizeRenamedTitleSource,
   parseCodexTurnErrorMessage,
   permissionForActionId,
   permissionForCommandVerb,
@@ -14844,6 +14845,7 @@ export class MessagingController {
     const params = event.notification.params as {
       threadId?: unknown;
       threadName?: unknown;
+      titleSource?: unknown;
     };
     if (
       typeof params.threadId !== "string" ||
@@ -14854,6 +14856,12 @@ export class MessagingController {
     }
     const threadId = params.threadId;
     const threadName = params.threadName.trim();
+    // The new name's own provenance. Carrying the row's previous source over
+    // to a new title is the orphaned pair the thread information store
+    // refuses to hold: the status and monitor cards read `derived` to decide
+    // whether to shorten a title, so a stale source formats the same rename
+    // two different ways depending on what the row said before.
+    const titleSource = normalizeRenamedTitleSource(params.titleSource);
 
     return {
       ...snapshot,
@@ -14862,6 +14870,7 @@ export class MessagingController {
           ? {
               ...thread,
               title: threadName,
+              titleSource,
             }
           : thread,
       ),

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@pwragent/shared";
 import type {
   AgentEvent,
+  AppServerThreadTitleSource,
   FederationRemoteTarget,
   NavigationLaunchpadDefaults,
   NavigationLaunchpadDraft,
@@ -42,6 +43,54 @@ function latestThreadActionError(
     ([event]) => event?.kind === kind,
   );
   return calls.at(-1)?.[0]?.message;
+}
+
+/**
+ * One ACP thread whose title provenance the caller chooses. The rename path
+ * only reveals what it recorded when the row starts as something other than
+ * the source under test, so these deliberately start at `fallback`.
+ */
+function acpTitleSnapshot(
+  title: string,
+  titleSource: AppServerThreadTitleSource,
+  updatedAt: number,
+): NavigationSnapshot {
+  return {
+    backend: "all",
+    fetchedAt: updatedAt,
+    unchanged: false,
+    inboxThreadKeys: ["acp:kimi:thread-1"],
+    threads: [
+      {
+        id: "thread-1",
+        title,
+        titleSource,
+        source: "acp:kimi",
+        linkedDirectories: [],
+        inbox: { inInbox: true, reason: "new-thread" },
+        updatedAt,
+      },
+    ],
+    directories: [],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+    },
+  };
+}
+
+function acpFallbackTitleSnapshot(
+  title: string,
+  updatedAt: number,
+): NavigationSnapshot {
+  return acpTitleSnapshot(title, "fallback", updatedAt);
+}
+
+function acpDerivedTitleSnapshot(
+  title: string,
+  updatedAt: number,
+): NavigationSnapshot {
+  return acpTitleSnapshot(title, "derived", updatedAt);
 }
 
 describe("useThreadNavigation", () => {
@@ -4796,6 +4845,140 @@ describe("useThreadNavigation", () => {
       await result.current.refresh();
     });
     expect(result.current.threads[0]?.title).toBe("Generated title");
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.threads[0]?.title).toBe("Newer remote title");
+  });
+
+  it("records the provenance a rename notification states", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValue(acpFallbackTitleSnapshot("ACP session", 1_000));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.title).toBe("ACP session");
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:kimi",
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "thread-1",
+            threadName: "Investigate the flaky handshake test",
+            titleSource: "derived",
+          },
+        },
+      });
+    });
+
+    // The agent named its own session. Stamping `explicit` here is what made
+    // the placeholder-title paths skip a generated title.
+    expect(result.current.threads[0]?.title).toBe(
+      "Investigate the flaky handshake test",
+    );
+    expect(result.current.threads[0]?.titleSource).toBe("derived");
+  });
+
+  it("treats a rename that states no provenance as an operator rename", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValue(acpFallbackTitleSnapshot("ACP session", 1_000));
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.title).toBe("ACP session");
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:kimi",
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "thread-1",
+            threadName: "Ship the release runbook",
+          },
+        },
+      });
+    });
+
+    // A Codex or federated rename carries no provenance, and the default has
+    // to stay what this assumed before the field existed.
+    expect(result.current.threads[0]?.titleSource).toBe("explicit");
+  });
+
+  it("retires a derived name observation after a snapshot acknowledges it", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const getNavigationSnapshot = vi
+      .fn()
+      .mockResolvedValueOnce(acpFallbackTitleSnapshot("ACP session", 1_000))
+      .mockResolvedValueOnce(
+        acpDerivedTitleSnapshot("Investigate the flaky handshake test", 2_000),
+      )
+      .mockResolvedValueOnce(
+        acpDerivedTitleSnapshot("Newer remote title", 3_000),
+      );
+    const desktopApi: DesktopApi = {
+      getNavigationSnapshot,
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.threads[0]?.title).toBe("ACP session");
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "acp:kimi",
+        notification: {
+          method: "thread/name/updated",
+          params: {
+            threadId: "thread-1",
+            threadName: "Investigate the flaky handshake test",
+            titleSource: "derived",
+          },
+        },
+      });
+    });
+
+    // The snapshot catches up and agrees, which is what retires the pending
+    // observation. Comparing it against a hardcoded `explicit` never matches a
+    // derived row, so the observation would be re-applied on every refresh and
+    // pin the title forever.
+    await act(async () => {
+      await result.current.refresh();
+    });
+    expect(result.current.threads[0]?.title).toBe(
+      "Investigate the flaky handshake test",
+    );
 
     await act(async () => {
       await result.current.refresh();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -4852,7 +4852,21 @@ describe("useThreadNavigation", () => {
     expect(result.current.threads[0]?.title).toBe("Newer remote title");
   });
 
-  it("records the provenance a rename notification states", async () => {
+  it.each([
+    // The agent named its own session. Stamping `explicit` here is what made
+    // the placeholder-title paths skip a generated title.
+    ["a stated provenance", "derived", "derived"],
+    // A Codex or federated rename can carry none, and the default has to stay
+    // what this assumed before the field existed.
+    ["no provenance", undefined, "explicit"],
+    // Federation forwards a peer's params verbatim, so this recorder reads
+    // another instance's JSON and a peer on a different build can send
+    // anything. An unrecognized value must not reach the row: no snapshot row
+    // could ever report it back, and the observation retires by comparing the
+    // two — it would re-pin this title on every refresh for the life of the
+    // hook, which is the failure this provenance exists to remove.
+    ["an unrecognized provenance", "generated", "explicit"],
+  ])("records %s on a rename notification", async (_label, stated, expected) => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
       | undefined;
@@ -4879,55 +4893,16 @@ describe("useThreadNavigation", () => {
           params: {
             threadId: "thread-1",
             threadName: "Investigate the flaky handshake test",
-            titleSource: "derived",
+            ...(stated !== undefined ? { titleSource: stated } : {}),
           },
         },
-      });
+      } as never);
     });
 
-    // The agent named its own session. Stamping `explicit` here is what made
-    // the placeholder-title paths skip a generated title.
     expect(result.current.threads[0]?.title).toBe(
       "Investigate the flaky handshake test",
     );
-    expect(result.current.threads[0]?.titleSource).toBe("derived");
-  });
-
-  it("treats a rename that states no provenance as an operator rename", async () => {
-    let agentEventHandler:
-      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
-      | undefined;
-    const getNavigationSnapshot = vi
-      .fn()
-      .mockResolvedValue(acpFallbackTitleSnapshot("ACP session", 1_000));
-    const desktopApi: DesktopApi = {
-      getNavigationSnapshot,
-      onAgentEvent: (callback) => {
-        agentEventHandler = callback;
-        return () => undefined;
-      },
-    };
-    const { result } = renderHook(() => useThreadNavigation(desktopApi));
-
-    await waitFor(() => {
-      expect(result.current.threads[0]?.title).toBe("ACP session");
-    });
-    act(() => {
-      agentEventHandler?.({
-        backend: "acp:kimi",
-        notification: {
-          method: "thread/name/updated",
-          params: {
-            threadId: "thread-1",
-            threadName: "Ship the release runbook",
-          },
-        },
-      });
-    });
-
-    // A Codex or federated rename carries no provenance, and the default has
-    // to stay what this assumed before the field existed.
-    expect(result.current.threads[0]?.titleSource).toBe("explicit");
+    expect(result.current.threads[0]?.titleSource).toBe(expected);
   });
 
   it("retires a derived name observation after a snapshot acknowledges it", async () => {

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -2,10 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
   AppServerCollaborationModeRequest,
+  AppServerRenamedTitleSource,
   AppServerReviewTarget,
   AppServerThreadImagePart,
   AppServerThreadStatus,
-  AppServerThreadTitleSource,
   AppServerTurnInputItem,
   ArchiveThreadCleanupResult,
   CodexThreadEnvironmentRuntime,
@@ -44,6 +44,7 @@ import {
   isRemoteFederationTarget,
   isSubthreadLaunchpadKey,
   normalizeNavigationBrowseMode,
+  normalizeRenamedTitleSource,
   resolveThreadParentKey,
   shortenDerivedThreadTitle,
   sortSubthreadSummaries,
@@ -174,7 +175,9 @@ type FederationPeerStatusObservation = {
 
 type ThreadNameObservation = {
   threadName: string;
-  titleSource: AppServerThreadTitleSource;
+  // Normalized, not raw: the retire check compares this against a snapshot
+  // row's source, so a value no row can carry would never retire.
+  titleSource: AppServerRenamedTitleSource;
 };
 
 type PrChipLocation = {
@@ -1101,6 +1104,9 @@ function applyObservedThreadNames(
   snapshot: NavigationSnapshot,
   observations: Map<string, ThreadNameObservation>,
 ): NavigationSnapshot {
+  if (observations.size === 0) {
+    return snapshot;
+  }
   let changed = false;
   const threads = snapshot.threads.map((thread) => {
     const threadKey = threadSummaryIdentityKey(thread);
@@ -1944,15 +1950,14 @@ function applyThreadNameUpdate(
     federationTarget?: FederationTarget;
     threadId: string;
     threadName?: string;
-    titleSource?: AppServerThreadTitleSource;
+    titleSource: AppServerRenamedTitleSource;
   }
 ): NavigationSnapshot | undefined {
   const threadName = params.threadName?.trim();
   if (!snapshot || !threadName) {
     return snapshot;
   }
-  const titleSource = params.titleSource ?? "explicit";
-
+  const titleSource = params.titleSource;
   const threadKey = params.federationTarget
     ? federatedThreadIdentityKey({
         backend: params.backend,
@@ -4329,7 +4334,7 @@ export function useThreadNavigation(
           .params as {
           threadId: string;
           threadName?: string;
-          titleSource?: AppServerThreadTitleSource;
+          titleSource?: unknown;
         };
         const nextThreadName = threadName?.trim();
         if (!nextThreadName) {
@@ -4340,7 +4345,13 @@ export function useThreadNavigation(
         // the notification carried the field. Asserting `explicit` here is
         // what made a generated title suppress the placeholder-title paths in
         // `mergeHydratedThreadWithOptimisticTitle`.
-        const nextTitleSource = titleSource ?? "explicit";
+        //
+        // Normalized rather than trusted: federation forwards a peer's params
+        // verbatim, so this is the one recorder reading another instance's
+        // JSON. A value outside the union would match no snapshot row, and the
+        // observation below retires by comparison — it would never retire, and
+        // would re-pin this title on every refresh for the life of the hook.
+        const nextTitleSource = normalizeRenamedTitleSource(titleSource);
         threadNameObservationsRef.current.set(
           agentEventThreadIdentityKey(event, threadId),
           { threadName: nextThreadName, titleSource: nextTitleSource },
@@ -7552,6 +7563,8 @@ export function useThreadNavigation(
           federationTarget: thread.federation?.ref.target,
           threadId: thread.id,
           threadName: nextName,
+          // The operator typed this one.
+          titleSource: "explicit",
         }),
       }));
       setRetainedUnreadThread((current) =>

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5,6 +5,7 @@ import type {
   AppServerReviewTarget,
   AppServerThreadImagePart,
   AppServerThreadStatus,
+  AppServerThreadTitleSource,
   AppServerTurnInputItem,
   ArchiveThreadCleanupResult,
   CodexThreadEnvironmentRuntime,
@@ -173,6 +174,7 @@ type FederationPeerStatusObservation = {
 
 type ThreadNameObservation = {
   threadName: string;
+  titleSource: AppServerThreadTitleSource;
 };
 
 type PrChipLocation = {
@@ -1108,7 +1110,7 @@ function applyObservedThreadNames(
     }
     if (
       thread.title === observation.threadName
-      && thread.titleSource === "explicit"
+      && thread.titleSource === observation.titleSource
     ) {
       observations.delete(threadKey);
       return thread;
@@ -1117,7 +1119,7 @@ function applyObservedThreadNames(
     return {
       ...thread,
       title: observation.threadName,
-      titleSource: "explicit" as const,
+      titleSource: observation.titleSource,
     };
   });
   return changed ? { ...snapshot, threads } : snapshot;
@@ -1942,12 +1944,14 @@ function applyThreadNameUpdate(
     federationTarget?: FederationTarget;
     threadId: string;
     threadName?: string;
+    titleSource?: AppServerThreadTitleSource;
   }
 ): NavigationSnapshot | undefined {
   const threadName = params.threadName?.trim();
   if (!snapshot || !threadName) {
     return snapshot;
   }
+  const titleSource = params.titleSource ?? "explicit";
 
   const threadKey = params.federationTarget
     ? federatedThreadIdentityKey({
@@ -1962,7 +1966,7 @@ function applyThreadNameUpdate(
       return thread;
     }
 
-    if (thread.title === threadName && thread.titleSource === "explicit") {
+    if (thread.title === threadName && thread.titleSource === titleSource) {
       return thread;
     }
 
@@ -1970,7 +1974,7 @@ function applyThreadNameUpdate(
     return {
       ...thread,
       title: threadName,
-      titleSource: "explicit" as const,
+      titleSource,
     };
   });
 
@@ -4321,17 +4325,25 @@ export function useThreadNavigation(
       }
 
       if (method === "thread/name/updated") {
-        const { threadId, threadName } = event.notification.params as {
+        const { threadId, threadName, titleSource } = event.notification
+          .params as {
           threadId: string;
           threadName?: string;
+          titleSource?: AppServerThreadTitleSource;
         };
         const nextThreadName = threadName?.trim();
         if (!nextThreadName) {
           return;
         }
+        // An emitter that knows the provenance says so; silence means an
+        // operator rename, which is what this assumed for every rename before
+        // the notification carried the field. Asserting `explicit` here is
+        // what made a generated title suppress the placeholder-title paths in
+        // `mergeHydratedThreadWithOptimisticTitle`.
+        const nextTitleSource = titleSource ?? "explicit";
         threadNameObservationsRef.current.set(
           agentEventThreadIdentityKey(event, threadId),
-          { threadName: nextThreadName },
+          { threadName: nextThreadName, titleSource: nextTitleSource },
         );
         setState((current) => ({
           ...current,
@@ -4340,6 +4352,7 @@ export function useThreadNavigation(
             federationTarget: event.federationTarget,
             threadId,
             threadName: nextThreadName,
+            titleSource: nextTitleSource,
           }),
         }));
         setOptimisticThread((current) => {
@@ -4350,7 +4363,7 @@ export function useThreadNavigation(
           return {
             ...current,
             title: nextThreadName,
-            titleSource: "explicit",
+            titleSource: nextTitleSource,
           };
         });
         return;
@@ -7031,7 +7044,7 @@ export function useThreadNavigation(
             }
           : undefined,
       });
-      const observedThreadName = threadNameObservationsRef.current.get(
+      const observedThreadNameEntry = threadNameObservationsRef.current.get(
         federationTarget
           ? federatedThreadIdentityKey({
               backend: response.backend,
@@ -7039,12 +7052,12 @@ export function useThreadNavigation(
               threadId: response.threadId,
             })
           : buildThreadIdentityKey(response.backend, response.threadId),
-      )?.threadName;
-      const namedOptimisticMaterializedThread = observedThreadName
+      );
+      const namedOptimisticMaterializedThread = observedThreadNameEntry
         ? {
             ...optimisticMaterializedThread,
-            title: observedThreadName,
-            titleSource: "explicit" as const,
+            title: observedThreadNameEntry.threadName,
+            titleSource: observedThreadNameEntry.titleSource,
           }
         : optimisticMaterializedThread;
       if (

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1732,6 +1732,15 @@ export type AppServerNotification =
       params: {
         threadId: string;
         threadName?: string;
+        /**
+         * Where the new name came from, when the emitter knows. A rename
+         * carries no provenance of its own, so a recorder that guesses calls
+         * every generated title an operator rename. Optional because a
+         * provider-forwarded or federated rename genuinely does not know;
+         * absent means "assume an operator", which is what every consumer
+         * assumed before this existed.
+         */
+        titleSource?: AppServerThreadTitleSource;
       };
     }
   | {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -303,6 +303,39 @@ export type CodexThreadEnvironmentRuntime = {
 export const CODEX_ENVIRONMENT_ACTION_RUNS_MAX = 10;
 
 export type AppServerThreadTitleSource = "explicit" | "derived" | "fallback";
+
+/**
+ * The provenance a rename is allowed to announce.
+ *
+ * `fallback` is absent on purpose. In a thread summary it means "this thread
+ * has no name yet", which is why `ThreadChip`, the quit dialog, and the
+ * federated summary cache all read it as "show something else instead". A
+ * rename carries a name, so announcing one as `fallback` tells every consumer
+ * to discard the very title being announced. The ACP prompt-derived stopgap
+ * does store `fallback` against its own session — there it means "replaceable
+ * by a better title", a different question — and that value must not reach
+ * the wire.
+ */
+export type AppServerRenamedTitleSource = Exclude<
+  AppServerThreadTitleSource,
+  "fallback"
+>;
+
+/**
+ * Read the provenance off a rename notification.
+ *
+ * Both recorders need this and neither can trust its input: the renderer reads
+ * payloads a federated peer built, and a peer on another build can send
+ * anything. Silence means `explicit` — that is what every consumer assumed
+ * before the field existed, and it is what a provider-forwarded rename still
+ * means, since no provider reports provenance.
+ */
+export function normalizeRenamedTitleSource(
+  value: unknown,
+): AppServerRenamedTitleSource {
+  return value === "derived" ? "derived" : "explicit";
+}
+
 export type AppServerThreadStatus = "active" | "idle" | "notLoaded" | "unknown";
 
 /** Provider provenance carried by a native Codex `spawn_agent` thread. */
@@ -1738,9 +1771,11 @@ export type AppServerNotification =
          * every generated title an operator rename. Optional because a
          * provider-forwarded or federated rename genuinely does not know;
          * absent means "assume an operator", which is what every consumer
-         * assumed before this existed.
+         * assumed before this existed. Read it with
+         * `normalizeRenamedTitleSource` — the type is a compile-time contract
+         * and a federated payload is another instance's JSON.
          */
-        titleSource?: AppServerThreadTitleSource;
+        titleSource?: AppServerRenamedTitleSource;
       };
     }
   | {


### PR DESCRIPTION
## Summary

- `thread/name/updated` carried `{threadId, threadName}` and no provenance, so every recorder assumed `explicit` — which calls each machine-generated title an operator rename. That matters because only a `derived` title is shortened by `formatStatusBindingTitle` before a messaging status card prints it, and `mergeHydratedThreadWithOptimisticTitle` only holds a generated title over a placeholder when the source says `derived`.
- The notification now carries an optional `titleSource`. `renameAcpSession` and the ACP adapter's agent-summary emit pass the source they just recorded; the main-process recorder and the renderer both read it. Absent means `explicit`, so a Codex or federated rename is unchanged.
- `fallback` is deliberately not honored, and the comment says why: `ThreadInfoStore.isUsableTitle` refuses a fallback-sourced title outright, so forwarding it would strand the placeholder the stopgap replaced.

## Verification

- `pnpm test` — 648 files, 9552 passed, 6 skipped, exit 0.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` — all clean.
- The new ACP test is verified to fail when the recorder ignores the wire value. It colds the thread-list cache and deliberately does not list again after the rename: a warm cache answers from the provider row, and a listing observed after the rename outranks the notification's own record, so either would make the assertion hold regardless of what was carried.

## Notes

- **This replaces the approach the PR opened with.** The first version read the ACP session store from `rememberThreadTitleFromEvent` to recover the source. A max-effort review found that wrong in four ways, three verified by execution:
  - It **regressed** the ACP prompt-derived stopgap. Mapping the session's `fallback` to "record no source" made `ThreadInfoStore.observe` delete the stored source, after which `projectSummary` fell through to the provider row and reported a real generated name as `titleSource: "fallback"` — the repo-wide "this title carries no information" signal, so `responseAttributionLabel` dropped the name and rendered "PwrAgent thread". A/B on the cold-cache read: `explicit` before, `fallback` after.
  - It put an **unguarded synchronous SQLite SELECT** and a full `JSON.parse` into a notification path that was pure in-memory. A throw there aborts the emit before listener fan-out, and the ACP adapter's caller swallows the rejection, so assistant text emitted after the rename disappears with no log.
  - It read the source **two `await`s after** the title was captured, so overlapping renames could pair one rename's name with another's source.
  - It could not reach the readers that need it most: the renderer is behind the IPC boundary and may only import `@pwragent/shared`, and a federation peer holds no ACP session row for the thread being renamed.
- The original test missed the regression by reading while the thread-list cache was still warm, where the provider row answers and both versions agree.
- **The Codex carve-out's stated reason was also wrong** and is corrected. `getThreadTitleInfo` never gets the chance to report `derived`, because `withObservedThreadName` force-stamps `explicit` on any Codex row it patches. PwrAgent, not the provider, is what makes a generated Codex title read as an operator rename. Fixing that needs durable PwrAgent-owned provenance for Codex, which is a design change.
- Two review findings were left unfixed on purpose: the stopgap test still calls `renameAcpSession` directly rather than driving `applyPromptDerivedAcpThreadTitle` (the invariant under test is caller-independent, and driving the real caller needs title-generation eligibility setup), and `ThreadInfoStore`'s `delete entry.fields.titleSource` still escapes the observation sequence guard for other sourceless callers — this diff no longer reaches it, and hardening the store is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)