### PR TITLE
test(desktop): pin revealed cost at compaction

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -609,7 +609,7 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
       .toBeGreaterThan(initialAccounting?.savingsMicros ?? 0);
   });
 
-  it("stops cached replay counting at a ContextCompaction item boundary", async () => {
+  it("stops baseline and revealed replay accounting at ContextCompaction", async () => {
     const { objectId, tokenMiserStore } = await startLiveReplayGate();
 
     await registry.publishLocalEvent(parentUsageEvent(2_000));
@@ -617,6 +617,8 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     await registry.publishLocalEvent(parentUsageEvent(4_000));
     expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
       cachedReplayCount: 1,
+      cachedBaselineTokens: 6_000,
+      cachedRevealedTokens: 225,
       parentRequestsObservedAfterGate: 3,
     });
 
@@ -640,6 +642,8 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
 
     expect(await tokenMiserStore.readMetadata(objectId)).toMatchObject({
       cachedReplayCount: 1,
+      cachedBaselineTokens: 6_000,
+      cachedRevealedTokens: 225,
       parentRequestsObservedAfterGate: 3,
     });
     expect(


### PR DESCRIPTION
## Summary

- I strengthened the ContextCompaction regression to cover both sides of Token Miser replay accounting.
- I now assert that cached baseline tokens and cached revealed-to-parent tokens both stop growing at the boundary.
- This pins the failure shape observed in a pre-#1926 thread where revealed cost exceeded the entire parent-thread cost after stale replay accounting crossed compactions.

## Verification

- `pnpm test apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts apps/desktop/src/main/__tests__/token-miser-store.test.ts` (27 passed)
- `pnpm exec eslint apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts`

## Notes

- No production change is needed: the merged #1926 implementation already stops both counters through the shared `replayTrackingStoppedAt` guard.
- The supplied old-version thread had no recorded compaction markers, which is consistent with its revealed-cost estimate continuing across boundaries.
