### PR TITLE
fix(desktop): stop the Profiles pane clipping its own actions

### DIFF
--- a/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
@@ -5,6 +5,8 @@ import type {
 } from "@pwragent/shared";
 import { normalizeProfileName } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { tildifyPath } from "../../lib/tildify-path";
+import { SettingsSplitPath } from "./SettingsSplitPath";
 
 const CREATE_VALUE = "__create_codex_profile__";
 
@@ -36,7 +38,7 @@ export function CodexAuthProfileSelect(props: {
     <div className="settings-codex-profile-select">
       <select
         aria-label={props["aria-label"]}
-        className="settings-select"
+        className="settings-select settings-codex-profile-select__control"
         disabled={props.disabled}
         value={selectedValue}
         onChange={(event) => {
@@ -59,7 +61,7 @@ export function CodexAuthProfileSelect(props: {
         <option value={CREATE_VALUE}>Create New Codex Profile...</option>
       </select>
 
-      {selected ? <CodexAuthProfileDetails profile={selected} /> : null}
+      {selected ? <CodexAuthProfileStatus profile={selected} /> : null}
 
       {createOpen ? (
         <CodexAuthProfileCreateDialog
@@ -139,16 +141,26 @@ export function CodexAuthProfileLoginButton(props: {
   );
 }
 
-function CodexAuthProfileDetails(props: {
+/**
+ * The selected auth profile's home and state, on the same line as the
+ * control that picks it.
+ *
+ * This replaced a nested detail card that reprinted the display name already
+ * shown in the select directly above it, on the same elevation as its own
+ * parent card — 52px of row height whose only unique content was the codex
+ * home plus these chips.
+ */
+function CodexAuthProfileStatus(props: {
   profile: DesktopCodexAuthProfileCandidate;
 }) {
   const profile = props.profile;
   return (
-    <div className="settings-codex-profile-details">
-      <div className="settings-codex-profile-details__body">
-        <span className="settings-pathrow__title">{profile.displayName}</span>
-        <span className="settings-pathrow__path">{profile.codexHome}</span>
-      </div>
+    <>
+      <SettingsSplitPath
+        className="settings-codex-profile-select__home"
+        title={profile.codexHome}
+        value={tildifyPath(profile.codexHome)}
+      />
       <div className="settings-pathrow__chips">
         <span className="settings-pathrow__chip">
           {profile.source === "default" ? "default" : "profile"}
@@ -171,7 +183,7 @@ function CodexAuthProfileDetails(props: {
           </span>
         ) : null}
       </div>
-    </div>
+    </>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
@@ -12,6 +12,14 @@ const CREATE_VALUE = "__create_codex_profile__";
 
 type CreationStep = "form" | "waiting" | "authenticated";
 
+/**
+ * Renders as THREE siblings, not one box: the select, the selected
+ * profile's codex home, and its state chips. The wrapper carries
+ * `display: contents`, so the parent owns the layout — render this
+ * inside a wrapping flex row (`.settings-profile-card__codex` is the
+ * only one today). A block or grid parent stacks the three parts with
+ * no error and no failing test.
+ */
 export function CodexAuthProfileSelect(props: {
   "aria-label": string;
   desktopApi?: DesktopApi;

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -491,7 +491,7 @@ export function PluginsSettings(props: {
                 Cancel
               </button>
               <button
-                className="button button--ghost settings-profile-row__button--danger"
+                className="button button--ghost settings-danger-button"
                 disabled={actionsDisabled}
                 type="button"
                 onClick={() => void removeServer()}

--- a/apps/desktop/src/renderer/src/features/settings/ProfilesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ProfilesSettings.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@pwragent/shared";
 import { normalizeProfileName } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { tildifyPath } from "../../lib/tildify-path";
 import {
   usePwrAgentProfiles,
   type PwrAgentProfilesState,
@@ -16,6 +17,7 @@ import {
   SettingsSectionStack,
 } from "./SettingsLayout";
 import { CodexAuthProfileSelect } from "./CodexAuthProfileSelect";
+import { SettingsSplitPath } from "./SettingsSplitPath";
 
 export function ProfilesSettings(props: {
   desktopApi?: DesktopApi;
@@ -68,7 +70,7 @@ export function ProfilesSettings(props: {
       <SettingsSection
         eyebrow="Profiles"
         title="Profile list"
-        description="Choose which profile opens when no environment profile is set, or open another profile in a new app instance."
+        description="Choose which profile opens when no environment profile is set, or open another profile in a new app instance. A Codex auth change applies the next time that profile launches."
         chip={
           profiles.activeProfile ? `active:${profiles.activeProfile}` : "profiles"
         }
@@ -79,7 +81,7 @@ export function ProfilesSettings(props: {
         ) : profiles.profiles.length ? (
           <div className="settings-paths">
             {profiles.profiles.map((profile) => (
-              <PwrAgentProfileRow
+              <PwrAgentProfileCard
                 key={profile.name}
                 busy={busyProfile === profile.name}
                 profile={profile}
@@ -161,7 +163,7 @@ export function ProfilesSettings(props: {
   );
 }
 
-function PwrAgentProfileRow(props: {
+function PwrAgentProfileCard(props: {
   busy: boolean;
   codexProfileControl: ReactNode;
   profile: DesktopPwrAgentProfileSummary;
@@ -178,59 +180,70 @@ function PwrAgentProfileRow(props: {
 
   return (
     <div
-      className={`settings-pathrow settings-profile-row${
-        profile.active ? " is-selected" : ""
-      }`}
+      className={`settings-profile-card${profile.active ? " is-active" : ""}`}
     >
-      <div className="settings-pathrow__body">
-        <span className="settings-pathrow__title">{displayName}</span>
-        <span className="settings-pathrow__path">{profile.profileDir}</span>
-        <span className="settings-profile-row__meta">{lastUsed}</span>
-        <div className="settings-profile-row__codex">
-          <span className="settings-profile-row__label">Codex auth profile</span>
-          {props.codexProfileControl}
-          <span className="settings-profile-row__meta">
-            Applies the next time this PwrAgent profile launches.
+      <div className="settings-profile-card__head">
+        <div className="settings-profile-card__ident">
+          <span className="settings-profile-card__name" title={displayName}>
+            {displayName}
           </span>
+          {profile.active ? (
+            <span className="settings-pathrow__chip settings-pathrow__chip--ok">
+              Active
+            </span>
+          ) : null}
+          {profile.default ? (
+            <span className="settings-pathrow__chip settings-pathrow__chip--warn">
+              Startup default
+            </span>
+          ) : null}
+        </div>
+        <div className="settings-profile-card__actions">
+          <button
+            className="button button--secondary settings-profile-card__button"
+            disabled={props.busy || profile.default}
+            type="button"
+            onClick={props.onUseDefault}
+          >
+            Use on startup
+          </button>
+          <button
+            className="button button--secondary settings-profile-card__button"
+            disabled={props.busy || !canOpen}
+            type="button"
+            onClick={props.onOpen}
+          >
+            Open
+          </button>
+          {/*
+            Delete is the one irreversible action on this pane. It keeps a
+            visible button — it is not worth hiding behind a menu — but sits
+            past a wider gap so it is not a misclick neighbour of Open.
+          */}
+          <button
+            className="button button--ghost settings-profile-card__button settings-danger-button settings-profile-card__button--apart"
+            disabled={props.busy || !profile.canDelete}
+            type="button"
+            onClick={props.onDelete}
+          >
+            Delete
+          </button>
         </div>
       </div>
-      <div className="settings-pathrow__chips">
-        {profile.active ? (
-          <span className="settings-pathrow__chip settings-pathrow__chip--ok">
-            Active
-          </span>
-        ) : null}
-        {profile.default ? (
-          <span className="settings-pathrow__chip settings-pathrow__chip--warn">
-            Startup default
-          </span>
-        ) : null}
-      </div>
-      <div className="settings-profile-row__actions">
-        <button
-          className="button button--secondary settings-profile-row__button"
-          disabled={props.busy || profile.default}
-          type="button"
-          onClick={props.onUseDefault}
-        >
-          Use on startup
-        </button>
-        <button
-          className="button button--secondary settings-profile-row__button"
-          disabled={props.busy || !canOpen}
-          type="button"
-          onClick={props.onOpen}
-        >
-          Open
-        </button>
-        <button
-          className="button button--ghost settings-profile-row__button settings-profile-row__button--danger"
-          disabled={props.busy || !profile.canDelete}
-          type="button"
-          onClick={props.onDelete}
-        >
-          Delete
-        </button>
+      <p className="settings-profile-card__where">
+        <SettingsSplitPath
+          className="settings-profile-card__path"
+          title={profile.profileDir}
+          value={tildifyPath(profile.profileDir)}
+        />
+        <span aria-hidden="true" className="settings-profile-card__dot">
+          ·
+        </span>
+        <span className="settings-profile-card__when">{lastUsed}</span>
+      </p>
+      <div className="settings-profile-card__codex">
+        <span className="settings-profile-card__codex-label">Codex auth</span>
+        {props.codexProfileControl}
       </div>
     </div>
   );
@@ -283,7 +296,7 @@ function ProfileDeleteDialog(props: {
             Cancel
           </button>
           <button
-            className="button button--ghost settings-profile-row__button--danger"
+            className="button button--ghost settings-danger-button"
             disabled={props.busy}
             type="button"
             onClick={props.onConfirm}

--- a/apps/desktop/src/renderer/src/features/settings/ProfilesSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ProfilesSettings.tsx
@@ -242,7 +242,18 @@ function PwrAgentProfileCard(props: {
         <span className="settings-profile-card__when">{lastUsed}</span>
       </p>
       <div className="settings-profile-card__codex">
-        <span className="settings-profile-card__codex-label">Codex auth</span>
+        {/*
+          Sighted-only: the select carries the full name ("Codex auth
+          profile for <name>") on its own `aria-label`, so announcing this
+          span too would read the same words twice, the first time as text
+          with no owner.
+        */}
+        <span
+          aria-hidden="true"
+          className="settings-profile-card__codex-label"
+        >
+          Codex auth
+        </span>
         {props.codexProfileControl}
       </div>
     </div>

--- a/apps/desktop/src/renderer/src/features/settings/SettingsSplitPath.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsSplitPath.tsx
@@ -1,0 +1,41 @@
+/**
+ * A filesystem path that truncates in the middle rather than at the tail.
+ *
+ * `text-overflow: ellipsis` always eats the end of the string, which for a
+ * path is the only part that identifies it: three profile directories under
+ * one long temp home clip to the same visible prefix. Splitting at the last
+ * separator and pinning that final segment keeps `/default`, `/work`,
+ * `/.codex` on screen and ellipsizes the shared prefix instead.
+ *
+ * The full value stays on the container's `title`, and the two spans have no
+ * separator between them, so the accessible name and any text selection read
+ * as the original path.
+ */
+export function SettingsSplitPath(props: {
+  className?: string;
+  /** Display form — usually `tildifyPath(value)`. */
+  value: string;
+  /** Hover/`title` form. Defaults to `value`. Pass the untildified path. */
+  title?: string;
+}) {
+  const separator = Math.max(
+    props.value.lastIndexOf("/"),
+    props.value.lastIndexOf("\\"),
+  );
+  // `> 0` rather than `>= 0`: a root-level `/work` has nothing to ellipsize,
+  // so it stays one span instead of becoming an empty head plus the whole
+  // value pinned, which would size the box to the full string.
+  const split = separator > 0;
+  const head = split ? props.value.slice(0, separator) : props.value;
+  const tail = split ? props.value.slice(separator) : "";
+
+  return (
+    <span
+      className={`settings-splitpath${props.className ? ` ${props.className}` : ""}`}
+      title={props.title ?? props.value}
+    >
+      <span className="settings-splitpath__head">{head}</span>
+      {tail ? <span className="settings-splitpath__tail">{tail}</span> : null}
+    </span>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/SettingsSplitPath.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/SettingsSplitPath.test.tsx
@@ -1,0 +1,69 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { SettingsSplitPath } from "../SettingsSplitPath";
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * The split is what makes middle truncation possible in pure CSS: the head
+ * ellipsizes, the tail is pinned. Getting the boundary wrong is invisible
+ * until a path is long enough to clip, which is exactly when it matters.
+ */
+describe("SettingsSplitPath", () => {
+  const parts = (path: string) => {
+    const { container } = render(<SettingsSplitPath value={path} />);
+    return {
+      head: container.querySelector(".settings-splitpath__head")?.textContent,
+      tail: container.querySelector(".settings-splitpath__tail")?.textContent,
+      text: container.querySelector(".settings-splitpath")?.textContent,
+    };
+  };
+
+  it("pins the last POSIX segment", () => {
+    expect(parts("/Users/operator/.pwragent/profiles/work")).toEqual({
+      head: "/Users/operator/.pwragent/profiles",
+      tail: "/work",
+      text: "/Users/operator/.pwragent/profiles/work",
+    });
+  });
+
+  it("pins the last Windows segment", () => {
+    expect(parts("C:\\Users\\operator\\.pwragent\\profiles\\work")).toEqual({
+      head: "C:\\Users\\operator\\.pwragent\\profiles",
+      tail: "\\work",
+      text: "C:\\Users\\operator\\.pwragent\\profiles\\work",
+    });
+  });
+
+  it("keeps a root-level path whole", () => {
+    // Splitting at index 0 would leave an empty head and pin the entire
+    // string, which sizes the box to the full value and defeats the point.
+    expect(parts("/work")).toEqual({
+      head: "/work",
+      tail: undefined,
+      text: "/work",
+    });
+  });
+
+  it("keeps a value with no separator whole", () => {
+    expect(parts("~")).toEqual({ head: "~", tail: undefined, text: "~" });
+  });
+
+  it("carries the untruncated value on title, defaulting to the display value", () => {
+    render(
+      <SettingsSplitPath
+        title="/var/folders/07/abc/.pwragent/profiles/default"
+        value="~/.pwragent/profiles/default"
+      />,
+    );
+    expect(
+      screen.getByTitle("/var/folders/07/abc/.pwragent/profiles/default"),
+    ).toBeInTheDocument();
+
+    render(<SettingsSplitPath value="~/.codex" />);
+    expect(screen.getByTitle("~/.codex")).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/SettingsSplitPath.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/SettingsSplitPath.test.tsx
@@ -52,7 +52,7 @@ describe("SettingsSplitPath", () => {
     expect(parts("~")).toEqual({ head: "~", tail: undefined, text: "~" });
   });
 
-  it("carries the untruncated value on title, defaulting to the display value", () => {
+  it("carries the untruncated value on title when the display value is tildified", () => {
     render(
       <SettingsSplitPath
         title="/var/folders/07/abc/.pwragent/profiles/default"
@@ -62,7 +62,9 @@ describe("SettingsSplitPath", () => {
     expect(
       screen.getByTitle("/var/folders/07/abc/.pwragent/profiles/default"),
     ).toBeInTheDocument();
+  });
 
+  it("falls back to the display value when no title is given", () => {
     render(<SettingsSplitPath value="~/.codex" />);
     expect(screen.getByTitle("~/.codex")).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -5447,11 +5447,13 @@ describe("SettingsScreen", () => {
     });
 
     expect(await screen.findByText("scratch")).toBeInTheDocument();
-    expect(screen.getByText("/home/example/.pwragent/profiles/dev")).toBeInTheDocument();
+    expect(
+      screen.getByTitle("/home/example/.pwragent/profiles/dev"),
+    ).toBeInTheDocument();
 
     const scratchRow = screen
       .getByText("scratch")
-      .closest(".settings-profile-row") as HTMLElement;
+      .closest(".settings-profile-card") as HTMLElement;
     expect(
       within(scratchRow).getByRole("combobox", {
         name: "Codex auth profile for scratch",
@@ -5558,9 +5560,12 @@ describe("SettingsScreen", () => {
       />,
     );
 
+    // The path renders as a head + pinned tail pair for middle
+    // truncation, so its text is split across two spans; the container
+    // carries the untruncated value on `title`.
     const workRow = screen
-      .getByText("/home/example/.pwragent/profiles/work")
-      .closest(".settings-profile-row") as HTMLElement;
+      .getByTitle("/home/example/.pwragent/profiles/work")
+      .closest(".settings-profile-card") as HTMLElement;
     fireEvent.click(within(workRow).getByRole("button", { name: "Use on startup" }));
 
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/settings-shrink-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/settings-shrink-contract.test.ts
@@ -51,11 +51,37 @@ describe("settings panel shrink contract", () => {
     ".settings-profile-card__ident",
     ".settings-profile-card__where",
     ".settings-profile-card__codex",
+    // The leaf, not just the containers. This is the one actually holding
+    // a nowrap run — a container that can shrink around a child that
+    // cannot has not solved anything. Both path call sites compose this
+    // class, so asserting it here covers them without each re-declaring
+    // the property.
+    ".settings-splitpath",
   ])("lets %s shrink below its content", (selector) => {
     // A flex child's `min-width: auto` is its content size, so dropping any
     // one of these puts the nowrap paths and buttons back in charge of the
     // card's width and the clip starts eating them again.
     expect(ruleBody(selector)).toMatch(/min-width:\s*0/);
+  });
+
+  it("clips the split path rather than letting it size the row", () => {
+    // `min-width: 0` alone is not enough for a nowrap run: without the
+    // clip the head span still paints past the box it was shrunk into.
+    const body = ruleBody(".settings-splitpath");
+    expect(body).toMatch(/overflow:\s*hidden/);
+    expect(ruleBody(".settings-splitpath__head")).toMatch(
+      /text-overflow:\s*ellipsis/,
+    );
+    // The tail is pinned — that is the whole point of the split.
+    expect(ruleBody(".settings-splitpath__tail")).toMatch(/flex:\s*0 0 auto/);
+  });
+
+  it("keeps the codex auth select legible when the row cannot wrap further", () => {
+    // `.settings-select` sets `min-width: 0`; this rule is the floor that
+    // stops the control shrinking past a usable width in a narrow window.
+    expect(ruleBody(".settings-codex-profile-select__control")).toMatch(
+      /min-width:\s*(?!0)\d+px/,
+    );
   });
 });
 
@@ -65,20 +91,16 @@ describe("settings panel shrink contract", () => {
  * the profile row's three never did, so they rendered at 16px in a pane
  * whose largest body text is 13.5px. That is the "chonky" half of the same
  * report.
+ *
+ * The real fix is a `font-size` on `.button` itself; until that lands, this
+ * asserts the local override is present. It deliberately pins only rules
+ * this pane owns — a neighbouring button's size is not this contract's to
+ * hold.
  */
 describe("settings button scale", () => {
   it("sizes the profile card's actions to the pane, not the UA default", () => {
     const body = ruleBody(".settings-profile-card__button");
     expect(body).toMatch(/font-size:\s*12px/);
     expect(body).toMatch(/min-height:\s*28px/);
-  });
-
-  it("keeps the settings bulk controls at their own smaller scale", () => {
-    // The neighbour this is measured against. If someone normalizes the two
-    // to one size, that is a deliberate design change and both rows of this
-    // contract should move together.
-    expect(ruleBody(".settings-section-controls__button")).toMatch(
-      /font-size:\s*11px/,
-    );
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/settings-shrink-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/settings-shrink-contract.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Locks the declarations that let a settings panel narrow to its column.
+ *
+ * The bug this exists to prevent: `.settings-section__body-clip` is a grid
+ * with `overflow: hidden`, and with no `grid-template-columns` its implicit
+ * `auto` track's minimum is the body's min-content width. A panel holding a
+ * nowrap run — a filesystem path, a row of nowrap buttons — therefore sized
+ * the track to its own content and the clip ate the tail. The Profiles pane
+ * rendered its row at 1261px inside a 1202px column at 1440, 1200, 1000 and
+ * 880px windows alike, which left 5 of the Delete button's 69px on screen.
+ * The docs screenshot recapture is what caught it.
+ *
+ * `minmax(0, 1fr)` is identical to `auto` whenever the content fits (both
+ * stretch to the column), so this only changes the over-wide case — but
+ * nothing in a render test can see it, because jsdom does no layout. Only
+ * the stylesheet can be asserted here.
+ */
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+/** Body of the first top-level CSS rule whose selector matches exactly. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+describe("settings panel shrink contract", () => {
+  it("gives the collapsible body a column track with no min-content floor", () => {
+    const body = ruleBody(".settings-section__body-clip");
+    // The `overflow: hidden` is what makes the track floor destructive
+    // rather than merely wide — if it ever goes away this assertion has
+    // lost its subject and should be revisited, not deleted.
+    expect(body).toContain("overflow: hidden");
+    expect(body).toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+  });
+
+  it.each([
+    ".settings-profile-card",
+    ".settings-profile-card__head",
+    ".settings-profile-card__ident",
+    ".settings-profile-card__where",
+    ".settings-profile-card__codex",
+  ])("lets %s shrink below its content", (selector) => {
+    // A flex child's `min-width: auto` is its content size, so dropping any
+    // one of these puts the nowrap paths and buttons back in charge of the
+    // card's width and the clip starts eating them again.
+    expect(ruleBody(selector)).toMatch(/min-width:\s*0/);
+  });
+});
+
+/**
+ * `button { font: inherit }` with no root `font-size` lands every `.button`
+ * on the 16px UA default. Every other button in Settings sets its own size;
+ * the profile row's three never did, so they rendered at 16px in a pane
+ * whose largest body text is 13.5px. That is the "chonky" half of the same
+ * report.
+ */
+describe("settings button scale", () => {
+  it("sizes the profile card's actions to the pane, not the UA default", () => {
+    const body = ruleBody(".settings-profile-card__button");
+    expect(body).toMatch(/font-size:\s*12px/);
+    expect(body).toMatch(/min-height:\s*28px/);
+  });
+
+  it("keeps the settings bulk controls at their own smaller scale", () => {
+    // The neighbour this is measured against. If someone normalizes the two
+    // to one size, that is a deliberate design change and both rows of this
+    // contract should move together.
+    expect(ruleBody(".settings-section-controls__button")).toMatch(
+      /font-size:\s*11px/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9228,6 +9228,17 @@ textarea,
 .settings-section__body-clip {
   display: grid;
   overflow: hidden;
+  /*
+   * The column track is load-bearing. Left implicit, it is an `auto` track
+   * whose minimum is the body's min-content width, so a panel holding a
+   * nowrap run — a filesystem path, a row of nowrap buttons — sizes the
+   * track to that content and `overflow: hidden` above eats the tail. The
+   * Profiles pane rendered its row at 1261px in a 1202px column at every
+   * window size, which clipped 64 of the Delete button's 69px. `minmax(0,
+   * 1fr)` drops the min-content floor so the body tracks the column and the
+   * shrinkable children inside it can actually shrink.
+   */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: 1fr;
   opacity: 1;
   transition:
@@ -10673,52 +10684,184 @@ textarea,
   flex: 0 0 auto;
 }
 
-.settings-profile-row {
-  align-items: flex-start;
-}
+/* ------------------------------------------------------------------
+   PROFILE CARD (Settings -> Profiles)
 
-.settings-profile-row__meta {
-  display: block;
-  margin-top: 4px;
-  color: var(--text-muted);
-  font-size: 11.5px;
-  line-height: 1.3;
-}
+   Three lines, in the order the questions get asked: which profile
+   (name + state + actions), where and when (path + last used), and
+   which Codex identity it runs as.
 
-.settings-profile-row__codex {
-  display: grid;
-  gap: 6px;
-  margin-top: 10px;
-}
+   This replaced a `.settings-pathrow` variant that stacked eight
+   blocks for four facts and measured 219px per profile. The pathrow
+   primitive is built for one title + one path + chips + one action;
+   a profile also carries a control, a second path, a second chip set,
+   and three actions, which is a different shape rather than a denser
+   one.
+   ------------------------------------------------------------------ */
 
-.settings-profile-row__label {
-  color: var(--text-muted);
-  font-size: 11px;
-  font-weight: 650;
-  line-height: 1.2;
-  text-transform: uppercase;
-}
-
-.settings-profile-row__actions {
+.settings-profile-card {
   display: flex;
+  flex-direction: column;
+  gap: 8px;
+  /* Load-bearing with `.settings-section__body-clip`'s `minmax(0, 1fr)`:
+     the card must be allowed below its own min-content width, or the
+     nowrap paths and buttons inside it push it back past the clip. */
+  min-width: 0;
+  padding: 11px 13px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-panel-elevated);
+}
+
+.settings-profile-card.is-active {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+}
+
+.settings-profile-card__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+}
+
+/* `flex: 1 1 260px` rather than `1 1 auto`: below ~260px of name the
+   whole action group wraps to its own line instead of the buttons
+   squeezing the name to an ellipsis. */
+.settings-profile-card__ident {
+  display: flex;
+  flex: 1 1 260px;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.settings-profile-card__name {
+  overflow: hidden;
+  color: var(--text-primary);
+  font-size: 13.5px;
+  font-weight: 650;
+  letter-spacing: -0.01em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-profile-card.is-active .settings-profile-card__name {
+  color: var(--accent-bright);
+}
+
+.settings-profile-card__actions {
+  display: inline-flex;
   flex: 0 0 auto;
   align-items: center;
   gap: 6px;
 }
 
-.settings-profile-row__button {
-  min-height: 30px;
+/*
+ * `button { font: inherit }` with no root font-size lands every
+ * `.button` on the 16px UA default. Every other settings button sets
+ * its own size; these never did, so three 16px labels sat in a 12px
+ * pane. 28px/12px is the pane's own scale.
+ */
+.settings-profile-card__button {
+  min-height: 28px;
   padding: 0 10px;
+  font-size: 12px;
+  font-weight: 550;
   white-space: nowrap;
 }
 
-.settings-profile-row__button--danger {
+/* Delete is the one irreversible action here. Keeping it visible is
+   worth more than hiding it behind a menu, but it should not be a
+   misclick neighbour of Open. */
+.settings-profile-card__button--apart {
+  margin-left: 6px;
+}
+
+.settings-profile-card__where {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  margin: 0;
+}
+
+.settings-profile-card__path {
+  min-width: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+
+.settings-profile-card__dot {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11px;
+  opacity: 0.5;
+}
+
+.settings-profile-card__when {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 11.5px;
+  line-height: 1.35;
+}
+
+.settings-profile-card__codex {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding-top: 9px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-profile-card__codex-label {
+  flex: 0 0 auto;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 650;
+  letter-spacing: 0.09em;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+/* Shared by the profile Delete button and the confirm dialogs that
+   follow it (and by the Plugins pane's remove action). */
+.settings-danger-button {
   border-color: var(--danger-border);
   color: var(--danger-text);
 }
 
-.settings-profile-row__button--danger:hover:not([disabled]) {
+.settings-danger-button:hover:not([disabled]) {
   background: var(--danger-soft);
+}
+
+/* ------------------------------------------------------------------
+   SPLIT PATH — middle truncation for filesystem paths.
+   See `SettingsSplitPath.tsx` for why the tail is pinned.
+   ------------------------------------------------------------------ */
+
+.settings-splitpath {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.settings-splitpath__head {
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-splitpath__tail {
+  flex: 0 0 auto;
 }
 
 .settings-plugin-profile {
@@ -11387,26 +11530,31 @@ textarea,
   font-size: 11px;
 }
 
+/*
+ * The control, the selected profile's home, and its state chips on one
+ * line. This used to be a stacked grid whose second row was a nested
+ * detail card reprinting the display name the select already showed.
+ * `display: contents` lets the three parts participate directly in the
+ * parent's flex row, so the chips can right-align into a column the eye
+ * can run down across profiles.
+ */
 .settings-codex-profile-select {
-  display: grid;
-  gap: 6px;
-  min-width: 0;
+  display: contents;
 }
 
-.settings-codex-profile-details {
-  display: flex;
-  align-items: center;
-  gap: 10px;
+.settings-codex-profile-select__control {
+  flex: 0 1 260px;
+  width: auto;
   min-width: 0;
-  padding: 8px 10px;
-  border: 1px solid var(--border-subtle);
-  border-radius: 6px;
-  background: var(--bg-panel-elevated);
+  height: 28px;
+  font-size: 11.5px;
 }
 
-.settings-codex-profile-details__body {
-  flex: 1;
-  min-width: 0;
+.settings-codex-profile-select__home {
+  flex: 1 1 120px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 
 .settings-codex-profile-dialog .settings-input,
@@ -11450,17 +11598,9 @@ textarea,
     justify-content: space-between;
   }
 
-  .settings-profile-row,
-  .settings-profile-row__actions,
-  .settings-codex-profile-details {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .settings-profile-row__actions,
-  .settings-profile-row__button {
-    width: 100%;
-  }
+  /* The profile card wraps on its own now that the section body no
+     longer floors at min-content, so it needs no stacking override
+     here — see `.settings-profile-card__head`. */
 }
 
 /* Composer-options list — full-width radio cards. Each option is its

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10718,6 +10718,12 @@ textarea,
   background: var(--bg-row-active);
 }
 
+/* This wrap is what replaced the old `@media (max-width: 760px)` block
+   that stacked the row and forced every action full-width. The action
+   group's flex base size is fixed, so the head breaks to a second line
+   on its own once the ident's 260px basis no longer fits beside it —
+   no breakpoint, and it tracks the real card width rather than the
+   window's. */
 .settings-profile-card__head {
   display: flex;
   flex-wrap: wrap;
@@ -10787,8 +10793,9 @@ textarea,
   margin: 0;
 }
 
+/* `min-width: 0` and the overflow clip come from `.settings-splitpath`,
+   which this class is always composed with. */
 .settings-profile-card__path {
-  min-width: 0;
   color: var(--text-muted);
   font-family: var(--font-mono);
   font-size: 11.5px;
@@ -11537,15 +11544,28 @@ textarea,
  * `display: contents` lets the three parts participate directly in the
  * parent's flex row, so the chips can right-align into a column the eye
  * can run down across profiles.
+ *
+ * CONTRACT: because this box is erased, `CodexAuthProfileSelect` emits
+ * three siblings that the PARENT lays out. It must be rendered inside a
+ * wrapping flex row (see `.settings-profile-card__codex`). Dropping it
+ * into a block or grid container yields three stacked children with no
+ * error and no failing test — the component's JSDoc says so too.
  */
 .settings-codex-profile-select {
   display: contents;
 }
 
+/*
+ * `min-width` beats the `0` inherited from `.settings-select`. Without a
+ * floor the control keeps shrinking once the codex line can no longer
+ * relieve pressure by wrapping (below roughly a 400px pane, reachable
+ * because the window's `minWidth` is `min(960, restoredWidth)`), and a
+ * select narrower than its own caret is not a control any more.
+ */
 .settings-codex-profile-select__control {
   flex: 0 1 260px;
   width: auto;
-  min-width: 0;
+  min-width: 140px;
   height: 28px;
   font-size: 11.5px;
 }
@@ -11598,9 +11618,6 @@ textarea,
     justify-content: space-between;
   }
 
-  /* The profile card wraps on its own now that the section body no
-     longer floors at min-content, so it needs no stacking override
-     here — see `.settings-profile-card__head`. */
 }
 
 /* Composer-options list — full-width radio cards. Each option is its


### PR DESCRIPTION
The docs screenshot recapture caught the `Delete` button running off the right edge of **Settings → Profiles**. The clip is a container bug, not a button bug — and measuring it turned up two more things in the same pane.

## What was wrong

Measured in headless Chromium with the real `ProfilesSettings` mounted against the real `app.css`, at the docs capture size (1440 × 900):

| Defect | Measured | Cause |
|---|---|---|
| Actions clipped | Delete 69 px wide, **5 px inside the clip** | `.settings-section__body-clip` is `display: grid; overflow: hidden` with no `grid-template-columns`. Its implicit `auto` track floors at the body's min-content width, so the row was **1261 px at 1440, 1200, 1000 and 880 px windows alike** and the clip ate whatever hung past 1202 px. |
| Buttons oversized | 16 px text in a 12 px pane | `button { font: inherit }` plus no root `font-size` lands every `.button` on the 16 px UA default. Every sibling settings button sets one (`.settings-section-controls__button` is 11 px); `.settings-profile-row__button` never did. |
| Rows tall | **219 px** per row, 698 px for three | Eight stacked blocks for four facts. |
| Card inside a card | 52 px detail box | Reprinted the display name the select above it already showed, on the same elevation as its parent. |
| Control out of scale | 778 px select | Full body width for a 24-character value. |
| Repeated boilerplate | × 1 per profile | "Applies the next time this PwrAgent profile launches." is a property of the feature, not of a profile. |
| Status far from subject | ≈ 700 px apart | `Active` / `Startup default` sat at the far right, separated from the name they qualify by the whole body column. |

## What changed

**The container fix** — `grid-template-columns: minmax(0, 1fr)` on `.settings-section__body-clip`. This is identical to `auto` whenever the content already fits (both stretch to the column), so it only changes the over-wide case: a panel that previously overflowed into `overflow: hidden` now shrinks to fit. Strictly an improvement for every pane that shares the primitive.

**The pane redesign** — the row is now a three-line card in the order the questions get asked:

- name + state chips + actions
- path + last used
- Codex identity on one line: label, a 260 px control, the codex home, and the status chips right-aligned into a column

Actions drop to 28 px / 12 px, and `Delete` keeps its danger colour and gains a wider gap so it is not a misclick neighbour of `Open`. The nested detail box is gone; the repeated helper sentence moved into the section description. **123 px per card**, wrapping rather than clipping down to 760 px.

**Paths** are tildified and truncate in the middle. `text-overflow: ellipsis` always eats the end of a path, which is the only part that identifies it — three profile directories under one long temp home clip to the same visible prefix. `SettingsSplitPath` splits at the last separator and pins the tail, with the full value on `title`.

## Verification

- Cards track the column at 1440 / 1200 / 1000 / 880 / 760 px; **0 elements overflow the clip** at any of them, and the document never scrolls horizontally.
- axe (`wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa`) clean in **both themes** at 1440 and 880.
- Busy state stays scoped to the acted-on profile; delete + create dialogs unchanged.
- `pnpm test` — 653 files, 9649 passed. `typecheck`, `lint:eslint` (0 errors), `lint:boundaries`, `lint:colors`, `lint:sql`, `lint:codex-storage` all pass.
- New `settings-shrink-contract.test.ts` **fails on the pre-fix stylesheet** with the grid-track assertion — negative-controlled, not written to agree with the fix.

`pnpm licenses:check` fails in this worktree on a stale `@napi-rs/canvas` install path; no dependency was touched by this change.

## Not in this PR

The pane head's action button (`Add profile`) is still the 16 px UA default sitting next to the 11 px bulk controls — same defect class, but `.settings-head__action` is shared by every pane and changing it would alter several committed docs screenshots. Worth a follow-up.

## Design review

Findings, the measured "as built" recreation showing the real cut, and the proposed card are in the **PwrAgent** Claude Design project as *Settings Profiles UX Review*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)