### PR TITLE
fix(desktop): retain queued user messages at admission

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -216,7 +216,8 @@ type ComposerProps = {
   addOptimisticReviewEntry?: (displayText: string) => string;
   addOptimisticUserMessage?: (
     text: string,
-    imageParts?: AppServerThreadImagePart[]
+    imageParts?: AppServerThreadImagePart[],
+    turnId?: string,
   ) => string;
   backends?: BackendSummary[];
   applications?: DesktopApplicationsSnapshot;
@@ -6281,6 +6282,7 @@ export function Composer(props: ComposerProps) {
             optimisticMessageId = props.addOptimisticUserMessage?.(
               payload.displayText,
               payload.imageParts,
+              response.turnId,
             );
             setActiveOptimisticMessageId(optimisticMessageId);
           }

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -7599,6 +7599,77 @@ describe("Composer", () => {
     expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
   });
 
+  it("reconciles a late optimistic message with its admitted turn", async () => {
+    const startTurnDeferred = createDeferred<StartTurnResponse>();
+    const startTurn = vi.fn(
+      (_request: StartTurnRequest) => startTurnDeferred.promise,
+    );
+    const addOptimisticUserMessage = vi.fn(() => "optimistic-1");
+    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
+
+    render(
+      <Composer
+        activeTurnId="turn-1"
+        addOptimisticUserMessage={addOptimisticUserMessage}
+        desktopApi={{
+          onAgentEvent: (listener) => {
+            agentEventHandler = listener;
+            return () => undefined;
+          },
+          startTurn,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Active turn",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "Admit before optimistic reconciliation" },
+    });
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+
+    await waitFor(() => expect(startTurn).toHaveBeenCalledTimes(1));
+    const queueEntryId = startTurn.mock.calls[0]?.[0].queueEntryId;
+    expect(queueEntryId).toBeDefined();
+
+    await act(async () => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/turnQueue/updated",
+          params: {
+            threadId: "thread-1",
+            queueEntryId: queueEntryId!,
+            origin: "manual",
+            status: "started",
+            turnId: "turn-2",
+          },
+        },
+      });
+      startTurnDeferred.resolve({
+        backend: "codex",
+        threadId: "thread-1",
+        turnId: "turn-2",
+      });
+      await startTurnDeferred.promise;
+    });
+
+    expect(addOptimisticUserMessage).toHaveBeenCalledWith(
+      "Admit before optimistic reconciliation",
+      [],
+      "turn-2",
+    );
+  });
+
   it("keeps a delayed backend queue acknowledgement scoped to its thread", async () => {
     const draftStore = createComposerDraftStore();
     const startTurnDeferred = createDeferred<StartTurnResponse>();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2848,6 +2848,93 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("materializes a started user message before assistant output", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "acp:grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread: async () => readThreadResponse({
+        entries: [],
+        hasPreviousPage: false,
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            item: {
+              id: "user-message-2",
+              type: "userMessage",
+              content: [{ type: "text", text: "Run the corrected command." }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            item: {
+              id: "user-message-2",
+              type: "userMessage",
+              content: [{ type: "text", text: "Run the corrected command." }],
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            item: {
+              id: "assistant-message-2",
+              type: "agentMessage",
+              text: "The corrected command is running.",
+            },
+          },
+        },
+      });
+    });
+
+    expect(
+      result.current.entries.map((entry) =>
+        entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+      )
+    ).toEqual([
+      "user:Run the corrected command.",
+      "assistant:The corrected command is running.",
+    ]);
+  });
+
   it("does not duplicate a final reported by both item and turn completion", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -2881,6 +2881,20 @@ describe("useThreadSessionState", () => {
       agentEventHandler?.({
         backend: "codex",
         notification: {
+          method: "turn/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            turn: {
+              id: "turn-2",
+              status: "in_progress",
+            },
+          },
+        },
+      });
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
           method: "item/started",
           params: {
             threadId: "thread-1",
@@ -2908,6 +2922,17 @@ describe("useThreadSessionState", () => {
           },
         },
       });
+    });
+
+    act(() => {
+      result.current.addOptimisticUserMessage(
+        "Run the corrected command.",
+        [],
+        "turn-2",
+      );
+    });
+
+    act(() => {
       agentEventHandler?.({
         backend: "codex",
         notification: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3348,6 +3348,27 @@ function removePromotedOptimisticUserMessage(
   };
 }
 
+function findAuthoritativeUserMessageForOptimisticEntry(params: {
+  entry: AppServerThreadMessageEntry;
+  response: AppServerReadThreadResponse | undefined;
+  turnId: string | undefined;
+}): AppServerThreadMessageEntry | undefined {
+  if (!params.turnId) {
+    return undefined;
+  }
+
+  return params.response?.replay.entries.find(
+    (entry): entry is AppServerThreadMessageEntry =>
+      entry.type === "message"
+      && entry.role === "user"
+      && !entry.id.startsWith("optimistic-")
+      && entry.turn?.id === params.turnId
+      && messageMatchesOptimisticEntry(entry, params.entry, {
+        allowImageUrlMismatch: true,
+      })
+  );
+}
+
 function appendMessageEntries(
   response: AppServerReadThreadResponse | undefined,
   params: {
@@ -4134,7 +4155,8 @@ export function useThreadSessionState(params: {
   activeTurnStartedAt?: number;
   addOptimisticUserMessage: (
     text: string,
-    imageParts?: AppServerThreadImagePart[]
+    imageParts?: AppServerThreadImagePart[],
+    turnId?: string,
   ) => string;
   addOptimisticReviewEntry: (displayText: string) => string;
   clearPendingRequest: (requestId: string, nextStatus?: string) => void;
@@ -6367,33 +6389,63 @@ export function useThreadSessionState(params: {
   ]);
 
   const addOptimisticUserMessage = useCallback(
-    (text: string, imageParts: AppServerThreadImagePart[] = []): string => {
+    (
+      text: string,
+      imageParts: AppServerThreadImagePart[] = [],
+      turnId?: string,
+    ): string => {
       if (!thread || !threadKey) {
         return `optimistic-${Date.now()}`;
       }
 
       const id = `optimistic-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const createdAt = Date.now();
       const parts: AppServerThreadMessageEntry["parts"] = [
         ...(text ? [{ type: "text" as const, text }] : []),
         ...imageParts,
       ];
-      updateSession(threadKey, (current) => ({
-        ...current,
-        expectOwnUpdate: true,
-        interacted: true,
-        lastTouchedAt: Date.now(),
-        optimisticEntries: [
-          ...current.optimisticEntries,
-          {
-            type: "message",
-            id,
-            role: "user",
-            text,
-            parts,
-            createdAt: Date.now(),
-          },
-        ],
-      }));
+      const optimisticEntry: AppServerThreadMessageEntry = {
+        type: "message",
+        id,
+        role: "user",
+        text,
+        parts,
+        createdAt,
+      };
+      updateSession(threadKey, (current) => {
+        const authoritativeEntry =
+          findAuthoritativeUserMessageForOptimisticEntry({
+            entry: optimisticEntry,
+            response: current.response,
+            turnId: turnId ?? current.activeTurnId,
+          });
+        const nextResponse = authoritativeEntry
+          ? appendMessageEntries(
+              current.response,
+              {
+                backend: thread.source,
+                threadId: thread.id,
+              },
+              [
+                mergeCompletedUserMessageWithOptimisticEntry(
+                  authoritativeEntry,
+                  [optimisticEntry],
+                ),
+              ],
+            )
+          : current.response;
+
+        return {
+          ...current,
+          expectOwnUpdate: true,
+          interacted: true,
+          lastTouchedAt: Date.now(),
+          optimisticEntries: authoritativeEntry
+            ? current.optimisticEntries
+            : [...current.optimisticEntries, optimisticEntry],
+          response: nextResponse,
+        };
+      });
       return id;
     },
     [thread, threadKey, updateSession]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3598,7 +3598,7 @@ function messageContentFromUserItem(item: Record<string, unknown>): {
   };
 }
 
-function userMessageEntryFromCompletedItem(params: {
+function userMessageEntryFromItem(params: {
   turnId?: string;
   item?: {
     id?: string;
@@ -5136,6 +5136,86 @@ export function useThreadSessionState(params: {
           };
         }
 
+        // Queue admission can publish the authoritative user item before the
+        // Composer's startTurn promise adds its optimistic row. Materialize
+        // the started item; a later completion reconciles by the same id.
+        if (
+          event.notification.method === "item/started"
+          || event.notification.method === "item/completed"
+        ) {
+          const userMessageEntry = userMessageEntryFromItem(
+            event.notification.params
+          );
+          if (userMessageEntry) {
+            const launchpadMessageCandidate =
+              launchpadMessageCandidateRef.current?.threadKey === targetThreadKey
+                ? launchpadMessageCandidateRef.current.candidate
+                : undefined;
+            const unreconciledLaunchpadMessageCandidate =
+              reconciledLaunchpadMessageIdsRef.current[targetThreadKey]
+                === undefined
+                ? launchpadMessageCandidate
+                : undefined;
+            const reconcilesLaunchpadMessage = Boolean(
+              unreconciledLaunchpadMessageCandidate
+              && matchesAuthoritativeLaunchpadMessage(
+                userMessageEntry,
+                unreconciledLaunchpadMessageCandidate,
+              )
+            );
+            const authoritativeUserMessageEntry =
+              mergeCompletedUserMessageWithPromotedOptimisticEntry(
+                mergeCompletedUserMessageWithOptimisticEntry(
+                  userMessageEntry,
+                  reconcilesLaunchpadMessage
+                    && unreconciledLaunchpadMessageCandidate
+                    ? [unreconciledLaunchpadMessageCandidate.entry]
+                    : current.optimisticEntries
+                ),
+                current.response
+              );
+            if (reconcilesLaunchpadMessage) {
+              reconciledLaunchpadMessageIdsRef.current[targetThreadKey] =
+                authoritativeUserMessageEntry.id;
+            }
+            const nextResponse = appendMessageEntries(
+              removePromotedOptimisticUserMessage(
+                current.response,
+                authoritativeUserMessageEntry
+              ),
+              {
+                backend: event.backend,
+                threadId: notificationThreadId,
+              },
+              [authoritativeUserMessageEntry]
+            );
+
+            return {
+              ...current,
+              expectOwnUpdate: true,
+              interacted: true,
+              lastTouchedAt: nextLastTouchedAt,
+              optimisticEntries:
+                reconcilesLaunchpadMessage
+                  && unreconciledLaunchpadMessageCandidate
+                  ? current.optimisticEntries.filter(
+                      (entry) =>
+                        entry.id !== unreconciledLaunchpadMessageCandidate.entry.id
+                    )
+                  : current.optimisticEntries.filter(
+                      (entry) =>
+                        entry.id === unreconciledLaunchpadMessageCandidate?.entry.id
+                        || entry.type !== "message"
+                        || !messageTextMatchesOptimisticEntry(
+                          authoritativeUserMessageEntry,
+                          entry,
+                        )
+                    ),
+              response: nextResponse,
+            };
+          }
+        }
+
         if (event.notification.method === "item/started") {
           const item = getNotificationItem(event.notification.params);
           const details = item ? buildLiveToolDetails(item) : [];
@@ -5436,78 +5516,6 @@ export function useThreadSessionState(params: {
         }
 
         if (event.notification.method === "item/completed") {
-          const userMessageEntry = userMessageEntryFromCompletedItem(
-            event.notification.params
-          );
-          if (userMessageEntry) {
-            const launchpadMessageCandidate =
-              launchpadMessageCandidateRef.current?.threadKey === targetThreadKey
-                ? launchpadMessageCandidateRef.current.candidate
-                : undefined;
-            const unreconciledLaunchpadMessageCandidate =
-              reconciledLaunchpadMessageIdsRef.current[targetThreadKey]
-                === undefined
-                ? launchpadMessageCandidate
-                : undefined;
-            const reconcilesLaunchpadMessage = Boolean(
-              unreconciledLaunchpadMessageCandidate
-              && matchesAuthoritativeLaunchpadMessage(
-                userMessageEntry,
-                unreconciledLaunchpadMessageCandidate,
-              )
-            );
-            const completedUserMessageEntry =
-              mergeCompletedUserMessageWithPromotedOptimisticEntry(
-                mergeCompletedUserMessageWithOptimisticEntry(
-                  userMessageEntry,
-                  reconcilesLaunchpadMessage
-                    && unreconciledLaunchpadMessageCandidate
-                    ? [unreconciledLaunchpadMessageCandidate.entry]
-                    : current.optimisticEntries
-                ),
-                current.response
-              );
-            if (reconcilesLaunchpadMessage) {
-              reconciledLaunchpadMessageIdsRef.current[targetThreadKey] =
-                completedUserMessageEntry.id;
-            }
-            const nextResponse = appendMessageEntries(
-              removePromotedOptimisticUserMessage(
-                current.response,
-                completedUserMessageEntry
-              ),
-              {
-                backend: event.backend,
-                threadId: notificationThreadId,
-              },
-              [completedUserMessageEntry]
-            );
-
-            return {
-              ...current,
-              expectOwnUpdate: true,
-              interacted: true,
-              lastTouchedAt: nextLastTouchedAt,
-              optimisticEntries:
-                reconcilesLaunchpadMessage
-                  && unreconciledLaunchpadMessageCandidate
-                  ? current.optimisticEntries.filter(
-                      (entry) =>
-                        entry.id !== unreconciledLaunchpadMessageCandidate.entry.id
-                    )
-                  : current.optimisticEntries.filter(
-                      (entry) =>
-                        entry.id === unreconciledLaunchpadMessageCandidate?.entry.id
-                        || entry.type !== "message"
-                        || !messageTextMatchesOptimisticEntry(
-                          completedUserMessageEntry,
-                          entry,
-                        )
-                    ),
-              response: nextResponse,
-            };
-          }
-
           const assistantTurn = buildTurnMetadata({
             fallbackId:
               typeof event.notification.params.turnId === "string"


### PR DESCRIPTION
Summary
- materialize authoritative userMessage items on item/started as well as item/completed
- preserve optimistic and launchpad reconciliation while making completion idempotent by item id
- add a regression for the queue-admission race where assistant output arrives after a started user item

Incident evidence
- thread 01a0592a-149c-75d0-8d13-b5c943dea48c
- prior turn completed at 2026-09-01 17:18:27.938 America/New_York
- next turn became active at 17:18:28.557
- rollout contains the missing user item msg_01a05ed6-76d4-7091-8441-5b4c4248fde4 at 17:18:28.564-correlated time, so Codex accepted the message and the renderer dropped it

Validation
- pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx (136 passed)
- pnpm lint:eslint (0 errors; 43 existing warnings)
- pnpm typecheck
- pnpm lint:codex-storage
- pnpm lint:boundaries