### PR TITLE
fix(tests): correct the Full Access config-load count after the PDF skip

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-runtime.test.ts
@@ -134,11 +134,7 @@ describe("DesktopMessagingRuntime", () => {
   it("does not reload config to authorize an allowed Full Access bound reply", async () => {
     const config = buildFullAccessRuntimeConfig(true);
     let configLoadsAtStartTurn = -1;
-    const loadConfig = vi.fn()
-      .mockResolvedValueOnce(config)
-      // PDF policy remains outside this span and still resolves dynamically.
-      .mockResolvedValueOnce(config)
-      .mockResolvedValue(config);
+    const loadConfig = vi.fn().mockResolvedValue(config);
     const { runtime, adapter, bridge } = await createFullAccessRuntimeHarness(
       loadConfig,
     );
@@ -155,7 +151,11 @@ describe("DesktopMessagingRuntime", () => {
     await adapter.listener!(buildTextEvent("continue"));
 
     expect(bridge.startTurn).toHaveBeenCalledTimes(1);
-    expect(configLoadsAtStartTurn).toBe(2);
+    // Only the lifecycle read. This was 2 when the test was written, because
+    // the PDF policy resolved on every inbound message; #1920 made that read
+    // conditional on the event actually carrying an attachment, and this one
+    // is plain text.
+    expect(configLoadsAtStartTurn).toBe(1);
     const policy = messagingLog.info.mock.calls.find(
       (call) => call[0] === "messaging Full Access resume policy evaluated",
     );


### PR DESCRIPTION
## Summary

- `main` has been red since #1921 (`41f7172cf`), on both the `Test` and `Windows desktop-main` jobs. Every PR opened since inherits the failure.
- #1921 added `messaging-runtime.test.ts > does not reload config to authorize an allowed Full Access bound reply`, asserting `configLoadsAtStartTurn === 2`: one lifecycle read plus the PDF policy read, which at the time resolved on every inbound message.
- #1920 (`2edbe365a`) made `resolveMessagingPdfHandling` conditional on `turnEvent.attachments.length > 0`. This event is plain text, so the count is now 1 and the assertion fails with `expected 1 to be 2`.
- The two merged 37 seconds apart, so neither branch's CI saw the other. The break landed on `main` rather than on either PR.
- The test's premise is unharmed: it asserts that authorizing the reply adds *no* config read, and one fewer read satisfies that more strongly than two did. The expectation drops to 1, with a comment naming #1920 so the next person to move this number knows which change owns it.

## Verification

- `pnpm test` — 648 files, 9548 passed, 6 skipped, exit 0. This is the first green full run on `main` since #1921.
- `messaging-runtime.test.ts` alone — 73 passed.

## Notes

- The mock collapses to a plain `mockResolvedValue`. Its two `mockResolvedValueOnce` entries existed to feed the PDF read that no longer happens, and the comment on the second one ("PDF policy remains outside this span and still resolves dynamically") is now false.
- I did not change the production behavior. #1920 skipping PDF setup for plain text is deliberate, has its own tests, and is the newer intent; the assertion is what went stale.
- Worth noting for process rather than for this diff: both PRs were green individually and the conflict was semantic, so nothing short of re-running the merge queue against the true base would have caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)