### PR TITLE
fix(desktop): keep Discord icons visible in light theme

### DIFF
--- a/apps/desktop/src/renderer/src/assets/discord/README.md
+++ b/apps/desktop/src/renderer/src/assets/discord/README.md
@@ -33,7 +33,9 @@ platform labels, activity rows, and thread binding chips with tooltips.
 The full wordmark is too small to read at 12-14px. We therefore render
 Discord's official Symbol SVGs verbatim via `<img>`, do not apply
 `currentColor`, CSS filters, effects, or path edits, and default to the
-white variant on the desktop app's dark surfaces.
+Blurple variant because it remains visible across the desktop app's light
+and dark themes. Callers may select the official white or black variant for
+surfaces whose background is independent of the app theme.
 
 ## Updating these files
 

--- a/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/MessagingSettings.tsx
@@ -873,7 +873,7 @@ export function MessagingSettings(props: {
               <SettingsTestBlock
                 kind="discord"
                 desktopApi={props.desktopApi}
-                icon={<DiscordIcon size={14} variant="white" />}
+                icon={<DiscordIcon size={14} />}
                 defaultName="Your bot"
                 defaultSub="discord.com/api/v10"
               />

--- a/apps/desktop/src/renderer/src/icons/DiscordIcon.tsx
+++ b/apps/desktop/src/renderer/src/icons/DiscordIcon.tsx
@@ -24,10 +24,11 @@ export type DiscordIconProps = Omit<
  * Official Discord Symbol asset from Discord's brand kit. Discord
  * permits white, black, and Blurple variants, but forbids recoloring
  * or reconfiguring the mark, so this renders the verbatim SVG via img.
+ * Blurple is the default because it remains visible on both PwrAgent themes.
  */
 export function DiscordIcon({
   size = DEFAULT_ICON_SIZE,
-  variant = "white",
+  variant = "blurple",
   alt = "",
   ...rest
 }: DiscordIconProps) {

--- a/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
+++ b/apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx
@@ -130,6 +130,20 @@ describe("icon library", () => {
       }
       expect(sources.size).toBe(3);
     });
+
+    it("uses the official blurple asset by default", () => {
+      const { container: blurpleContainer } = render(
+        <DiscordIcon variant="blurple" />,
+      );
+      const blurpleSrc = blurpleContainer
+        .querySelector("img")
+        ?.getAttribute("src");
+      cleanup();
+
+      const { container } = render(<DiscordIcon />);
+
+      expect(container.querySelector("img")).toHaveAttribute("src", blurpleSrc);
+    });
   });
 
   describe("MattermostIcon", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/messaging-platform-branding.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/messaging-platform-branding.test.tsx
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, render } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
-import { MattermostIcon } from "../../icons";
+import { DiscordIcon, MattermostIcon } from "../../icons";
 import { MESSAGING_PLATFORM_ICONS } from "../messaging-platform-branding";
 
 afterEach(() => {
@@ -10,6 +10,22 @@ afterEach(() => {
 });
 
 describe("MESSAGING_PLATFORM_ICONS", () => {
+  it("uses the light-safe Discord blurple mark across shared surfaces", () => {
+    const { container: blurpleContainer } = render(
+      <DiscordIcon variant="blurple" />,
+    );
+    const blurpleSrc = blurpleContainer
+      .querySelector("img")
+      ?.getAttribute("src");
+    cleanup();
+
+    document.documentElement.setAttribute("data-theme", "light");
+    const Discord = MESSAGING_PLATFORM_ICONS.discord;
+    const { container } = render(Discord ? <Discord size={14} /> : null);
+
+    expect(container.querySelector("img")).toHaveAttribute("src", blurpleSrc);
+  });
+
   it("uses the light-safe Mattermost mark across shared messaging surfaces", () => {
     const { container: denimContainer } = render(
       <MattermostIcon variant="denim" />,

--- a/apps/desktop/src/renderer/src/lib/messaging-platform-branding.tsx
+++ b/apps/desktop/src/renderer/src/lib/messaging-platform-branding.tsx
@@ -17,7 +17,7 @@ export const MESSAGING_PLATFORM_ICONS: Partial<
   Record<MessagingChannelKind, (props: IconProps) => ReactElement>
 > = {
   telegram: ({ size }) => <TelegramIcon size={size} variant="color" />,
-  discord: ({ size }) => <DiscordIcon size={size} variant="blurple" />,
+  discord: ({ size }) => <DiscordIcon size={size} />,
   mattermost: ({ size }) => <MattermostIcon size={size} />,
   slack: ({ size }) => <SlackIcon size={size} />,
   feishu: ({ size }) => <FeishuIcon size={size} />,


### PR DESCRIPTION
## Summary

- make official Discord blurple the default icon variant across renderer surfaces
- remove the Settings connection-test row's forced white Discord mark
- retain Mattermost's existing theme-aware white/denim behavior and add regression coverage for both providers

## Testing

- `pnpm test apps/desktop/src/renderer/src/icons/__tests__/icons.test.tsx apps/desktop/src/renderer/src/lib/__tests__/messaging-platform-branding.test.tsx`
- `pnpm lint:colors`
- `pnpm lint:eslint`
- `pnpm typecheck`