### PR TITLE
feat(desktop): say which project and PR a review ran against

### DIFF
--- a/apps/desktop/src/main/__tests__/managed-review.test.ts
+++ b/apps/desktop/src/main/__tests__/managed-review.test.ts
@@ -175,3 +175,77 @@ describe("managed review", () => {
     expect(prompt).toContain('"patch is incorrect"');
   });
 });
+
+describe("managed review confidence", () => {
+  const base = {
+    findings: [],
+    overall_correctness: "patch is correct",
+    overall_explanation: "Nothing regressed.",
+  };
+
+  it("keeps a reported confidence in range", () => {
+    expect(
+      parseManagedReviewOutput(JSON.stringify({
+        ...base,
+        overall_confidence_score: 0.85,
+      }))?.overall_confidence_score,
+    ).toBeCloseTo(0.85);
+  });
+
+  it("keeps the findings when the reviewer omits the score", () => {
+    // The prompt now tells a reviewer that cannot distinguish to leave the
+    // field out. Rejecting the whole object for a missing score would throw
+    // away real findings the moment a model takes that branch.
+    const parsed = parseManagedReviewOutput(JSON.stringify({
+      ...base,
+      findings: [{
+        title: "Unreleased queue",
+        body: "The failure path does not release queued work.",
+        confidence_score: 0.9,
+        code_location: {
+          absolute_file_path: "/repo/review.ts",
+          line_range: { start: 42, end: 44 },
+        },
+      }],
+      overall_correctness: "patch is incorrect",
+    }));
+
+    expect(parsed?.findings).toHaveLength(1);
+    expect(parsed?.overall_confidence_score).toBeUndefined();
+  });
+
+  it("drops a literal zero rather than printing 0% confidence", () => {
+    // The output schema in the prompt has to show the field, and a weaker
+    // model copies whatever value it shows. A zero beside "patch is correct"
+    // is a transcription, not a reviewer with no confidence.
+    expect(
+      parseManagedReviewOutput(JSON.stringify({
+        ...base,
+        overall_confidence_score: 0,
+      }))?.overall_confidence_score,
+    ).toBeUndefined();
+  });
+
+  it("drops a score outside 0-1 instead of guessing at percent", () => {
+    for (const score of [95, 1.5, -0.2, Number.NaN]) {
+      expect(
+        parseManagedReviewOutput(JSON.stringify({
+          ...base,
+          overall_confidence_score: score,
+        }))?.overall_confidence_score,
+      ).toBeUndefined();
+    }
+  });
+
+  it("defines the score in the prompt it asks the reviewer to fill", () => {
+    const prompt = buildManagedReviewPrompt({ type: "uncommittedChanges" });
+
+    expect(prompt).toContain(
+      "that overall_correctness is the right verdict",
+    );
+    expect(prompt).toContain("Omit the field entirely if you cannot distinguish");
+    // The schema example is part of the definition: a 0.0 there is the value
+    // that comes back as a 0% badge.
+    expect(prompt).not.toContain('"overall_confidence_score":0.0');
+  });
+});

--- a/apps/desktop/src/main/__tests__/review-provenance.test.ts
+++ b/apps/desktop/src/main/__tests__/review-provenance.test.ts
@@ -1,0 +1,290 @@
+import type { LinkedDirectorySummary, PrSummary } from "@pwragent/shared";
+import { describe, expect, it } from "vitest";
+import { resolveReviewProvenance } from "../app-server/review-provenance";
+
+const WORKSPACE = "/Users/dev/pwrdrvr/PwrAgent";
+const WORKTREE = "/Users/dev/.codex/worktrees/mti5p133/PwrAgent";
+
+function directory(
+  overrides: Partial<LinkedDirectorySummary> = {},
+): LinkedDirectorySummary {
+  return {
+    id: "dir-1",
+    kind: "local",
+    label: "PwrAgent",
+    path: WORKSPACE,
+    ...overrides,
+  };
+}
+
+function pullRequest(overrides: Partial<PrSummary> = {}): PrSummary {
+  return {
+    provider: "github.com",
+    number: 1918,
+    org: "pwrdrvr",
+    repo: "PwrAgent",
+    state: "passing",
+    lifecycleState: "open",
+    headRefName: "fix/macos-dock-icon-safe-area",
+    baseRefName: "main",
+    linkedDirectoryPaths: [WORKSPACE],
+    url: "https://github.com/pwrdrvr/PwrAgent/pull/1918",
+    ...overrides,
+  };
+}
+
+function gitRunner(branch: string | undefined) {
+  return async (_cwd: string, args: string[]): Promise<{ stdout: string }> => {
+    if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") {
+      if (branch === undefined) {
+        throw new Error("not a git repository");
+      }
+      return { stdout: `${branch}\n` };
+    }
+    throw new Error(`unexpected git args: ${args.join(" ")}`);
+  };
+}
+
+const noRepos = async () => [];
+
+describe("resolveReviewProvenance", () => {
+  it("names the pull request open on the checked-out branch", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      prs: [pullRequest()],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("fix/macos-dock-icon-safe-area"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context).toMatchObject({
+      baseBranch: "origin/main",
+      gitBranch: "fix/macos-dock-icon-safe-area",
+      projectLabel: "PwrAgent",
+      workspacePath: WORKSPACE,
+    });
+    expect(context?.pullRequest).toMatchObject({
+      baseRefName: "main",
+      number: 1918,
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+    });
+  });
+
+  it("carries no check, review, or merge status onto the frozen record", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      prs: [pullRequest({ checkState: "passing", mergeState: "mergeable" })],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("fix/macos-dock-icon-safe-area"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    // A status frozen at review start is still painting that day's CI result
+    // months later. Identity is the only thing safe to keep.
+    expect(Object.keys(context?.pullRequest ?? {}).sort()).toEqual([
+      "baseRefName",
+      "headRefName",
+      "number",
+      "org",
+      "provider",
+      "repo",
+      "url",
+    ]);
+  });
+
+  it("keeps the pull request when the operator overrode its base", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      prs: [
+        pullRequest({
+          baseRefName: "feat/star-map-layer",
+          headRefName: "feat/star-map-float",
+          number: 1252,
+        }),
+      ],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("feat/star-map-float"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    // The branch carried this PR; what the diff swept in from the PRs below it
+    // is unknowable, so the record says nothing about them either way.
+    expect(context?.pullRequest?.number).toBe(1252);
+    expect(context?.baseBranch).toBe("origin/main");
+    expect(context?.pullRequest?.baseRefName).toBe("feat/star-map-layer");
+  });
+
+  it("follows the selected project rather than the thread's other repositories", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: "/Users/dev/pwrdrvr/PwrSuiteLab",
+      linkedDirectories: [
+        directory(),
+        directory({
+          id: "dir-2",
+          label: "PwrSuiteLab",
+          path: "/Users/dev/pwrdrvr/PwrSuiteLab",
+        }),
+      ],
+      prs: [
+        pullRequest(),
+        pullRequest({
+          headRefName: "agent/windows-warm-e2e",
+          linkedDirectoryPaths: ["/Users/dev/pwrdrvr/PwrSuiteLab"],
+          number: 21,
+          repo: "PwrSuiteLab",
+          url: "https://github.com/pwrdrvr/PwrSuiteLab/pull/21",
+        }),
+      ],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("agent/windows-warm-e2e"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.projectLabel).toBe("PwrSuiteLab");
+    expect(context?.pullRequest?.number).toBe(21);
+  });
+
+  it("reports null when the branch was checked and carried no pull request", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      // The thread holds a PR — for a different branch. It is not evidence
+      // about this diff and must not be named here.
+      prs: [pullRequest()],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("main"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.gitBranch).toBe("main");
+    expect(context?.pullRequest).toBeNull();
+  });
+
+  it("never crosses a shared branch name into another repository", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: "/Users/dev/pwrdrvr/PwrSnap",
+      linkedDirectories: [
+        directory({
+          id: "dir-3",
+          label: "PwrSnap",
+          path: "/Users/dev/pwrdrvr/PwrSnap",
+        }),
+      ],
+      prs: [pullRequest({ headRefName: "main" })],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("main"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.pullRequest).toBeNull();
+  });
+
+  it("makes no branch or pull-request claim for a commit target", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      prs: [pullRequest()],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("fix/macos-dock-icon-safe-area"),
+      target: { type: "commit", sha: "8117be6f9", title: null },
+    });
+
+    expect(context?.gitBranch).toBeUndefined();
+    // Absent, not null: nothing was checked, so "there was none" would be a
+    // claim we did not earn.
+    expect(context?.pullRequest).toBeUndefined();
+  });
+
+  it("makes no pull-request claim on a detached HEAD", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      prs: [pullRequest()],
+      resolveGitHubRepos: noRepos,
+      // Git answers a detached HEAD with the literal string rather than failing.
+      runGit: gitRunner("HEAD"),
+      target: { type: "uncommittedChanges" },
+    });
+
+    expect(context?.gitBranch).toBeUndefined();
+    expect(context?.pullRequest).toBeUndefined();
+  });
+
+  it("leaves the pull request unknown when no pull-request data was fetched", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("fix/macos-dock-icon-safe-area"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.gitBranch).toBe("fix/macos-dock-icon-safe-area");
+    expect(context?.pullRequest).toBeUndefined();
+  });
+
+  it("records the repository a worktree belongs to", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKTREE,
+      linkedDirectories: [
+        directory({ kind: "worktree", worktreePath: WORKTREE }),
+      ],
+      prs: [pullRequest({ linkedDirectoryPaths: [WORKTREE] })],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("fix/macos-dock-icon-safe-area"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.workspacePath).toBe(WORKTREE);
+    expect(context?.repositoryPath).toBe(WORKSPACE);
+    expect(context?.projectLabel).toBe("PwrAgent");
+  });
+
+  it("prefers the open pull request when a branch carries more than one", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      linkedDirectories: [directory()],
+      prs: [
+        pullRequest({ lifecycleState: "open", number: 1900 }),
+        pullRequest({ lifecycleState: "closed", number: 1999 }),
+      ],
+      resolveGitHubRepos: noRepos,
+      runGit: gitRunner("fix/macos-dock-icon-safe-area"),
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.pullRequest?.number).toBe(1900);
+  });
+
+  it("does not read local Git for a remote workspace", async () => {
+    const context = await resolveReviewProvenance({
+      cwd: WORKSPACE,
+      executionTarget: "remote",
+      linkedDirectories: [
+        directory({ gitBranch: "fix/macos-dock-icon-safe-area" }),
+      ],
+      prs: [pullRequest()],
+      resolveGitHubRepos: noRepos,
+      runGit: async () => {
+        throw new Error("local git must not run for a remote workspace");
+      },
+      target: { type: "baseBranch", branch: "origin/main" },
+    });
+
+    expect(context?.gitBranch).toBe("fix/macos-dock-icon-safe-area");
+    expect(context?.pullRequest?.number).toBe(1918);
+  });
+
+  it("returns nothing at all when there is no workspace to name", async () => {
+    await expect(
+      resolveReviewProvenance({
+        prs: [pullRequest()],
+        target: { type: "uncommittedChanges" },
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -60,6 +60,7 @@ import {
   isUsageActivityEntry,
   usageActivityScope,
 } from "./overlay-transcript-entries";
+import { resolveReviewProvenance } from "./review-provenance";
 import { assertReviewWorkspaceMatchesAttachedPullRequest } from "./review-workspace-guard";
 import { pageNormalizedReplay } from "./thread-replay-pagination";
 import {
@@ -89,6 +90,8 @@ import {
   type AppServerReadThreadResponse,
   type AppServerThreadActivityEntry,
   type AppServerThreadEntry,
+  type AppServerReviewContext,
+  type AppServerReviewTarget,
   type AppServerThreadImagePart,
   type AppServerThreadMessage,
   type AppServerThreadMessageOrigin,
@@ -2775,6 +2778,13 @@ type TaskMonitorDelegationRecord = {
 type ReviewSubAgentRecord = {
   /** Backend running the review child. */
   backend: AppServerBackendKind;
+  /**
+   * Workspace, branch, and pull request the review was started against,
+   * resolved once at start. Held on the record so the completion entry reports
+   * the same facts as the start entry rather than re-deriving them from a
+   * thread that may have moved on.
+   */
+  context?: AppServerReviewContext;
   createdAt: number;
   displayText: string;
   fastMode?: boolean;
@@ -15231,6 +15241,7 @@ export class DesktopBackendRegistry {
     let overlay: ThreadOverlayState | undefined;
     let cwd: string | undefined;
     let codexEnvironmentRuntime: CodexThreadEnvironmentRuntime | undefined;
+    let reviewContext: AppServerReviewContext | undefined;
     let tokenMiserEnabled = false;
     try {
       if (params.backend === "codex") {
@@ -15298,6 +15309,14 @@ export class DesktopBackendRegistry {
         executionTarget: codexEnvironmentRuntime?.executionTarget,
         prs: overlay?.prs,
         target: params.target,
+      });
+      reviewContext = await this.resolveReviewContext({
+        backend: params.backend,
+        cwd,
+        executionTarget: codexEnvironmentRuntime?.executionTarget,
+        overlay,
+        target: params.target,
+        threadId: params.threadId,
       });
       // A review on another provider cannot inherit the parent thread's model
       // settings — that model belongs to a different catalog. Fall back to the
@@ -15422,6 +15441,7 @@ export class DesktopBackendRegistry {
         ? { reasoningEffort: modelSettings.reasoningEffort }
         : {}),
       mode: managedMode ? "managed" : "native",
+      ...(reviewContext ? { context: reviewContext } : {}),
       parentBackend: params.backend,
       parentThreadId: result.threadId,
       reviewThreadId: result.reviewThreadId || result.threadId,
@@ -15621,6 +15641,51 @@ export class DesktopBackendRegistry {
     }
   }
 
+  /**
+   * Never fails a review. Provenance is reporting: a card that cannot say which
+   * project it ran in is worse than one that can, but it is not worth refusing
+   * to run the review the operator asked for.
+   */
+  private async resolveReviewContext(params: {
+    backend: AppServerBackendKind;
+    cwd?: string;
+    executionTarget?: "local" | "remote";
+    overlay?: ThreadOverlayState;
+    target: AppServerReviewTarget;
+    threadId: string;
+  }): Promise<AppServerReviewContext | undefined> {
+    if (!params.cwd?.trim()) {
+      return undefined;
+    }
+    try {
+      const thread = await this.findThreadForWorkspaceHandoff({
+        backend: params.backend,
+        callerReason: "review-provenance",
+        freshness: "last-known",
+        threadId: params.threadId,
+      });
+      return await resolveReviewProvenance({
+        cwd: params.cwd,
+        ...(params.executionTarget
+          ? { executionTarget: params.executionTarget }
+          : {}),
+        linkedDirectories: [
+          ...(thread?.linkedDirectories ?? []),
+          ...(params.overlay?.extraLinkedDirectories ?? []),
+        ],
+        ...(params.overlay?.prs ? { prs: params.overlay.prs } : {}),
+        target: params.target,
+      });
+    } catch (error) {
+      backendRegistryLog.warn("failed to resolve review provenance", {
+        backend: params.backend,
+        error: error instanceof Error ? error.message : String(error),
+        threadId: params.threadId,
+      });
+      return undefined;
+    }
+  }
+
   private async emitManagedReviewStarted(
     record: ReviewSubAgentRecord,
   ): Promise<void> {
@@ -15632,6 +15697,7 @@ export class DesktopBackendRegistry {
       displayText: record.displayText,
       createdAt: startedAt,
       reviewer: reviewEntryReviewer(record),
+      ...(record.context ? { context: record.context } : {}),
       turn: {
         id: record.turnId,
         status: "in_progress",
@@ -24964,6 +25030,7 @@ export class DesktopBackendRegistry {
         review,
         createdAt: completedAt,
         reviewer: reviewEntryReviewer(params.record),
+        ...(params.record.context ? { context: params.record.context } : {}),
         ...(parsed ? { output: parsed } : {}),
         turn: {
           id: params.record.turnId,
@@ -36059,6 +36126,7 @@ export class DesktopBackendRegistry {
             data: {
               ...(readRecord(item.data) ?? {}),
               reviewer: reviewEntryReviewer(record),
+              ...(record.context ? { context: record.context } : {}),
             },
           },
         },

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -15658,12 +15658,20 @@ export class DesktopBackendRegistry {
       return undefined;
     }
     try {
-      const thread = await this.findThreadForWorkspaceHandoff({
+      // Read the remembered summary directly rather than through
+      // `findThreadForWorkspaceHandoff`, which falls through to `thread/list`
+      // on a miss. `resolveThreadEnvironmentCwd` already looked this thread up
+      // moments ago; provenance is reporting and must not add an uncached
+      // round trip to the app server before the review starts. The enriched
+      // row carries directory labels, so prefer it and settle for the plain
+      // row — a basename label beats a blocked review.
+      const threadKey = {
         backend: params.backend,
-        callerReason: "review-provenance",
-        freshness: "last-known",
         threadId: params.threadId,
-      });
+      };
+      const thread =
+        this.threadInfoStore.getSummary(threadKey, { requireEnriched: true })
+        ?? this.threadInfoStore.getSummary(threadKey);
       return await resolveReviewProvenance({
         cwd: params.cwd,
         ...(params.executionTarget
@@ -36112,7 +36120,19 @@ export class DesktopBackendRegistry {
     const record =
       this.activeReviewSubAgents.get(reviewKey)
       ?? this.reviewSubAgentsByReviewTurn.get(reviewKey);
-    if (!record || readRecord(item.data)?.reviewer) {
+    if (!record) {
+      return event;
+    }
+    const data = readRecord(item.data) ?? {};
+    // Each field guards itself. Keying the whole decoration off `reviewer`
+    // made a later field's delivery depend on an unrelated field's absence:
+    // an item that already carried a reviewer would silently ship without
+    // provenance.
+    const additions = {
+      ...(data.reviewer ? {} : { reviewer: reviewEntryReviewer(record) }),
+      ...(record.context && !data.context ? { context: record.context } : {}),
+    };
+    if (Object.keys(additions).length === 0) {
       return event;
     }
     return {
@@ -36124,9 +36144,8 @@ export class DesktopBackendRegistry {
           item: {
             ...item,
             data: {
-              ...(readRecord(item.data) ?? {}),
-              reviewer: reviewEntryReviewer(record),
-              ...(record.context ? { context: record.context } : {}),
+              ...data,
+              ...additions,
             },
           },
         },

--- a/apps/desktop/src/main/app-server/managed-review.ts
+++ b/apps/desktop/src/main/app-server/managed-review.ts
@@ -5,12 +5,19 @@ import type {
 import {
   MANAGED_REVIEW_CONTEXT_CLOSE_MARKER,
   MANAGED_REVIEW_CONTEXT_OPEN_MARKER,
+  normalizeReviewConfidenceScore,
 } from "../../shared/review-command";
 
 const REVIEW_OUTPUT_INSTRUCTIONS = [
   "Return only one JSON object with this exact top-level shape:",
-  '{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"...","overall_confidence_score":0.0}',
+  '{"findings":[],"overall_correctness":"patch is correct","overall_explanation":"...","overall_confidence_score":0.85}',
   'overall_correctness must be exactly "patch is correct" or "patch is incorrect" — no other wording.',
+  // The field had no stated meaning for most of its life, so the number the
+  // card printed was whatever each model decided it meant. The example value
+  // is part of the definition: a schema showing 0.0 is a value weaker models
+  // copy through, and a literal zero renders as "0% confidence" beside a
+  // correct verdict.
+  "overall_confidence_score is how confident you are, from 0 to 1, that overall_correctness is the right verdict. It is not a quality score for the patch and not a merge recommendation. Omit the field entirely if you cannot distinguish.",
   "Each finding must contain title, body, confidence_score, optional priority (0-3), and code_location with absolute_file_path plus line_range.start/end.",
   "Do not wrap the JSON in Markdown fences and do not include prose outside it.",
 ].join("\n");
@@ -64,11 +71,13 @@ export function parseManagedReviewOutput(
     || typeof record.overall_correctness !== "string"
     || !record.overall_correctness.trim()
     || typeof record.overall_explanation !== "string"
-    || typeof record.overall_confidence_score !== "number"
   ) {
     return undefined;
   }
 
+  const confidenceScore = normalizeReviewConfidenceScore(
+    record.overall_confidence_score,
+  );
   const findings = record.findings.flatMap(
     (value): AppServerReviewOutput["findings"] => {
       if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -112,7 +121,9 @@ export function parseManagedReviewOutput(
       findings,
     ),
     overall_explanation: record.overall_explanation,
-    overall_confidence_score: record.overall_confidence_score,
+    ...(confidenceScore === undefined
+      ? {}
+      : { overall_confidence_score: confidenceScore }),
   };
 }
 

--- a/apps/desktop/src/main/app-server/review-provenance.ts
+++ b/apps/desktop/src/main/app-server/review-provenance.ts
@@ -1,0 +1,215 @@
+import type {
+  AppServerReviewContext,
+  AppServerReviewPullRequest,
+  AppServerReviewTarget,
+  LinkedDirectorySummary,
+  PrSummary,
+} from "@pwragent/shared";
+import { runGitCommand } from "./git-executable";
+import {
+  normalizeFullRef,
+  normalizeWorkspacePath,
+  prBelongsToWorkspace,
+  prMatchesRepository,
+  type ReviewGitRunner,
+} from "./review-workspace-guard";
+import {
+  resolveGitHubReposForDirectory,
+  type GitHubRepoRef,
+} from "../pr-status/git-remote";
+
+/**
+ * Git reports a detached HEAD as the literal string "HEAD" rather than
+ * failing, so it has to be rejected by name.
+ */
+const DETACHED_HEAD = "HEAD";
+
+function directoryMatchesWorkspace(
+  directory: LinkedDirectorySummary,
+  workspacePath: string,
+): boolean {
+  const workspace = normalizeWorkspacePath(workspacePath);
+  return (
+    normalizeWorkspacePath(directory.worktreePath ?? "") === workspace
+    || normalizeWorkspacePath(directory.path) === workspace
+  );
+}
+
+/**
+ * The label the operator picked the project by. Falling back to the workspace's
+ * own basename keeps a review that ran outside any linked directory nameable
+ * without inventing a label the sidebar never showed.
+ */
+function resolveProjectLabel(
+  directory: LinkedDirectorySummary | undefined,
+  workspacePath: string,
+): string | undefined {
+  const label = directory?.label.trim();
+  if (label) {
+    return label;
+  }
+  return normalizeWorkspacePath(workspacePath).split("/").pop() || undefined;
+}
+
+async function resolveCheckedOutBranch(
+  runGit: ReviewGitRunner,
+  cwd: string,
+): Promise<string | undefined> {
+  try {
+    const result = await runGit(cwd, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    const branch = result.stdout.trim();
+    return branch && branch !== DETACHED_HEAD ? branch : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function toReviewPullRequest(pr: PrSummary): AppServerReviewPullRequest {
+  return {
+    provider: pr.provider,
+    org: pr.org,
+    repo: pr.repo,
+    number: pr.number,
+    url: pr.url,
+    ...(pr.title?.trim() ? { title: pr.title.trim() } : {}),
+    ...(pr.headRefName?.trim() ? { headRefName: pr.headRefName.trim() } : {}),
+    ...(pr.baseRefName?.trim() ? { baseRefName: pr.baseRefName.trim() } : {}),
+  };
+}
+
+/**
+ * The checked-out branch is the signal. A branch carrying a pull request is
+ * strong evidence that the pull request is what was reviewed; nothing else the
+ * thread happens to hold says anything about this diff, so a thread's other
+ * pull requests are never candidates.
+ *
+ * `linkedDirectoryPaths` is thread-local provenance recorded by PR discovery.
+ * It is what keeps two of the thread's repositories sharing a branch name —
+ * `main`, or a shared `agent/...` convention — from crossing over. Where it is
+ * absent (an older row, a peer that predates it) the workspace's own Git
+ * remotes narrow the field instead.
+ */
+async function selectPullRequestForBranch(params: {
+  cwd: string;
+  branch: string;
+  prs: PrSummary[];
+  resolveGitHubRepos: (cwd: string) => Promise<GitHubRepoRef[]>;
+}): Promise<PrSummary | undefined> {
+  const branch = normalizeFullRef(params.branch);
+  const onBranch = params.prs.filter(
+    (pr) =>
+      Boolean(pr.headRefName?.trim())
+      && normalizeFullRef(pr.headRefName ?? "") === branch,
+  );
+  if (onBranch.length === 0) {
+    return undefined;
+  }
+
+  const scoped = onBranch.filter((pr) => pr.linkedDirectoryPaths?.length);
+  let candidates = scoped.filter((pr) => prBelongsToWorkspace(pr, params.cwd));
+  if (candidates.length === 0) {
+    // Only fall back to the unscoped rows. A PR that named its directories and
+    // did not name this one has already answered the question.
+    candidates = onBranch.filter((pr) => !pr.linkedDirectoryPaths?.length);
+  }
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  if (candidates.length > 1) {
+    const repositories = await params.resolveGitHubRepos(params.cwd).catch(
+      () => [] as GitHubRepoRef[],
+    );
+    if (repositories.length > 0) {
+      const inRepository = candidates.filter((pr) =>
+        repositories.some((repo) => prMatchesRepository(pr, repo))
+      );
+      if (inRepository.length > 0) {
+        candidates = inRepository;
+      }
+    }
+  }
+
+  // One branch can carry a closed PR and its reopened successor. The open one
+  // is the review's subject; ties break on the newer number so the choice is
+  // stable rather than dependent on fetch order.
+  const open = candidates.filter((pr) => pr.lifecycleState === "open");
+  const ranked = open.length > 0 ? open : candidates;
+  return ranked.reduce((best, pr) => (pr.number > best.number ? pr : best));
+}
+
+/**
+ * Freezes what a review card needs to say what it reviewed. Returns undefined
+ * only when there is no workspace to name at all — every other unknown is
+ * carried as an absent field, because "we could not check" and "we checked and
+ * there was none" have to stay distinguishable on the card.
+ */
+export async function resolveReviewProvenance(params: {
+  cwd?: string;
+  executionTarget?: "local" | "remote";
+  linkedDirectories?: LinkedDirectorySummary[];
+  prs?: PrSummary[];
+  resolveGitHubRepos?: (cwd: string) => Promise<GitHubRepoRef[]>;
+  runGit?: ReviewGitRunner;
+  target: AppServerReviewTarget;
+}): Promise<AppServerReviewContext | undefined> {
+  const cwd = params.cwd?.trim();
+  if (!cwd) {
+    return undefined;
+  }
+
+  const directory = (params.linkedDirectories ?? []).find((candidate) =>
+    directoryMatchesWorkspace(candidate, cwd)
+  );
+  const context: AppServerReviewContext = {
+    workspacePath: cwd,
+  };
+  const projectLabel = resolveProjectLabel(directory, cwd);
+  if (projectLabel) {
+    context.projectLabel = projectLabel;
+  }
+  if (
+    directory?.kind === "worktree"
+    && directory.path.trim()
+    && normalizeWorkspacePath(directory.path) !== normalizeWorkspacePath(cwd)
+  ) {
+    context.repositoryPath = directory.path.trim();
+  }
+  if (params.target.type === "baseBranch") {
+    context.baseBranch = params.target.branch;
+  }
+
+  // A commit target reviews that commit, not the branch that happens to be
+  // checked out beside it. Naming the branch would attach the review to work it
+  // did not look at, and the pull-request match rests on the same signal.
+  if (params.target.type === "commit") {
+    return context;
+  }
+
+  // Local Git is the only workspace inspection available here. A remote
+  // workspace keeps whatever branch navigation last observed and stops short of
+  // a pull-request claim it cannot verify.
+  const branch = params.executionTarget === "remote"
+    ? directory?.gitBranch?.trim()
+    : await resolveCheckedOutBranch(params.runGit ?? runGitCommand, cwd)
+      ?? directory?.gitBranch?.trim();
+  if (!branch) {
+    return context;
+  }
+  context.gitBranch = branch;
+
+  if (!params.prs) {
+    // No pull-request data was fetched for this thread, so nothing was checked.
+    return context;
+  }
+
+  const pullRequest = await selectPullRequestForBranch({
+    branch,
+    cwd,
+    prs: params.prs,
+    resolveGitHubRepos:
+      params.resolveGitHubRepos ?? resolveGitHubReposForDirectory,
+  });
+  context.pullRequest = pullRequest ? toReviewPullRequest(pullRequest) : null;
+  return context;
+}

--- a/apps/desktop/src/main/app-server/review-provenance.ts
+++ b/apps/desktop/src/main/app-server/review-provenance.ts
@@ -5,9 +5,9 @@ import type {
   LinkedDirectorySummary,
   PrSummary,
 } from "@pwragent/shared";
+import { normalizeFullRef } from "../../shared/review-command";
 import { runGitCommand } from "./git-executable";
 import {
-  normalizeFullRef,
   normalizeWorkspacePath,
   prBelongsToWorkspace,
   prMatchesRepository,
@@ -48,7 +48,16 @@ function resolveProjectLabel(
   if (label) {
     return label;
   }
-  return normalizeWorkspacePath(workspacePath).split("/").pop() || undefined;
+  // Not `normalizeWorkspacePath`: it case-folds a Windows drive-letter path so
+  // two paths can be compared, which would label `C:\Users\dev\PwrAgent` as
+  // "pwragent". A displayed name keeps the casing the operator gave it.
+  return workspacePath
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/\/+$/, "")
+    .split("/")
+    .pop()
+    || undefined;
 }
 
 async function resolveCheckedOutBranch(

--- a/apps/desktop/src/main/app-server/review-workspace-guard.ts
+++ b/apps/desktop/src/main/app-server/review-workspace-guard.ts
@@ -5,30 +5,30 @@ import {
   type GitHubRepoRef,
 } from "../pr-status/git-remote";
 
-type ReviewGitRunner = (
+export type ReviewGitRunner = (
   cwd: string,
   args: string[],
 ) => Promise<{ stdout: string }>;
 
-function normalizeWorkspacePath(value: string): string {
+export function normalizeWorkspacePath(value: string): string {
   const normalized = value.trim().replace(/\\/g, "/").replace(/\/+$/, "");
   return /^[a-z]:\//i.test(normalized) ? normalized.toLowerCase() : normalized;
 }
 
-function prBelongsToWorkspace(pr: PrSummary, cwd: string): boolean {
+export function prBelongsToWorkspace(pr: PrSummary, cwd: string): boolean {
   const selectedWorkspace = normalizeWorkspacePath(cwd);
   return (pr.linkedDirectoryPaths ?? []).some(
     (directoryPath) => normalizeWorkspacePath(directoryPath) === selectedWorkspace,
   );
 }
 
-function prMatchesRepository(pr: PrSummary, repo: GitHubRepoRef): boolean {
+export function prMatchesRepository(pr: PrSummary, repo: GitHubRepoRef): boolean {
   return pr.provider.trim().toLowerCase() === repo.host.toLowerCase()
     && pr.org.trim().toLowerCase() === repo.owner.toLowerCase()
     && pr.repo.trim().toLowerCase() === repo.repo.toLowerCase();
 }
 
-function normalizeFullRef(ref: string): string {
+export function normalizeFullRef(ref: string): string {
   const normalized = ref.trim();
   const localMatch = normalized.match(/^refs\/heads\/(.+)$/);
   if (localMatch?.[1]) {

--- a/apps/desktop/src/main/app-server/review-workspace-guard.ts
+++ b/apps/desktop/src/main/app-server/review-workspace-guard.ts
@@ -1,4 +1,5 @@
 import type { AppServerReviewTarget, PrSummary } from "@pwragent/shared";
+import { normalizeFullRef } from "../../shared/review-command";
 import { runGitCommand } from "./git-executable";
 import {
   resolveGitHubReposForDirectory,
@@ -26,16 +27,6 @@ export function prMatchesRepository(pr: PrSummary, repo: GitHubRepoRef): boolean
   return pr.provider.trim().toLowerCase() === repo.host.toLowerCase()
     && pr.org.trim().toLowerCase() === repo.owner.toLowerCase()
     && pr.repo.trim().toLowerCase() === repo.repo.toLowerCase();
-}
-
-export function normalizeFullRef(ref: string): string {
-  const normalized = ref.trim();
-  const localMatch = normalized.match(/^refs\/heads\/(.+)$/);
-  if (localMatch?.[1]) {
-    return localMatch[1];
-  }
-  const remoteMatch = normalized.match(/^refs\/remotes\/[^/]+\/(.+)$/);
-  return remoteMatch?.[1] ?? normalized;
 }
 
 async function resolveLocalTargetBranch(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -108,8 +108,8 @@ import {
   type ThreadDirectoryEnrichment,
 } from "../app-server/thread-directory-enricher";
 import {
-  normalizeReviewConfidenceScore,
   normalizeReviewDisplayText,
+  normalizeReviewOutputRecord,
 } from "../../shared/review-command";
 import {
   formatDynamicToolOutput,
@@ -2933,31 +2933,7 @@ function normalizeReviewOutput(
     asRecord(data?.review_output) ??
     asRecord(item.reviewOutput) ??
     asRecord(item.review_output);
-  const findings = Array.isArray(reviewOutput?.findings)
-    ? reviewOutput.findings
-    : undefined;
-
-  if (
-    !reviewOutput ||
-    !findings ||
-    (reviewOutput.overall_correctness !== "patch is correct" &&
-      reviewOutput.overall_correctness !== "patch is incorrect") ||
-    typeof reviewOutput.overall_explanation !== "string"
-  ) {
-    return undefined;
-  }
-
-  const confidenceScore = normalizeReviewConfidenceScore(
-    reviewOutput.overall_confidence_score,
-  );
-  return {
-    findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
-    overall_correctness: reviewOutput.overall_correctness,
-    overall_explanation: reviewOutput.overall_explanation,
-    ...(confidenceScore === undefined
-      ? {}
-      : { overall_confidence_score: confidenceScore }),
-  };
+  return normalizeReviewOutputRecord(reviewOutput);
 }
 
 function reviewDisplayText(item: Record<string, unknown>): string | undefined {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -107,7 +107,10 @@ import {
   createThreadDirectoryEnricher,
   type ThreadDirectoryEnrichment,
 } from "../app-server/thread-directory-enricher";
-import { normalizeReviewDisplayText } from "../../shared/review-command";
+import {
+  normalizeReviewConfidenceScore,
+  normalizeReviewDisplayText,
+} from "../../shared/review-command";
 import {
   formatDynamicToolOutput,
   formatMcpToolOutput,
@@ -2939,17 +2942,21 @@ function normalizeReviewOutput(
     !findings ||
     (reviewOutput.overall_correctness !== "patch is correct" &&
       reviewOutput.overall_correctness !== "patch is incorrect") ||
-    typeof reviewOutput.overall_explanation !== "string" ||
-    typeof reviewOutput.overall_confidence_score !== "number"
+    typeof reviewOutput.overall_explanation !== "string"
   ) {
     return undefined;
   }
 
+  const confidenceScore = normalizeReviewConfidenceScore(
+    reviewOutput.overall_confidence_score,
+  );
   return {
     findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
     overall_correctness: reviewOutput.overall_correctness,
     overall_explanation: reviewOutput.overall_explanation,
-    overall_confidence_score: reviewOutput.overall_confidence_score,
+    ...(confidenceScore === undefined
+      ? {}
+      : { overall_confidence_score: confidenceScore }),
   };
 }
 

--- a/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
@@ -275,8 +275,12 @@ function renderReviewMarkdown(review: AppServerThreadReviewEntry): string {
     // line anyway would put "undefined" — or a substituted zero — where a
     // judgement is supposed to be.
     if (review.output.overall_confidence_score !== undefined) {
+      // Percent, matching the desktop card. One number rendered two ways
+      // across two surfaces is the ambiguity this field already suffered from.
       lines.push(
-        `- Confidence in verdict: ${review.output.overall_confidence_score}`,
+        `- Confidence in verdict: ${Math.round(
+          review.output.overall_confidence_score * 100,
+        )}%`,
       );
     }
     if (

--- a/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-artifact-renderer.ts
@@ -271,7 +271,14 @@ function renderReviewMarkdown(review: AppServerThreadReviewEntry): string {
   if (review.output) {
     lines.push("", "## Summary");
     lines.push(`- Correctness: ${review.output.overall_correctness}`);
-    lines.push(`- Confidence: ${review.output.overall_confidence_score}`);
+    // Absent when the reviewer reported no usable confidence. Printing the
+    // line anyway would put "undefined" — or a substituted zero — where a
+    // judgement is supposed to be.
+    if (review.output.overall_confidence_score !== undefined) {
+      lines.push(
+        `- Confidence in verdict: ${review.output.overall_confidence_score}`,
+      );
+    }
     if (
       !reviewTextContainsExplanation(
         reviewText,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -192,7 +192,7 @@ import { PerKeyAsyncLock } from "../../util/per-key-async-lock.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
 import { actionsForIntent } from "./deterministic-interaction-mapper.js";
 import {
-  normalizeReviewConfidenceScore,
+  normalizeReviewOutputRecord,
   parseReviewCommand,
 } from "../../../shared/review-command.js";
 import type { MessagingInteractionMapper } from "./interaction-mapper.js";
@@ -20671,31 +20671,7 @@ function normalizeStructuredReviewOutput(
     asPlainRecord(data?.review_output) ??
     asPlainRecord(item.reviewOutput) ??
     asPlainRecord(item.review_output);
-  const findings = Array.isArray(reviewOutput?.findings)
-    ? reviewOutput.findings
-    : undefined;
-
-  if (
-    !reviewOutput ||
-    !findings ||
-    (reviewOutput.overall_correctness !== "patch is correct" &&
-      reviewOutput.overall_correctness !== "patch is incorrect") ||
-    typeof reviewOutput.overall_explanation !== "string"
-  ) {
-    return undefined;
-  }
-
-  const confidenceScore = normalizeReviewConfidenceScore(
-    reviewOutput.overall_confidence_score,
-  );
-  return {
-    findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
-    overall_correctness: reviewOutput.overall_correctness,
-    overall_explanation: reviewOutput.overall_explanation,
-    ...(confidenceScore === undefined
-      ? {}
-      : { overall_confidence_score: confidenceScore }),
-  };
+  return normalizeReviewOutputRecord(reviewOutput);
 }
 
 function isPlanStepStatus(value: unknown): value is AppServerThreadPlanEntry["steps"][number]["status"] {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -191,7 +191,10 @@ import { getMainLogger } from "../../log.js";
 import { PerKeyAsyncLock } from "../../util/per-key-async-lock.js";
 import { DeterministicInteractionMapper } from "./deterministic-interaction-mapper.js";
 import { actionsForIntent } from "./deterministic-interaction-mapper.js";
-import { parseReviewCommand } from "../../../shared/review-command.js";
+import {
+  normalizeReviewConfidenceScore,
+  parseReviewCommand,
+} from "../../../shared/review-command.js";
 import type { MessagingInteractionMapper } from "./interaction-mapper.js";
 import {
   buildResumeIntent,
@@ -20677,17 +20680,21 @@ function normalizeStructuredReviewOutput(
     !findings ||
     (reviewOutput.overall_correctness !== "patch is correct" &&
       reviewOutput.overall_correctness !== "patch is incorrect") ||
-    typeof reviewOutput.overall_explanation !== "string" ||
-    typeof reviewOutput.overall_confidence_score !== "number"
+    typeof reviewOutput.overall_explanation !== "string"
   ) {
     return undefined;
   }
 
+  const confidenceScore = normalizeReviewConfidenceScore(
+    reviewOutput.overall_confidence_score,
+  );
   return {
     findings: findings as NonNullable<AppServerThreadReviewEntry["output"]>["findings"],
     overall_correctness: reviewOutput.overall_correctness,
     overall_explanation: reviewOutput.overall_explanation,
-    overall_confidence_score: reviewOutput.overall_confidence_score,
+    ...(confidenceScore === undefined
+      ? {}
+      : { overall_confidence_score: confidenceScore }),
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadMetaChips.tsx
@@ -517,7 +517,11 @@ function formatBranchTooltip(
     .join("\n");
 }
 
-function CopyableThreadChip(props: {
+/**
+ * Shared with the transcript's review provenance row, which copies a review's
+ * workspace path from the same primitive so both surfaces behave identically.
+ */
+export function CopyableThreadChip(props: {
   "aria-label": string;
   children: ReactNode;
   className: string;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ReviewProvenance.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ReviewProvenance.tsx
@@ -1,4 +1,5 @@
 import type { AppServerReviewContext } from "@pwragent/shared";
+import { reviewComparedPastPullRequestBase } from "../../../../shared/review-command";
 import { BranchIcon } from "../../icons/BranchIcon";
 import { FolderIcon } from "../../icons/FolderIcon";
 import { WorktreeIcon } from "../../icons/WorktreeIcon";
@@ -94,10 +95,16 @@ function formatBranchLabel(
     return undefined;
   }
   const base = context.baseBranch?.trim();
-  const pullRequestBase = context.pullRequest?.baseRefName?.trim();
-  const comparedPastPullRequestBase =
-    Boolean(base) && Boolean(pullRequestBase) && base !== pullRequestBase;
-  return comparedPastPullRequestBase ? `${branch} → ${base}` : branch;
+  // GitHub reports a bare `main` while a review target is usually written
+  // `origin/main`, so the two have to be compared as refs. Comparing the raw
+  // strings put the arrow on every ordinary review and hid it on the stacked
+  // one it exists for.
+  return reviewComparedPastPullRequestBase(
+    base,
+    context.pullRequest?.baseRefName,
+  )
+    ? `${branch} → ${base}`
+    : branch;
 }
 
 function formatWorkspaceTooltip(context: AppServerReviewContext): string {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ReviewProvenance.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ReviewProvenance.tsx
@@ -1,0 +1,108 @@
+import type { AppServerReviewContext } from "@pwragent/shared";
+import { BranchIcon } from "../../icons/BranchIcon";
+import { FolderIcon } from "../../icons/FolderIcon";
+import { WorktreeIcon } from "../../icons/WorktreeIcon";
+import { CopyableThreadChip } from "../navigation/ThreadMetaChips";
+
+type ReviewProvenanceProps = {
+  context: AppServerReviewContext;
+};
+
+/**
+ * A review runs in one of a thread's linked directories, and the card's summary
+ * line never says which. The chips answer that before the card gets to what the
+ * review found: which project, which branch, and which pull request.
+ *
+ * Everything here is frozen — resolved once when the review started. Nothing on
+ * this row is looked up again, so a card from last month keeps saying what was
+ * true when its review ran.
+ */
+export function ReviewProvenance(props: ReviewProvenanceProps) {
+  const context = props.context;
+  const isWorktree = Boolean(context.repositoryPath);
+  const projectLabel = context.projectLabel ?? "Project";
+  const branchLabel = formatBranchLabel(context);
+  const pullRequest = context.pullRequest;
+
+  return (
+    <div
+      aria-label="What was reviewed"
+      className="transcript-review__provenance"
+      role="group"
+    >
+      <CopyableThreadChip
+        aria-label={`Copy workspace path for ${projectLabel}`}
+        className="review-chip review-chip--project path-copy-target"
+        tooltipText={formatWorkspaceTooltip(context)}
+        value={context.workspacePath}
+      >
+        <span aria-hidden="true" className="review-chip__icon">
+          <FolderIcon size={12} />
+        </span>
+        <span className="review-chip__label">{projectLabel}</span>
+        {isWorktree ? (
+          <span aria-hidden="true" className="review-chip__icon">
+            <WorktreeIcon size={11} />
+          </span>
+        ) : null}
+      </CopyableThreadChip>
+
+      {branchLabel ? (
+        <span className="review-chip">
+          <span aria-hidden="true" className="review-chip__icon">
+            <BranchIcon size={12} />
+          </span>
+          <span className="review-chip__label">{branchLabel}</span>
+        </span>
+      ) : null}
+
+      {pullRequest ? (
+        <a
+          className="review-chip review-chip--pull-request"
+          href={pullRequest.url}
+          rel="noopener noreferrer"
+          target="_blank"
+          title={pullRequest.title ?? undefined}
+        >
+          <span className="review-chip__label">
+            {`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}
+          </span>
+        </a>
+      ) : pullRequest === null ? (
+        // Distinct from an absent field: the branch was checked and carried no
+        // pull request. Saying so is the difference between an answer and a
+        // reader wondering whether anything was looked at.
+        <span className="review-chip review-chip--empty">
+          <span className="review-chip__label">no PR at review time</span>
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * The base half only earns its space when the review did not compare against
+ * the pull request's own base — a stacked branch reviewed against `origin/main`
+ * rather than the branch below it. Everywhere else the card's summary line
+ * already names the base, and repeating it here would be noise.
+ */
+function formatBranchLabel(
+  context: AppServerReviewContext,
+): string | undefined {
+  const branch = context.gitBranch?.trim();
+  if (!branch) {
+    return undefined;
+  }
+  const base = context.baseBranch?.trim();
+  const pullRequestBase = context.pullRequest?.baseRefName?.trim();
+  const comparedPastPullRequestBase =
+    Boolean(base) && Boolean(pullRequestBase) && base !== pullRequestBase;
+  return comparedPastPullRequestBase ? `${branch} → ${base}` : branch;
+}
+
+function formatWorkspaceTooltip(context: AppServerReviewContext): string {
+  const repositoryPath = context.repositoryPath?.trim();
+  return repositoryPath
+    ? `${context.workspacePath}\nWorktree of ${repositoryPath}`
+    : context.workspacePath;
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptReview.tsx
@@ -1,5 +1,6 @@
 import type {
   AppServerReviewFinding,
+  AppServerReviewOutput,
   AppServerThreadReviewEntry,
   DesktopApplicationsSnapshot,
   MarkdownFileViewerContext,
@@ -8,8 +9,10 @@ import { formatPathRelativeToDirectories } from "@pwragent/shared";
 import { useCallback, useMemo, type MouseEvent } from "react";
 import { normalizeReviewDisplayText } from "../../../../shared/review-command";
 import { formatBackendLabel } from "../../lib/backend-label";
+import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import type { DesktopApi } from "../../lib/desktop-api";
 import type { ThreadLinkSource } from "../../lib/thread-links";
+import { ReviewProvenance } from "./ReviewProvenance";
 import { ThreadMarkdown } from "./ThreadMarkdown";
 
 type TranscriptReviewProps = {
@@ -24,12 +27,45 @@ type TranscriptReviewProps = {
   threadLinkSource?: ThreadLinkSource;
 };
 
-function formatConfidence(value: number | undefined): string | undefined {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
+/**
+ * The percentage is fused into the verdict badge rather than standing beside it
+ * as its own pill. Alone, "98% confidence" names no subject: a reader can take
+ * it for a quality score on the code just as easily as for the reviewer's
+ * confidence in its own verdict. Printed inside the verdict, it can only modify
+ * the verdict.
+ *
+ * `normalizeReviewConfidenceScore` has already dropped values that cannot mean
+ * anything, so an absent score here means the reviewer reported none and the
+ * verdict is shown without a number.
+ */
+function formatVerdict(
+  correctness: AppServerReviewOutput["overall_correctness"] | undefined,
+  confidence: number | undefined,
+): string | undefined {
+  if (!correctness) {
     return undefined;
   }
+  const verdict =
+    correctness === "patch is correct" ? "Patch correct" : "Patch needs work";
+  return confidence === undefined
+    ? verdict
+    : `${verdict} · ${Math.round(confidence * 100)}%`;
+}
 
-  return `${Math.round(value * 100)}% confidence`;
+function formatVerdictTooltip(
+  correctness: AppServerReviewOutput["overall_correctness"],
+  confidence: number | undefined,
+  reviewer: AppServerThreadReviewEntry["reviewer"],
+): string {
+  const verdict =
+    correctness === "patch is correct"
+      ? "the patch is correct"
+      : "the patch needs work";
+  const who = reviewer?.model?.trim() || "The reviewer";
+  if (confidence === undefined) {
+    return `${who} judged that ${verdict}. It reported no confidence in that judgement.`;
+  }
+  return `How sure ${who} is that its own verdict — ${verdict} — is right. It is not a score for the code, and not a judgement about whether the change is ready to merge.`;
 }
 
 function formatPath(path: string, directoryPaths: string[] | undefined): string {
@@ -116,6 +152,49 @@ function parsePlainReview(review: string): {
   };
 }
 
+/**
+ * The transcript scrolls, so the CSS pseudo-element tooltip would be clipped
+ * against the scroll container for any card near its top edge. The portalled
+ * tooltip escapes it, and `aria-describedby` is what makes the explanation
+ * reachable to a screen reader — the badge's own text is the verdict, and
+ * folding the explanation into its label would rename the thing rather than
+ * describe it.
+ */
+function ReviewVerdictBadge(props: {
+  confidence: number | undefined;
+  correctness: NonNullable<AppServerReviewOutput["overall_correctness"]>;
+  reviewer: AppServerThreadReviewEntry["reviewer"];
+  verdict: string;
+}) {
+  const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const text = formatVerdictTooltip(
+    props.correctness,
+    props.confidence,
+    props.reviewer
+  );
+
+  return (
+    <>
+      <span
+        aria-describedby={tooltip.visible ? tooltip.tooltipId : undefined}
+        className={`transcript-review__badge transcript-review__badge--${
+          props.correctness === "patch is correct" ? "success" : "danger"
+        }`}
+        tabIndex={0}
+        onBlur={tooltip.hide}
+        onFocus={(event) => tooltip.show(event.currentTarget, text)}
+        onMouseEnter={(event) =>
+          tooltip.showAfterDelay(event.currentTarget, text)
+        }
+        onMouseLeave={tooltip.hide}
+      >
+        {props.verdict}
+      </span>
+      {tooltip.tooltipNode}
+    </>
+  );
+}
+
 export function TranscriptReview(props: TranscriptReviewProps) {
   const editorApplication = useMemo(
     () =>
@@ -164,13 +243,10 @@ export function TranscriptReview(props: TranscriptReviewProps) {
     (shouldHideReviewBody(summary, props.entry.review)
       ? ""
       : plainReview?.explanation ?? props.entry.review);
-  const confidence = formatConfidence(output?.overall_confidence_score);
-  const correctness =
-    output?.overall_correctness === "patch is correct"
-      ? "Patch correct"
-      : output?.overall_correctness === "patch is incorrect"
-        ? "Patch needs work"
-        : undefined;
+  const verdict = formatVerdict(
+    output?.overall_correctness,
+    output?.overall_confidence_score,
+  );
   const reviewer = props.entry.reviewer;
 
   return (
@@ -179,6 +255,9 @@ export function TranscriptReview(props: TranscriptReviewProps) {
         <div className="transcript-review__copy">
           <p className="transcript-review__eyebrow">Review</p>
           <p className="transcript-review__summary">{summary}</p>
+          {props.entry.context ? (
+            <ReviewProvenance context={props.entry.context} />
+          ) : null}
           {body ? (
             <ThreadMarkdown
               applications={props.applications}
@@ -204,21 +283,17 @@ export function TranscriptReview(props: TranscriptReviewProps) {
 
       {output ? (
         <div className="transcript-review__meta" aria-label="Review summary">
-          {correctness ? (
-            <span
-              className={`transcript-review__badge transcript-review__badge--${
-                output.overall_correctness === "patch is correct" ? "success" : "danger"
-              }`}
-            >
-              {correctness}
-            </span>
+          {verdict ? (
+            <ReviewVerdictBadge
+              confidence={output.overall_confidence_score}
+              correctness={output.overall_correctness}
+              reviewer={reviewer}
+              verdict={verdict}
+            />
           ) : null}
           <span className="transcript-review__badge">
             {findingCount} {findingCount === 1 ? "finding" : "findings"}
           </span>
-          {confidence ? (
-            <span className="transcript-review__badge">{confidence}</span>
-          ) : null}
         </div>
       ) : null}
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
@@ -1,5 +1,9 @@
+import type {
+  AppServerReviewOutput,
+  AppServerThreadReviewEntry,
+} from "@pwragent/shared";
 import "@testing-library/jest-dom/vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { TranscriptReview } from "../TranscriptReview";
 
@@ -49,9 +53,8 @@ describe("TranscriptReview", () => {
 
     expect(screen.getByText("Review")).toBeInTheDocument();
     expect(screen.getByText("Review changes against main")).toBeInTheDocument();
-    expect(screen.getByText("Patch needs work")).toBeInTheDocument();
+    expect(screen.getByText("Patch needs work · 87%")).toBeInTheDocument();
     expect(screen.getByText("1 finding")).toBeInTheDocument();
-    expect(screen.getByText("87% confidence")).toBeInTheDocument();
     const runtime = screen.getByLabelText("Review runtime");
     expect(runtime).toHaveTextContent("OpenAI");
     expect(runtime).toHaveTextContent("gpt-5.6-sol");
@@ -165,5 +168,154 @@ describe("TranscriptReview", () => {
       screen.getByRole("link", { name: "/outside/repository/VeryLongOutsideFileName.ts" })
     ).toHaveAttribute("href", "file:///outside/repository/VeryLongOutsideFileName.ts:1");
     expect(screen.getByRole("link", { name: "packages/app/high.ts" })).toBeInTheDocument();
+  });
+});
+
+describe("TranscriptReview provenance", () => {
+  const context = {
+    workspacePath: "/Users/dev/.codex/worktrees/mti5p133/PwrAgent",
+    projectLabel: "PwrAgent",
+    repositoryPath: "/Users/dev/pwrdrvr/PwrAgent",
+    gitBranch: "fix/macos-dock-icon-safe-area",
+    baseBranch: "origin/main",
+    pullRequest: {
+      provider: "github.com",
+      org: "pwrdrvr",
+      repo: "PwrAgent",
+      number: 1918,
+      baseRefName: "origin/main",
+      url: "https://github.com/pwrdrvr/PwrAgent/pull/1918",
+    },
+  } as const;
+
+  function renderReview(
+    entry: Partial<AppServerThreadReviewEntry> = {},
+  ): void {
+    render(
+      <TranscriptReview
+        entry={{
+          type: "review",
+          id: "review-provenance",
+          review: "",
+          displayText: "Review changes against origin/main",
+          ...entry,
+        }}
+      />
+    );
+  }
+
+  it("names the project, branch, and pull request the review ran against", () => {
+    renderReview({ context });
+
+    const row = screen.getByLabelText("What was reviewed");
+    expect(row).toHaveTextContent("PwrAgent");
+    expect(row).toHaveTextContent("fix/macos-dock-icon-safe-area");
+    expect(row).toHaveTextContent("pwrdrvr/PwrAgent#1918");
+    expect(
+      screen.getByRole("link", { name: /pwrdrvr\/PwrAgent#1918/ })
+    ).toHaveAttribute("href", "https://github.com/pwrdrvr/PwrAgent/pull/1918");
+  });
+
+  it("offers the full workspace path to copy", () => {
+    renderReview({ context });
+
+    expect(
+      screen.getByLabelText("Copy workspace path for PwrAgent")
+    ).toBeInTheDocument();
+  });
+
+  it("shows the base only when it is not the pull request's own", () => {
+    renderReview({ context });
+    // Same base as the PR: the summary line already says it, so the chip does
+    // not repeat it.
+    expect(screen.getByLabelText("What was reviewed")).not.toHaveTextContent(
+      "→"
+    );
+    cleanup();
+
+    renderReview({
+      context: {
+        ...context,
+        gitBranch: "feat/star-map-float",
+        pullRequest: { ...context.pullRequest, baseRefName: "feat/star-map-layer" },
+      },
+    });
+    expect(screen.getByLabelText("What was reviewed")).toHaveTextContent(
+      "feat/star-map-float → origin/main"
+    );
+  });
+
+  it("says the branch carried no pull request rather than listing others", () => {
+    renderReview({
+      context: { ...context, pullRequest: null, gitBranch: "main" },
+    });
+
+    expect(screen.getByText("no PR at review time")).toBeInTheDocument();
+  });
+
+  it("shows no pull-request chip at all when none could be checked", () => {
+    const { pullRequest: _pullRequest, ...unchecked } = context;
+    renderReview({ context: unchecked });
+
+    expect(screen.queryByText("no PR at review time")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders no row for a review that predates the capture", () => {
+    renderReview();
+
+    expect(screen.queryByLabelText("What was reviewed")).not.toBeInTheDocument();
+  });
+});
+
+describe("TranscriptReview verdict", () => {
+  function renderVerdict(
+    output: Partial<AppServerReviewOutput> = {},
+  ): void {
+    render(
+      <TranscriptReview
+        entry={{
+          type: "review",
+          id: "review-verdict",
+          review: "",
+          reviewer: { backend: "codex", model: "gpt-5.6-sol" },
+          output: {
+            findings: [],
+            overall_correctness: "patch is correct",
+            overall_explanation: "Nothing regressed.",
+            ...output,
+          },
+        }}
+      />
+    );
+  }
+
+  it("fuses the confidence into the verdict it modifies", () => {
+    renderVerdict({ overall_confidence_score: 0.98 });
+
+    expect(screen.getByText("Patch correct · 98%")).toBeInTheDocument();
+  });
+
+  it("describes what the number is a confidence in, on focus", async () => {
+    renderVerdict({ overall_confidence_score: 0.98 });
+
+    const badge = screen.getByText("Patch correct · 98%");
+    // Standing alone the number names no subject, so the explanation has to be
+    // reachable — and as a description, not by renaming the badge.
+    expect(badge).not.toHaveAccessibleDescription();
+    act(() => {
+      badge.focus();
+    });
+    expect(badge).toHaveAccessibleDescription(
+      /its own verdict — the patch is correct/
+    );
+    expect(badge).toHaveAccessibleDescription(/not a score for the code/);
+  });
+
+  it("shows the verdict alone when the reviewer reported no confidence", () => {
+    renderVerdict();
+
+    expect(screen.getByText("Patch correct")).toBeInTheDocument();
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
@@ -183,7 +183,9 @@ describe("TranscriptReview provenance", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       number: 1918,
-      baseRefName: "origin/main",
+      // GitHub reports the bare branch name. Writing `origin/main` here was
+      // what let the raw string comparison in `formatBranchLabel` pass.
+      baseRefName: "main",
       url: "https://github.com/pwrdrvr/PwrAgent/pull/1918",
     },
   } as const;
@@ -224,22 +226,28 @@ describe("TranscriptReview provenance", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows the base only when it is not the pull request's own", () => {
+  it("treats a remote-qualified target as the pull request's own base", () => {
+    // The ordinary review: target `origin/main`, GitHub base `main`. The
+    // summary line already says it, so the chip does not repeat it.
     renderReview({ context });
-    // Same base as the PR: the summary line already says it, so the chip does
-    // not repeat it.
+
     expect(screen.getByLabelText("What was reviewed")).not.toHaveTextContent(
       "→"
     );
-    cleanup();
+  });
 
+  it("shows the base when the review skipped past the pull request's own", () => {
     renderReview({
       context: {
         ...context,
         gitBranch: "feat/star-map-float",
-        pullRequest: { ...context.pullRequest, baseRefName: "feat/star-map-layer" },
+        pullRequest: {
+          ...context.pullRequest,
+          baseRefName: "feat/star-map-layer",
+        },
       },
     });
+
     expect(screen.getByLabelText("What was reviewed")).toHaveTextContent(
       "feat/star-map-float → origin/main"
     );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -11376,6 +11376,159 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("carries the review's frozen workspace and pull request onto the entry", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventHandler = listener;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review-2",
+            item: {
+              id: "turn-review-2-item",
+              type: "exitedReviewMode",
+              review: "One finding.",
+              data: {
+                reviewer: { backend: "codex", model: "gpt-5.6-sol" },
+                // The registry freezes this onto the live item beside
+                // `reviewer`; dropping it here is what once made the
+                // provenance row invisible on the native review path.
+                context: {
+                  workspacePath: "/Users/dev/pwrdrvr/PwrAgent",
+                  projectLabel: "PwrAgent",
+                  gitBranch: "fix/dock-icon",
+                  baseBranch: "origin/main",
+                  pullRequest: {
+                    provider: "github.com",
+                    org: "pwrdrvr",
+                    repo: "PwrAgent",
+                    number: 1918,
+                    baseRefName: "main",
+                    url: "https://github.com/pwrdrvr/PwrAgent/pull/1918",
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+    expect(result.current.entries[0]).toMatchObject({
+      type: "review",
+      context: {
+        workspacePath: "/Users/dev/pwrdrvr/PwrAgent",
+        projectLabel: "PwrAgent",
+        gitBranch: "fix/dock-icon",
+        baseBranch: "origin/main",
+        pullRequest: { number: 1918, baseRefName: "main" },
+      },
+      reviewer: { backend: "codex", model: "gpt-5.6-sol" },
+    });
+  });
+
+  it("keeps a checked branch that carried no pull request distinguishable", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventHandler = listener;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review-3",
+            item: {
+              id: "turn-review-3-item",
+              type: "exitedReviewMode",
+              review: "No findings.",
+              data: {
+                context: {
+                  workspacePath: "/Users/dev/pwrdrvr/PwrAgent",
+                  gitBranch: "main",
+                  // An answer, not a gap: the card says so out loud.
+                  pullRequest: null,
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+    });
+    const entry = result.current.entries[0];
+    expect(entry.type === "review" && entry.context?.pullRequest).toBeNull();
+  });
+
   it("keeps a review turn active when a separate turn/started arrives", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -34,7 +34,10 @@ import {
   createQuestionnaireState,
   type PendingQuestionnaireState,
 } from "../features/thread-detail/questionnaire";
-import { normalizeReviewDisplayText } from "../../../shared/review-command";
+import {
+  normalizeReviewConfidenceScore,
+  normalizeReviewDisplayText,
+} from "../../../shared/review-command";
 import {
   createMcpElicitationState,
   type PendingMcpInteractionState,
@@ -3434,17 +3437,21 @@ function normalizeReviewOutput(value: unknown): AppServerReviewOutput | undefine
     !findings ||
     (record.overall_correctness !== "patch is correct" &&
       record.overall_correctness !== "patch is incorrect") ||
-    typeof record.overall_explanation !== "string" ||
-    typeof record.overall_confidence_score !== "number"
+    typeof record.overall_explanation !== "string"
   ) {
     return undefined;
   }
 
+  const confidenceScore = normalizeReviewConfidenceScore(
+    record.overall_confidence_score,
+  );
   return {
     findings: findings as AppServerReviewOutput["findings"],
     overall_correctness: record.overall_correctness,
     overall_explanation: record.overall_explanation,
-    overall_confidence_score: record.overall_confidence_score,
+    ...(confidenceScore === undefined
+      ? {}
+      : { overall_confidence_score: confidenceScore }),
   };
 }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -5,7 +5,6 @@ import type {
   AppServerMcpElicitationRequestNotification,
   AppServerPendingRequestNotification,
   AppServerReadThreadResponse,
-  AppServerReviewOutput,
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerToolRequestUserInputNotification,
@@ -35,8 +34,8 @@ import {
   type PendingQuestionnaireState,
 } from "../features/thread-detail/questionnaire";
 import {
-  normalizeReviewConfidenceScore,
   normalizeReviewDisplayText,
+  normalizeReviewOutputRecord,
 } from "../../../shared/review-command";
 import {
   createMcpElicitationState,
@@ -3426,35 +3425,6 @@ function appendPendingAssistantMessage(
   ]);
 }
 
-function normalizeReviewOutput(value: unknown): AppServerReviewOutput | undefined {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return undefined;
-  }
-
-  const record = value as Record<string, unknown>;
-  const findings = Array.isArray(record.findings) ? record.findings : undefined;
-  if (
-    !findings ||
-    (record.overall_correctness !== "patch is correct" &&
-      record.overall_correctness !== "patch is incorrect") ||
-    typeof record.overall_explanation !== "string"
-  ) {
-    return undefined;
-  }
-
-  const confidenceScore = normalizeReviewConfidenceScore(
-    record.overall_confidence_score,
-  );
-  return {
-    findings: findings as AppServerReviewOutput["findings"],
-    overall_correctness: record.overall_correctness,
-    overall_explanation: record.overall_explanation,
-    ...(confidenceScore === undefined
-      ? {}
-      : { overall_confidence_score: confidenceScore }),
-  };
-}
-
 function reviewEntryFromCompletedItem(params: {
   turnId?: string;
   item?: {
@@ -3497,8 +3467,9 @@ function reviewEntryFromCompletedItem(params: {
         ? normalizeReviewDisplayText(review)
         : "Code review started"
       : undefined;
-  const output = normalizeReviewOutput(record.data?.reviewOutput);
+  const output = normalizeReviewOutputRecord(record.data?.reviewOutput);
   const reviewer = normalizeReviewer(record.data?.reviewer);
+  const context = normalizeReviewContext(record.data?.context);
   const turn = buildTurnMetadata({
     fallbackId: typeof params.turnId === "string" ? params.turnId : undefined,
     fallbackStatus:
@@ -3512,6 +3483,7 @@ function reviewEntryFromCompletedItem(params: {
     ...(displayText ? { displayText } : {}),
     ...(output ? { output } : {}),
     ...(reviewer ? { reviewer } : {}),
+    ...(context ? { context } : {}),
     ...(turn ? { turn } : {}),
     createdAt:
       normalizeNotificationTimestamp(record.createdAt) ??
@@ -3544,6 +3516,86 @@ function normalizeReviewer(
     ...(model ? { model } : {}),
     ...(reasoningEffort ? { reasoningEffort } : {}),
   };
+}
+
+/**
+ * The registry freezes a review's workspace, branch, and pull request onto the
+ * live `item/completed` notification the same way it freezes `reviewer`, so
+ * this has to read it back the same way. Without it the provenance row is
+ * dropped on the native review path even though the main process put it on the
+ * wire.
+ *
+ * `pullRequest: null` is load-bearing and survives: it means the branch was
+ * checked and carried no pull request, which the card renders differently from
+ * an absent field.
+ */
+function normalizeReviewContext(
+  value: unknown,
+): AppServerThreadReviewEntry["context"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const workspacePath = readTrimmedString(record.workspacePath);
+  if (!workspacePath) {
+    return undefined;
+  }
+  const projectLabel = readTrimmedString(record.projectLabel);
+  const repositoryPath = readTrimmedString(record.repositoryPath);
+  const gitBranch = readTrimmedString(record.gitBranch);
+  const baseBranch = readTrimmedString(record.baseBranch);
+  const pullRequest = normalizeReviewPullRequest(record.pullRequest);
+  return {
+    workspacePath,
+    ...(projectLabel ? { projectLabel } : {}),
+    ...(repositoryPath ? { repositoryPath } : {}),
+    ...(gitBranch ? { gitBranch } : {}),
+    ...(baseBranch ? { baseBranch } : {}),
+    ...(record.pullRequest === null || pullRequest
+      ? { pullRequest: pullRequest ?? null }
+      : {}),
+  };
+}
+
+function normalizeReviewPullRequest(
+  value: unknown,
+): NonNullable<AppServerThreadReviewEntry["context"]>["pullRequest"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const provider = readTrimmedString(record.provider);
+  const org = readTrimmedString(record.org);
+  const repo = readTrimmedString(record.repo);
+  const url = readTrimmedString(record.url);
+  const number = record.number;
+  if (
+    !provider
+    || !org
+    || !repo
+    || !url
+    || typeof number !== "number"
+    || !Number.isFinite(number)
+  ) {
+    return undefined;
+  }
+  const title = readTrimmedString(record.title);
+  const headRefName = readTrimmedString(record.headRefName);
+  const baseRefName = readTrimmedString(record.baseRefName);
+  return {
+    provider,
+    org,
+    repo,
+    number,
+    url,
+    ...(title ? { title } : {}),
+    ...(headRefName ? { headRefName } : {}),
+    ...(baseRefName ? { baseRefName } : {}),
+  };
+}
+
+function readTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
 function messageContentFromUserItem(item: Record<string, unknown>): {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20370,10 +20370,11 @@ a.transcript-message__messaging-origin:focus-visible {
   line-height: normal;
 }
 
+/* `.path-copy-target` on the same element already supplies `cursor: pointer`
+   and the hover brightness. */
 .review-chip--project {
   border-color: transparent;
   background: var(--accent-soft);
-  cursor: pointer;
 }
 
 .review-chip--project:hover,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20323,6 +20323,81 @@ a.transcript-message__messaging-origin:focus-visible {
   margin-top: 8px;
 }
 
+/* The review's provenance row: which project, branch, and pull request the
+   review actually ran against. It sits inside `__copy` rather than beside the
+   header so the chips wrap in the copy column and never run under the
+   timestamp. Chip geometry matches `.pr-chip` so a review card and a sidebar
+   row read as the same vocabulary. */
+.transcript-review__provenance {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.review-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 22px;
+  max-width: 100%;
+  padding: 0 8px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.review-chip__icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--text-muted);
+}
+
+.review-chip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* The pill squishes line-height to 1, which leaves monospace digits sitting
+     high in their line box. A natural line box re-centers them against the
+     icons. */
+  line-height: normal;
+}
+
+.review-chip--project {
+  border-color: transparent;
+  background: var(--accent-soft);
+  cursor: pointer;
+}
+
+.review-chip--project:hover,
+.review-chip--project:focus-visible {
+  border-color: var(--accent-border-soft);
+  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  outline: none;
+}
+
+.review-chip--pull-request:hover,
+.review-chip--pull-request:focus-visible {
+  border-color: var(--accent-border);
+  background: var(--bg-panel-hover);
+  outline: none;
+}
+
+/* "no PR at review time" is an answer, not a control. Dashed and muted so it
+   reads as a recorded absence rather than something to click. */
+.review-chip--empty {
+  border-style: dashed;
+  background: transparent;
+  color: var(--text-muted);
+}
+
 .transcript-review__meta {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop/src/shared/review-command.ts
+++ b/apps/desktop/src/shared/review-command.ts
@@ -1,4 +1,4 @@
-import type { AppServerReviewTarget } from "@pwragent/shared";
+import type { AppServerReviewOutput, AppServerReviewTarget } from "@pwragent/shared";
 
 export type ParsedReviewCommand = {
   target: AppServerReviewTarget;
@@ -179,4 +179,84 @@ export function normalizeReviewConfidenceScore(
     && value <= 1
     ? value
     : undefined;
+}
+
+/**
+ * Reduce a Git ref to the branch name both sides of a comparison can agree on.
+ *
+ * The same branch reaches us written three ways: `refs/heads/main` from Git
+ * plumbing, `origin/main` from a review target the operator picked, and bare
+ * `main` from the GitHub API. Comparing the raw strings makes those three
+ * different branches.
+ */
+export function normalizeFullRef(ref: string): string {
+  const normalized = ref.trim();
+  const localMatch = normalized.match(/^refs\/heads\/(.+)$/);
+  if (localMatch?.[1]) {
+    return localMatch[1];
+  }
+  const remoteMatch = normalized.match(/^refs\/remotes\/[^/]+\/(.+)$/);
+  return remoteMatch?.[1] ?? normalized;
+}
+
+/**
+ * Whether a review's base target names something other than the pull request's
+ * own base — the stacked-branch case, where the operator skipped past the
+ * branch below to compare against `origin/main` directly.
+ *
+ * A remote-qualified target still names the pull request's base, so `main`,
+ * `origin/main`, and `refs/remotes/origin/main` all have to compare equal to
+ * GitHub's bare `main`. Answering `false` when either side is unknown keeps a
+ * missing value from reading as a deliberate override.
+ */
+export function reviewComparedPastPullRequestBase(
+  baseBranch: string | undefined,
+  pullRequestBase: string | undefined,
+): boolean {
+  const base = normalizeFullRef(baseBranch ?? "");
+  const pullRequest = normalizeFullRef(pullRequestBase ?? "");
+  if (!base || !pullRequest) {
+    return false;
+  }
+  return base !== pullRequest && !base.endsWith(`/${pullRequest}`);
+}
+
+/**
+ * Validate a candidate structured review output.
+ *
+ * Four surfaces normalize this shape — the Codex client, the messaging
+ * controller, the renderer's session state, and the managed-review parser —
+ * and a copy that falls behind does not fail loudly: it returns `undefined`
+ * and the card silently loses its verdict, explanation, and every finding. The
+ * validation therefore lives in one place that main and the renderer can both
+ * import; callers keep only their own shape-digging.
+ */
+export function normalizeReviewOutputRecord(
+  value: unknown,
+): AppServerReviewOutput | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  const findings = Array.isArray(record.findings) ? record.findings : undefined;
+  if (
+    !findings
+    || (record.overall_correctness !== "patch is correct"
+      && record.overall_correctness !== "patch is incorrect")
+    || typeof record.overall_explanation !== "string"
+  ) {
+    return undefined;
+  }
+
+  const confidenceScore = normalizeReviewConfidenceScore(
+    record.overall_confidence_score,
+  );
+  return {
+    findings: findings as AppServerReviewOutput["findings"],
+    overall_correctness: record.overall_correctness,
+    overall_explanation: record.overall_explanation,
+    ...(confidenceScore === undefined
+      ? {}
+      : { overall_confidence_score: confidenceScore }),
+  };
 }

--- a/apps/desktop/src/shared/review-command.ts
+++ b/apps/desktop/src/shared/review-command.ts
@@ -152,3 +152,31 @@ function stripWrappingQuotes(value: string): string {
   const trimmed = value.trim();
   return trimmed.replace(/^(['"])(.*)\1$/, "$2").trim();
 }
+
+/**
+ * Keeps a reviewer-reported confidence only when it can mean something.
+ *
+ * The score is the reviewer's own confidence that its `overall_correctness`
+ * verdict is right. Three values look like numbers and are not judgements:
+ *
+ * - Exactly `0`. The output schema in the review prompt has to show the field,
+ *   and whatever value it shows is the one a weaker model copies through. A
+ *   literal zero next to "patch is correct" is a transcription, not a reviewer
+ *   with no confidence at all.
+ * - Anything above 1. A model answering `95` may mean 95%, or may mean nothing.
+ *   Rescaling it guesses at intent; dropping it does not.
+ * - Anything below 0, or non-finite.
+ *
+ * Dropping the value is safe because the verdict stands on its own — readers
+ * render the correctness without a number. Substituting zero would not.
+ */
+export function normalizeReviewConfidenceScore(
+  value: unknown,
+): number | undefined {
+  return typeof value === "number"
+    && Number.isFinite(value)
+    && value > 0
+    && value <= 1
+    ? value
+    : undefined;
+}

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -148,7 +148,68 @@ export type AppServerReviewOutput = {
   findings: AppServerReviewFinding[];
   overall_correctness: "patch is correct" | "patch is incorrect";
   overall_explanation: string;
-  overall_confidence_score: number;
+  /**
+   * The reviewer's own confidence, from 0 to 1, that `overall_correctness` is
+   * the right verdict. Absent when the reviewer did not report one — readers
+   * must render the verdict without a number rather than substituting zero.
+   */
+  overall_confidence_score?: number;
+};
+
+/**
+ * Identity of the pull request a review was about. Deliberately carries no
+ * check, review, or merge status: this is frozen at review start and a status
+ * frozen alongside it would still be painting last month's CI result today.
+ * Callers that want live status look the PR up by this identity.
+ */
+export type AppServerReviewPullRequest = {
+  /** Forge host that owns the PR namespace, e.g. "github.com". */
+  provider: string;
+  org: string;
+  repo: string;
+  number: number;
+  url: string;
+  title?: string;
+  headRefName?: string;
+  baseRefName?: string;
+};
+
+/**
+ * Where a review ran, captured when it started. A thread can link several Git
+ * directories and a review runs in exactly one of them, so this belongs to the
+ * review artifact rather than to the thread's ambient state — the same reason
+ * `reviewer` does. Resolving it at render time would relabel a month-old card
+ * with today's workspace and today's pull requests.
+ */
+export type AppServerReviewContext = {
+  /** Absolute workspace the review ran in — the `cwd` on StartReviewRequest. */
+  workspacePath: string;
+  /** Linked-directory label for `workspacePath`, e.g. "PwrAgent". */
+  projectLabel?: string;
+  /** Repository checkout when `workspacePath` is one of its worktrees. */
+  repositoryPath?: string;
+  /**
+   * Branch checked out in `workspacePath` at start. Absent when there was no
+   * branch to read — a commit target, or a detached HEAD.
+   */
+  gitBranch?: string;
+  /**
+   * Base the diff was taken against, when the target named one. Lets a reader
+   * tell a review against the PR's own base from one against an override.
+   */
+  baseBranch?: string;
+  /**
+   * The pull request open on `gitBranch` in this workspace at start.
+   *
+   * `null` means the branch was checked and carried none. Absent means no
+   * check was possible — there was no branch, or no PR data had been fetched.
+   * The two are not interchangeable: one is an answer, the other is a gap.
+   *
+   * Never a list. A pull request that is not on the reviewed branch is not
+   * evidence about the reviewed diff, and printing the thread's other PRs here
+   * would imply a connection that does not exist.
+   */
+  pullRequest?: AppServerReviewPullRequest | null;
 };
 
 export type LinkedDirectorySummary = {
@@ -675,6 +736,12 @@ export type AppServerThreadReviewEntry = {
     model?: string;
     reasoningEffort?: string;
   };
+  /**
+   * Workspace, branch, and pull request this review was about, frozen at
+   * start. Absent on reviews that predate the capture — render nothing rather
+   * than an "unknown" row on every historical card.
+   */
+  context?: AppServerReviewContext;
   output?: AppServerReviewOutput;
   turn?: AppServerThreadTurnMetadata;
 };


### PR DESCRIPTION
## Summary

- A thread can link several Git directories and a review runs in exactly one of them, but neither review card said which. `StartReviewRequest` already carries the `cwd` the operator picked in the review-target panel; `AppServerThreadReviewEntry` had nowhere to keep it, so it was dropped the moment the review started. The head branch was missing too — the summary line names the base the diff was taken against, and nothing named the branch the work was on.
- Capture workspace, branch, and pull request onto the review entry at start (`AppServerReviewContext`), and render them as a chip row under the summary on **both** the start and completion cards. Freezing is the point: re-deriving any of it at render time would relabel a month-old card with today's workspace and today's PRs, which is exactly the question this answers. `reviewer` already lives on this entry for the same reason.
- The pull request is chosen by **the branch the reviewed workspace had checked out**, matched against `PrSummary.headRefName` and narrowed by `linkedDirectoryPaths` so a branch name living in two of the thread's repositories cannot cross over. At most one, never a list — a PR that is not on the reviewed branch is not evidence about the reviewed diff.
- Fix the confidence badge, which printed a number with no referent. `REVIEW_OUTPUT_INSTRUCTIONS` asked for `overall_confidence_score` and never said what it measured, so "98% confidence" could be read as a quality score for the code or as the reviewer's confidence in its own verdict — and on managed reviews (every non-Codex backend) both were guesses. Define it in the prompt, fuse it into the verdict badge it modifies (`Patch correct · 98%`) with a tooltip saying what it is a confidence *in*, and drop values that cannot mean anything.

## Verification

- `pnpm test` — 9574 passing, 6 skipped, 24 of them new (`review-provenance.test.ts` covers the 13 selection/state cases; `transcript-review.test.tsx` and `managed-review.test.ts` cover the rendering and confidence rules).
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries` (no dependency violations, 1639 modules), `pnpm lint:colors`, `pnpm lint:codex-storage`, `pnpm lint:sql` — all clean.
- **One pre-existing failure is not fixed here:** `messaging-runtime.test.ts › does not reload config to authorize an allowed Full Access bound reply` (expects 2 config loads, gets 1). Verified pre-existing by reverting both messaging edits in this branch and re-running — it still fails. It sits in the area of #1921 / #1922 on `main` and is unrelated to this change.
- No new SQLite writes. `emitManagedReviewStarted` already persisted the review entry; `context` adds bytes to one existing JSON payload, not a commit. `sqlite-write-metrics.test.ts` budgets are unmoved.

## Notes

**Two states that must stay distinguishable.** `pullRequest: null` records a branch that was checked and carried no PR — the card says "no PR at review time". Absent records that no check was possible (a commit target, a detached HEAD, or no PR data fetched) — the card shows no PR chip at all. One is an answer, the other is a gap, and collapsing them would have the card claim a check it never made. Same for `context` itself: absent on reviews that predate this, which render with no row rather than an "unknown" chip on every historical card.

**Identity is frozen, status is not.** The stored `AppServerReviewPullRequest` deliberately carries no check/review/merge state. A status frozen at review start would still be painting that day's CI result months later, so the chip is neutral rather than carrying the live `.pr-chip` status dot. This is a deliberate departure from the approved mockup. If a live dot is wanted, the honest version is looking the frozen identity up against the current PR set at render time — a follow-up, not this PR.

**Stacked PRs.** When the operator overrides the base past the PR's own (reviewing `feat/x` against `origin/main` rather than the branch below it), the card names the PR that was on the branch and makes no claim about what the diff swept in from PRs underneath — that is genuinely unknowable. The branch chip grows its `→ base` half only in that case; elsewhere the summary line already says the base.

**`overall_confidence_score` is now optional on `AppServerReviewOutput`.** Four parse sites (`managed-review`, `codex-app-server/client`, `messaging-controller`, `useThreadSessionState`) share one `normalizeReviewConfidenceScore` so they cannot drift. It drops a literal `0` — the schema example weaker models copy through, which rendered as a `0% confidence` badge beside `Patch correct` — anything outside 0–1, and anything non-finite. Because the verdict now renders fine without a number, the prompt can tell a reviewer to omit the field: `parseManagedReviewOutput` no longer discards real findings over a missing score. The messaging artifact's `- Confidence:` line is likewise omitted rather than printing `undefined`.

**Tooltip is portalled, not a pseudo-element.** The transcript is a scroll region, so `tooltip-target` + `data-tooltip` would clip for any card near its top edge; the verdict badge uses `useViewportTooltip` and wires `aria-describedby` so the explanation is a description rather than a rename of the control.

**Reuse over new primitives.** `review-provenance.ts` uses the existing `review-workspace-guard` helpers (`prBelongsToWorkspace`, `prMatchesRepository`, `normalizeFullRef`) rather than a second matching implementation, and the project chip reuses `CopyableThreadChip` so copy-path behaves identically to the sidebar's. Provenance resolution never fails a review — it is reporting, and a card that cannot name its project is not worth refusing to run the review over.

Design exploration for this change lives in the PwrAgent Claude Design project (`Review Card Provenance`).
