### PR TITLE
fix(desktop): put every top-of-window chrome bar on one band

### DIFF
--- a/apps/desktop/e2e/star-map-thread-flow.spec.ts
+++ b/apps/desktop/e2e/star-map-thread-flow.spec.ts
@@ -159,6 +159,13 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
   // checks above both stayed green through it, because wrapped chips
   // overlap nothing. Measure the band against its tallest slot: equal
   // means the slots sit side by side, taller means something wrapped.
+  //
+  // The band also reserves `--chrome-band-h`, so its row centres on the
+  // same line the window's stoplights sit on. That floor is the OTHER
+  // legitimate reason for the band to exceed its tallest slot, so read it
+  // off the element rather than pinning a number here — the check is still
+  // exact, and a stacked second row clears the floor on its own (two 25px
+  // slots plus the 12px gap is 62 against a 40px reservation).
   const rowHeight = await mapWindow.evaluate(() => {
     const band = document.querySelector(".star-map__top-band");
     if (!band) return undefined;
@@ -168,14 +175,16 @@ async function expectTopBandLaidOut(mapWindow: Page, at: string): Promise<void> 
     return {
       band: Math.round(band.getBoundingClientRect().height - padding),
       tallestSlot: Math.round(Math.max(...slots)),
+      reserved: Math.round((parseFloat(style.minHeight) || 0) - padding),
     };
   });
   expect(
     rowHeight,
     `top band is taller than one row ${at}: ${JSON.stringify(rowHeight)}`,
   ).toEqual({
-    band: rowHeight?.tallestSlot,
+    band: Math.max(rowHeight?.tallestSlot ?? 0, rowHeight?.reserved ?? 0),
     tallestSlot: rowHeight?.tallestSlot,
+    reserved: rowHeight?.reserved,
   });
 
   // Which of the two filter renderings shows is a property of the data —

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8df1f979ed894eb6ef68fb2b5406d99f42d383778687074eabf1eb11171c1279
-size 128662
+oid sha256:3aff25be51395899b39c7331aaf0c7759c7cb9398d832dbf24ff391363a32fb8
+size 123946

--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3aff25be51395899b39c7331aaf0c7759c7cb9398d832dbf24ff391363a32fb8
-size 123946
+oid sha256:230c01396a1f445f493d9fab9e426af7956ff138ac7658c4b6bb35aafd18a22b
+size 124714

--- a/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
@@ -232,6 +232,29 @@ describe("macOS window chrome", () => {
     }
   });
 
+  it("gives the chrome row equal air above and below it", () => {
+    // A band centred in `--chrome-band-h` puts the same air above and
+    // below its row, and then the next thing down adds its own — so the
+    // window's top edge, which contributes nothing, ends up the tight
+    // side. Two surfaces paid for that and both are asserted here.
+
+    // The Star Map's glass strip IS its title bar, so its height is the
+    // band; at 52px it left 8.5px over the chips and 20.5px under them.
+    expect(
+      ruleFor(".star-map-window__titlebar").join("\n"),
+      "the Star Map drag strip should be the shared band",
+    ).toContain("height: var(--chrome-band-h);");
+
+    // The rail's first row does not re-pad against the masthead. Every
+    // other boundary there is paid twice (6px each side); the top edge
+    // pays once, so this row's own 6px put 12px under the buttons and 6
+    // above them.
+    expect(
+      paddingOf(ruleFor(".sidebar__masthead + .runtime-identity"), "top"),
+      "the row under the masthead should not re-pad against the band",
+    ).toBe("0");
+  });
+
   it("keeps the Windows caption strip taller than its OS overlay", () => {
     // On win32 `.activity-titlebar` IS the Window Controls Overlay strip,
     // and this change moved its height onto `--chrome-band-h`. The OS draws

--- a/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
@@ -15,34 +15,74 @@ const css = readFileSync(
 const windowSource = readFileSync(path.resolve(testDir, "../window.ts"), "utf8");
 
 /**
- * Every top-level declaration block for a selector, concatenated. Several of
- * these bars are declared twice (once grouped for the drag region, once for
- * layout), so a single-block lookup would read the wrong half.
+ * Every top-level declaration block for a selector, in source order. Several
+ * of these bars are declared twice (once grouped for the drag region, once
+ * for layout), so a single-block lookup would read the wrong half — and
+ * because CSS resolves them by source order, the helpers below have to walk
+ * all of them rather than stopping at the first hit.
  */
-function ruleFor(selector: string): string {
+function ruleFor(selector: string): string[] {
   const blocks: string[] = [];
   const needle = `\n${selector} {`;
   for (let i = css.indexOf(needle); i !== -1; i = css.indexOf(needle, i + 1)) {
     blocks.push(css.slice(i, css.indexOf("\n}", i)));
   }
   if (blocks.length === 0) throw new Error(`app.css has no ${selector} rule`);
-  return blocks.join("\n");
+  return blocks;
 }
+
+/** Whether `selector` declares `declaration` in any of its blocks. */
+function declares(blocks: string[], declaration: string): boolean {
+  return blocks.some((block) => block.includes(declaration));
+}
+
+/** The value a rule ends up with for one property: the last one declared wins. */
+function lastValueOf(blocks: string[], property: string): string | undefined {
+  let value: string | undefined;
+  for (const block of blocks) {
+    const pattern = new RegExp(`\\n\\s*${property}:\\s*([^;]+);`, "g");
+    for (const match of block.matchAll(pattern)) value = match[1].trim();
+  }
+  return value;
+}
+
+const PADDING_SIDES = ["top", "right", "bottom", "left"] as const;
+type PaddingSide = (typeof PADDING_SIDES)[number];
 
 /**
- * The top padding a rule sets, via either the longhand or the shorthand's
- * first value. One-sided top padding is what pushed these bars below their
- * own centre, so the band test asserts every one of them leaves it at 0.
+ * The padding a rule ends up with on one side, resolved the way the cascade
+ * resolves it: a later shorthand overrides an earlier longhand and vice
+ * versa. One-sided top padding is what pushed these bars below their own
+ * centre, so reading it correctly is the whole point of the band test.
  */
-function topPaddingOf(rule: string): string {
-  const longhand = /padding-top:\s*([^;]+);/.exec(rule);
-  if (longhand) return longhand[1].trim();
-  const shorthand = /\n\s*padding:\s*([^;]+);/.exec(rule);
-  if (shorthand) return shorthand[1].trim().split(/\s+/)[0];
-  return "0";
+function paddingOf(blocks: string[], side: PaddingSide): string {
+  const index = PADDING_SIDES.indexOf(side);
+  let value = "0";
+  for (const block of blocks) {
+    const pattern = /\n\s*padding(-top|-right|-bottom|-left)?:\s*([^;]+);/g;
+    for (const match of block.matchAll(pattern)) {
+      const declared = match[2].trim();
+      if (match[1]) {
+        if (match[1] === `-${side}`) value = declared;
+        continue;
+      }
+      // Shorthand fill order: 1 value is every side, 2 is vertical then
+      // horizontal, 3 adds a separate bottom, 4 is top/right/bottom/left.
+      const parts = declared.split(/\s+/);
+      value = [
+        parts[0],
+        parts[1] ?? parts[0],
+        parts[2] ?? parts[0],
+        parts[3] ?? parts[1] ?? parts[0],
+      ][index];
+    }
+  }
+  return value;
 }
 
-const originalPlatform = process.platform;
+function px(value: string): number {
+  return Number.parseFloat(value) || 0;
+}
 
 /**
  * macOS stoplight metrics, measured off a live screen capture: each button
@@ -56,11 +96,36 @@ const BUTTON_PITCH = 23;
 /** `--chrome-band-h` in app.css — the band every top-of-window bar centres in. */
 const CHROME_BAND = 40;
 
+/**
+ * Every bar that sits on the band, with the flex axis that carries its
+ * vertical centring: a row centres on the cross axis, a column on the main
+ * one. `.thread-header` is the column.
+ */
+const CHROME_BARS = [
+  ".sidebar__masthead",
+  ".thread-header",
+  ".activity-titlebar",
+  ".settings-nav__masthead",
+  ".settings-titlebar",
+  ".star-map__top-band",
+] as const;
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+  process,
+  "platform",
+);
+
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", {
     configurable: true,
     value: platform,
   });
+}
+
+function restorePlatform(): void {
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
 }
 
 /**
@@ -71,7 +136,7 @@ function setPlatform(platform: NodeJS.Platform): void {
  */
 describe("macOS window chrome", () => {
   afterEach(() => {
-    setPlatform(originalPlatform);
+    restorePlatform();
   });
 
   it("starts the stoplights on the sidebar's own rail", () => {
@@ -97,29 +162,87 @@ describe("macOS window chrome", () => {
     // A bar that opts out of the band, or re-introduces one-sided padding
     // to position its content, silently drops off the shared centreline —
     // which is exactly how these four drifted to 24 / 24 / 26.5 / 27.
-    for (const bar of [
-      ".sidebar__masthead",
-      ".thread-header",
-      ".activity-titlebar",
-      ".settings-nav__masthead",
-      ".settings-titlebar",
-    ]) {
-      const rule = ruleFor(bar);
-      expect(rule, `${bar} should declare the shared band`).toContain(
-        "min-height: var(--chrome-band-h);",
-      );
-      expect(topPaddingOf(rule), `${bar} should not pad its content off centre`)
-        .toBe("0");
+    for (const bar of CHROME_BARS) {
+      const blocks = ruleFor(bar);
+      expect(
+        declares(blocks, "min-height: var(--chrome-band-h);"),
+        `${bar} should declare the shared band`,
+      ).toBe(true);
+      expect(
+        paddingOf(blocks, "top"),
+        `${bar} should not pad its content off centre`,
+      ).toBe("0");
     }
   });
 
-  it("keeps the 80px masthead reservation clear of the button group", () => {
-    // Three 14px buttons on a 23px pitch: the group ends at x=76, inside
-    // the 80px every masthead reserves for it.
+  it("centres every chrome bar's content in the band", () => {
+    // The band alone does not put anything on the centreline; the centring
+    // does. `.sidebar__masthead, .thread-header` is declared `flex-start`
+    // for the drag region, and only each bar's own block overrides that —
+    // drop the override and the band stays 40px while the content pins to
+    // its top edge, 20px above the stoplights.
+    for (const bar of CHROME_BARS) {
+      const blocks = ruleFor(bar);
+      // In a row the vertical axis is the cross axis; in a column it is
+      // the main one. Read the direction rather than listing exceptions.
+      const axis =
+        lastValueOf(blocks, "flex-direction") === "column"
+          ? "justify-content"
+          : "align-items";
+      expect(
+        lastValueOf(blocks, axis),
+        `${bar} should centre its content with ${axis}`,
+      ).toBe("center");
+    }
+  });
+
+  it("keeps every masthead's stoplight reservation clear of the buttons", () => {
+    // Three 14px buttons on a 23px pitch: the group ends at x=76.
     const groupEnd =
       MACOS_TRAFFIC_LIGHT_POSITION.x + 2 * BUTTON_PITCH + BUTTON_SIZE;
     expect(groupEnd).toBe(76);
-    expect(css).toContain("padding-left: 80px;");
+
+    // Every bar that shares its top row with the stoplights lands its brand
+    // at x=96 from the window edge, each through its own container's inset:
+    // the sidebar's 16px rail, the Settings nav's tighter 8px lane, the
+    // Activity title bar flat against the edge, and the Star Map band's own
+    // 16px padding. The reservations differ; the resulting x must not.
+    const brandX: Array<[string, number]> = [
+      [".sidebar__masthead", 16 + px(paddingOf(ruleFor(".sidebar__masthead"), "left"))],
+      [
+        ".settings-nav__masthead",
+        8 + px(paddingOf(ruleFor(".settings-nav__masthead"), "left")),
+      ],
+      [".activity-titlebar", px(paddingOf(ruleFor(".activity-titlebar"), "left"))],
+      [
+        ".star-map__chrome",
+        px(paddingOf(ruleFor(".star-map__top-band"), "left"))
+          + px(
+            paddingOf(
+              ruleFor(':root[data-platform="darwin"] .star-map__chrome'),
+              "left",
+            ),
+          ),
+      ],
+    ];
+
+    for (const [bar, x] of brandX) {
+      expect(x, `${bar} should put its brand at x=96`).toBe(96);
+      expect(x, `${bar} should clear the button group`).toBeGreaterThan(groupEnd);
+    }
+  });
+
+  it("keeps the Windows caption strip taller than its OS overlay", () => {
+    // On win32 `.activity-titlebar` IS the Window Controls Overlay strip,
+    // and this change moved its height onto `--chrome-band-h`. The OS draws
+    // the caption buttons at `TITLE_BAR_OVERLAY_HEIGHT` (native-appearance.ts,
+    // mirrored by `--win-titlebar-h`), so a shorter band would leave them
+    // hanging past the strip's bottom border and its --bg-sidebar blend.
+    const overlay = /--win-titlebar-h:\s*(\d+)px;/.exec(css);
+    expect(overlay, "app.css should declare --win-titlebar-h").not.toBeNull();
+    const band = /--chrome-band-h:\s*(\d+)px;/.exec(css);
+    expect(band, "app.css should declare --chrome-band-h").not.toBeNull();
+    expect(Number(band?.[1])).toBeGreaterThanOrEqual(Number(overlay?.[1]));
   });
 
   it("gives auxiliary windows the same chrome as the main window", async () => {
@@ -133,8 +256,10 @@ describe("macOS window chrome", () => {
 
   it("keeps the main window off a hardcoded position", () => {
     // window.ts must reach the position through the shared helper; a
-    // literal here is how the two windows drifted apart before.
-    expect(windowSource).not.toContain("trafficLightPosition");
+    // literal here is how the two windows drifted apart before. Match the
+    // assignment, not the word, so a comment pointing at the helper is
+    // still allowed to name it.
+    expect(windowSource).not.toMatch(/trafficLightPosition\s*:/);
     expect(windowSource).toContain("macosTitleBarChrome()");
   });
 });

--- a/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
@@ -14,6 +14,34 @@ const css = readFileSync(
 );
 const windowSource = readFileSync(path.resolve(testDir, "../window.ts"), "utf8");
 
+/**
+ * Every top-level declaration block for a selector, concatenated. Several of
+ * these bars are declared twice (once grouped for the drag region, once for
+ * layout), so a single-block lookup would read the wrong half.
+ */
+function ruleFor(selector: string): string {
+  const blocks: string[] = [];
+  const needle = `\n${selector} {`;
+  for (let i = css.indexOf(needle); i !== -1; i = css.indexOf(needle, i + 1)) {
+    blocks.push(css.slice(i, css.indexOf("\n}", i)));
+  }
+  if (blocks.length === 0) throw new Error(`app.css has no ${selector} rule`);
+  return blocks.join("\n");
+}
+
+/**
+ * The top padding a rule sets, via either the longhand or the shorthand's
+ * first value. One-sided top padding is what pushed these bars below their
+ * own centre, so the band test asserts every one of them leaves it at 0.
+ */
+function topPaddingOf(rule: string): string {
+  const longhand = /padding-top:\s*([^;]+);/.exec(rule);
+  if (longhand) return longhand[1].trim();
+  const shorthand = /\n\s*padding:\s*([^;]+);/.exec(rule);
+  if (shorthand) return shorthand[1].trim().split(/\s+/)[0];
+  return "0";
+}
+
 const originalPlatform = process.platform;
 
 /**
@@ -24,6 +52,9 @@ const originalPlatform = process.platform;
  */
 const BUTTON_SIZE = 14;
 const BUTTON_PITCH = 23;
+
+/** `--chrome-band-h` in app.css — the band every top-of-window bar centres in. */
+const CHROME_BAND = 40;
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, "platform", {
@@ -51,13 +82,35 @@ describe("macOS window chrome", () => {
     expect(MACOS_TRAFFIC_LIGHT_POSITION.x).toBe(16);
   });
 
-  it("centres the stoplights on the wordmark's cap height", () => {
-    // The masthead is 10px of top padding above a 34px icon-button row, so
-    // the 17px/700 wordmark's cap centre lands at y=23. A 14px button at
-    // y=16 centres at 23 too.
-    expect(css).toContain("padding: 10px 0 0 80px;");
+  it("centres the stoplights in the shared chrome band", () => {
+    // Every top-of-window bar centres its content in `--chrome-band-h`, so
+    // the stoplights centre in it too and land on the same y=20 centreline
+    // as the wordmark, the thread title, and the breadcrumbs.
+    expect(css).toContain("--chrome-band-h: 40px;");
+    const bandCentre = CHROME_BAND / 2;
     const buttonCentre = MACOS_TRAFFIC_LIGHT_POSITION.y + BUTTON_SIZE / 2;
-    expect(buttonCentre).toBe(23);
+    expect(buttonCentre).toBe(bandCentre);
+    expect(buttonCentre).toBe(20);
+  });
+
+  it("keeps every chrome bar on that one band", () => {
+    // A bar that opts out of the band, or re-introduces one-sided padding
+    // to position its content, silently drops off the shared centreline —
+    // which is exactly how these four drifted to 24 / 24 / 26.5 / 27.
+    for (const bar of [
+      ".sidebar__masthead",
+      ".thread-header",
+      ".activity-titlebar",
+      ".settings-nav__masthead",
+      ".settings-titlebar",
+    ]) {
+      const rule = ruleFor(bar);
+      expect(rule, `${bar} should declare the shared band`).toContain(
+        "min-height: var(--chrome-band-h);",
+      );
+      expect(topPaddingOf(rule), `${bar} should not pad its content off centre`)
+        .toBe("0");
+    }
   });
 
   it("keeps the 80px masthead reservation clear of the button group", () => {

--- a/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
+++ b/apps/desktop/src/main/__tests__/macos-window-chrome.test.ts
@@ -1,0 +1,87 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  MACOS_TRAFFIC_LIGHT_POSITION,
+  macosTitleBarChrome,
+} from "../macos-window-chrome";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(
+  path.resolve(testDir, "../../renderer/src/styles/app.css"),
+  "utf8",
+);
+const windowSource = readFileSync(path.resolve(testDir, "../window.ts"), "utf8");
+
+const originalPlatform = process.platform;
+
+/**
+ * macOS stoplight metrics, measured off a live screen capture: each button
+ * occupies a 14px frame and the three sit on a 23px pitch, so the group is
+ * 60px wide. These are the OS's numbers, not ours — they are here so the
+ * derivations below read as arithmetic rather than as magic constants.
+ */
+const BUTTON_SIZE = 14;
+const BUTTON_PITCH = 23;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    value: platform,
+  });
+}
+
+/**
+ * The stoplight inset is derived from the sidebar masthead it sits in, not
+ * eyeballed — so these tests pin the derivation, not just the number. If a
+ * layout change moves the rail or the masthead height, the failing test is
+ * the prompt to re-derive `MACOS_TRAFFIC_LIGHT_POSITION` in the same commit.
+ */
+describe("macOS window chrome", () => {
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it("starts the stoplights on the sidebar's own rail", () => {
+    // `--sidebar-rail-inset` is the left edge every sidebar element sits
+    // on. The stoplights are the first item in the masthead row, so x is
+    // that inset — not a separate number.
+    expect(css).toContain("--sidebar-rail-inset: 16px;");
+    expect(MACOS_TRAFFIC_LIGHT_POSITION.x).toBe(16);
+  });
+
+  it("centres the stoplights on the wordmark's cap height", () => {
+    // The masthead is 10px of top padding above a 34px icon-button row, so
+    // the 17px/700 wordmark's cap centre lands at y=23. A 14px button at
+    // y=16 centres at 23 too.
+    expect(css).toContain("padding: 10px 0 0 80px;");
+    const buttonCentre = MACOS_TRAFFIC_LIGHT_POSITION.y + BUTTON_SIZE / 2;
+    expect(buttonCentre).toBe(23);
+  });
+
+  it("keeps the 80px masthead reservation clear of the button group", () => {
+    // Three 14px buttons on a 23px pitch: the group ends at x=76, inside
+    // the 80px every masthead reserves for it.
+    const groupEnd =
+      MACOS_TRAFFIC_LIGHT_POSITION.x + 2 * BUTTON_PITCH + BUTTON_SIZE;
+    expect(groupEnd).toBe(76);
+    expect(css).toContain("padding-left: 80px;");
+  });
+
+  it("gives auxiliary windows the same chrome as the main window", async () => {
+    setPlatform("darwin");
+    const { auxiliaryWindowChromeOptions } = await import(
+      "../auxiliary-window-chrome"
+    );
+
+    expect(auxiliaryWindowChromeOptions()).toMatchObject(macosTitleBarChrome());
+  });
+
+  it("keeps the main window off a hardcoded position", () => {
+    // window.ts must reach the position through the shared helper; a
+    // literal here is how the two windows drifted apart before.
+    expect(windowSource).not.toContain("trafficLightPosition");
+    expect(windowSource).toContain("macosTitleBarChrome()");
+  });
+});

--- a/apps/desktop/src/main/auxiliary-window-chrome.ts
+++ b/apps/desktop/src/main/auxiliary-window-chrome.ts
@@ -2,6 +2,7 @@ import type {
   BrowserWindow,
   BrowserWindowConstructorOptions,
 } from "electron";
+import { macosTitleBarChrome } from "./macos-window-chrome";
 import { readBootstrapAppearance } from "./settings/appearance-bootstrap";
 import { themedTitleBarOverlay } from "./native-appearance";
 
@@ -40,8 +41,7 @@ export function auxiliaryWindowChromeOptions(): Pick<
     // without leaving the current Space. Keep `maximizable` true so that
     // button stays live (it'd grey out otherwise).
     return {
-      titleBarStyle: "hiddenInset",
-      trafficLightPosition: { x: 20, y: 18 },
+      ...macosTitleBarChrome(),
       fullscreenable: false,
       maximizable: true,
     };

--- a/apps/desktop/src/main/macos-window-chrome.ts
+++ b/apps/desktop/src/main/macos-window-chrome.ts
@@ -9,12 +9,11 @@ import type { BrowserWindowConstructorOptions } from "electron";
  *   stoplights are the first thing in the sidebar's top row, so they start
  *   on the same rail as the wordmark, the lens switch, and every thread
  *   row below them.
- * - **y = 16** puts the 14px button's centre at y=23, which is the
- *   wordmark's cap-height centre in the 44px masthead (`.sidebar__masthead`
- *   pads 10px above a 34px `.sidebar__icon-button` row). The masthead has
- *   no bottom border, so the wordmark — not the band — is what the eye
- *   lines the buttons up against. `.activity-titlebar` on the auxiliary
- *   windows is the same 44px box, so one value serves both.
+ * - **y = 13** centres the 14px button in `--chrome-band-h` (40px, in
+ *   app.css): (40 - 14) / 2 = 13. That band is the one every top-of-window
+ *   bar centres its content in, so the stoplights land on the same y=20
+ *   centreline as the wordmark, the thread title, and the Activity and
+ *   Settings breadcrumbs.
  *
  * The group is 60px wide, so the buttons end at x=76 and the 80px
  * reservations in `.sidebar__masthead`, `.settings-nav__masthead`,
@@ -23,10 +22,10 @@ import type { BrowserWindowConstructorOptions } from "electron";
  * This was `{ x: 20, y: 18 }` from May 2026 until Sept 2026, when
  * `.sidebar` still carried `padding: 42px 16px 0` and the buttons floated
  * in a dead strip above the masthead. The sidebar was rebuilt out from
- * under the number: 20 was 4px past the rail, and 18 left 18px above the
- * buttons against 12px below.
+ * under the number: 20 was 4px past the rail, and 18 sat 5px below the
+ * band's centre.
  */
-export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 16, y: 16 } as const;
+export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 16, y: 13 } as const;
 
 /**
  * The macOS half of our window chrome: no native title bar, stoplights

--- a/apps/desktop/src/main/macos-window-chrome.ts
+++ b/apps/desktop/src/main/macos-window-chrome.ts
@@ -1,0 +1,44 @@
+import type { BrowserWindowConstructorOptions } from "electron";
+
+/**
+ * Where macOS draws the stoplights inside our `hiddenInset` windows.
+ *
+ * Both numbers are derived from the chrome they sit in, not tuned by eye:
+ *
+ * - **x = 16** is `--sidebar-rail-inset` (`.sidebar` in app.css). The
+ *   stoplights are the first thing in the sidebar's top row, so they start
+ *   on the same rail as the wordmark, the lens switch, and every thread
+ *   row below them.
+ * - **y = 16** puts the 14px button's centre at y=23, which is the
+ *   wordmark's cap-height centre in the 44px masthead (`.sidebar__masthead`
+ *   pads 10px above a 34px `.sidebar__icon-button` row). The masthead has
+ *   no bottom border, so the wordmark — not the band — is what the eye
+ *   lines the buttons up against. `.activity-titlebar` on the auxiliary
+ *   windows is the same 44px box, so one value serves both.
+ *
+ * The group is 60px wide, so the buttons end at x=76 and the 80px
+ * reservations in `.sidebar__masthead`, `.settings-nav__masthead`,
+ * `.activity-titlebar`, and `.star-map__chrome` still clear them.
+ *
+ * This was `{ x: 20, y: 18 }` from May 2026 until Sept 2026, when
+ * `.sidebar` still carried `padding: 42px 16px 0` and the buttons floated
+ * in a dead strip above the masthead. The sidebar was rebuilt out from
+ * under the number: 20 was 4px past the rail, and 18 left 18px above the
+ * buttons against 12px below.
+ */
+export const MACOS_TRAFFIC_LIGHT_POSITION = { x: 16, y: 16 } as const;
+
+/**
+ * The macOS half of our window chrome: no native title bar, stoplights
+ * floated over the renderer at the shared position above. The main window
+ * and every auxiliary window spread this, so the two can't drift.
+ */
+export function macosTitleBarChrome(): Pick<
+  BrowserWindowConstructorOptions,
+  "titleBarStyle" | "trafficLightPosition"
+> {
+  return {
+    titleBarStyle: "hiddenInset",
+    trafficLightPosition: { ...MACOS_TRAFFIC_LIGHT_POSITION },
+  };
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -28,6 +28,7 @@ import { RendererHeapMonitor } from "./diagnostics/renderer-heap-monitor";
 import { RendererHotCpuProfiler } from "./diagnostics/renderer-hot-cpu-profiler";
 import { isSafeExternalOpenUrl } from "./external-url-policy";
 import { getMainLogger } from "./log";
+import { macosTitleBarChrome } from "./macos-window-chrome";
 import { lockMainWindowTitle, mainWindowTitle } from "./main-window-title";
 import { recordStartupProfileEvent } from "./diagnostics/startup-profile-events";
 import { resolveActiveProfilePath } from "./profile";
@@ -357,10 +358,7 @@ export function createMainWindow(options?: {
     MAIN_WINDOW_HEIGHT,
   );
   const windowChrome = isMac
-    ? {
-        titleBarStyle: "hiddenInset" as const,
-        trafficLightPosition: { x: 20, y: 18 },
-      }
+    ? macosTitleBarChrome()
     : isWindows
       ? {
           // Frameless + Window Controls Overlay: the OS draws min/max/close in

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-edge-arrows.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-edge-arrows.ts
@@ -35,11 +35,13 @@ export type StarMapEdgeInset = {
  *
  * The top is deeper than the rest because the top of the map is not sky.
  * The top band (wordmark, Find, View, the filter chips) owns the first
- * ~40px, and on macOS the window's glass drag strip covers 52px: an arrow
- * drawn under either is an arrow nobody can click. The other three sides
- * only clear the window edge by enough to read as "at the edge" rather
- * than "cut off by it"; the bottom matches the key hint's own inset so the
- * two line up when they share the row.
+ * `--chrome-band-h` — 40px — and on macOS the window's glass drag strip
+ * covers exactly the same band; an arrow drawn under either is an arrow
+ * nobody can click. So the top is that band plus the 16px the left and
+ * right sides clear the window edge by. The other three sides only clear
+ * the edge by enough to read as "at the edge" rather than "cut off by
+ * it"; the bottom matches the key hint's own inset so the two line up
+ * when they share the row.
  */
 export const STAR_MAP_EDGE_INSET: StarMapEdgeInset = {
   top: 56,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1459,12 +1459,16 @@ describe("Tangerine Terminal theme contract", () => {
     const sidebarMasthead = extractRuleBody(css, ".sidebar__masthead");
     const settingsMasthead = extractRuleBody(css, ".settings-nav__masthead");
 
-    expect(activityTitlebar).toContain("padding: 10px 14px 0 96px;");
-    expect(sidebarMasthead).toContain("padding: 10px 0 0 80px;");
+    // Only the horizontal gutters are this test's subject. The top value is
+    // 0 on all three because they centre their content in `--chrome-band-h`
+    // instead of padding it down; see macos-window-chrome.test.ts.
+
+    expect(activityTitlebar).toContain("padding: 0 14px 0 96px;");
+    expect(sidebarMasthead).toContain("padding: 0 0 0 80px;");
     // The Settings nav runs its rows in the narrower 8px lane rather than the
     // sidebar's 16px rail, so its masthead pads 88px to put the brand at the
     // same x≈96. Both numbers must move together or the two brands drift.
-    expect(settingsMasthead).toContain("padding: 10px 0 0 88px;");
+    expect(settingsMasthead).toContain("padding: 0 0 0 88px;");
     expect(css).toMatch(
       /:root\[data-platform\]:not\(\[data-platform="darwin"\]\):not\(\[data-platform="win32"\]\)\s*\.activity-titlebar\s*\{[\s\S]*?padding-left:\s*14px;[\s\S]*?\}/,
     );

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -688,10 +688,11 @@ textarea,
 
 /* With the sidebar gone, its wordmark + action buttons relocate into the
    thread header's left as a sidebar-colored cluster (see ThreadHeader).
-   Drop the header's own left/top padding so the cluster sits flush in the
-   top-left corner; the cluster reserves the macOS stoplight strip itself. */
+   Drop the header's own left padding so the cluster sits flush against the
+   window edge; the cluster reserves the macOS stoplight strip itself. The
+   header keeps `--chrome-band-h` and its centering from the base rule, so
+   the relocated wordmark lands on the same centerline as the stoplights. */
 .app-shell[data-sidebar-hidden="true"] .thread-header {
-  padding-top: 0;
   padding-left: 0;
 }
 
@@ -2235,7 +2236,14 @@ textarea,
    .activity-titlebar header IS the title strip: drop the macOS stoplight
    reservation on the left, reserve the caption-button width on the right, and
    match the WCO overlay color (--bg-sidebar) so the buttons blend in. It's
-   already draggable + on `--chrome-band-h` from the base rule. */
+   already draggable + on `--chrome-band-h` from the base rule.
+
+   That band is load bearing here in a way it is not on macOS: the OS draws
+   the caption buttons at `TITLE_BAR_OVERLAY_HEIGHT` (native-appearance.ts,
+   mirrored by `--win-titlebar-h`), so this strip cannot be shorter than
+   that or the buttons hang past its bottom border and out of the blend.
+   The two tokens are equal today; `macos-window-chrome.test.ts` holds the
+   floor so lowering the band fails there instead of on Windows. */
 :root[data-platform="win32"] .activity-titlebar {
   padding-left: 14px;
   padding-right: var(--win-caption-w, 140px);
@@ -8134,7 +8142,7 @@ textarea,
    - Lives inside the nav's own 8px horizontal padding, so
      `padding-left: 88px` puts the brand at x≈96 from the window
      edge (stoplights end at x=76 with
-     `MACOS_TRAFFIC_LIGHT_POSITION` = `{ x: 16, y: 16 }`).
+     `MACOS_TRAFFIC_LIGHT_POSITION` = `{ x: 16, y: 13 }`).
    - Main's rail is 16px and its masthead pads 80px to the same x=96.
      The nav runs its rows in a tighter lane, so the masthead carries
      the difference: every platform branch below re-inserts 8px too,
@@ -13793,7 +13801,18 @@ textarea,
    that strip is the only handle this window has (see the note there). So
    the band declares no `-webkit-app-region` at all and passes its pointer
    events through; each slot punches its own hole and takes its pointer
-   events back. The gaps between the slots stay draggable sky. */
+   events back. The gaps between the slots stay draggable sky.
+
+   The band is a chrome bar like any other, so it centers its row in
+   `--chrome-band-h` instead of padding it down from the top edge. This
+   window spreads `auxiliaryWindowChromeOptions()` like every other
+   secondary window, so macOS floats its stoplights over the sky at
+   `MACOS_TRAFFIC_LIGHT_POSITION` - a position derived from that same band.
+   Center here and the wordmark, Find, View, and the filter chips land on
+   the y=20 centerline the buttons sit on; pad from the top instead and
+   they drift below it, which is what the 14px top padding did. Pinning the
+   height to the token also means a chip that grows (the Attention chip's
+   stacked turn column) can no longer move the whole band. */
 .star-map__top-band {
   display: flex;
   position: absolute;
@@ -13801,9 +13820,10 @@ textarea,
   right: 0;
   left: 0;
   z-index: 4;
-  align-items: start;
+  align-items: center;
   gap: 12px;
-  padding: 14px 16px 0;
+  min-height: var(--chrome-band-h);
+  padding: 0 16px;
   pointer-events: none;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -8,6 +8,24 @@
      buttons sit on the same line. Only consumed under [data-platform="win32"];
      zero contribution elsewhere. */
   --win-titlebar-h: 40px;
+  /* Height of every top-of-window chrome band: the sidebar masthead, the
+     thread header, the Activity/Settings title bars, and the Settings nav
+     masthead. All of them center their content in this box, so one
+     centerline (y=20) runs across the whole top of the app — and the macOS
+     stoplights land on it too (`MACOS_TRAFFIC_LIGHT_POSITION`).
+
+     Derived, not chosen: `.sidebar__icon-button` is 28px around a 16px
+     icon, i.e. a 6px ring. The band gives the button row the same 6px
+     ring, so 28 + 6 + 6 = 40 and the row nests concentrically.
+
+     These bands used to declare `min-height: 44px` with `padding-top:
+     10px` and no bottom padding — "10px + the 34px icon button". The
+     button was tightened to 28px and the bands were never re-derived, so
+     every one of them put all its slack above the content and drifted
+     below its own center, by different amounts (24 / 24 / 26.5 / 27
+     against `.settings-titlebar`'s balanced 19.5). Center content in this
+     band; never re-introduce one-sided padding to position it. */
+  --chrome-band-h: 40px;
   /* Width reserved at the strip's right edge for the OS caption buttons
      (min/max/close) so title-bar content never sits under them. */
   --win-caption-w: 140px;
@@ -678,7 +696,7 @@ textarea,
 }
 
 .app-shell[data-sidebar-hidden="true"] .thread-header__top {
-  min-height: 44px;
+  min-height: var(--chrome-band-h);
 }
 
 .app-shell[data-sidebar-hidden="true"] .thread-header__main {
@@ -1460,7 +1478,8 @@ textarea,
 
 .sidebar__masthead {
   align-items: center;
-  padding: 10px 0 0 80px;
+  min-height: var(--chrome-band-h);
+  padding: 0 0 0 80px;
   border-bottom: none;
   /* Tighter than the shared 16px so the brand sits closer to its actions. */
   gap: 8px;
@@ -1524,14 +1543,13 @@ textarea,
 }
 
 .thread-header {
-  /* Vertically center the title row + chips + MessagingStatusBar in
-     a 44px box that matches the sidebar masthead's effective height
-     (10px top padding + 34px set by `.sidebar__icon-button`). With
-     `box-sizing: border-box`, `min-height: 44px` + `padding-top: 10px`
-     gives a 34px content area; `align-items: center` puts the
-     compact title's top at y=18.5 — exactly where the brand sits in
-     the sidebar masthead. Result: title, brand, and messaging pills
-     all share the same vertical centerline.
+  /* Vertically center the title row + chips + MessagingStatusBar in the
+     shared `--chrome-band-h` box, the same band the sidebar masthead
+     uses. `justify-content: center` on this column is what does the
+     centering — do NOT go back to `flex-start` plus a top padding, which
+     is how this row drifted below the brand it is supposed to line up
+     with. Result: title, brand, and messaging pills all share the same
+     vertical centerline as the stoplights.
      The header is a column holding exactly ONE row (breadcrumb + chips on
      the left, layout toggles + MessagingStatusBar on the right). Keeping MSG
      in that row — instead of vertically centered against a `__main` that
@@ -1542,10 +1560,10 @@ textarea,
      constant. Do not add a second row here. */
   flex-direction: column;
   align-items: stretch;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 6px;
-  min-height: 44px;
-  padding-top: 10px;
+  min-height: var(--chrome-band-h);
+  padding-top: 0;
   /* Issue #240 follow-up: the thread header carries its OWN left
      inset, decoupled from the transcript / composer below it. The
      previous 28px sidebar gutter on `.app-main` provided this for
@@ -2200,8 +2218,8 @@ textarea,
   align-items: center;
   gap: 16px;
   flex: 0 0 auto;
-  min-height: 44px;
-  padding: 10px 14px 0 96px;
+  min-height: var(--chrome-band-h);
+  padding: 0 14px 0 96px;
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-panel-elevated);
   -webkit-app-region: drag;
@@ -2217,7 +2235,7 @@ textarea,
    .activity-titlebar header IS the title strip: drop the macOS stoplight
    reservation on the left, reserve the caption-button width on the right, and
    match the WCO overlay color (--bg-sidebar) so the buttons blend in. It's
-   already draggable + min-height 44px from the base rule. */
+   already draggable + on `--chrome-band-h` from the base rule. */
 :root[data-platform="win32"] .activity-titlebar {
   padding-left: 14px;
   padding-right: var(--win-caption-w, 140px);
@@ -7994,9 +8012,11 @@ textarea,
   gap: 12px;
   /* No 80px stoplight gutter here — the nav masthead on the left
      handles that. The right pane's title bar starts at x=188 (past
-     the stoplight area) so it doesn't need any clearance. Match
-     `.thread-header`'s 10px top padding for visual rhythm. */
-  padding: 10px 14px;
+     the stoplight area) so it doesn't need any clearance. Shares the
+     app-wide chrome band so its breadcrumb sits on the same centerline
+     as the nav brand beside it. */
+  min-height: var(--chrome-band-h);
+  padding: 0 14px;
   border-bottom: 1px solid var(--border-subtle);
   -webkit-app-region: drag;
 }
@@ -8119,19 +8139,17 @@ textarea,
      The nav runs its rows in a tighter lane, so the masthead carries
      the difference: every platform branch below re-inserts 8px too,
      which is why the brand lands identically on both screens.
-   - `min-height: 44px` gives the masthead the same effective
-     height that `.sidebar__masthead` has on the main screen
-     (10px top padding + 34px from the icon buttons it contains).
-     Without this, the masthead would collapse to brand-height +
-     padding, putting the brand ~8.5px higher than main's brand.
-     With it, the brand vertically centers in the same 34px content
-     area that main uses, so the two screens read identically. */
+   - `min-height: var(--chrome-band-h)` gives the masthead the same
+     band `.sidebar__masthead` has on the main screen. Without it the
+     masthead would collapse to brand height, floating the brand above
+     main's. With it, the brand centers in the same band main uses, so
+     the two screens read identically. */
 .settings-nav__masthead {
   display: flex;
   align-items: center;
   gap: 16px;
-  min-height: 44px;
-  padding: 10px 0 0 88px;
+  min-height: var(--chrome-band-h);
+  padding: 0 0 0 88px;
   -webkit-app-region: drag;
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -2192,7 +2192,7 @@ textarea,
    stoplight clearance on the left: the same x=96 the two nav mastheads
    reach (`.sidebar__masthead` pads 80px inside a 16px rail,
    `.settings-nav__masthead` 88px inside an 8px lane); stoplights end at
-   ~x=72, brand lands at x=96. Platforms without macOS/Windows chrome conventions override
+   x=76, brand lands at x=96. Platforms without macOS/Windows chrome conventions override
    the left padding below so auxiliary-window titles don't float
    awkwardly away from the window edge. */
 .activity-titlebar {
@@ -8113,8 +8113,8 @@ textarea,
    `.sidebar__masthead` pattern:
    - Lives inside the nav's own 8px horizontal padding, so
      `padding-left: 88px` puts the brand at x≈96 from the window
-     edge (stoplights end at ~x=72 with
-     `trafficLightPosition: { x: 20, y: 18 }` from window.ts).
+     edge (stoplights end at x=76 with
+     `MACOS_TRAFFIC_LIGHT_POSITION` = `{ x: 16, y: 16 }`).
    - Main's rail is 16px and its masthead pads 80px to the same x=96.
      The nav runs its rows in a tighter lane, so the masthead carries
      the difference: every platform branch below re-inserts 8px too,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3238,6 +3238,20 @@ textarea,
   -webkit-app-region: no-drag;
 }
 
+/* The first row under the masthead does not re-pad against it. Every other
+   boundary in the rail is paid for twice — 6px from the row above and 6px
+   from the row below — but the window's top edge contributes nothing, so
+   the masthead's own 6px of air was the only thing above its buttons while
+   12px sat below them. The band already ends with its air; this row adding
+   6px more is what made the chrome read as stuck to the top edge.
+
+   Adjacency, not `:first-of-type`: the federation window swaps which
+   `.runtime-identity` renders first, and a rail with no runtime row at all
+   should leave the rule inert rather than move the next thing up. */
+.sidebar__masthead + .runtime-identity {
+  padding-top: 0;
+}
+
 .sidebar__menu--profile {
   right: auto;
   left: 0;
@@ -11974,14 +11988,23 @@ textarea,
    map, deliberately, so a press can never start both a window drag and a
    canvas pan. Not rendered on Windows (painted `.activity-titlebar` above
    the map) or Linux (OS frame); hidden in fullscreen, which
-   `star-map-window.ts` forwards to `<html data-fullscreen>`. */
+   `star-map-window.ts` forwards to `<html data-fullscreen>`.
+
+   Its height is the shared chrome band, because on this window the strip
+   IS the visible title bar: the row inside it centers on `--chrome-band-h`
+   and so do the stoplights, so a strip of any other height puts unequal
+   air above and below the one row it contains. It was 52px, which centered
+   the row when the band paid for its position with a 14px top padding;
+   once the band centered itself the strip left 8.5px above the chips and
+   20.5px below. 40px is still a generous drag handle - a native macOS
+   title bar is 28. */
 .star-map-window__titlebar {
   position: absolute;
   top: 0;
   right: 0;
   left: 0;
   z-index: 2;
-  height: 52px;
+  height: var(--chrome-band-h);
   backdrop-filter: blur(12px) saturate(135%);
   -webkit-app-region: drag;
 }


### PR DESCRIPTION
## What

Two commits on one root cause:

1. **`fix(desktop): re-derive the macOS stoplight inset from the masthead`** — `trafficLightPosition` off a stale layout.
2. **`fix(desktop): put every chrome bar on one 40px band`** — the bands those stoplights sit in, off a stale button height.

The second is the real fix; the first is the symptom that made me look.

## Why

`.sidebar__icon-button` was tightened from 34px to 28px at some point. Four chrome bars still declared `min-height: 44px` with `padding-top: 10px` and no bottom padding, all commented *"10px + the 34px icon button"*. The bands kept the old height, the content kept all its slack above it, and each bar drifted below its own centre by a different amount.

Measured off the real stylesheet in a render harness with real markup — distance from the window's top edge to each bar's content centre:

| Bar | Surface | Band was | Centre was | Now | Lift |
|---|---|---|---|---|---|
| `.sidebar__masthead` | wordmark | 38 | 24 | 20 | 4 |
| `.thread-header` | thread title, breadcrumb | 44 | 24 | 20 | 4 |
| `.activity-titlebar` | aux window breadcrumb | 44 | 26.5 | 20 | 6.5 |
| `.settings-nav__masthead` | Settings wordmark | 44 | 27 | 20 | 7 |
| `.settings-titlebar` | Settings breadcrumb | 40 | 19.5 | 20 | 0 |

Five bars, four centrelines. In the Settings window that reads as a visible misalignment rather than a general lowness: the left nav brand at 27 and the right-pane breadcrumb at 19.5, side by side, 7.5px apart. And note the one bar that padded symmetrically was already at 19.5 — the target isn't a taste call, it's where the correctly-built bar already sat.

## The band

`--chrome-band-h: 40px`, with every bar centring its content in it.

Derived, not chosen: the 28px button puts a 6px ring around its 16px icon; the band gives the button row that same 6px ring, so 28 + 6 + 6 = 40 and the row nests concentrically.

Side effect worth noting: the sidebar's first thread row and the thread transcript now start at the same y. Their bands were 38 and 44.

## Stoplights

Measured on screen (window origins from AXPosition, buttons by connected-component detection):

| Window | Band | Left | Top | Below | Centred at |
|---|---|---|---|---|---|
| macOS standard (Terminal, Ghostty) | 28 | 9 | 9 | 5 | 7 |
| PwrGit | 32 | 12 | 10 | 8 | 9 |
| Microsoft Edge | — | 13 | 13 | — | — |
| Claude Desktop | — | 17 | 17 | — | — |
| PwrSnap | 52 | 20 | 18 | 20 | 19 |
| **PwrAgent was** | **38** | **20** | **18** | **6** | **12** |
| **PwrAgent now** | **40** | **16** | **13** | **13** | **13** |

`{ x: 16, y: 13 }`. **x = 16** is `--sidebar-rail-inset` — the buttons start where every other sidebar element does. **y = 13** is half of (40 − 14), so they land on the same y=20 centreline as everything else.

The first commit derived y from the wordmark's cap centre, which was itself sitting low; the second re-derives it from the band now that the band is governed. Reviewing the two commits in order shows that reasoning; the net change is `{ 20, 18 } → { 16, 13 }`.

The group is 60px wide and ends at x=76, so the 80px reservations in `.sidebar__masthead`, `.settings-nav__masthead`, `.activity-titlebar`, and `.star-map__chrome` still clear it and the wordmark stays at x=96 — the gap between OS chrome and the wordmark grows 16 → 20px.

## Verification

Real OS-drawn buttons at the old and new x, in a standalone Electron window captured with `screencapture -l`: first button 20 → 16, pitch 23 unchanged. Band geometry measured in a headless render harness against the actual `app.css`, before and after.

## Drift guard

`macos-window-chrome.test.ts` walks all five selectors and fails if one drops `min-height: var(--chrome-band-h)` or re-introduces a non-zero top padding — the two moves that let a bar off the centreline. It also pins the stoplight y to half the band, and both window factories now spread one `macosTitleBarChrome()` instead of each carrying its own literal. `theme-contract` keeps asserting the horizontal stoplight gutters (96/80/88), which don't change; only their top value moves to 0.

## Not in scope

- **PwrGit** keeps `{ 12, 10 }` — correct for its 32px bar.
- **PwrSnap** keeps `y: 18` — genuinely centred in its 52px bar. Only its `x` is off its own 16px inset; separate repo, tracked separately.

## Checks

`pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries` (no violations), and 8,649 workspace tests.

Design review with the measurements, the band audit, and before/after anatomy: [PwrAgent → Window Chrome - Stoplight Inset](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Window+Chrome+-+Stoplight+Inset.dc.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
