### PR TITLE
fix(desktop): gate remote startup reads on peer health

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -617,10 +617,9 @@ test.describe("federation remote window", () => {
       await expect(
         window.locator(".federation-disconnected-banner"),
       ).toBeVisible({ timeout: 30_000 });
-      await expect(window.locator(".transcript-error")).toContainText(
-        "not connected",
-        { timeout: 30_000 },
-      );
+      // Peer readiness suspends hydration before IPC, so the expected outage
+      // state is the reconnecting banner without a raw handler exception.
+      await expect(window.locator(".transcript-error")).toHaveCount(0);
 
       await localRow.click();
       await expect(window.getByText("Local thread is ready.")).toBeVisible();

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1982,11 +1982,11 @@ function DesktopAppShell(props: {
       return;
     }
 
-    // A restored selection is already a valid startup landing. Backend
-    // discovery can change scope while that remote owner is still resolving;
-    // do not reinterpret a transient empty result as first-run evidence.
-    if (navigation.selectedThreadKey) {
-      startupLandingStateRef.current = "complete";
+    // Backend discovery changes scope after restoring a remote selection.
+    // While its owner is unresolved or disconnected, the previous local
+    // result is not evidence that setup is required. Keep the decision
+    // pending so reconnect can provide authoritative remote capabilities.
+    if (navigation.selectedThreadKey && remoteReadsSuspended) {
       return;
     }
 
@@ -2005,6 +2005,9 @@ function DesktopAppShell(props: {
     }
 
     startupLandingStateRef.current = "complete";
+    if (navigation.selectedThreadKey) {
+      return;
+    }
     setMainView("thread");
     void openWorkspaceLaunchpad(startupBackend.kind);
   }, [
@@ -2015,6 +2018,7 @@ function DesktopAppShell(props: {
     navigation.selectedThreadKey,
     onboardingOpen,
     openWorkspaceLaunchpad,
+    remoteReadsSuspended,
     settings.snapshot?.onboarding?.completed.value,
     startupBackend,
   ]);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1408,10 +1408,15 @@ function DesktopAppShell(props: {
     desktopApi,
     target: activeFederationTarget,
   });
+  const remoteReadsSuspended = Boolean(
+    activeFederationTarget
+    && (!peerConnectivity.ready || !peerConnectivity.connected),
+  );
   const applications = useDesktopApplications({
     desktopApi,
     localApplications: settings.snapshot?.applications,
     remoteInstanceId: remoteApplicationInstanceId,
+    suspended: remoteReadsSuspended,
   });
   // Keep the backend-error toast's thread lookup fresh without making the
   // toast subscription depend on (and re-subscribe to) the thread list.
@@ -1442,7 +1447,7 @@ function DesktopAppShell(props: {
   const backendSummaries = useBackendSummaries(desktopApi, {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,
-    suspended: !peerConnectivity.connected,
+    suspended: remoteReadsSuspended,
   });
   const startupBackend = useMemo(
     () => resolveNewThreadBackend(backendSummaries.backends),
@@ -1769,7 +1774,7 @@ function DesktopAppShell(props: {
     () => readRendererFederationTarget()
       ? [{
           federationTarget: activeFederationTarget,
-          suspended: !peerConnectivity.connected,
+          suspended: remoteReadsSuspended,
         }]
       : [
           { federationTarget: undefined },
@@ -1779,7 +1784,7 @@ function DesktopAppShell(props: {
         ],
     [
       activeFederationTarget,
-      peerConnectivity.connected,
+      remoteReadsSuspended,
       scheduledActionFederationTargets,
     ],
   );
@@ -1977,6 +1982,14 @@ function DesktopAppShell(props: {
       return;
     }
 
+    // A restored selection is already a valid startup landing. Backend
+    // discovery can change scope while that remote owner is still resolving;
+    // do not reinterpret a transient empty result as first-run evidence.
+    if (navigation.selectedThreadKey) {
+      startupLandingStateRef.current = "complete";
+      return;
+    }
+
     if (!startupBackend) {
       // A discovery failure is not proof that the profile has no configured
       // provider. Let a later refresh make the startup decision instead of
@@ -1992,14 +2005,6 @@ function DesktopAppShell(props: {
     }
 
     startupLandingStateRef.current = "complete";
-    if (navigation.selectedThreadKey) {
-      // Navigation already landed on a thread: a selection restored across a
-      // renderer reload, or the snapshot's fallback pick. Swapping that for
-      // the workspace composer flashes the thread's transcript and leaves a
-      // back entry pointing at it, so the composer is the startup landing
-      // only when there is no thread to show.
-      return;
-    }
     setMainView("thread");
     void openWorkspaceLaunchpad(startupBackend.kind);
   }, [
@@ -2019,6 +2024,7 @@ function DesktopAppShell(props: {
     initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
     liveTranscriptEventFiltering:
       settings.snapshot?.experimental.liveTranscriptEventFiltering?.value ?? false,
+    suspended: remoteReadsSuspended,
     thread: loadThreadDetail ? navigation.selectedThread : undefined,
   });
   const skills = useThreadSkills({
@@ -2153,7 +2159,7 @@ function DesktopAppShell(props: {
       !navigation.selectedThread ||
       // A remote thread cannot accept input while its owning instance is
       // unreachable — typing would only queue into a dead RPC.
-      !peerConnectivity.connected ||
+      remoteReadsSuspended ||
       !backendSummaries.backends.some(
         (backend) =>
           backend.kind === navigation.selectedThread?.source &&
@@ -2161,7 +2167,7 @@ function DesktopAppShell(props: {
       ),
     composerImplementation: settings.composerImplementation,
     composerDraftStore,
-    desktopApi: threadDesktopApi,
+    desktopApi: remoteReadsSuspended ? undefined : threadDesktopApi,
     launchpadError: navigation.launchpadError,
     onProviderSelected: refreshSelectedAcpProvider,
     onShowNotice: showAppNotice,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3298,7 +3298,7 @@ describe("App", () => {
     expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
   });
 
-  it("reopens onboarding on startup when no backend can create a thread", async () => {
+  it("reopens onboarding when a stale selection has no usable backend", async () => {
     const ensureDirectoryLaunchpad = vi.fn();
 
     Object.defineProperty(window, "pwragent", {
@@ -3353,8 +3353,19 @@ describe("App", () => {
           backend: "all" as const,
           fetchedAt: Date.now(),
           unchanged: false,
-          inboxThreadKeys: [],
-          threads: [],
+          inboxThreadKeys: ["codex:stale-thread"],
+          threads: [{
+            id: "stale-thread",
+            title: "Stale historical thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: {
+              inInbox: true,
+              reason: "new-thread" as const,
+            },
+            updatedAt: 1,
+          }],
           directories: [],
           launchpadDefaults: {
             backend: "codex" as const,

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3058,6 +3058,147 @@ describe("App", () => {
     ).toHaveAttribute("aria-pressed", "true");
   });
 
+  it("waits for peer health before reading a restored remote thread", async () => {
+    const peerHealth = createDeferred<{
+      health: {
+        enabled: true;
+        role: "client";
+        status: "connected";
+        peers: Array<{
+          id: string;
+          label: string;
+          role: "client";
+          status: "disconnected";
+          capabilities: [];
+        }>;
+      };
+    }>();
+    const remoteTarget = {
+      scope: "remote" as const,
+      instanceId: "peer-restored-offline",
+    };
+    const listBackends = vi.fn(async (request?: {
+      federationTarget?: FederationTarget;
+    }) => {
+      if (request?.federationTarget) {
+        throw new Error("Remote backend read must wait for peer health.");
+      }
+      return { fetchedAt: Date.now(), backends: [] };
+    });
+    const readApplications = vi.fn(async () => {
+      throw new Error("Remote applications read must wait for peer health.");
+    });
+    const readThread = vi.fn(async () => {
+      throw new Error("Remote thread read must wait for peer health.");
+    });
+    const checkThreadBranchDrift = vi.fn(async () => {
+      throw new Error("Remote branch read must wait for peer health.");
+    });
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings: async () => ({
+          snapshot: {
+            general: {
+              appearance: {
+                theme: { value: "system", source: "default" },
+                density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
+                transcriptTextSize: { value: "md", source: "default" },
+              },
+            },
+            onboarding: {
+              completed: { value: true, source: "config" },
+              completedSource: { value: "migrated", source: "default" },
+            },
+            imageUploads: {
+              pastedImageMaxPatches: { value: 1536, source: "default" },
+            },
+            experimental: {
+              fullAccessRiskWarningDismissed: {
+                value: false,
+                source: "default",
+              },
+            },
+          } as DesktopSettingsSnapshot,
+        }),
+        listBackends,
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:remote-thread"],
+          threads: [{
+            id: "remote-thread",
+            title: "Restored remote thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            gitBranch: "main",
+            linkedDirectories: [],
+            inbox: {
+              inInbox: true,
+              reason: "new-thread" as const,
+            },
+            updatedAt: 1,
+            federation: {
+              ref: {
+                backend: "codex" as const,
+                target: remoteTarget,
+                threadId: "remote-thread",
+              },
+              instanceLabel: "Offline studio",
+              peerStatus: "disconnected" as const,
+            },
+          }],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        readFederationHealth: vi.fn(() => peerHealth.promise),
+        readApplications,
+        readThread,
+        checkThreadBranchDrift,
+        markThreadSeen: async () => ({
+          backend: "codex" as const,
+          threadId: "remote-thread",
+          seenAt: Date.now(),
+        }),
+        onAgentEvent: () => () => undefined,
+        onWindowFocus: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("button", { name: "Restored remote thread" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await flushReactUpdates();
+    await flushReactUpdates();
+    await flushReactUpdates();
+
+    expect({
+      remoteBackendReads: listBackends.mock.calls.filter(
+        ([request]) => request?.federationTarget,
+      ).length,
+      applicationReads: readApplications.mock.calls.length,
+      threadReads: readThread.mock.calls.length,
+      branchDriftReads: checkThreadBranchDrift.mock.calls.length,
+      onboardingVisible: Boolean(
+        screen.queryByRole("heading", { name: /A few short choices/i }),
+      ),
+    }).toEqual({
+      remoteBackendReads: 0,
+      applicationReads: 0,
+      threadReads: 0,
+      branchDriftReads: 0,
+      onboardingVisible: false,
+    });
+  });
+
   it("preserves replay fixture navigation instead of opening the startup composer", async () => {
     const ensureDirectoryLaunchpad = vi.fn();
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useFederationPeerConnectivity.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useFederationPeerConnectivity.test.tsx
@@ -5,6 +5,7 @@ import type { DesktopApi } from "../desktop-api";
 import { useFederationPeerConnectivity } from "../useFederationPeerConnectivity";
 
 function buildDesktopApi(params: {
+  rejectHealth?: boolean;
   seededStatus?: "connected" | "disconnected";
 }): {
   desktopApi: DesktopApi;
@@ -12,24 +13,29 @@ function buildDesktopApi(params: {
 } {
   let listener: ((event: AgentEvent) => void) | undefined;
   const desktopApi: DesktopApi = {
-    readFederationHealth: vi.fn(async () => ({
-      health: {
-        enabled: true,
-        role: "client" as const,
-        status: "connected" as const,
-        peers: params.seededStatus
-          ? [
-              {
-                id: "peer_one",
-                label: "Mac-Mini-M4",
-                role: "gateway" as const,
-                status: params.seededStatus,
-                capabilities: [],
-              },
-            ]
-          : [],
-      },
-    })),
+    readFederationHealth: vi.fn(async () => {
+      if (params.rejectHealth) {
+        throw new Error("Federation health is temporarily unavailable.");
+      }
+      return {
+        health: {
+          enabled: true,
+          role: "client" as const,
+          status: "connected" as const,
+          peers: params.seededStatus
+            ? [
+                {
+                  id: "peer_one",
+                  label: "Mac-Mini-M4",
+                  role: "gateway" as const,
+                  status: params.seededStatus,
+                  capabilities: [],
+                },
+              ]
+            : [],
+        },
+      };
+    }),
     onAgentEvent: vi.fn((callback: (event: AgentEvent) => void) => {
       listener = callback;
       return () => {
@@ -115,5 +121,23 @@ describe("useFederationPeerConnectivity", () => {
       emit(peerStatusEvent("peer_other", "disconnected"));
     });
     expect(result.current.connected).toBe(true);
+  });
+
+  it("releases readiness when the health seed fails", async () => {
+    const { desktopApi } = buildDesktopApi({ rejectHealth: true });
+    const { result } = renderHook(() =>
+      useFederationPeerConnectivity({
+        desktopApi,
+        target: { scope: "remote", instanceId: "peer_one" },
+      }),
+    );
+
+    expect(result.current.ready).toBe(false);
+    expect(result.current.connected).toBe(true);
+    await waitFor(() => {
+      expect(result.current.ready).toBe(true);
+    });
+    expect(result.current.connected).toBe(true);
+    expect(result.current.status).toBeUndefined();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/useDesktopApplications.ts
+++ b/apps/desktop/src/renderer/src/lib/useDesktopApplications.ts
@@ -6,6 +6,7 @@ export function useDesktopApplications(params: {
   desktopApi?: DesktopApi;
   localApplications?: DesktopApplicationsSnapshot;
   remoteInstanceId?: string;
+  suspended?: boolean;
 }): DesktopApplicationsSnapshot | undefined {
   const [remoteApplications, setRemoteApplications] = useState<{
     applications: DesktopApplicationsSnapshot;
@@ -13,7 +14,11 @@ export function useDesktopApplications(params: {
   }>();
 
   useEffect(() => {
-    if (!params.remoteInstanceId || !params.desktopApi?.readApplications) {
+    if (
+      !params.remoteInstanceId
+      || params.suspended
+      || !params.desktopApi?.readApplications
+    ) {
       setRemoteApplications(undefined);
       return;
     }
@@ -41,7 +46,7 @@ export function useDesktopApplications(params: {
     return () => {
       cancelled = true;
     };
-  }, [params.desktopApi, params.remoteInstanceId]);
+  }, [params.desktopApi, params.remoteInstanceId, params.suspended]);
 
   if (!params.remoteInstanceId) {
     return params.localApplications;

--- a/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
@@ -103,11 +103,12 @@ export function useFederationPeerConnectivity(params: {
   return useMemo(() => {
     const targetState = state.instanceId === instanceId ? state : undefined;
     const healthReadable = Boolean(desktopApi?.readFederationHealth);
-    const ready = !instanceId || !healthReadable || targetState?.ready === true;
+    const targetReady = targetState?.ready === true;
+    const ready = !instanceId || !healthReadable || targetReady;
     return {
       connected:
         !instanceId
-        || !healthReadable
+        || (!healthReadable && !targetReady)
         || !ready
         || targetState?.status === "connected",
       ready,

--- a/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
@@ -33,6 +33,7 @@ export function useFederationPeerConnectivity(params: {
   const desktopApi = params.desktopApi;
   const instanceId = params.target?.instanceId;
   const [state, setState] = useState<{
+    healthSeedFailed?: boolean;
     instanceId?: string;
     ready: boolean;
     status?: FederationConnectionState;
@@ -75,7 +76,14 @@ export function useFederationPeerConnectivity(params: {
         }
       })
       .catch(() => {
-        // Health is a seed; the event stream below is the live source.
+        if (cancelled) return;
+        // A failed seed is not evidence that the peer is disconnected. Let
+        // remote reads proceed; a later status event remains authoritative.
+        setState((current) =>
+          current.instanceId === instanceId && !current.ready
+            ? { healthSeedFailed: true, instanceId, ready: true }
+            : current,
+        );
       });
     const unsubscribe = desktopApi?.onAgentEvent?.((event) => {
       if (event.notification.method !== "federation/peerStatus/changed") {
@@ -109,6 +117,7 @@ export function useFederationPeerConnectivity(params: {
       connected:
         !instanceId
         || (!healthReadable && !targetReady)
+        || targetState?.healthSeedFailed === true
         || !ready
         || targetState?.status === "connected",
       ready,

--- a/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederationPeerConnectivity.ts
@@ -12,6 +12,8 @@ export type FederationPeerConnectivity = {
    * boot. Local windows (no target) are always connected.
    */
   connected: boolean;
+  /** True once health or a live peer-status event has identified the target. */
+  ready: boolean;
   status?: FederationConnectionState;
   unavailableReason?: string;
 };
@@ -31,15 +33,18 @@ export function useFederationPeerConnectivity(params: {
   const desktopApi = params.desktopApi;
   const instanceId = params.target?.instanceId;
   const [state, setState] = useState<{
+    instanceId?: string;
+    ready: boolean;
     status?: FederationConnectionState;
     unavailableReason?: string;
-  }>({});
+  }>({ ready: false });
 
   useEffect(() => {
     if (!instanceId) {
-      setState({});
+      setState({ ready: true });
       return;
     }
+    setState({ instanceId, ready: false });
     let cancelled = false;
     void desktopApi
       ?.readFederationHealth?.({})
@@ -52,11 +57,19 @@ export function useFederationPeerConnectivity(params: {
           // Functional update: a peerStatus event that raced the health
           // read is newer — do not clobber it with the snapshot.
           setState((current) =>
-            current.status === undefined
+            current.instanceId === instanceId && current.status === undefined
               ? {
+                  instanceId,
+                  ready: true,
                   status: peer.status,
                   unavailableReason: peer.unavailableReason,
                 }
+              : current,
+          );
+        } else {
+          setState((current) =>
+            current.instanceId === instanceId && current.status === undefined
+              ? { instanceId, ready: true }
               : current,
           );
         }
@@ -75,6 +88,8 @@ export function useFederationPeerConnectivity(params: {
       };
       if (status.instanceId !== instanceId) return;
       setState({
+        instanceId,
+        ready: true,
         status: status.status,
         unavailableReason: status.unavailableReason,
       });
@@ -85,15 +100,19 @@ export function useFederationPeerConnectivity(params: {
     };
   }, [desktopApi, instanceId]);
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    const targetState = state.instanceId === instanceId ? state : undefined;
+    const healthReadable = Boolean(desktopApi?.readFederationHealth);
+    const ready = !instanceId || !healthReadable || targetState?.ready === true;
+    return {
       connected:
         !instanceId
-        || state.status === undefined
-        || state.status === "connected",
-      status: state.status,
-      unavailableReason: state.unavailableReason,
-    }),
-    [instanceId, state],
-  );
+        || !healthReadable
+        || !ready
+        || targetState?.status === "connected",
+      ready,
+      status: targetState?.status,
+      unavailableReason: targetState?.unavailableReason,
+    };
+  }, [desktopApi?.readFederationHealth, instanceId, state]);
 }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4260,6 +4260,7 @@ export function useThreadSessionState(params: {
   desktopApi?: DesktopApi;
   initialHistoryLimit?: number;
   liveTranscriptEventFiltering?: boolean;
+  suspended?: boolean;
   thread?: NavigationThreadSummary;
 }): {
   activeTurnId?: string;
@@ -4314,7 +4315,12 @@ export function useThreadSessionState(params: {
   setViewport: (viewport?: ThreadViewportState) => void;
   viewport?: ThreadViewportState;
 } {
-  const { desktopApi, liveTranscriptEventFiltering = false, thread } = params;
+  const {
+    desktopApi,
+    liveTranscriptEventFiltering = false,
+    suspended = false,
+    thread,
+  } = params;
   const threadKey = thread
     ? threadSummaryIdentityKey(thread)
     : undefined;
@@ -4484,6 +4490,9 @@ export function useThreadSessionState(params: {
 
   const loadLatest = useCallback(
     async (targetThread: NavigationThreadSummary): Promise<void> => {
+      if (suspended) {
+        return;
+      }
       const readThread = desktopApi?.readThread;
       const targetThreadKey = threadSummaryIdentityKey(targetThread);
       const hydrationVersion = getThreadHydrationVersion(targetThread);
@@ -4797,6 +4806,7 @@ export function useThreadSessionState(params: {
       desktopApi?.recordStartupProfileEvent,
       initialHistoryLimit,
       logStaleThinkingState,
+      suspended,
       updateSession,
     ]
   );


### PR DESCRIPTION
## Summary

- Gate restored remote-thread startup reads on peer-health readiness so Electron does not emit a burst of `FEDERATION_PEER_UNAVAILABLE` handler failures for `applications:read`, `backend:list`, `app-server:read-thread`, and `agent:check-thread-branch-drift`.
- Keep the disconnected surface graceful: remote reads and writes stay suspended behind the reconnecting banner, then resume when the peer becomes reachable.
- Defer replay onboarding only while a restored remote owner is unresolved or disconnected. Historical local selections with no usable backend still reopen setup.
- Treat a failed health seed as unavailable evidence rather than proof of disconnection, allowing remote reads to proceed while later peer-status events remain authoritative.

## Why

On startup, `App.tsx` derives the active federation target from the restored selected thread. `useFederationPeerConnectivity` intentionally rendered the peer as optimistically connected before its first health read, which also authorized remote IPC too early. If local backend discovery changed scope during the same startup window, its transient empty result could additionally open replay onboarding over the restored thread.

The fix separates UI optimism from operation readiness. Remote IPC waits for health or live status evidence, without adding timeouts or retries. The startup decision remains pending only for the remote-owner race instead of treating every restored selection as proof that setup is unnecessary.

## Existing-fix search

Searched open and merged PRs plus current branch history for `FederationPeerUnavailableError`, `FEDERATION_PEER_UNAVAILABLE`, and disconnected-peer startup behavior. Related work in #1285, #1836, and #1858 did not cover this initial restored-thread readiness race.

## Regression evidence

Before the fix, the focused App-shell regression observed premature calls while peer health was unresolved:

```text
remoteBackendReads: 1
applicationReads: 1
```

After the fix, it observes zero remote startup reads, no raw transcript exception, and no spurious onboarding overlay. Additional regressions cover failed health seeding, peer-event precedence without a health API, reconnect polling, and stale local selections with no usable backend.

## Validation

- Focused renderer suites: 208 tests passed
- `pnpm typecheck`: passed
- `pnpm lint:eslint`: 0 errors
- `git diff --check`: passed

The branch was rebased onto current `origin/main`; CI is running on the updated head.