### PR TITLE
fix(desktop): place sub-agent groups under the thread that owns them

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1282,16 +1282,14 @@ export function DirectoriesList(props: DirectoriesListProps) {
             // A child's workers belong to the child, so they render under its
             // own row. They follow it out of this tray when it is unlinked,
             // because the child summary is what carries them.
-            ...(child.codexNativeSubAgents?.length
-              ? [
-                  <NativeSubAgentsDisclosure
-                    key={`${directory.key}:${childKey}:subagents`}
-                    compact
-                    nested
-                    thread={child}
-                  />,
-                ]
-              : []),
+            child.codexNativeSubAgents?.length ? (
+              <NativeSubAgentsDisclosure
+                key={`${directory.key}:${childKey}:subagents`}
+                compact
+                nested
+                thread={child}
+              />
+            ) : null,
             ];
           })}
         </div>

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1166,10 +1166,18 @@ export function DirectoriesList(props: DirectoriesListProps) {
         && Boolean(props.onUpdateSubthreadOrder);
       return (
         <div className="subthread-list subthread-list--compact" role="list" aria-label={`Sub-threads of ${parent.title}`}>
-          {children.map((child) => {
+          {/* The parent's own workers lead its tray. Trailing them after every
+              child read as the last child's workers and buried them under a
+              long child list. */}
+          {nativeSubAgentCount > 0 ? (
+            <NativeSubAgentsDisclosure compact thread={parent} />
+          ) : null}
+          {children.flatMap((child) => {
             const childKey = threadSummaryIdentityKey(child);
             const rowDropKey = `subthread:${parentKey}:${childKey}`;
-            return (
+            // A row plus its own worker group, as siblings of this list. A
+            // wrapping element would break the tray's flat list semantics.
+            return [
             <ThreadRow
               key={`${directory.key}:${childKey}`}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
@@ -1270,12 +1278,22 @@ export function DirectoriesList(props: DirectoriesListProps) {
               onSetReaction={props.onSetReaction}
               onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
-            />
-            );
+            />,
+            // A child's workers belong to the child, so they render under its
+            // own row. They follow it out of this tray when it is unlinked,
+            // because the child summary is what carries them.
+            ...(child.codexNativeSubAgents?.length
+              ? [
+                  <NativeSubAgentsDisclosure
+                    key={`${directory.key}:${childKey}:subagents`}
+                    compact
+                    nested
+                    thread={child}
+                  />,
+                ]
+              : []),
+            ];
           })}
-          {nativeSubAgentCount > 0 ? (
-            <NativeSubAgentsDisclosure compact thread={parent} />
-          ) : null}
         </div>
       );
     };

--- a/apps/desktop/src/renderer/src/features/navigation/NativeSubAgentsDisclosure.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/NativeSubAgentsDisclosure.tsx
@@ -6,6 +6,12 @@ import { readRendererFederationTarget } from "../../lib/federation-window";
 
 type NativeSubAgentsDisclosureProps = {
   compact?: boolean;
+  /**
+   * Set on a group that belongs to a child thread rather than to the tray's
+   * parent. It only adds the extra indent that puts the group under the row
+   * that owns it.
+   */
+  nested?: boolean;
   thread: NavigationThreadSummary;
 };
 
@@ -13,6 +19,10 @@ type NativeSubAgentsDisclosureProps = {
  * The parent row's existing disclosure owns all child content. Native Codex
  * workers occupy one child slot, so they do not inflate ordinary thread rows
  * while still remaining reachable from their parent.
+ *
+ * A child thread's own workers do not count here: they render inside the tray
+ * this count opens, under the child row that owns them, so they can never be
+ * the reason the tray exists.
  */
 export function getSubthreadDisclosureCount(
   thread: NavigationThreadSummary,
@@ -42,12 +52,18 @@ export function NativeSubAgentsDisclosure(props: NativeSubAgentsDisclosureProps)
 
   return (
     <div
-      className={`native-subagents${props.compact ? " native-subagents--compact" : ""}`}
+      className={`native-subagents${props.compact ? " native-subagents--compact" : ""}${
+        props.nested ? " native-subagents--nested" : ""
+      }`}
+      data-subagents-thread={props.thread.id}
       role="listitem"
     >
       <button
         aria-expanded={expanded}
-        aria-label={`${expanded ? "Collapse" : "Expand"} ${nativeSubAgents.length} native Codex sub-agents`}
+        /* A tray can hold several of these groups — the parent's and one per
+           child that spawned workers — so the owning thread has to be in the
+           name for the buttons to be tellable apart. */
+        aria-label={`${expanded ? "Collapse" : "Expand"} ${nativeSubAgents.length} native Codex sub-agents for ${props.thread.title}`}
         className={`native-subagents__toggle${expanded ? " is-open" : ""}`}
         type="button"
         onClick={() => {

--- a/apps/desktop/src/renderer/src/features/navigation/NativeSubAgentsDisclosure.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/NativeSubAgentsDisclosure.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { SubAgentsIcon } from "../../icons";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
 import { useDesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
 
@@ -55,7 +56,12 @@ export function NativeSubAgentsDisclosure(props: NativeSubAgentsDisclosureProps)
       className={`native-subagents${props.compact ? " native-subagents--compact" : ""}${
         props.nested ? " native-subagents--nested" : ""
       }`}
-      data-subagents-thread={props.thread.id}
+      /* The tray freezes while a pointer rests on its rows. A group sits
+         BETWEEN child rows, so without this the freeze releases the moment
+         the pointer crosses one on its way down the tray, and the list can
+         reorder mid-traverse. */
+      data-hover-stable-row="subagents"
+      data-subagents-thread={threadSummaryIdentityKey(props.thread)}
       role="listitem"
     >
       <button
@@ -65,6 +71,9 @@ export function NativeSubAgentsDisclosure(props: NativeSubAgentsDisclosureProps)
            name for the buttons to be tellable apart. */
         aria-label={`${expanded ? "Collapse" : "Expand"} ${nativeSubAgents.length} native Codex sub-agents for ${props.thread.title}`}
         className={`native-subagents__toggle${expanded ? " is-open" : ""}`}
+        /* Expanding changes the tray's height, so let the frozen snapshot go,
+           the way the sibling sub-thread toggle does. */
+        data-hover-stable-release="subagents"
         type="button"
         onClick={() => {
           setExpanded((current) => !current);

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -251,15 +251,13 @@ export function RecentsList(props: RecentsListProps) {
             // A child's workers belong to the child, so they render under its
             // own row. They follow it out of this tray when it is unlinked,
             // because the child summary is what carries them.
-            ...(child.codexNativeSubAgents?.length
-              ? [
-                  <NativeSubAgentsDisclosure
-                    key={`${childKey}:subagents`}
-                    nested
-                    thread={child}
-                  />,
-                ]
-              : []),
+            child.codexNativeSubAgents?.length ? (
+              <NativeSubAgentsDisclosure
+                key={`${childKey}:subagents`}
+                nested
+                thread={child}
+              />
+            ) : null,
           ];
         })}
       </div>

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -140,10 +140,18 @@ export function RecentsList(props: RecentsListProps) {
     );
     return (
       <div className="subthread-list" role="list" aria-label={`Sub-threads of ${parent.title}`}>
-        {children.map((child) => {
+        {/* The parent's own workers lead its tray. Trailing them after every
+            child read as the last child's workers and buried them under a
+            long child list. */}
+        {nativeSubAgentCount > 0 ? (
+          <NativeSubAgentsDisclosure thread={parent} />
+        ) : null}
+        {children.flatMap((child) => {
           const childKey = threadSummaryIdentityKey(child);
           const rowDropKey = `${parentKey}:${childKey}`;
-          return (
+          // A row plus its own worker group, as siblings of this list. A
+          // wrapping element would break the tray's flat list semantics.
+          return [
             <ThreadRow
               key={childKey}
               approvalRequestThreadKeys={props.approvalRequestThreadKeys}
@@ -239,12 +247,21 @@ export function RecentsList(props: RecentsListProps) {
               onSetReaction={props.onSetReaction}
               onSetThreadPin={props.onSetThreadPin}
               onUnbindMessagingBinding={props.onUnbindMessagingBinding}
-            />
-          );
+            />,
+            // A child's workers belong to the child, so they render under its
+            // own row. They follow it out of this tray when it is unlinked,
+            // because the child summary is what carries them.
+            ...(child.codexNativeSubAgents?.length
+              ? [
+                  <NativeSubAgentsDisclosure
+                    key={`${childKey}:subagents`}
+                    nested
+                    thread={child}
+                  />,
+                ]
+              : []),
+          ];
         })}
-        {nativeSubAgentCount > 0 ? (
-          <NativeSubAgentsDisclosure thread={parent} />
-        ) : null}
       </div>
     );
   };

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -413,6 +413,54 @@ describe("Sidebar hover-stable thread ordering", () => {
     })).toBeInTheDocument();
   });
 
+  it("keeps the freeze when the pointer crosses a child's sub-agent group", () => {
+    const parent = thread({
+      id: "parent",
+      title: "Parent thread",
+      updatedAt: 3,
+    });
+    const child: NavigationThreadSummary = {
+      ...thread({ id: "child", title: "Child thread", updatedAt: 2 }),
+      parentThreadId: parent.id,
+      codexNativeSubAgents: [
+        {
+          threadId: "native-worker",
+          title: "Native worker",
+          depth: 1,
+          agentNickname: "worker",
+          threadStatus: "idle",
+        },
+      ],
+    };
+    const tail = thread({ id: "tail", title: "Tail thread", updatedAt: 1 });
+    const view = render(renderSidebar({
+      browseMode: "inbox",
+      threads: [parent, child, tail],
+    }));
+    const childRow = threadRow("Child thread");
+    fireEvent.pointerOver(childRow, { pointerType: "mouse" });
+
+    view.rerender(renderSidebar({
+      browseMode: "inbox",
+      threads: [parent, child],
+    }));
+    expect(threadTitles()).toContain("Tail thread");
+
+    // The child's group is the next thing under the child row, so a pointer
+    // travelling down the tray crosses it. It is a hover-stable row itself,
+    // or the list would reorder under a pointer mid-traverse.
+    const group = document.querySelector(".native-subagents");
+    expect(group).not.toBeNull();
+    fireEvent.pointerOut(childRow, {
+      pointerType: "mouse",
+      relatedTarget: group,
+    });
+    expect(threadTitles()).toContain("Tail thread");
+
+    leaveThreadBrowser();
+    expect(threadTitles()).not.toContain("Tail thread");
+  });
+
   it("releases the frozen snapshot for an explicit subthread toggle", () => {
     const parent = thread({
       id: "parent",

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -16,6 +16,7 @@ import type {
 } from "@pwragent/shared";
 import type { FederationThreadTarget } from "../../chrome/federation-thread-targets";
 import { HOVER_TRANSITION_GRACE_MS } from "../../../lib/useHoverTransitionGrace";
+import { threadSummaryIdentityKey } from "../../../lib/federated-thread-events";
 import { Sidebar } from "../Sidebar";
 
 /**
@@ -267,6 +268,75 @@ function releaseThreadPinPointer(
     pointerId: THREAD_PIN_POINTER_ID,
   });
 }
+
+/**
+ * The rendered order of one sub-thread tray. Sub-agent groups and child rows
+ * are siblings in the same list, so their relative order — and which of them
+ * carries the nested indent — is the placement contract under test.
+ */
+function subthreadTrayItems(
+  container: HTMLElement,
+  selector = ".subthread-list",
+): string[] {
+  const tray = container.querySelector(selector);
+  if (!(tray instanceof HTMLElement)) {
+    throw new Error(`Expected a ${selector} tray`);
+  }
+  return Array.from(tray.children).map((item) => {
+    const subAgentOwner = item.getAttribute("data-subagents-thread");
+    if (subAgentOwner) {
+      const nested = item.classList.contains("native-subagents--nested");
+      return `sub-agents${nested ? "(nested)" : ""}:${subAgentOwner}`;
+    }
+    const title = item.querySelector(".thread-row__title");
+    if (!title) {
+      throw new Error("Expected a tray entry to be a sub-agent group or a thread row");
+    }
+    return `thread:${title.textContent}`;
+  });
+}
+
+const nativeParentThread: NavigationThreadSummary = {
+  ...sharedThread,
+  id: "thread-native-tray-parent",
+  title: "Coordinate the launch",
+  codexNativeSubAgents: [
+    {
+      threadId: "thread-parent-worker",
+      title: "Draft the launch plan",
+      depth: 1,
+      agentNickname: "parent-scout",
+      agentRole: "researcher",
+      threadStatus: "idle",
+    },
+  ],
+};
+
+const nativeChildThread: NavigationThreadSummary = {
+  ...sharedThread,
+  id: "thread-native-tray-child",
+  title: "Review the rollout",
+  parentThreadId: nativeParentThread.id,
+  parentThreadBackend: "codex",
+  codexNativeSubAgents: [
+    {
+      threadId: "thread-child-worker",
+      title: "Check the rollout gates",
+      depth: 1,
+      agentNickname: "child-scout",
+      agentRole: "reviewer",
+      threadStatus: "active",
+    },
+    {
+      threadId: "thread-child-worker-two",
+      title: "Summarize the gate results",
+      depth: 2,
+      agentNickname: "child-summarizer",
+      agentRole: "writer",
+      threadStatus: "idle",
+    },
+  ],
+};
 
 afterEach(() => {
   delete (window as unknown as {
@@ -1341,70 +1411,6 @@ describe("Sidebar", () => {
     expect(screen.queryByText("directory-scout")).not.toBeInTheDocument();
   });
 
-  /**
-   * The rendered order of one sub-thread tray. Sub-agent groups and child
-   * rows are siblings in the same list, so their relative order — not just
-   * their presence — is the placement contract under test.
-   */
-  function subthreadTrayItems(
-    container: HTMLElement,
-    selector = ".subthread-list",
-  ): string[] {
-    const tray = container.querySelector(selector);
-    if (!(tray instanceof HTMLElement)) {
-      throw new Error(`Expected a ${selector} tray`);
-    }
-    return Array.from(tray.children).map((item) => {
-      const subAgentOwner = item.getAttribute("data-subagents-thread");
-      if (subAgentOwner) {
-        return `sub-agents:${subAgentOwner}`;
-      }
-      return `thread:${item.querySelector(".thread-row__title")?.textContent ?? "?"}`;
-    });
-  }
-
-  const nativeParentThread: NavigationThreadSummary = {
-    ...sharedThread,
-    id: "thread-native-tray-parent",
-    title: "Coordinate the launch",
-    codexNativeSubAgents: [
-      {
-        threadId: "thread-parent-worker",
-        title: "Draft the launch plan",
-        depth: 1,
-        agentNickname: "parent-scout",
-        agentRole: "researcher",
-        threadStatus: "idle",
-      },
-    ],
-  };
-
-  const nativeChildThread: NavigationThreadSummary = {
-    ...sharedThread,
-    id: "thread-native-tray-child",
-    title: "Review the rollout",
-    parentThreadId: nativeParentThread.id,
-    parentThreadBackend: "codex",
-    codexNativeSubAgents: [
-      {
-        threadId: "thread-child-worker",
-        title: "Check the rollout gates",
-        depth: 1,
-        agentNickname: "child-scout",
-        agentRole: "reviewer",
-        threadStatus: "active",
-      },
-      {
-        threadId: "thread-child-worker-two",
-        title: "Summarize the gate results",
-        depth: 2,
-        agentNickname: "child-summarizer",
-        agentRole: "writer",
-        threadStatus: "idle",
-      },
-    ],
-  };
-
   it("puts a parent's sub-agents above its child rows in Inbox", () => {
     const { container } = render(
       <Sidebar
@@ -1425,9 +1431,9 @@ describe("Sidebar", () => {
     // The parent owns the first slot of its own tray: a reader finds its
     // workers directly under the parent row, not after every child.
     expect(subthreadTrayItems(container)).toEqual([
-      `sub-agents:${nativeParentThread.id}`,
+      `sub-agents:${threadSummaryIdentityKey(nativeParentThread)}`,
       "thread:Review the rollout",
-      `sub-agents:${nativeChildThread.id}`,
+      `sub-agents(nested):${threadSummaryIdentityKey(nativeChildThread)}`,
     ]);
   });
 
@@ -1496,8 +1502,38 @@ describe("Sidebar", () => {
 
     expect(subthreadTrayItems(container)).toEqual([
       "thread:Review the rollout",
-      `sub-agents:${nativeChildThread.id}`,
+      `sub-agents(nested):${threadSummaryIdentityKey(nativeChildThread)}`,
     ]);
+  });
+
+  it("hides every sub-agent group while the parent's tray is collapsed", () => {
+    const collapsedParent: NavigationThreadSummary = {
+      ...nativeParentThread,
+      subthreadsCollapsed: true,
+    };
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[nativeChildThread, collapsedParent]}
+        loading={false}
+        selectedItemKey="codex:thread-native-tray-parent"
+        threads={[nativeChildThread, collapsedParent]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    // A child's group hangs off the child row, so it goes away with the row.
+    // Collapsing must not become a way to reach sub-agents without children.
+    expect(container.querySelector(".subthread-list")).toBeNull();
+    expect(container.querySelectorAll(".native-subagents")).toHaveLength(0);
+    expect(
+      screen.queryByRole("button", { name: "Review the rollout" }),
+    ).not.toBeInTheDocument();
   });
 
   it("puts a parent's sub-agents above its child rows in Directories", () => {
@@ -1528,9 +1564,9 @@ describe("Sidebar", () => {
     expect(
       subthreadTrayItems(container, ".subthread-list--compact"),
     ).toEqual([
-      `sub-agents:${nativeParentThread.id}`,
+      `sub-agents:${threadSummaryIdentityKey(nativeParentThread)}`,
       "thread:Review the rollout",
-      `sub-agents:${nativeChildThread.id}`,
+      `sub-agents(nested):${threadSummaryIdentityKey(nativeChildThread)}`,
     ]);
   });
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1269,7 +1269,7 @@ describe("Sidebar", () => {
     expect(screen.queryByText("launch-scout")).not.toBeInTheDocument();
 
     const nativeSubAgentsToggle = screen.getByRole("button", {
-      name: "Expand 3 native Codex sub-agents",
+      name: "Expand 3 native Codex sub-agents for Coordinate the launch",
     });
     expect(screen.queryByText("launch-scout")).not.toBeInTheDocument();
 
@@ -1334,9 +1334,270 @@ describe("Sidebar", () => {
     );
 
     expect(
-      screen.getByRole("button", { name: "Expand 1 native Codex sub-agents" }),
+      screen.getByRole("button", {
+        name: "Expand 1 native Codex sub-agents for Coordinate the directory launch",
+      }),
     ).toBeInTheDocument();
     expect(screen.queryByText("directory-scout")).not.toBeInTheDocument();
+  });
+
+  /**
+   * The rendered order of one sub-thread tray. Sub-agent groups and child
+   * rows are siblings in the same list, so their relative order — not just
+   * their presence — is the placement contract under test.
+   */
+  function subthreadTrayItems(
+    container: HTMLElement,
+    selector = ".subthread-list",
+  ): string[] {
+    const tray = container.querySelector(selector);
+    if (!(tray instanceof HTMLElement)) {
+      throw new Error(`Expected a ${selector} tray`);
+    }
+    return Array.from(tray.children).map((item) => {
+      const subAgentOwner = item.getAttribute("data-subagents-thread");
+      if (subAgentOwner) {
+        return `sub-agents:${subAgentOwner}`;
+      }
+      return `thread:${item.querySelector(".thread-row__title")?.textContent ?? "?"}`;
+    });
+  }
+
+  const nativeParentThread: NavigationThreadSummary = {
+    ...sharedThread,
+    id: "thread-native-tray-parent",
+    title: "Coordinate the launch",
+    codexNativeSubAgents: [
+      {
+        threadId: "thread-parent-worker",
+        title: "Draft the launch plan",
+        depth: 1,
+        agentNickname: "parent-scout",
+        agentRole: "researcher",
+        threadStatus: "idle",
+      },
+    ],
+  };
+
+  const nativeChildThread: NavigationThreadSummary = {
+    ...sharedThread,
+    id: "thread-native-tray-child",
+    title: "Review the rollout",
+    parentThreadId: nativeParentThread.id,
+    parentThreadBackend: "codex",
+    codexNativeSubAgents: [
+      {
+        threadId: "thread-child-worker",
+        title: "Check the rollout gates",
+        depth: 1,
+        agentNickname: "child-scout",
+        agentRole: "reviewer",
+        threadStatus: "active",
+      },
+      {
+        threadId: "thread-child-worker-two",
+        title: "Summarize the gate results",
+        depth: 2,
+        agentNickname: "child-summarizer",
+        agentRole: "writer",
+        threadStatus: "idle",
+      },
+    ],
+  };
+
+  it("puts a parent's sub-agents above its child rows in Inbox", () => {
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[nativeChildThread, nativeParentThread]}
+        loading={false}
+        selectedItemKey="codex:thread-native-tray-parent"
+        threads={[nativeChildThread, nativeParentThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    // The parent owns the first slot of its own tray: a reader finds its
+    // workers directly under the parent row, not after every child.
+    expect(subthreadTrayItems(container)).toEqual([
+      `sub-agents:${nativeParentThread.id}`,
+      "thread:Review the rollout",
+      `sub-agents:${nativeChildThread.id}`,
+    ]);
+  });
+
+  it("gives each child thread its own sub-agent group in Inbox", () => {
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[nativeChildThread, nativeParentThread]}
+        loading={false}
+        selectedItemKey="codex:thread-native-tray-parent"
+        threads={[nativeChildThread, nativeParentThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(container.querySelectorAll(".native-subagents")).toHaveLength(2);
+
+    // Each group expands independently and lists only its own workers. A
+    // merged list would make a child's workers unfindable.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand 1 native Codex sub-agents for Coordinate the launch",
+      }),
+    );
+    expect(screen.getByText("parent-scout")).toBeInTheDocument();
+    expect(screen.queryByText("child-scout")).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand 2 native Codex sub-agents for Review the rollout",
+      }),
+    );
+    const childList = screen.getByRole("list", {
+      name: "Native Codex sub-agents for Review the rollout",
+    });
+    expect(within(childList).getByText("child-scout")).toBeInTheDocument();
+    expect(within(childList).getByText("child-summarizer")).toBeInTheDocument();
+    expect(within(childList).queryByText("parent-scout")).not.toBeInTheDocument();
+  });
+
+  it("shows a child's sub-agents when the parent has none", () => {
+    const parentWithoutSubAgents: NavigationThreadSummary = {
+      ...nativeParentThread,
+      codexNativeSubAgents: undefined,
+    };
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={[nativeChildThread, parentWithoutSubAgents]}
+        loading={false}
+        selectedItemKey="codex:thread-native-tray-parent"
+        threads={[nativeChildThread, parentWithoutSubAgents]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(subthreadTrayItems(container)).toEqual([
+      "thread:Review the rollout",
+      `sub-agents:${nativeChildThread.id}`,
+    ]);
+  });
+
+  it("puts a parent's sub-agents above its child rows in Directories", () => {
+    const directory: NavigationDirectorySummary = {
+      ...directories[0]!,
+      threadKeys: [
+        "codex:thread-native-tray-parent",
+        "codex:thread-native-tray-child",
+      ],
+    };
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        directories={[directory]}
+        inboxThreads={[nativeChildThread, nativeParentThread]}
+        loading={false}
+        selectedItemKey="codex:thread-native-tray-parent"
+        threads={[nativeChildThread, nativeParentThread]}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    expect(
+      subthreadTrayItems(container, ".subthread-list--compact"),
+    ).toEqual([
+      `sub-agents:${nativeParentThread.id}`,
+      "thread:Review the rollout",
+      `sub-agents:${nativeChildThread.id}`,
+    ]);
+  });
+
+  it("keeps a child's sub-agents with it when it is unlinked from its parent", () => {
+    const onUnlinkThreads = vi.fn(async () => undefined);
+    const renderSidebar = (threads: NavigationThreadSummary[]) => (
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={threads}
+        loading={false}
+        selectedItemKey="codex:thread-native-tray-child"
+        threads={threads}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+        onUnlinkThreads={onUnlinkThreads}
+      />
+    );
+    const view = render(
+      renderSidebar([nativeChildThread, nativeParentThread]),
+    );
+
+    fireEvent.contextMenu(
+      screen.getByRole("button", { name: "Review the rollout" }),
+    );
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Unlink from Parent" }),
+    );
+    expect(onUnlinkThreads).toHaveBeenCalledWith([
+      expect.objectContaining({ id: nativeChildThread.id }),
+    ]);
+
+    // The unlink promotes the child to the top level. Its workers belong to
+    // it, not to the parent it left, so they move with it.
+    const unlinkedChild: NavigationThreadSummary = {
+      ...nativeChildThread,
+      parentThreadBackend: undefined,
+      parentThreadId: undefined,
+    };
+    view.rerender(renderSidebar([unlinkedChild, nativeParentThread]));
+
+    expect(view.container.querySelectorAll(".native-subagents")).toHaveLength(2);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand 2 native Codex sub-agents for Review the rollout",
+      }),
+    );
+    const childList = screen.getByRole("list", {
+      name: "Native Codex sub-agents for Review the rollout",
+    });
+    expect(within(childList).getByText("child-scout")).toBeInTheDocument();
+    expect(within(childList).getByText("child-summarizer")).toBeInTheDocument();
+
+    // The former parent keeps only the workers it started.
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand 1 native Codex sub-agents for Coordinate the launch",
+      }),
+    );
+    const parentList = screen.getByRole("list", {
+      name: "Native Codex sub-agents for Coordinate the launch",
+    });
+    expect(within(parentList).getByText("parent-scout")).toBeInTheDocument();
+    expect(within(parentList).queryByText("child-scout")).not.toBeInTheDocument();
   });
 
   it("opens worktree sub-thread launchpads from the thread context menu", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4024,6 +4024,15 @@ textarea,
   padding-bottom: 3px;
 }
 
+/* A child thread's own workers. The guide and indent follow `.subthread-list`
+   so the group reads as hanging off the child row above it, not as another
+   entry in the parent's tray. */
+.native-subagents--nested {
+  margin: 1px 0 2px 14px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border-subtle);
+}
+
 .thread-row-shell--nested .thread-row {
   padding-left: 12px;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4024,13 +4024,18 @@ textarea,
   padding-bottom: 3px;
 }
 
-/* A child thread's own workers. The guide and indent follow `.subthread-list`
-   so the group reads as hanging off the child row above it, not as another
-   entry in the parent's tray. */
+/* A child thread's own workers. The guide and indent take one full step of
+   whichever tray the group is in — `.subthread-list` and its compact variant
+   step by different amounts — so the group reads as hanging off the child row
+   above it, not as another entry in the parent's tray. */
 .native-subagents--nested {
-  margin: 1px 0 2px 14px;
+  margin: 1px 0 2px 18px;
   padding-left: 10px;
   border-left: 1px solid var(--border-subtle);
+}
+
+.native-subagents--compact.native-subagents--nested {
+  margin-left: 14px;
 }
 
 .thread-row-shell--nested .thread-row {


### PR DESCRIPTION
## The bug

The sidebar's sub-thread tray rendered a parent thread's native Codex
sub-agents as its **last** entry, after every child row, and never rendered a
child thread's own sub-agents at all.

Both of the states in the report were real, and they were the same line of
code:

1. The parent's group appeared at the bottom of the child list, where it reads
   as belonging to the last child. With 21 workers and five children, it was
   effectively unfindable.
2. A child's own workers were shown nowhere — `renderSubthreads` passed only
   `parent` to `NativeSubAgentsDisclosure`, so a child's `codexNativeSubAgents`
   never reached a component. They only became visible if you unlinked the
   child, which promoted it to top level.

The main process already attaches `codexNativeSubAgents` to each owning thread
(`groupCodexNativeSubAgents`), so the data was correct the whole time — only the
renderer dropped it.

## The fix

- The parent's group leads its own tray, directly under the parent row.
- Each child row gets its own group immediately beneath it, indented so it
  hangs off that row.
- Applied in both tray renderers: `RecentsList` (Attention / Drafts / Inbox /
  Recents) and `DirectoriesList` (Directories).

The trays are flat `role="list"`s whose entries carry `role="listitem"`, so the
groups go in as siblings via `flatMap` rather than inside a wrapper element.

A tray can now hold several of these toggles, so the toggle's accessible name
names the thread that owns it — `Expand 3 native Codex sub-agents for
Coordinate the launch`. Two existing assertions moved with it.

Measured against a standalone `app.css` harness in Chromium — parent row at
x=12, the parent's group and the child rows both at x=41 (one tray indent), the
child's group at x=66.

## Tests

Five new tests in `sidebar.test.tsx`, all of which fail on `main`:

| Test | Fails today with |
|---|---|
| puts a parent's sub-agents above its child rows in Inbox | `['thread:…', 'sub-agents:parent']` instead of parent-first |
| gives each child thread its own sub-agent group in Inbox | 1 group rendered, expected 2 |
| shows a child's sub-agents when the parent has none | no group rendered at all |
| puts a parent's sub-agents above its child rows in Directories | same inversion, compact tray |
| keeps a child's sub-agents with it when it is unlinked from its parent | child's group missing before **and** after the unlink |

The unlink test is the one that pins the ownership question raised in the
report: it drives **Unlink from Parent** through the context menu, asserts
`onUnlinkThreads` fires for the child, then re-renders with the child promoted
to top level and asserts each thread's group still lists only its own workers —
`child-scout` / `child-summarizer` under the unlinked child, `parent-scout`
under the thread it left.

Full workspace suite: 648 files, 9553 passed. `typecheck`, `lint:eslint`
(0 errors), and `lint:colors` clean.

## Not covered

No Desktop E2E run — no spec exercises this tray, and the geometry check above
was done off a static harness rather than the lab guest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
