### PR TITLE
fix(desktop): stop Token Miser replay savings at ContextCompaction

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
@@ -22,6 +22,7 @@ describe("detectObservedContextWindowDrop", () => {
       cursor,
       tokenUsage: {
         last: {
+          cachedInputTokens: 0,
           inputTokens: 21_000,
           outputTokens: 500,
           totalTokens: 21_500,
@@ -49,6 +50,24 @@ describe("detectObservedContextWindowDrop", () => {
       tokenUsage: {
         last: { inputTokens: 241_000, totalTokens: 241_000 },
         total: { inputTokens: 641_000 },
+      },
+    })).toBeUndefined();
+  });
+
+  it("does not classify the real-shape smaller hot replay as compaction", () => {
+    expect(detectObservedContextWindowDrop({
+      cursor: {
+        cumulativeInputTokens: 2_024_300,
+        lastContextTokens: 182_485,
+      },
+      tokenUsage: {
+        last: {
+          cachedInputTokens: 159_104,
+          inputTokens: 159_821,
+          outputTokens: 6,
+          totalTokens: 159_827,
+        },
+        total: { inputTokens: 2_184_121 },
       },
     })).toBeUndefined();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
@@ -31,6 +31,7 @@ describe("detectObservedContextWindowDrop", () => {
     })).toEqual({
       cumulativeInputTokens: 421_000,
       currentContextTokens: 21_500,
+      previousCumulativeInputTokens: 400_000,
       previousContextTokens: 240_000,
     });
   });

--- a/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import type { AgentEvent } from "@pwragent/shared";
 import {
   buildThreadCompactionIdentity,
   foldObservedContextReplay,
+  readThreadCompactionBoundary,
   type ObservedContextReplayCursor,
   type ObservedContextReplayTally,
 } from "../app-server/backend-registry";
@@ -31,6 +33,103 @@ describe("buildThreadCompactionIdentity", () => {
 
     expect(duplicate).toBe(first);
     expect(later).not.toBe(first);
+  });
+});
+
+describe("readThreadCompactionBoundary", () => {
+  it("reads automatic window compaction from a ContextCompaction item", () => {
+    expect(readThreadCompactionBoundary({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "compact-item-1",
+            type: "ContextCompaction",
+          },
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    })).toEqual({
+      itemId: "compact-item-1",
+      threadId: "thread-1",
+      turnId: "turn-1",
+    });
+  });
+
+  it("accepts camelCase contextCompaction on item/started", () => {
+    expect(readThreadCompactionBoundary({
+      backend: "codex",
+      notification: {
+        method: "item/started",
+        params: {
+          item: {
+            id: "compact-item-1",
+            type: "contextCompaction",
+          },
+          threadId: "thread-1",
+        },
+      },
+    })).toEqual({
+      itemId: "compact-item-1",
+      threadId: "thread-1",
+    });
+  });
+
+  it("ignores non-compaction items", () => {
+    expect(readThreadCompactionBoundary({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "command-1",
+            type: "CommandExecution",
+          },
+          threadId: "thread-1",
+        },
+      },
+    })).toBeUndefined();
+  });
+
+  it("keys a ContextCompaction item with the same id as thread/compacted", () => {
+    const itemEvent = {
+      backend: "codex" as const,
+      notification: {
+        method: "item/completed" as const,
+        params: {
+          item: {
+            id: "compact-item-1",
+            type: "ContextCompaction",
+          },
+          threadId: "thread-1",
+          turnId: "turn-1",
+        },
+      },
+    } satisfies AgentEvent;
+    const compactedEvent = {
+      backend: "codex" as const,
+      notification: {
+        method: "thread/compacted" as const,
+        params: {
+          itemId: "compact-item-1",
+          threadId: "thread-1",
+        },
+      },
+    } satisfies AgentEvent;
+    const itemBoundary = readThreadCompactionBoundary(itemEvent);
+    const compactedBoundary = readThreadCompactionBoundary(compactedEvent);
+
+    expect(itemBoundary).toBeDefined();
+    expect(compactedBoundary).toBeDefined();
+    expect(buildThreadCompactionIdentity({
+      backend: "codex",
+      ...itemBoundary!,
+    })).toBe(buildThreadCompactionIdentity({
+      backend: "codex",
+      ...compactedBoundary!,
+    }));
   });
 });
 

--- a/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts
@@ -4,11 +4,54 @@ import { describe, expect, it } from "vitest";
 import type { AgentEvent } from "@pwragent/shared";
 import {
   buildThreadCompactionIdentity,
+  detectObservedContextWindowDrop,
   foldObservedContextReplay,
   readThreadCompactionBoundary,
   type ObservedContextReplayCursor,
   type ObservedContextReplayTally,
 } from "../app-server/backend-registry";
+
+describe("detectObservedContextWindowDrop", () => {
+  const cursor: ObservedContextReplayCursor = {
+    cumulativeInputTokens: 400_000,
+    lastContextTokens: 240_000,
+  };
+
+  it("detects a smaller context at a new request boundary", () => {
+    expect(detectObservedContextWindowDrop({
+      cursor,
+      tokenUsage: {
+        last: {
+          inputTokens: 21_000,
+          outputTokens: 500,
+          totalTokens: 21_500,
+        },
+        total: { inputTokens: 421_000 },
+      },
+    })).toEqual({
+      cumulativeInputTokens: 421_000,
+      currentContextTokens: 21_500,
+      previousContextTokens: 240_000,
+    });
+  });
+
+  it("ignores duplicate usage and a growing context", () => {
+    expect(detectObservedContextWindowDrop({
+      cursor,
+      tokenUsage: {
+        last: { inputTokens: 21_000, totalTokens: 21_000 },
+        total: { inputTokens: 400_000 },
+      },
+    })).toBeUndefined();
+    expect(detectObservedContextWindowDrop({
+      cursor,
+      tokenUsage: {
+        last: { inputTokens: 241_000, totalTokens: 241_000 },
+        total: { inputTokens: 641_000 },
+      },
+    })).toBeUndefined();
+  });
+});
 
 describe("buildThreadCompactionIdentity", () => {
   it("deduplicates an item-less notification at one request boundary", () => {

--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -686,6 +686,78 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     });
   });
 
+  it("infers a missing compaction boundary when live context drops", async () => {
+    const { objectId, tokenMiserStore } = await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 199_000,
+      cumulativeInputTokens: 200_000,
+      inputTokens: 200_000,
+      outputTokens: 1_000,
+    }));
+    const beforeDrop = await tokenMiserStore.readMetadata(objectId);
+
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 0,
+      cumulativeInputTokens: 221_000,
+      inputTokens: 21_000,
+      outputTokens: 500,
+    }));
+
+    expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
+      parentRequestsObservedAfterGate:
+        beforeDrop?.parentRequestsObservedAfterGate,
+      replayTrackingStoppedAt: expect.any(Number),
+    });
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([
+      expect.objectContaining({
+        threadId: "thread-parent",
+        turnId: "turn-parent",
+      }),
+    ]);
+  });
+
+  it("does not infer a second marker for an already reported compaction", async () => {
+    await startLiveReplayGate();
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 199_000,
+      cumulativeInputTokens: 200_000,
+      inputTokens: 200_000,
+      outputTokens: 1_000,
+    }));
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "compact-item-before-drop",
+            type: "ContextCompaction",
+          },
+          threadId: "thread-parent",
+          turnId: "turn-parent",
+        },
+      },
+    });
+
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 0,
+      cumulativeInputTokens: 221_000,
+      inputTokens: 21_000,
+      outputTokens: 500,
+    }));
+
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([
+      expect.objectContaining({ itemId: "compact-item-before-drop" }),
+    ]);
+  });
+
   it("does not treat a non-compaction item as a replay boundary", async () => {
     const { objectId, tokenMiserStore } = await startLiveReplayGate();
 
@@ -819,6 +891,41 @@ function parentUsageEvent(inputTokens: number): AgentEvent {
             outputTokens: 0,
             reasoningOutputTokens: 0,
             totalTokens: inputTokens,
+          },
+        },
+      },
+    },
+  };
+}
+
+function parentContextUsageEvent(params: {
+  cachedInputTokens: number;
+  cumulativeInputTokens: number;
+  inputTokens: number;
+  outputTokens: number;
+}): AgentEvent {
+  return {
+    backend: "codex",
+    notification: {
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-parent",
+        tokenUsage: {
+          last: {
+            cachedInputTokens: params.cachedInputTokens,
+            inputTokens: params.inputTokens,
+            outputTokens: params.outputTokens,
+            reasoningOutputTokens: 0,
+            totalTokens: params.inputTokens + params.outputTokens,
+          },
+          modelContextWindow: 258_400,
+          total: {
+            cachedInputTokens: params.cachedInputTokens,
+            inputTokens: params.cumulativeInputTokens,
+            outputTokens: params.outputTokens,
+            reasoningOutputTokens: 0,
+            totalTokens: params.cumulativeInputTokens + params.outputTokens,
           },
         },
       },

--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -608,7 +608,223 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     expect(replayAccounting?.savingsMicros)
       .toBeGreaterThan(initialAccounting?.savingsMicros ?? 0);
   });
+
+  it("stops cached replay counting at a ContextCompaction item boundary", async () => {
+    const { objectId, tokenMiserStore } = await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentUsageEvent(2_000));
+    await registry.publishLocalEvent(parentUsageEvent(3_000));
+    await registry.publishLocalEvent(parentUsageEvent(4_000));
+    expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
+      cachedReplayCount: 1,
+      parentRequestsObservedAfterGate: 3,
+    });
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "compact-item-1",
+            type: "ContextCompaction",
+          },
+          threadId: "thread-parent",
+          turnId: "turn-parent",
+        },
+      },
+    });
+
+    await registry.publishLocalEvent(parentUsageEvent(5_000));
+    await registry.publishLocalEvent(parentUsageEvent(6_000));
+
+    expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
+      cachedReplayCount: 1,
+      parentRequestsObservedAfterGate: 3,
+    });
+    expect(
+      (await tokenMiserStore.readMetadata(objectId))?.replayTrackingStoppedAt,
+    ).toEqual(expect.any(Number));
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([
+      expect.objectContaining({
+        itemId: "compact-item-1",
+        threadId: "thread-parent",
+        turnId: "turn-parent",
+      }),
+    ]);
+  });
+
+  it("stops cached replay counting when a ContextCompaction item starts", async () => {
+    const { objectId, tokenMiserStore } = await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentUsageEvent(2_000));
+    await registry.publishLocalEvent(parentUsageEvent(3_000));
+    await registry.publishLocalEvent(parentUsageEvent(4_000));
+
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/started",
+        params: {
+          item: {
+            id: "compact-item-started",
+            type: "contextCompaction",
+          },
+          threadId: "thread-parent",
+          turnId: "turn-parent",
+        },
+      },
+    });
+    await registry.publishLocalEvent(parentUsageEvent(5_000));
+
+    expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
+      cachedReplayCount: 1,
+      parentRequestsObservedAfterGate: 3,
+    });
+  });
+
+  it("does not treat a non-compaction item as a replay boundary", async () => {
+    const { objectId, tokenMiserStore } = await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentUsageEvent(2_000));
+    await registry.publishLocalEvent(parentUsageEvent(3_000));
+    await registry.publishLocalEvent(parentUsageEvent(4_000));
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "command-1",
+            type: "CommandExecution",
+          },
+          threadId: "thread-parent",
+          turnId: "turn-parent",
+        },
+      },
+    });
+    await registry.publishLocalEvent(parentUsageEvent(5_000));
+
+    expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
+      cachedReplayCount: 2,
+      parentRequestsObservedAfterGate: 4,
+    });
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([]);
+  });
+
+  it("records one marker when ContextCompaction and thread/compacted share an item id", async () => {
+    const { objectId, tokenMiserStore } = await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentUsageEvent(2_000));
+    await registry.publishLocalEvent(parentUsageEvent(3_000));
+    await registry.publishLocalEvent(parentUsageEvent(4_000));
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "compact-item-shared",
+            type: "ContextCompaction",
+          },
+          threadId: "thread-parent",
+          turnId: "turn-parent",
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/compacted",
+        params: {
+          itemId: "compact-item-shared",
+          threadId: "thread-parent",
+        },
+      },
+    });
+    await registry.publishLocalEvent(parentUsageEvent(5_000));
+
+    expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
+      cachedReplayCount: 1,
+    });
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toHaveLength(1);
+  });
+
+  async function startLiveReplayGate(): Promise<{
+    objectId: string;
+    tokenMiserStore: TokenMiserStore;
+  }> {
+    const objectId = "22222222-2222-4222-8222-222222222222";
+    const tokenMiserStore = new TokenMiserStore(
+      path.join(directory, "token-miser-objects"),
+    );
+    const entry = await tokenMiserStore.store({
+      baselineCharacters: 24_000,
+      helperUsage: metadata("gate-live", "helper-live").helperUsage,
+      objectId,
+      output: "x".repeat(24_000),
+      parentCumulativeInputTokens: 1_000,
+      parentModel: "gpt-5.6-terra",
+      parentServiceTier: "standard",
+      replacementCharacters: 900,
+      summary: {
+        summary: "The command returned a large result.",
+        usefulDetails: [],
+      },
+      threadId: "thread-parent",
+      toolName: "commandExecution",
+      toolUseId: "tool-live",
+      turnId: "turn-parent",
+    });
+    const internals = registry as unknown as {
+      rememberActiveTokenMiserReplayEntry(
+        metadata: TokenMiserObjectMetadata,
+      ): void;
+      tokenMiserStore?: TokenMiserStore;
+    };
+    internals.tokenMiserStore = tokenMiserStore;
+    internals.rememberActiveTokenMiserReplayEntry(entry);
+    return { objectId, tokenMiserStore };
+  }
 });
+
+function parentUsageEvent(inputTokens: number): AgentEvent {
+  return {
+    backend: "codex",
+    notification: {
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-parent",
+        turnId: "turn-parent",
+        tokenUsage: {
+          last: {
+            cachedInputTokens: inputTokens - 100,
+            inputTokens,
+            outputTokens: 0,
+            reasoningOutputTokens: 0,
+            totalTokens: inputTokens,
+          },
+          total: {
+            cachedInputTokens: inputTokens - 100,
+            inputTokens,
+            outputTokens: 0,
+            reasoningOutputTokens: 0,
+            totalTokens: inputTokens,
+          },
+        },
+      },
+    },
+  };
+}
 
 function metadata(
   objectId: string,

--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -720,6 +720,35 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     ]);
   });
 
+  it("keeps counting when a hot replay has a smaller context", async () => {
+    const { objectId, tokenMiserStore } = await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 178_400,
+      cumulativeInputTokens: 182_300,
+      inputTokens: 182_300,
+      outputTokens: 185,
+    }));
+    const beforeSmallerReplay = await tokenMiserStore.readMetadata(objectId);
+
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 159_104,
+      cumulativeInputTokens: 342_121,
+      inputTokens: 159_821,
+      outputTokens: 6,
+    }));
+    const afterSmallerReplay = await tokenMiserStore.readMetadata(objectId);
+
+    expect(afterSmallerReplay?.parentRequestsObservedAfterGate).toBe(
+      (beforeSmallerReplay?.parentRequestsObservedAfterGate ?? 0) + 1,
+    );
+    expect(afterSmallerReplay?.replayTrackingStoppedAt).toBeUndefined();
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([]);
+  });
+
   it("does not infer a second marker for an already reported compaction", async () => {
     await startLiveReplayGate();
     await registry.publishLocalEvent(parentContextUsageEvent({
@@ -871,6 +900,44 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
       backend: "codex",
       threadId: "thread-parent",
     })).toHaveLength(1);
+  });
+
+  it("records one marker when thread/compacted omits the ContextCompaction item id", async () => {
+    await startLiveReplayGate();
+
+    await registry.publishLocalEvent(parentUsageEvent(2_000));
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "item/completed",
+        params: {
+          item: {
+            id: "compact-item-with-optional-id",
+            type: "ContextCompaction",
+          },
+          threadId: "thread-parent",
+          turnId: "turn-parent",
+        },
+      },
+    });
+    await registry.publishLocalEvent({
+      backend: "codex",
+      notification: {
+        method: "thread/compacted",
+        params: {
+          threadId: "thread-parent",
+        },
+      },
+    });
+
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([
+      expect.objectContaining({
+        itemId: "compact-item-with-optional-id",
+      }),
+    ]);
   });
 
   async function startLiveReplayGate(): Promise<{

--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -758,6 +758,48 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     ]);
   });
 
+  it("does infer a new boundary past an older unattributed marker", async () => {
+    await startLiveReplayGate();
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 199_000,
+      cumulativeInputTokens: 200_000,
+      inputTokens: 200_000,
+      outputTokens: 1_000,
+    }));
+    const staleObservedAt = Date.now();
+    await store.recordThreadCompaction({
+      compaction: {
+        backend: "codex",
+        compactionId: "stale-unattributed-marker",
+        observedAt: staleObservedAt,
+        threadId: "thread-parent",
+        turnId: "turn-old",
+        updatedAt: staleObservedAt,
+      },
+    });
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 209_000,
+      cumulativeInputTokens: 410_000,
+      inputTokens: 210_000,
+      outputTokens: 1_000,
+    }));
+
+    await registry.publishLocalEvent(parentContextUsageEvent({
+      cachedInputTokens: 0,
+      cumulativeInputTokens: 431_000,
+      inputTokens: 21_000,
+      outputTokens: 500,
+    }));
+
+    expect(await store.listThreadCompactions({
+      backend: "codex",
+      threadId: "thread-parent",
+    })).toEqual([
+      expect.objectContaining({ compactionId: "stale-unattributed-marker" }),
+      expect.objectContaining({ turnId: "turn-parent" }),
+    ]);
+  });
+
   it("does not treat a non-compaction item as a replay boundary", async () => {
     const { objectId, tokenMiserStore } = await startLiveReplayGate();
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3807,9 +3807,7 @@ describe("DesktopBackendRegistry", () => {
   });
 
   it("does not stop newer Token Miser replay gates for a duplicate compaction", async () => {
-    const recordThreadCompaction = vi.fn()
-      .mockResolvedValueOnce(true)
-      .mockResolvedValueOnce(false);
+    const recordThreadCompaction = vi.fn().mockResolvedValueOnce(true);
     const overlayStore = {
       ...createOverlayStoreMock(),
       recordThreadCompaction,
@@ -3847,7 +3845,7 @@ describe("DesktopBackendRegistry", () => {
       await internals.handleThreadCompactionReplayBoundary(event);
       await internals.handleThreadCompactionReplayBoundary(event);
 
-      expect(recordThreadCompaction).toHaveBeenCalledTimes(2);
+      expect(recordThreadCompaction).toHaveBeenCalledTimes(1);
       expect(stopReplayTracking).toHaveBeenCalledTimes(1);
     } finally {
       await registry.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3589,24 +3589,28 @@ export function readThreadCompactionBoundary(
         : {}),
     };
   }
+  // `item/started` and `item/completed` share one union member, so method
+  // narrowing does not expose `params.item`. Read it the same way the rest of
+  // this file does.
+  const itemType = readNotificationItemType(notification);
   if (
-    notification.method !== "item/started"
-    && notification.method !== "item/completed"
+    !itemType
+    || itemType.replace(/[-_\s]/g, "").toLowerCase() !== "contextcompaction"
   ) {
     return undefined;
   }
-  const itemType = notification.params.item.type;
-  if (
-    itemType.replace(/[-_\s]/g, "").toLowerCase() !== "contextcompaction"
-  ) {
+  const params = readRecord(notification.params);
+  const item = readRecord(params?.item);
+  const threadId = readNonEmptyString(params?.threadId);
+  const itemId = readNonEmptyString(item?.id);
+  if (!threadId || !itemId) {
     return undefined;
   }
+  const turnId = readNonEmptyString(params?.turnId);
   return {
-    itemId: notification.params.item.id,
-    threadId: notification.params.threadId,
-    ...(typeof notification.params.turnId === "string"
-      ? { turnId: notification.params.turnId }
-      : {}),
+    itemId,
+    threadId,
+    ...(turnId ? { turnId } : {}),
   };
 }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3560,6 +3560,56 @@ export function buildThreadCompactionIdentity(params: {
   ].join(":");
 }
 
+export type ThreadCompactionBoundary = {
+  itemId?: string;
+  threadId: string;
+  turnId?: string;
+};
+
+/**
+ * Compaction is the hard stop for Token Miser replay savings: once Codex
+ * replaces the prior window, a preserved payload is no longer in context and
+ * must not keep accruing cached-replay credit.
+ *
+ * Codex's automatic window compaction surfaces as a `ContextCompaction` item
+ * (`item/started` then `item/completed`). The dedicated `thread/compacted`
+ * notification is the same boundary when the app-server emits it, often with
+ * the same item id. Treat both as one event so a missing `thread/compacted`
+ * cannot leave the replay window open across later windows.
+ */
+export function readThreadCompactionBoundary(
+  event: AgentEvent,
+): ThreadCompactionBoundary | undefined {
+  const notification = event.notification;
+  if (notification.method === "thread/compacted") {
+    return {
+      threadId: notification.params.threadId,
+      ...(typeof notification.params.itemId === "string"
+        ? { itemId: notification.params.itemId }
+        : {}),
+    };
+  }
+  if (
+    notification.method !== "item/started"
+    && notification.method !== "item/completed"
+  ) {
+    return undefined;
+  }
+  const itemType = notification.params.item.type;
+  if (
+    itemType.replace(/[-_\s]/g, "").toLowerCase() !== "contextcompaction"
+  ) {
+    return undefined;
+  }
+  return {
+    itemId: notification.params.item.id,
+    threadId: notification.params.threadId,
+    ...(typeof notification.params.turnId === "string"
+      ? { turnId: notification.params.turnId }
+      : {}),
+  };
+}
+
 // Pure core of the context-replay accumulator: fold one token-usage update into
 // a running per-turn tally, given the per-thread cursor. A replay is counted
 // only when the cumulative input grows past the cursor, the growing request
@@ -27408,18 +27458,19 @@ export class DesktopBackendRegistry {
    * it used to be live-only: a compaction seen while the app was closed stopped
    * nothing, and historical accounting had no boundary at all. The marker is
    * keyed on the backend's own item id when it reports one, so a re-emitted
-   * notification does not become a second compaction.
+   * notification — or a `ContextCompaction` item plus `thread/compacted` for
+   * the same item — does not become a second compaction.
    */
   private async recordThreadCompaction(event: AgentEvent): Promise<boolean> {
-    if (event.notification.method !== "thread/compacted") {
+    const boundary = readThreadCompactionBoundary(event);
+    if (!boundary) {
       return false;
     }
-    const threadId = event.notification.params.threadId;
-    const itemId = typeof event.notification.params.itemId === "string"
-      ? event.notification.params.itemId
-      : undefined;
+    const threadId = boundary.threadId;
+    const itemId = boundary.itemId;
     const observedAt = Date.now();
-    const turnId = this.findActiveTurnIdForThread(event.backend, threadId);
+    const turnId = boundary.turnId
+      ?? this.findActiveTurnIdForThread(event.backend, threadId);
     const compactionId = buildThreadCompactionIdentity({
       backend: event.backend,
       cumulativeInputTokens: this.liveThreadReplayInputCursor.get(
@@ -27473,16 +27524,15 @@ export class DesktopBackendRegistry {
   private async stopTokenMiserReplayTrackingAtCompaction(
     event: AgentEvent,
   ): Promise<void> {
+    const boundary = readThreadCompactionBoundary(event);
     if (
       event.backend !== "codex"
-      || event.notification.method !== "thread/compacted"
+      || !boundary
       || !this.tokenMiserStore
     ) {
       return;
     }
-    const entries = this.activeTokenMiserReplayEntries.get(
-      event.notification.params.threadId,
-    );
+    const entries = this.activeTokenMiserReplayEntries.get(boundary.threadId);
     if (!entries || entries.size === 0) {
       return;
     }
@@ -27496,7 +27546,7 @@ export class DesktopBackendRegistry {
     }
     await this.emitThreadToolAccountingUpdated({
       backend: "codex",
-      threadId: event.notification.params.threadId,
+      threadId: boundary.threadId,
     });
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3525,6 +3525,10 @@ type LiveThreadContextWindowObservation = {
 const MIN_OBSERVED_CONTEXT_REPLAY_INPUT_TOKENS = 32_000;
 // A replay counts as "hot" when at least this fraction of its input was cached.
 const OBSERVED_HOT_CACHE_FRACTION = 0.9;
+// The item lifecycle event and deprecated thread notification are emitted next
+// to each other. Keep their semantic boundary briefly so the notification can
+// omit its optional item id without creating a second durable marker.
+const COMPACTION_NOTIFICATION_DEDUP_WINDOW_MS = 30_000;
 
 // Per-thread replay-observation cursor.
 export type ObservedContextReplayCursor = {
@@ -3621,14 +3625,22 @@ export type ObservedContextWindowDrop = {
   previousContextTokens: number;
 };
 
+type ReportedCompactionRequestBoundary = {
+  cumulativeInputTokens?: number;
+  itemId?: string;
+  observedAt: number;
+  turnId?: string;
+};
+
 /**
- * Detect the safety-net compaction signal: a genuinely new model request whose
- * working context is smaller than the preceding request's context.
+ * Detect the safety-net compaction signal: a genuinely new cold model request
+ * whose working context is smaller than the preceding request's context.
  *
  * The cumulative input high-water mark rejects duplicate and stale usage
- * emissions. Any backwards movement at a new request boundary means prior
- * context left the window; whether Codex omitted the ContextCompaction item or
- * another backend reports only usage, replay savings must stop there.
+ * emissions. A smaller hot request is an ordinary replay whose fresh tail got
+ * shorter, so it is not enough to infer compaction. Requiring the smaller
+ * request to miss the cache gives the fallback independent evidence that the
+ * prior replay window was replaced.
  */
 export function detectObservedContextWindowDrop(params: {
   cursor: ObservedContextReplayCursor | undefined;
@@ -3646,13 +3658,19 @@ export function detectObservedContextWindowDrop(params: {
   const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
   const cumulativeInputTokens = records?.totalUsage?.inputTokens;
   const latest = records?.latestUsage;
+  const latestInputTokens = latest?.inputTokens;
+  const cachedInputTokens = latest?.cachedInputTokens;
   const currentContextTokens = latest?.totalTokens
-    ?? (typeof latest?.inputTokens === "number"
-      ? latest.inputTokens + (latest.outputTokens ?? 0)
+    ?? (typeof latestInputTokens === "number"
+      ? latestInputTokens + (latest?.outputTokens ?? 0)
       : undefined);
   if (
     typeof cumulativeInputTokens !== "number"
     || cumulativeInputTokens <= cursor.cumulativeInputTokens
+    || typeof latestInputTokens !== "number"
+    || latestInputTokens <= 0
+    || typeof cachedInputTokens !== "number"
+    || cachedInputTokens >= OBSERVED_HOT_CACHE_FRACTION * latestInputTokens
     || typeof currentContextTokens !== "number"
     || currentContextTokens < 0
     || currentContextTokens >= previousContextTokens
@@ -7744,13 +7762,16 @@ export class DesktopBackendRegistry {
     string,
     ObservedContextReplayCursor
   >();
-  // Request cursor at the latest successfully persisted reported compaction.
+  // Semantic boundary at the latest successfully persisted reported
+  // compaction. The cursor lets usage-only inference match the exact boundary;
+  // the remaining fields reconcile the item lifecycle event with an adjacent
+  // item-less `thread/compacted` notification.
   // A later context drop suppresses inference only when its immediately prior
   // request has this exact cursor; an older unattributed database row is not
   // evidence that the new drop was already marked.
   private readonly reportedCompactionRequestBoundaries = new Map<
     string,
-    number
+    ReportedCompactionRequestBoundary
   >();
   /**
    * Cumulative live usage waiting for one bulk sqlite transaction. The
@@ -27555,6 +27576,37 @@ export class DesktopBackendRegistry {
     const cumulativeInputTokens = this.liveThreadReplayInputCursor.get(
       threadKey,
     )?.cumulativeInputTokens;
+    const reportedBoundary = this.reportedCompactionRequestBoundaries.get(
+      threadKey,
+    );
+    const isRecentBoundary =
+      reportedBoundary !== undefined
+      && observedAt - reportedBoundary.observedAt
+        <= COMPACTION_NOTIFICATION_DEDUP_WINDOW_MS
+      && reportedBoundary.cumulativeInputTokens === cumulativeInputTokens
+      && (
+        reportedBoundary.turnId === undefined
+        || turnId === undefined
+        || reportedBoundary.turnId === turnId
+      );
+    const isSameItem =
+      itemId !== undefined
+      && itemId === reportedBoundary?.itemId;
+    const isDuplicateReportedBoundary =
+      isRecentBoundary
+      && (
+        isSameItem
+        || (reportedBoundary.itemId === undefined) !== (itemId === undefined)
+      );
+    if (isDuplicateReportedBoundary) {
+      this.reportedCompactionRequestBoundaries.set(threadKey, {
+        cumulativeInputTokens,
+        itemId: reportedBoundary.itemId ?? itemId,
+        observedAt,
+        turnId: reportedBoundary.turnId ?? turnId,
+      });
+      return false;
+    }
     const compactionId = buildThreadCompactionIdentity({
       backend: event.backend,
       cumulativeInputTokens,
@@ -27574,11 +27626,13 @@ export class DesktopBackendRegistry {
           ...(turnId ? { turnId } : {}),
         },
       }) ?? true;
-      if (recorded && cumulativeInputTokens !== undefined) {
-        this.reportedCompactionRequestBoundaries.set(
-          threadKey,
+      if (recorded) {
+        this.reportedCompactionRequestBoundaries.set(threadKey, {
           cumulativeInputTokens,
-        );
+          itemId,
+          observedAt,
+          turnId,
+        });
       }
       return recorded;
     } catch (error) {
@@ -27613,15 +27667,16 @@ export class DesktopBackendRegistry {
       threadKey,
     );
     if (
-      reportedBoundary
+      reportedBoundary?.cumulativeInputTokens
       === params.contextDrop.previousCumulativeInputTokens
     ) {
       this.reportedCompactionRequestBoundaries.delete(threadKey);
       return;
     }
     if (
-      reportedBoundary !== undefined
-      && reportedBoundary < params.contextDrop.previousCumulativeInputTokens
+      reportedBoundary?.cumulativeInputTokens !== undefined
+      && reportedBoundary.cumulativeInputTokens
+        < params.contextDrop.previousCumulativeInputTokens
     ) {
       this.reportedCompactionRequestBoundaries.delete(threadKey);
     }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3617,6 +3617,7 @@ export function readThreadCompactionBoundary(
 export type ObservedContextWindowDrop = {
   cumulativeInputTokens: number;
   currentContextTokens: number;
+  previousCumulativeInputTokens: number;
   previousContextTokens: number;
 };
 
@@ -3633,9 +3634,11 @@ export function detectObservedContextWindowDrop(params: {
   cursor: ObservedContextReplayCursor | undefined;
   tokenUsage: unknown;
 }): ObservedContextWindowDrop | undefined {
-  const previousContextTokens = params.cursor?.lastContextTokens;
+  const cursor = params.cursor;
+  const previousContextTokens = cursor?.lastContextTokens;
   if (
-    typeof previousContextTokens !== "number"
+    !cursor
+    || typeof previousContextTokens !== "number"
     || previousContextTokens <= 0
   ) {
     return undefined;
@@ -3649,7 +3652,7 @@ export function detectObservedContextWindowDrop(params: {
       : undefined);
   if (
     typeof cumulativeInputTokens !== "number"
-    || cumulativeInputTokens <= params.cursor!.cumulativeInputTokens
+    || cumulativeInputTokens <= cursor.cumulativeInputTokens
     || typeof currentContextTokens !== "number"
     || currentContextTokens < 0
     || currentContextTokens >= previousContextTokens
@@ -3659,6 +3662,7 @@ export function detectObservedContextWindowDrop(params: {
   return {
     cumulativeInputTokens,
     currentContextTokens,
+    previousCumulativeInputTokens: cursor.cumulativeInputTokens,
     previousContextTokens,
   };
 }
@@ -7739,6 +7743,14 @@ export class DesktopBackendRegistry {
   private readonly liveThreadReplayInputCursor = new Map<
     string,
     ObservedContextReplayCursor
+  >();
+  // Request cursor at the latest successfully persisted reported compaction.
+  // A later context drop suppresses inference only when its immediately prior
+  // request has this exact cursor; an older unattributed database row is not
+  // evidence that the new drop was already marked.
+  private readonly reportedCompactionRequestBoundaries = new Map<
+    string,
+    number
   >();
   /**
    * Cumulative live usage waiting for one bulk sqlite transaction. The
@@ -27539,17 +27551,19 @@ export class DesktopBackendRegistry {
     const observedAt = Date.now();
     const turnId = boundary.turnId
       ?? this.findActiveTurnIdForThread(event.backend, threadId);
+    const threadKey = [event.backend, threadId].join(":");
+    const cumulativeInputTokens = this.liveThreadReplayInputCursor.get(
+      threadKey,
+    )?.cumulativeInputTokens;
     const compactionId = buildThreadCompactionIdentity({
       backend: event.backend,
-      cumulativeInputTokens: this.liveThreadReplayInputCursor.get(
-        [event.backend, threadId].join(":"),
-      )?.cumulativeInputTokens,
+      cumulativeInputTokens,
       itemId,
       threadId,
       turnId,
     });
     try {
-      return await this.overlayStore.recordThreadCompaction?.({
+      const recorded = await this.overlayStore.recordThreadCompaction?.({
         compaction: {
           backend: event.backend,
           compactionId,
@@ -27560,6 +27574,13 @@ export class DesktopBackendRegistry {
           ...(turnId ? { turnId } : {}),
         },
       }) ?? true;
+      if (recorded && cumulativeInputTokens !== undefined) {
+        this.reportedCompactionRequestBoundaries.set(
+          threadKey,
+          cumulativeInputTokens,
+        );
+      }
+      return recorded;
     } catch (error) {
       backendRegistryLog.warn("compaction marker write failed", {
         backend: event.backend,
@@ -27576,10 +27597,10 @@ export class DesktopBackendRegistry {
    * Persist the usage-only safety boundary unless a reported compaction is
    * already waiting for this same post-boundary request.
    *
-   * Reported markers are written before the next usage update and remain
-   * unattributed until that update reaches the pricing ledger. That pending
-   * state is the exact deduplication seam: an inferred marker is needed only
-   * when no such marker exists.
+   * Match the reported marker's in-memory request cursor, not the database's
+   * attribution state. An old marker can remain unattributed when its next
+   * request was small or cache-served; treating every such row as current made
+   * it suppress a later genuinely unreported compaction.
    */
   private async handleInferredThreadCompaction(params: {
     backend: AppServerBackendKind;
@@ -27587,14 +27608,24 @@ export class DesktopBackendRegistry {
     threadId: string;
     turnId?: string;
   }): Promise<void> {
+    const threadKey = [params.backend, params.threadId].join(":");
+    const reportedBoundary = this.reportedCompactionRequestBoundaries.get(
+      threadKey,
+    );
+    if (
+      reportedBoundary
+      === params.contextDrop.previousCumulativeInputTokens
+    ) {
+      this.reportedCompactionRequestBoundaries.delete(threadKey);
+      return;
+    }
+    if (
+      reportedBoundary !== undefined
+      && reportedBoundary < params.contextDrop.previousCumulativeInputTokens
+    ) {
+      this.reportedCompactionRequestBoundaries.delete(threadKey);
+    }
     try {
-      const compactions = await this.overlayStore.listThreadCompactions?.({
-        backend: params.backend,
-        threadId: params.threadId,
-      });
-      if (compactions?.some((entry) => entry.coldUsageLineId === undefined)) {
-        return;
-      }
       const observedAt = Date.now();
       const recorded = await this.overlayStore.recordThreadCompaction?.({
         compaction: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -3614,6 +3614,55 @@ export function readThreadCompactionBoundary(
   };
 }
 
+export type ObservedContextWindowDrop = {
+  cumulativeInputTokens: number;
+  currentContextTokens: number;
+  previousContextTokens: number;
+};
+
+/**
+ * Detect the safety-net compaction signal: a genuinely new model request whose
+ * working context is smaller than the preceding request's context.
+ *
+ * The cumulative input high-water mark rejects duplicate and stale usage
+ * emissions. Any backwards movement at a new request boundary means prior
+ * context left the window; whether Codex omitted the ContextCompaction item or
+ * another backend reports only usage, replay savings must stop there.
+ */
+export function detectObservedContextWindowDrop(params: {
+  cursor: ObservedContextReplayCursor | undefined;
+  tokenUsage: unknown;
+}): ObservedContextWindowDrop | undefined {
+  const previousContextTokens = params.cursor?.lastContextTokens;
+  if (
+    typeof previousContextTokens !== "number"
+    || previousContextTokens <= 0
+  ) {
+    return undefined;
+  }
+  const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
+  const cumulativeInputTokens = records?.totalUsage?.inputTokens;
+  const latest = records?.latestUsage;
+  const currentContextTokens = latest?.totalTokens
+    ?? (typeof latest?.inputTokens === "number"
+      ? latest.inputTokens + (latest.outputTokens ?? 0)
+      : undefined);
+  if (
+    typeof cumulativeInputTokens !== "number"
+    || cumulativeInputTokens <= params.cursor!.cumulativeInputTokens
+    || typeof currentContextTokens !== "number"
+    || currentContextTokens < 0
+    || currentContextTokens >= previousContextTokens
+  ) {
+    return undefined;
+  }
+  return {
+    cumulativeInputTokens,
+    currentContextTokens,
+    previousContextTokens,
+  };
+}
+
 // Pure core of the context-replay accumulator: fold one token-usage update into
 // a running per-turn tally, given the per-thread cursor. A replay is counted
 // only when the cumulative input grows past the cursor, the growing request
@@ -23303,6 +23352,7 @@ export class DesktopBackendRegistry {
     }
     await work.precedingDerivation;
     let derivedUsage: DerivedLiveThreadTokenUsage | undefined;
+    let contextDrop: ObservedContextWindowDrop | undefined;
     let observedReplays: ObservedContextReplayTally | undefined;
     let contextWindow: LiveThreadContextWindowObservation | undefined;
     try {
@@ -23345,6 +23395,12 @@ export class DesktopBackendRegistry {
         tokenUsage,
         turnId: notification.params.turnId ?? undefined,
       });
+      contextDrop = detectObservedContextWindowDrop({
+        cursor: this.liveThreadReplayInputCursor.get(
+          [event.backend, threadId].join(":"),
+        ),
+        tokenUsage,
+      });
       observedReplays = this.observeLiveThreadContextReplay({
         backend: event.backend,
         threadId,
@@ -23364,6 +23420,14 @@ export class DesktopBackendRegistry {
     }
     if (!derivedUsage) {
       return;
+    }
+    if (contextDrop) {
+      await this.handleInferredThreadCompaction({
+        backend: event.backend,
+        contextDrop,
+        threadId,
+        turnId: notification.params.turnId ?? undefined,
+      });
     }
 
     const overlay = await this.overlayStore.getThreadOverlayState({
@@ -27508,6 +27572,74 @@ export class DesktopBackendRegistry {
     }
   }
 
+  /**
+   * Persist the usage-only safety boundary unless a reported compaction is
+   * already waiting for this same post-boundary request.
+   *
+   * Reported markers are written before the next usage update and remain
+   * unattributed until that update reaches the pricing ledger. That pending
+   * state is the exact deduplication seam: an inferred marker is needed only
+   * when no such marker exists.
+   */
+  private async handleInferredThreadCompaction(params: {
+    backend: AppServerBackendKind;
+    contextDrop: ObservedContextWindowDrop;
+    threadId: string;
+    turnId?: string;
+  }): Promise<void> {
+    try {
+      const compactions = await this.overlayStore.listThreadCompactions?.({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+      if (compactions?.some((entry) => entry.coldUsageLineId === undefined)) {
+        return;
+      }
+      const observedAt = Date.now();
+      const recorded = await this.overlayStore.recordThreadCompaction?.({
+        compaction: {
+          backend: params.backend,
+          compactionId: buildThreadCompactionIdentity({
+            backend: params.backend,
+            cumulativeInputTokens: params.contextDrop.cumulativeInputTokens,
+            threadId: params.threadId,
+            turnId: params.turnId,
+          }),
+          observedAt,
+          threadId: params.threadId,
+          updatedAt: observedAt,
+          ...(params.turnId ? { turnId: params.turnId } : {}),
+        },
+      }) ?? true;
+      if (!recorded) {
+        return;
+      }
+      backendRegistryLog.warn("compaction inferred from context-window drop", {
+        backend: params.backend,
+        currentContextTokens: params.contextDrop.currentContextTokens,
+        previousContextTokens: params.contextDrop.previousContextTokens,
+        threadId: params.threadId,
+        turnId: params.turnId,
+      });
+      await this.stopTokenMiserReplayTrackingAtBoundary({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("inferred compaction marker write failed", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+      });
+      // The observed context drop is still authoritative enough to end replay
+      // accounting even when durable marker storage is unavailable.
+      await this.stopTokenMiserReplayTrackingAtBoundary({
+        backend: params.backend,
+        threadId: params.threadId,
+      });
+    }
+  }
+
   // The compaction notification carries no turn id, so recover it from the
   // active-turn set: compaction happens inside a turn, and attributing the
   // marker to that turn is what lets the pricing view group it under the work
@@ -27529,14 +27661,23 @@ export class DesktopBackendRegistry {
     event: AgentEvent,
   ): Promise<void> {
     const boundary = readThreadCompactionBoundary(event);
-    if (
-      event.backend !== "codex"
-      || !boundary
-      || !this.tokenMiserStore
-    ) {
+    if (!boundary) {
       return;
     }
-    const entries = this.activeTokenMiserReplayEntries.get(boundary.threadId);
+    await this.stopTokenMiserReplayTrackingAtBoundary({
+      backend: event.backend,
+      threadId: boundary.threadId,
+    });
+  }
+
+  private async stopTokenMiserReplayTrackingAtBoundary(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    if (params.backend !== "codex" || !this.tokenMiserStore) {
+      return;
+    }
+    const entries = this.activeTokenMiserReplayEntries.get(params.threadId);
     if (!entries || entries.size === 0) {
       return;
     }
@@ -27550,7 +27691,7 @@ export class DesktopBackendRegistry {
     }
     await this.emitThreadToolAccountingUpdated({
       backend: "codex",
-      threadId: boundary.threadId,
+      threadId: params.threadId,
     });
   }
 

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -419,7 +419,8 @@ CREATE INDEX IF NOT EXISTS idx_acp_available_commands_observed
   ON acp_available_commands(observed_at DESC);
 `;
 
-// One row per observed `thread/compacted`. Compaction is the only event that
+// One row per observed compaction (`thread/compacted` or a ContextCompaction
+// item). Compaction is the only event that
 // bounds how long a preserved tool payload can still be replayed, and it was
 // previously live-only: a compaction seen while the app was closed stopped
 // nothing, and historical accounting had no boundary at all. Persisting it

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -597,6 +597,7 @@ export function ToolOutputIncidentExplorerWindow() {
           invocations={allInvocations}
           threadCostMicros={threadCostMicros}
           tokenMiser={activeTokenMiser}
+          usageLines={usageLines ?? []}
         />
       ) : (
       <>
@@ -1117,6 +1118,7 @@ function TokenMiserSavingsLens(props: {
   invocations: ThreadToolInvocationRecord[];
   threadCostMicros: number;
   tokenMiser?: ThreadToolAccounting["tokenMiser"];
+  usageLines: readonly ThreadUsageLineRecord[];
 }) {
   const tokenMiser = props.tokenMiser;
   if (!tokenMiser) {
@@ -1132,6 +1134,10 @@ function TokenMiserSavingsLens(props: {
   if (!props.comparison) {
     return (
       <div className="incident-explorer__savings">
+        <TokenMiserContextTimeline
+          compactions={props.compactions}
+          usageLines={props.usageLines}
+        />
         <TokenMiserCodeModeStats
           tokenMiser={tokenMiser}
         />
@@ -1329,6 +1335,10 @@ function TokenMiserSavingsLens(props: {
         {" · "}{(tokenMiser.policyPassThroughCount ?? 0).toLocaleString()} policy pass-throughs
         {" · "}{(tokenMiser.helperPassThroughCount ?? 0).toLocaleString()} helper pass-throughs
       </p>
+      <TokenMiserContextTimeline
+        compactions={props.compactions}
+        usageLines={props.usageLines}
+      />
       <TokenMiserCompactionStats
         compactions={props.compactions}
         contextWindow={props.contextWindow}
@@ -1341,6 +1351,213 @@ function TokenMiserSavingsLens(props: {
       <TokenMiserResultList entries={props.gates} tokenMiser={tokenMiser} />
     </div>
   );
+}
+
+type TokenMiserContextTurn = {
+  compactionCount: number;
+  finalContextTokens: number | undefined;
+  key: string;
+  label: string;
+  modelContextWindow: number | undefined;
+  observedAt: number;
+  peakContextTokens: number | undefined;
+  turnId: string | undefined;
+};
+
+/**
+ * Parent-context history is the Token Miser verification chart. It is built
+ * from pricing turns rather than tool invocations so a compaction remains
+ * visible even when that turn made no tool call or its tool history no longer
+ * survives replay.
+ */
+function TokenMiserContextTimeline(props: {
+  compactions: readonly ThreadCompactionRecord[];
+  usageLines: readonly ThreadUsageLineRecord[];
+}) {
+  const turns = useMemo(
+    () => buildTokenMiserContextTurns(props.usageLines, props.compactions),
+    [props.compactions, props.usageLines],
+  );
+  if (turns.length === 0) {
+    return null;
+  }
+  const compactionCount = turns.reduce(
+    (total, turn) => total + turn.compactionCount,
+    0,
+  );
+  const measuredTurnCount = turns.filter((turn) =>
+    turn.finalContextTokens !== undefined
+    && turn.modelContextWindow !== undefined
+  ).length;
+  const parentTurnCount = turns.filter((turn) => turn.turnId !== undefined).length;
+  const unassignedBoundaryCount = turns.length - parentTurnCount;
+  return (
+    <section
+      aria-label="Token Miser context by turn"
+      className="incident-explorer__context-turns"
+    >
+      <div className="incident-explorer__context-turns-head">
+        <p className="incident-explorer__eyebrow">Context by turn</p>
+        <p className="incident-explorer__context-turns-legend">
+          <span aria-hidden="true" data-kind="final" /> final
+          <span aria-hidden="true" data-kind="peak" /> peak
+          <span aria-hidden="true" data-kind="compaction" /> compaction boundary
+        </p>
+      </div>
+      <div
+        aria-label="Parent context per turn, in order"
+        className="incident-explorer__context-turns-chart"
+        role="group"
+      >
+        {turns.map((turn) => {
+          const peakPercent = contextWindowPercent(
+            turn.peakContextTokens,
+            turn.modelContextWindow,
+          );
+          const finalPercent = contextWindowPercent(
+            turn.finalContextTokens,
+            turn.modelContextWindow,
+          );
+          const description = [
+            turn.label,
+            new Date(turn.observedAt).toLocaleString(),
+            ...(turn.finalContextTokens !== undefined
+              && turn.modelContextWindow !== undefined
+              ? [`final context ${formatContextWindowPoint(
+                  turn.finalContextTokens,
+                  turn.modelContextWindow,
+                )}`]
+              : ["final context not observed"]),
+            ...(turn.peakContextTokens !== undefined
+              && turn.modelContextWindow !== undefined
+              ? [`peak context ${formatContextWindowPoint(
+                  turn.peakContextTokens,
+                  turn.modelContextWindow,
+                )}`]
+              : []),
+            ...(turn.compactionCount > 0
+              ? [`context compacted ${turn.compactionCount.toLocaleString()} ${turn.compactionCount === 1 ? "time" : "times"}`]
+              : []),
+          ].join(" · ");
+          return (
+            <span
+              aria-label={description}
+              className="incident-explorer__context-turn"
+              data-compaction={turn.compactionCount > 0}
+              key={turn.key}
+              role="img"
+              title={description}
+            >
+              <span
+                aria-hidden="true"
+                className="incident-explorer__context-turn-track"
+              >
+                <i style={{ height: `${peakPercent}%` }} />
+                <b style={{ height: `${finalPercent}%` }} />
+              </span>
+            </span>
+          );
+        })}
+      </div>
+      <p className="incident-explorer__savings-caption">
+        {parentTurnCount.toLocaleString()} parent turn
+        {parentTurnCount === 1 ? "" : "s"}
+        {" · "}{measuredTurnCount.toLocaleString()} with context measurements
+        {" · "}{compactionCount.toLocaleString()} compaction boundar
+        {compactionCount === 1 ? "y" : "ies"}
+        {unassignedBoundaryCount > 0
+          ? ` · ${unassignedBoundaryCount.toLocaleString()} without a turn id`
+          : ""}
+      </p>
+    </section>
+  );
+}
+
+function buildTokenMiserContextTurns(
+  usageLines: readonly ThreadUsageLineRecord[],
+  compactions: readonly ThreadCompactionRecord[],
+): TokenMiserContextTurn[] {
+  const byTurn = new Map<string, Omit<TokenMiserContextTurn, "label">>();
+  const turnByUsageLine = new Map<string, string>();
+  for (const line of usageLines) {
+    if (line.scope !== "turn" || !line.turnId) {
+      continue;
+    }
+    turnByUsageLine.set(line.usageLineId, line.turnId);
+    const observedAt = line.completedAt ?? line.startedAt ?? line.createdAt;
+    const existing = byTurn.get(line.turnId);
+    const lineIsNewer = !existing || observedAt >= existing.observedAt;
+    byTurn.set(line.turnId, {
+      compactionCount: existing?.compactionCount ?? 0,
+      finalContextTokens: lineIsNewer
+        ? line.finalContextTokens ?? existing?.finalContextTokens
+        : existing.finalContextTokens,
+      key: `turn:${line.turnId}`,
+      modelContextWindow: lineIsNewer
+        ? line.modelContextWindow ?? existing?.modelContextWindow
+        : existing.modelContextWindow,
+      observedAt: Math.max(observedAt, existing?.observedAt ?? observedAt),
+      peakContextTokens: Math.max(
+        line.peakContextTokens ?? 0,
+        existing?.peakContextTokens ?? 0,
+      ) || undefined,
+      turnId: line.turnId,
+    });
+  }
+  const unassigned: Array<Omit<TokenMiserContextTurn, "label">> = [];
+  for (const compaction of compactions) {
+    const turnId = compaction.turnId
+      ?? (compaction.coldUsageLineId
+        ? turnByUsageLine.get(compaction.coldUsageLineId)
+        : undefined);
+    if (!turnId) {
+      unassigned.push({
+        compactionCount: 1,
+        finalContextTokens: undefined,
+        key: `compaction:${compaction.compactionId}`,
+        modelContextWindow: undefined,
+        observedAt: compaction.observedAt,
+        peakContextTokens: undefined,
+        turnId: undefined,
+      });
+      continue;
+    }
+    const existing = byTurn.get(turnId);
+    byTurn.set(turnId, {
+      compactionCount: (existing?.compactionCount ?? 0) + 1,
+      finalContextTokens: existing?.finalContextTokens,
+      key: `turn:${turnId}`,
+      modelContextWindow: existing?.modelContextWindow,
+      observedAt: existing?.observedAt ?? compaction.observedAt,
+      peakContextTokens: existing?.peakContextTokens,
+      turnId,
+    });
+  }
+  const ordered = [...byTurn.values(), ...unassigned].sort(
+    (left, right) =>
+      left.observedAt - right.observedAt
+      || left.key.localeCompare(right.key),
+  );
+  let ordinal = 0;
+  return ordered.map((turn) => ({
+    ...turn,
+    label: turn.turnId ? `Turn ${(ordinal += 1)}` : "Unassigned boundary",
+  }));
+}
+
+function contextWindowPercent(
+  tokens: number | undefined,
+  modelContextWindow: number | undefined,
+): number {
+  if (
+    tokens === undefined
+    || modelContextWindow === undefined
+    || modelContextWindow <= 0
+  ) {
+    return 0;
+  }
+  const percent = tokens / modelContextWindow * 100;
+  return Math.min(100, Math.max(tokens > 0 ? 2 : 0, percent));
 }
 
 function TokenMiserCompactionStats(props: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -10,6 +10,7 @@ import type {
   ThreadCompactionRecord,
   ThreadTokenMiserSavings,
   ThreadToolInvocationRecord,
+  ThreadUsageLineRecord,
   ToolOutputIncidentExplorerLens,
 } from "@pwragent/shared";
 import {
@@ -297,6 +298,13 @@ export function ToolOutputIncidentExplorerWindow() {
       ...(usageLines ? { usageLines } : {}),
     }),
     [allInvocations, largeOutputThresholdChars, turnScope, usageLines],
+  );
+  const compactionsByTurn = useMemo(
+    () => countCompactionsByTurn(
+      latest?.pricing?.compactions ?? [],
+      usageLines ?? [],
+    ),
+    [latest?.pricing?.compactions, usageLines],
   );
   const currency = usageLines?.[0]?.currency;
   const contextWindowSummary = useMemo(
@@ -654,6 +662,7 @@ export function ToolOutputIncidentExplorerWindow() {
             ))}
           </div>
           <TurnTimeline
+            compactionsByTurn={compactionsByTurn}
             {...(currency ? { currency } : {})}
             now={renderedAt}
             onSelect={(row) => setTurnFilter(
@@ -702,6 +711,7 @@ export function ToolOutputIncidentExplorerWindow() {
       ) : null}
 
       <TurnStrip
+        compactionsByTurn={compactionsByTurn}
         {...(currency ? { currency } : {})}
         now={renderedAt}
         onScopeChange={setTurnScope}
@@ -1669,6 +1679,29 @@ function CompositionBar(props: { composition: CategoryShare[] }) {
   );
 }
 
+function countCompactionsByTurn(
+  compactions: readonly ThreadCompactionRecord[],
+  usageLines: readonly ThreadUsageLineRecord[],
+): Map<string, number> {
+  const turnByUsageLine = new Map(
+    usageLines.flatMap((line) =>
+      line.turnId ? [[line.usageLineId, line.turnId] as const] : []
+    ),
+  );
+  const counts = new Map<string, number>();
+  for (const compaction of compactions) {
+    const turnId = compaction.turnId
+      ?? (compaction.coldUsageLineId
+        ? turnByUsageLine.get(compaction.coldUsageLineId)
+        : undefined);
+    if (!turnId) {
+      continue;
+    }
+    counts.set(turnId, (counts.get(turnId) ?? 0) + 1);
+  }
+  return counts;
+}
+
 /**
  * The second cost driver. A solid bar reads as volume, a tick rail reads as
  * discrete events — deliberately different marks, because a turn that is long
@@ -1676,6 +1709,7 @@ function CompositionBar(props: { composition: CategoryShare[] }) {
  * the two need to be told apart at a glance.
  */
 function TurnStrip(props: {
+  compactionsByTurn: ReadonlyMap<string, number>;
   currency?: string;
   /* Captured once by the caller so every row in a render measures "ago"
      against the same instant. */
@@ -1724,53 +1758,66 @@ function TurnStrip(props: {
           <span className="incident-explorer__turns-key" data-kind="trips" /> round trips
         </p>
       </div>
-      {props.strip.rows.map((row) => (
-        <button
-          aria-pressed={props.selectedKey === row.key}
-          className="incident-explorer__turn"
-          data-cost={props.showCost}
-          key={row.key}
-          onClick={() => props.onSelect(row)}
-          type="button"
-        >
-          <span className="incident-explorer__turn-label">
-            {row.label}
-            <span title={new Date(row.firstObservedAt).toLocaleString()}>
-              {` · ${formatTurnWhen(row.firstObservedAt, props.now)}`}
-            </span>
-          </span>
-          <span aria-hidden="true" className="incident-explorer__turn-bar">
-            <i
-              data-critical={row.overCapCount > 0}
-              style={{ width: `${scaleWidth(row.estimatedOutputTokens, props.strip.maxTokens)}%` }}
-            />
-          </span>
-          <span
-            className="incident-explorer__turn-number"
-            title={`${formatCompactTokens(row.estimatedOutputTokens)} estimated tool-output tokens; this is not provider-billed usage`}
+      {props.strip.rows.map((row) => {
+        const compactionCount = row.turnId
+          ? (props.compactionsByTurn.get(row.turnId) ?? 0)
+          : 0;
+        return (
+          <button
+            aria-pressed={props.selectedKey === row.key}
+            className="incident-explorer__turn"
+            data-cost={props.showCost}
+            key={row.key}
+            onClick={() => props.onSelect(row)}
+            type="button"
           >
-            {formatCompactTokens(row.estimatedOutputTokens)} est.
-          </span>
-          <span aria-hidden="true" className="incident-explorer__turn-trips">
-            <i style={{ width: `${scaleWidth(row.callCount, props.strip.maxCallCount)}%` }} />
-          </span>
-          <span className="incident-explorer__turn-number">
-            {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
-          </span>
-          {props.showCost ? (
-            <span
-              className="incident-explorer__turn-cost"
-              title={row.costMicros !== undefined
-                ? `Billed cost from provider-reported usage: ${formatMicrosCurrency(row.costMicros, props.currency)}`
-                : undefined}
-            >
-              {row.costMicros !== undefined
-                ? formatMicrosCurrency(row.costMicros, props.currency)
-                : "—"}
+            <span className="incident-explorer__turn-label">
+              {row.label}
+              <span title={new Date(row.firstObservedAt).toLocaleString()}>
+                {` · ${formatTurnWhen(row.firstObservedAt, props.now)}`}
+              </span>
+              {compactionCount > 0 ? (
+                <span
+                  className="incident-explorer__turn-compaction"
+                  title={`Context compacted ${compactionCount.toLocaleString()} ${compactionCount === 1 ? "time" : "times"} during this turn`}
+                >
+                  {` · compacted${compactionCount === 1 ? "" : ` ×${compactionCount.toLocaleString()}`}`}
+                </span>
+              ) : null}
             </span>
-          ) : null}
-        </button>
-      ))}
+            <span aria-hidden="true" className="incident-explorer__turn-bar">
+              <i
+                data-critical={row.overCapCount > 0}
+                style={{ width: `${scaleWidth(row.estimatedOutputTokens, props.strip.maxTokens)}%` }}
+              />
+            </span>
+            <span
+              className="incident-explorer__turn-number"
+              title={`${formatCompactTokens(row.estimatedOutputTokens)} estimated tool-output tokens; this is not provider-billed usage`}
+            >
+              {formatCompactTokens(row.estimatedOutputTokens)} est.
+            </span>
+            <span aria-hidden="true" className="incident-explorer__turn-trips">
+              <i style={{ width: `${scaleWidth(row.callCount, props.strip.maxCallCount)}%` }} />
+            </span>
+            <span className="incident-explorer__turn-number">
+              {row.callCount.toLocaleString()} {row.callCount === 1 ? "call" : "calls"}
+            </span>
+            {props.showCost ? (
+              <span
+                className="incident-explorer__turn-cost"
+                title={row.costMicros !== undefined
+                  ? `Billed cost from provider-reported usage: ${formatMicrosCurrency(row.costMicros, props.currency)}`
+                  : undefined}
+              >
+                {row.costMicros !== undefined
+                  ? formatMicrosCurrency(row.costMicros, props.currency)
+                  : "—"}
+              </span>
+            ) : null}
+          </button>
+        );
+      })}
       {strip.hiddenTurnCount > 0 || strip.scope === "flagged" ? (
         <p className="incident-explorer__turns-note">
           {strip.hiddenTurnCount > 0
@@ -1792,6 +1839,7 @@ function TurnStrip(props: {
  * adjacency. Hover carries the numbers; click filters cases to the turn.
  */
 function TurnTimeline(props: {
+  compactionsByTurn: ReadonlyMap<string, number>;
   currency?: string;
   now: number;
   onSelect: (row: TurnCostRow) => void;
@@ -1807,15 +1855,28 @@ function TurnTimeline(props: {
     (max, row) => Math.max(max, row.callCount),
     0,
   );
+  const hasCompactions = props.timeline.some((row) =>
+    row.turnId && (props.compactionsByTurn.get(row.turnId) ?? 0) > 0
+  );
   return (
     <div className="incident-explorer__timeline-block">
-      <p className="incident-explorer__eyebrow">When it went</p>
+      <div className="incident-explorer__timeline-head">
+        <p className="incident-explorer__eyebrow">When it went</p>
+        {hasCompactions ? (
+          <p className="incident-explorer__timeline-legend">
+            <span aria-hidden="true" /> compaction boundary
+          </p>
+        ) : null}
+      </div>
       <div
         aria-label="Tool cost per turn, in order"
         className="incident-explorer__timeline"
         role="group"
       >
         {props.timeline.map((row) => {
+          const compactionCount = row.turnId
+            ? (props.compactionsByTurn.get(row.turnId) ?? 0)
+            : 0;
           const description = [
             row.label,
             formatTurnWhen(row.firstObservedAt, props.now),
@@ -1824,12 +1885,16 @@ function TurnTimeline(props: {
             ...(row.costMicros !== undefined
               ? [`billed cost ${formatMicrosCurrency(row.costMicros, props.currency)}`]
               : []),
+            ...(compactionCount > 0
+              ? [`context compacted ${compactionCount.toLocaleString()} ${compactionCount === 1 ? "time" : "times"}`]
+              : []),
           ].join(" · ");
           return (
             <button
               aria-label={description}
               aria-pressed={props.selectedKey === row.key}
               className="incident-explorer__timeline-turn"
+              data-compaction={compactionCount > 0}
               key={row.key}
               onClick={() => props.onSelect(row)}
               title={description}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -307,6 +307,73 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     )).toBeInTheDocument();
   });
 
+  it("shows every compaction on the Savings context-by-turn chart", async () => {
+    const response = buildResponse();
+    response.toolAccounting!.tokenMiser = {
+      baselineParentTokens: 10_000,
+      estimatedParentTokensSaved: 9_600,
+      interceptionCount: 1,
+      interceptions: [],
+      originalCharacters: 40_000,
+      replacementTokens: 400,
+      retrievedTokens: 0,
+    };
+    response.pricing = {
+      compactions: [
+        {
+          backend: "codex",
+          compactionId: "compaction-turn-2",
+          observedAt: 1_800_000_010_500,
+          threadId: "thread-1",
+          turnId: "turn-2",
+          updatedAt: 1_800_000_010_500,
+        },
+        {
+          backend: "codex",
+          compactionId: "compaction-turn-3",
+          observedAt: 1_800_000_020_000,
+          threadId: "thread-1",
+          turnId: "turn-3",
+          updatedAt: 1_800_000_020_000,
+        },
+      ],
+      lines: [
+        {
+          ...buildContextUsageLine(),
+          createdAt: 1_800_000_000_000,
+          finalContextTokens: 231_000,
+          peakContextTokens: 240_000,
+          turnId: "turn-1",
+          usageLineId: "usage-turn-1",
+        },
+        {
+          ...buildContextUsageLine(),
+          createdAt: 1_800_000_010_000,
+          finalContextTokens: 21_500,
+          peakContextTokens: 243_864,
+          turnId: "turn-2",
+          usageLineId: "usage-turn-2",
+        },
+      ],
+      summaries: [],
+    };
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Context%20history";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const chart = await screen.findByRole("region", {
+      name: "Token Miser context by turn",
+    });
+    expect(within(chart).getAllByRole("img")).toHaveLength(3);
+    expect(within(chart).getByRole("img", {
+      name: /Turn 2.*final context 21\.5k.*context compacted 1 time/,
+    })).toHaveAttribute("data-compaction", "true");
+    expect(within(chart).getByRole("img", {
+      name: /Turn 3.*final context not observed.*context compacted 1 time/,
+    })).toHaveAttribute("data-compaction", "true");
+    expect(within(chart).getByText(/compaction boundary/)).toBeInTheDocument();
+  });
+
   // The summary is what the parent actually received in place of the payload.
   // Without it the screen can only say how many tokens were traded, never what
   // was traded for — which is the only way to judge whether a "win" was one.

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -1015,6 +1015,36 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     )).toHaveTextContent("7.6k est.");
   });
 
+  it("marks compaction boundaries on the per-turn rows and timeline", async () => {
+    const response = buildMultiTurnResponse();
+    response.pricing = {
+      compactions: [{
+        backend: "codex",
+        compactionId: "compaction-turn-2",
+        observedAt: 1_800_000_003_500,
+        threadId: "thread-1",
+        turnId: "turn-2",
+        updatedAt: 1_800_000_003_500,
+      }],
+      lines: [],
+      summaries: [],
+    };
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const turns = await screen.findByLabelText("Cost by turn");
+    expect(within(turns).getByRole("button", { name: /Turn 2.*compacted/ }))
+      .toBeInTheDocument();
+    const timeline = screen.getByRole("group", {
+      name: "Tool cost per turn, in order",
+    });
+    expect(within(timeline).getByRole("button", {
+      name: /Turn 2.*context compacted 1 time/,
+    })).toHaveAttribute("data-compaction", "true");
+    expect(screen.getByText("compaction boundary")).toBeInTheDocument();
+  });
+
   it("labels the hover price as billed rather than treating tool output as usage", async () => {
     const response = buildMultiTurnResponse();
     response.pricing = {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -18126,6 +18126,30 @@ a.transcript-message__messaging-origin:focus-visible {
   margin-top: 10px;
 }
 
+.incident-explorer__timeline-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.incident-explorer__timeline-legend {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.incident-explorer__timeline-legend span {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  background: var(--status-warning);
+  transform: rotate(45deg);
+}
+
 .incident-explorer__timeline {
   display: flex;
   align-items: stretch;
@@ -18137,6 +18161,7 @@ a.transcript-message__messaging-origin:focus-visible {
    a 300-turn thread in a narrow window must compress to 1px columns instead
    of overflowing, and gaps do not shrink. */
 .incident-explorer .incident-explorer__timeline-turn {
+  position: relative;
   display: flex;
   flex: 1 1 0;
   flex-direction: column;
@@ -18147,6 +18172,38 @@ a.transcript-message__messaging-origin:focus-visible {
   border-radius: 0;
   background: transparent;
   cursor: pointer;
+}
+
+/* Compaction is an event, not another volume series. A dashed boundary and
+   diamond cap cross both halves of the bar, while the button's accessible name
+   carries the count for operators who do not see the mark. */
+.incident-explorer__timeline-turn[data-compaction="true"]::before {
+  position: absolute;
+  z-index: 2;
+  top: 2px;
+  bottom: 1px;
+  left: 50%;
+  width: 1px;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--status-warning) 0 2px,
+    transparent 2px 4px
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.incident-explorer__timeline-turn[data-compaction="true"]::after {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  left: calc(50% - 2px);
+  width: 5px;
+  height: 5px;
+  background: var(--status-warning);
+  content: "";
+  pointer-events: none;
+  transform: rotate(45deg);
 }
 
 .incident-explorer .incident-explorer__timeline-turn:last-child {
@@ -18326,6 +18383,10 @@ a.transcript-message__messaging-origin:focus-visible {
 
 .incident-explorer__turn-label span {
   color: var(--text-muted);
+}
+
+.incident-explorer__turn-label .incident-explorer__turn-compaction {
+  color: var(--status-warning);
 }
 
 .incident-explorer__turn-bar,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17727,6 +17727,129 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+/* Savings-lens verification chart. The axis comes from parent pricing turns,
+   not tool calls, so a no-tool compaction still owns a column. Peak context is
+   the quiet backdrop, final context is the solid signal, and compaction stays
+   a discrete event mark rather than becoming a third volume series. */
+.incident-explorer__context-turns {
+  flex: none;
+  padding: 9px 0 10px;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__context-turns-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.incident-explorer__context-turns-legend {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 10px;
+}
+
+.incident-explorer__context-turns-legend span {
+  display: inline-block;
+  width: 10px;
+  height: 5px;
+  margin-left: 5px;
+}
+
+.incident-explorer__context-turns-legend span:first-child {
+  margin-left: 0;
+}
+
+.incident-explorer__context-turns-legend span[data-kind="final"] {
+  background: var(--accent);
+}
+
+.incident-explorer__context-turns-legend span[data-kind="peak"] {
+  background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+}
+
+.incident-explorer__context-turns-legend span[data-kind="compaction"] {
+  width: 5px;
+  height: 5px;
+  background: var(--status-warning);
+  transform: rotate(45deg);
+}
+
+.incident-explorer__context-turns-chart {
+  display: flex;
+  align-items: stretch;
+  gap: 1px;
+  height: 72px;
+  margin-bottom: 7px;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__context-turn {
+  position: relative;
+  flex: 1 1 0;
+  max-width: 24px;
+  min-width: 2px;
+  height: 100%;
+}
+
+.incident-explorer__context-turn-track {
+  position: absolute;
+  inset: 0;
+}
+
+.incident-explorer__context-turn-track i,
+.incident-explorer__context-turn-track b {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: block;
+  min-height: 1px;
+}
+
+.incident-explorer__context-turn-track i {
+  background: color-mix(in srgb, var(--text-secondary) 28%, transparent);
+}
+
+.incident-explorer__context-turn-track b {
+  background: var(--accent);
+}
+
+.incident-explorer__context-turn[data-compaction="true"]::before {
+  position: absolute;
+  z-index: 2;
+  top: 3px;
+  bottom: 0;
+  left: 50%;
+  width: 1px;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--status-warning) 0 2px,
+    transparent 2px 4px
+  );
+  content: "";
+}
+
+.incident-explorer__context-turn[data-compaction="true"]::after {
+  position: absolute;
+  z-index: 3;
+  top: 0;
+  left: calc(50% - 2px);
+  width: 5px;
+  height: 5px;
+  background: var(--status-warning);
+  content: "";
+  transform: rotate(45deg);
+}
+
 .incident-explorer__gates {
   display: flex;
   flex: 1;


### PR DESCRIPTION
## Summary

Token Miser replay savings did not stop at Codex's automatic window compaction. The UI copy says they do; the live path only listened for `thread/compacted`.

On thread `01a05d7b-ff5d-7eb0-8c14-b35e00b24791` (Design targeted desktop config store):

- Token Miser Savings showed **141,478 payload replays** across 230 decisions, with **0 parent compactations**.
- The Codex rollout for that thread has **5 `compacted` records** and **5 `ContextCompaction` items**.
- Each compaction dropped last-request input from ~226k–245k tokens to ~21k.
- PwrAgent stored **zero** `thread_compactions` rows, and **none** of the 234 v2 gates had `replayTrackingStoppedAt`.
- The first gate kept counting through all five later windows (`cachedReplayCount` 1,089). The 43 gates created before the first compaction alone account for ~45k of those replays.

141k is combinatorially plausible as “every later request × every earlier gate.” It is not plausible as savings once those payloads have been compacted out of context.

The renderer already treats `item/started` / `item/completed` with type `ContextCompaction` (any casing) as compaction. The main-process Token Miser path now uses the same boundary: record a `thread_compactions` marker and stop replay tracking. `thread/compacted` still works. When both fire with the same item id, they collapse to one marker.

This is live-forward. Already-persisted `cachedReplayCount` values on this thread stay inflated; we do not rewrite Token Miser metadata from Codex rollouts.

## Test plan

- [x] Failing tests first: a live v2 gate keeps accruing cached replays after `item/completed` `ContextCompaction` (and after `item/started` `contextCompaction`).
- [x] After the fix, those events freeze `cachedReplayCount`, set `replayTrackingStoppedAt`, and persist one compaction marker.
- [x] A `CommandExecution` item does not stop tracking or write a marker.
- [x] `ContextCompaction` + `thread/compacted` with the same item id write one marker.
- [x] `readThreadCompactionBoundary` unit tests for PascalCase, camelCase, non-compaction items, and shared identity with `thread/compacted`.
- [x] Existing `backend-registry.test.ts` duplicate-`thread/compacted` coverage still passes.

```bash
pnpm test apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts apps/desktop/src/main/__tests__/backend-registry-context-replay.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts
```