### PR TITLE
fix(desktop): number nested ordered lists as 1.2 / 2.2.3

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -595,7 +595,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
         );
       },
       ol(listProps) {
-        return <ol className="transcript-message__list">{listProps.children}</ol>;
+        return (
+          <ol className="transcript-message__list" role="list">
+            {listProps.children}
+          </ol>
+        );
       },
       p(paragraphProps) {
         return (

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx
@@ -878,6 +878,34 @@ describe("ThreadMarkdown", () => {
     expect(screen.getByText("Change the admission path as described")).toBeInTheDocument();
   });
 
+  it("keeps a three-level numbered outline nested so CSS can label 1.2 and 2.2.3", () => {
+    const { container } = render(
+      <ThreadMarkdown
+        text={[
+          "1. What?",
+          "   1. I'm testing something",
+          "   2. 2nd item on indented list... should be 1.2",
+          "2. Hi",
+          "   1. Your mom",
+          "   2. Is nice",
+          "      1. Like the real kinda nice",
+          "      2. Not making a mom joke",
+          "      3. this should be 2.2.3",
+        ].join("\n")}
+      />
+    );
+
+    const rootList = container.querySelector(".thread-markdown > ol.transcript-message__list");
+    expect(rootList).toHaveAttribute("role", "list");
+    expect(rootList?.querySelectorAll(":scope > li")).toHaveLength(2);
+    expect(rootList?.querySelectorAll(":scope > li:first-child > ol > li")).toHaveLength(2);
+    expect(rootList?.querySelectorAll(":scope > li:last-child > ol > li")).toHaveLength(2);
+    expect(
+      rootList?.querySelectorAll(":scope > li:last-child > ol > li:nth-child(2) > ol > li"),
+    ).toHaveLength(3);
+    expect(screen.getByText("this should be 2.2.3")).toBeInTheDocument();
+  });
+
   it("keeps composer-style hyphen-only bullet items visible", () => {
     const { container } = render(
       <ThreadMarkdown

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1652,6 +1652,30 @@ describe("Tangerine Terminal theme contract", () => {
     expect(listRule).toContain("overflow-wrap: anywhere;");
   });
 
+  it("numbers nested ordered transcript lists as an outline instead of restarting at 1", () => {
+    const orderedListRule = extractRuleBody(css, "ol.transcript-message__list");
+    expect(orderedListRule).toContain("list-style: none;");
+    expect(orderedListRule).toContain("counter-reset: transcript-ol;");
+
+    const orderedItemRule = extractRuleBody(css, "ol.transcript-message__list > li");
+    expect(orderedItemRule).toContain("counter-increment: transcript-ol;");
+
+    const orderedMarkerRule = extractRuleBody(
+      css,
+      "ol.transcript-message__list > li::before",
+    );
+    expect(orderedMarkerRule).toContain("counters(transcript-ol, \".\")");
+
+    expect(css).toMatch(
+      /\.composer-tiptap-input__editor ol \{\n  list-style: none;\n  counter-reset: composer-ol;/,
+    );
+    const composerMarkerRule = extractRuleBody(
+      css,
+      ".composer-tiptap-input__editor ol > li::before",
+    );
+    expect(composerMarkerRule).toContain("counters(composer-ol, \".\")");
+  });
+
   it("bounds long transcript code and quote blocks with their own vertical scroll", () => {
     const preRule = extractRuleBody(css, ".transcript-message__pre");
     expect(preRule).toContain("max-height:");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16718,6 +16718,26 @@ a.transcript-message__messaging-origin:focus-visible {
   margin-top: 4px;
 }
 
+/* Nested ordered lists use outline numbers (1.2, 2.2.3) instead of restarting
+ * at 1. The first paragraph stays inline so the marker shares a line with the
+ * item text; nested lists remain block. */
+ol.transcript-message__list {
+  list-style: none;
+  counter-reset: transcript-ol;
+}
+
+ol.transcript-message__list > li {
+  counter-increment: transcript-ol;
+}
+
+ol.transcript-message__list > li::before {
+  content: counters(transcript-ol, ".") ". ";
+}
+
+ol.transcript-message__list > li > .transcript-message__paragraph:first-child {
+  display: inline;
+}
+
 .transcript-message__blockquote {
   position: relative;
   margin: 0;
@@ -25477,6 +25497,23 @@ button.pricing-token-miser__folded:focus-visible {
 .composer-tiptap-input__editor ol {
   margin: 0;
   padding-left: 20px;
+}
+
+.composer-tiptap-input__editor ol {
+  list-style: none;
+  counter-reset: composer-ol;
+}
+
+.composer-tiptap-input__editor ol > li {
+  counter-increment: composer-ol;
+}
+
+.composer-tiptap-input__editor ol > li::before {
+  content: counters(composer-ol, ".") ". ";
+}
+
+.composer-tiptap-input__editor ol > li > p:first-child {
+  display: inline;
 }
 
 .composer-tiptap-input.is-empty .composer-tiptap-input__editor::before {


### PR DESCRIPTION
## Summary

- Nested ordered lists no longer restart at `1` at each indent.
- Transcript and composer `ol` markers now use CSS `counters()`, so the list in the report reads `1`, `1.1`, `1.2`, `2`, `2.1`, `2.2`, `2.2.1`, `2.2.2`, `2.2.3`.
- `role="list"` stays on transcript ordered lists so Safari does not drop list semantics when `list-style` is none.

Follow-up to #1893, which preserved the nested structure but still showed a fresh `1.` at every level.

## Verification

- `pnpm test apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-markdown.test.tsx` (124 passed)