### PR TITLE
fix(desktop): preserve review provenance

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -32,6 +32,7 @@ import type {
   AppServerNotification,
   AppServerAvailableCommandSummary,
   AppServerPendingRequestNotification,
+  AppServerReviewContext,
   AppServerSkillSummary,
   AppServerThreadReplay,
   AppServerThreadActivityEntry,
@@ -25886,6 +25887,146 @@ command = "pnpm dev"
       threadId: "thread-fork",
     });
     expect(overlay?.forkBaselineCaptured).toBe(true);
+
+    await registry.close();
+  });
+
+  it("persists native review provenance on the existing sub-agent write", async () => {
+    const context: AppServerReviewContext = {
+      workspacePath: "/repo",
+      projectLabel: "PwrAgent",
+      gitBranch: "fix/review-provenance",
+      baseBranch: "origin/main",
+      pullRequest: {
+        provider: "github.com",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 1939,
+        headRefName: "fix/review-provenance",
+        baseRefName: "main",
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/1939",
+      },
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start", "review/start"] },
+      startReviewResult: {
+        threadId: "thread-1",
+        reviewThreadId: "thread-1",
+        turnId: "turn-review-1",
+      },
+    });
+    const overlayStore = createOverlayStoreMock();
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+    vi.spyOn(
+      registry as unknown as {
+        resolveReviewContext(): Promise<AppServerReviewContext | undefined>;
+      },
+      "resolveReviewContext",
+    ).mockResolvedValue(context);
+
+    await registry.startReview({
+      backend: "codex",
+      threadId: "thread-1",
+      target: { type: "baseBranch", branch: "origin/main" },
+      delivery: "inline",
+    });
+
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      subAgents: [
+        expect.objectContaining({
+          monitorId: "review:turn-review-1",
+          reviewContext: context,
+        }),
+      ],
+    });
+
+    await registry.close();
+  });
+
+  it("reattaches persisted provenance to native review replay", async () => {
+    const context: AppServerReviewContext = {
+      workspacePath: "/repo",
+      projectLabel: "PwrAgent",
+      gitBranch: "fix/review-provenance",
+      baseBranch: "origin/main",
+      pullRequest: {
+        provider: "github.com",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 1939,
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/1939",
+      },
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          subAgents: [
+            {
+              monitorId: "review:turn-review-1",
+              task: "Review changes against origin/main",
+              status: "success",
+              createdAt: 1_000,
+              updatedAt: 2_000,
+              backend: "codex",
+              preferredModel: "gpt-5.6-sol",
+              preferredReasoningEffort: "high",
+              monitorThreadId: "thread-1",
+              monitorTurnId: "turn-review-1",
+              reviewContext: context,
+            },
+          ],
+        },
+      },
+    });
+    const codexClient = new MockBackendClient({
+      replay: {
+        entries: [
+          {
+            type: "review",
+            id: "review-start",
+            review: "changes against 'origin/main'",
+            displayText: "Review changes against origin/main",
+            turn: {
+              id: "turn-review-1",
+              status: "completed",
+            },
+          },
+        ],
+        messages: [],
+        pagination: {
+          supportsPagination: true,
+          hasPreviousPage: false,
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    const response = await registry.readThread({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(response.replay.entries).toEqual([
+      expect.objectContaining({
+        type: "review",
+        id: "review-start",
+        context,
+        reviewer: {
+          backend: "codex",
+          model: "gpt-5.6-sol",
+          reasoningEffort: "high",
+        },
+      }),
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5963,17 +5963,18 @@ function reviewEntryReviewer(
 
 /**
  * Native review entries come from the provider transcript, which does not
- * carry the reviewer configuration. The durable review sub-agent summary is
- * the authority for that configuration, including after an app restart.
+ * carry reviewer configuration or PwrAgent's frozen workspace/PR provenance.
+ * The durable review sub-agent summary is the authority for both, including
+ * after an app restart.
  */
-function attachReviewEntryReviewers(params: {
+function attachReviewEntryMetadata(params: {
   replay: AppServerThreadReplay;
   subAgents?: ThreadSubAgentSummary[];
 }): AppServerThreadReplay {
-  const reviewerByTurnId = new Map<
-    string,
-    NonNullable<AppServerThreadReviewEntry["reviewer"]>
-  >();
+  const metadataByTurnId = new Map<string, {
+    context?: AppServerReviewContext;
+    reviewer: NonNullable<AppServerThreadReviewEntry["reviewer"]>;
+  }>();
   for (const subAgent of params.subAgents ?? []) {
     if (
       !subAgent.monitorId.startsWith("review:")
@@ -5986,16 +5987,19 @@ function attachReviewEntryReviewers(params: {
       subAgent.preferredModel
       ?? subAgent.monitorUsage?.model
       ?? subAgent.monitorUsage?.cost?.model;
-    reviewerByTurnId.set(subAgent.monitorTurnId, {
-      backend: subAgent.backend,
-      ...(model ? { model } : {}),
-      ...(subAgent.preferredReasoningEffort
-        ? { reasoningEffort: subAgent.preferredReasoningEffort }
-        : {}),
+    metadataByTurnId.set(subAgent.monitorTurnId, {
+      ...(subAgent.reviewContext ? { context: subAgent.reviewContext } : {}),
+      reviewer: {
+        backend: subAgent.backend,
+        ...(model ? { model } : {}),
+        ...(subAgent.preferredReasoningEffort
+          ? { reasoningEffort: subAgent.preferredReasoningEffort }
+          : {}),
+      },
     });
   }
 
-  if (reviewerByTurnId.size === 0) {
+  if (metadataByTurnId.size === 0) {
     return params.replay;
   }
 
@@ -6004,27 +6008,33 @@ function attachReviewEntryReviewers(params: {
     if (entry.type !== "review" || !entry.turn?.id) {
       return entry;
     }
-    const durableReviewer = reviewerByTurnId.get(entry.turn.id);
-    if (!durableReviewer) {
+    const metadata = metadataByTurnId.get(entry.turn.id);
+    if (!metadata) {
       return entry;
     }
-    const model = entry.reviewer?.model ?? durableReviewer.model;
+    const model = entry.reviewer?.model ?? metadata.reviewer.model;
     const reasoningEffort =
-      entry.reviewer?.reasoningEffort ?? durableReviewer.reasoningEffort;
+      entry.reviewer?.reasoningEffort ?? metadata.reviewer.reasoningEffort;
     const reviewer = {
-      backend: entry.reviewer?.backend ?? durableReviewer.backend,
+      backend: entry.reviewer?.backend ?? metadata.reviewer.backend,
       ...(model ? { model } : {}),
       ...(reasoningEffort ? { reasoningEffort } : {}),
     };
+    const context = entry.context ?? metadata.context;
     if (
       entry.reviewer?.backend === reviewer.backend
       && entry.reviewer?.model === reviewer.model
       && entry.reviewer?.reasoningEffort === reviewer.reasoningEffort
+      && entry.context === context
     ) {
       return entry;
     }
     changed = true;
-    return { ...entry, reviewer };
+    return {
+      ...entry,
+      reviewer,
+      ...(context ? { context } : {}),
+    };
   });
   return changed ? { ...params.replay, entries } : params.replay;
 }
@@ -10617,7 +10627,7 @@ export class DesktopBackendRegistry {
       replayWithTranscriptOverlays,
       messageOrigins,
     );
-    const replayWithReviewers = attachReviewEntryReviewers({
+    const replayWithReviewMetadata = attachReviewEntryMetadata({
       replay: replayWithMessageOrigins,
       subAgents: overlay?.subAgents,
     });
@@ -10663,10 +10673,10 @@ export class DesktopBackendRegistry {
         : {}),
       ...(toolAccounting ? { toolAccounting } : {}),
       ...(pendingRequest ? { pendingRequest } : {}),
-      ...(replayWithReviewers.threadStatus
-        ? { threadStatus: replayWithReviewers.threadStatus }
+      ...(replayWithReviewMetadata.threadStatus
+        ? { threadStatus: replayWithReviewMetadata.threadStatus }
         : {}),
-      replay: replayWithReviewers,
+      replay: replayWithReviewMetadata,
     };
   }
 
@@ -12612,7 +12622,7 @@ export class DesktopBackendRegistry {
       replayWithImmutableUsage,
       messageOrigins,
     );
-    const replayWithReviewers = attachReviewEntryReviewers({
+    const replayWithReviewMetadata = attachReviewEntryMetadata({
       replay: replayWithMessageOrigins,
       subAgents: overlay?.subAgents,
     });
@@ -12675,10 +12685,10 @@ export class DesktopBackendRegistry {
       pricing,
       ...(toolAccounting ? { toolAccounting } : {}),
       ...(pendingRequest ? { pendingRequest } : {}),
-      ...(replayWithReviewers.threadStatus
-        ? { threadStatus: replayWithReviewers.threadStatus }
+      ...(replayWithReviewMetadata.threadStatus
+        ? { threadStatus: replayWithReviewMetadata.threadStatus }
         : {}),
-      replay: replayWithReviewers,
+      replay: replayWithReviewMetadata,
     };
   }
 
@@ -25079,6 +25089,9 @@ export class DesktopBackendRegistry {
         : {}),
       monitorThreadId: record.reviewThreadId,
       monitorTurnId: record.turnId,
+      ...(record.context ?? existing?.reviewContext
+        ? { reviewContext: record.context ?? existing?.reviewContext }
+        : {}),
       ...(patch.lastMessage ?? existing?.lastMessage
         ? { lastMessage: patch.lastMessage ?? existing?.lastMessage }
         : {}),

--- a/apps/desktop/src/renderer/src/features/thread-detail/ReviewProvenance.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ReviewProvenance.tsx
@@ -1,9 +1,16 @@
-import type { AppServerReviewContext } from "@pwragent/shared";
+import type {
+  AppServerReviewContext,
+  AppServerReviewPullRequest,
+  PrSummary,
+} from "@pwragent/shared";
+import { useMemo } from "react";
 import { reviewComparedPastPullRequestBase } from "../../../../shared/review-command";
 import { BranchIcon } from "../../icons/BranchIcon";
 import { FolderIcon } from "../../icons/FolderIcon";
 import { WorktreeIcon } from "../../icons/WorktreeIcon";
+import { useLivePullRequest } from "../../lib/pull-request-links";
 import { CopyableThreadChip } from "../navigation/ThreadMetaChips";
+import { PrChip } from "../pr-status/PrChip";
 
 type ReviewProvenanceProps = {
   context: AppServerReviewContext;
@@ -14,14 +21,16 @@ type ReviewProvenanceProps = {
  * line never says which. The chips answer that before the card gets to what the
  * review found: which project, which branch, and which pull request.
  *
- * Everything here is frozen — resolved once when the review started. Nothing on
- * this row is looked up again, so a card from last month keeps saying what was
- * true when its review ran.
+ * The association is frozen — resolved once when the review started — so a
+ * card from last month keeps naming the workspace, branch, and PR it reviewed.
+ * The PR chip may hydrate that same PR identity with current canonical status;
+ * status can move without relabelling what the review was about.
  */
 export function ReviewProvenance(props: ReviewProvenanceProps) {
   const context = props.context;
   const isWorktree = Boolean(context.repositoryPath);
   const projectLabel = context.projectLabel ?? "Project";
+  const branch = context.gitBranch?.trim();
   const branchLabel = formatBranchLabel(context);
   const pullRequest = context.pullRequest;
 
@@ -49,26 +58,20 @@ export function ReviewProvenance(props: ReviewProvenanceProps) {
       </CopyableThreadChip>
 
       {branchLabel ? (
-        <span className="review-chip">
+        <CopyableThreadChip
+          aria-label={`Copy branch ${branch ?? branchLabel}`}
+          className="review-chip path-copy-target"
+          value={branch ?? branchLabel}
+        >
           <span aria-hidden="true" className="review-chip__icon">
             <BranchIcon size={12} />
           </span>
           <span className="review-chip__label">{branchLabel}</span>
-        </span>
+        </CopyableThreadChip>
       ) : null}
 
       {pullRequest ? (
-        <a
-          className="review-chip review-chip--pull-request"
-          href={pullRequest.url}
-          rel="noopener noreferrer"
-          target="_blank"
-          title={pullRequest.title ?? undefined}
-        >
-          <span className="review-chip__label">
-            {`${pullRequest.org}/${pullRequest.repo}#${pullRequest.number}`}
-          </span>
-        </a>
+        <ReviewPullRequestChip pullRequest={pullRequest} />
       ) : pullRequest === null ? (
         // Distinct from an absent field: the branch was checked and carried no
         // pull request. Saying so is the difference between an answer and a
@@ -79,6 +82,30 @@ export function ReviewProvenance(props: ReviewProvenanceProps) {
       ) : null}
     </div>
   );
+}
+
+function ReviewPullRequestChip(props: {
+  pullRequest: AppServerReviewPullRequest;
+}) {
+  const fallback = useMemo<PrSummary>(
+    () => ({ ...props.pullRequest, state: "unknown" }),
+    [props.pullRequest],
+  );
+  const pullRequest = useLivePullRequest(fallback);
+  return (
+    <PrChip
+      pr={pullRequest}
+      showRepoPrefix
+      onOpen={openPullRequest}
+    />
+  );
+}
+
+function openPullRequest(url: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+  window.open(url, "_blank", "noopener,noreferrer");
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx
@@ -1,10 +1,13 @@
 import type {
   AppServerReviewOutput,
   AppServerThreadReviewEntry,
+  NavigationThreadSummary,
+  PrSummary,
 } from "@pwragent/shared";
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
+import { PullRequestLinkProvider } from "../../../lib/pull-request-links";
 import { TranscriptReview } from "../TranscriptReview";
 
 afterEach(() => {
@@ -172,6 +175,32 @@ describe("TranscriptReview", () => {
 });
 
 describe("TranscriptReview provenance", () => {
+  const pullRequest: PrSummary = {
+    provider: "github.com",
+    org: "pwrdrvr",
+    repo: "PwrAgent",
+    number: 1918,
+    state: "passing",
+    checkState: "passing",
+    lifecycleState: "open",
+    reviewState: "ready_for_review",
+    mergeState: "mergeable",
+    headRefName: "fix/macos-dock-icon-safe-area",
+    baseRefName: "main",
+    title: "Keep the dock icon inside its safe area",
+    url: "https://github.com/pwrdrvr/PwrAgent/pull/1918",
+  };
+  const thread: NavigationThreadSummary = {
+    id: "thread-review-provenance",
+    title: "Review provenance",
+    titleSource: "explicit",
+    summary: "Review provenance",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { inInbox: false },
+    prs: [pullRequest],
+    updatedAt: 1,
+  };
   const context = {
     workspacePath: "/Users/dev/.codex/worktrees/mti5p133/PwrAgent",
     projectLabel: "PwrAgent",
@@ -183,6 +212,8 @@ describe("TranscriptReview provenance", () => {
       org: "pwrdrvr",
       repo: "PwrAgent",
       number: 1918,
+      headRefName: "fix/macos-dock-icon-safe-area",
+      title: "Keep the dock icon inside its safe area",
       // GitHub reports the bare branch name. Writing `origin/main` here was
       // what let the raw string comparison in `formatBranchLabel` pass.
       baseRefName: "main",
@@ -194,15 +225,17 @@ describe("TranscriptReview provenance", () => {
     entry: Partial<AppServerThreadReviewEntry> = {},
   ): void {
     render(
-      <TranscriptReview
-        entry={{
-          type: "review",
-          id: "review-provenance",
-          review: "",
-          displayText: "Review changes against origin/main",
-          ...entry,
-        }}
-      />
+      <PullRequestLinkProvider activeThread={thread} threads={[thread]}>
+        <TranscriptReview
+          entry={{
+            type: "review",
+            id: "review-provenance",
+            review: "",
+            displayText: "Review changes against origin/main",
+            ...entry,
+          }}
+        />
+      </PullRequestLinkProvider>
     );
   }
 
@@ -214,8 +247,10 @@ describe("TranscriptReview provenance", () => {
     expect(row).toHaveTextContent("fix/macos-dock-icon-safe-area");
     expect(row).toHaveTextContent("pwrdrvr/PwrAgent#1918");
     expect(
-      screen.getByRole("link", { name: /pwrdrvr\/PwrAgent#1918/ })
-    ).toHaveAttribute("href", "https://github.com/pwrdrvr/PwrAgent/pull/1918");
+      screen.getByRole("button", {
+        name: /Open pwrdrvr\/PwrAgent#1918 .* in browser/,
+      })
+    ).toBeInTheDocument();
   });
 
   it("offers the full workspace path to copy", () => {
@@ -224,6 +259,28 @@ describe("TranscriptReview provenance", () => {
     expect(
       screen.getByLabelText("Copy workspace path for PwrAgent")
     ).toBeInTheDocument();
+  });
+
+  it("uses the shared copyable branch and pull-request status chips", () => {
+    renderReview({ context });
+
+    expect(
+      screen.getByRole("button", {
+        name: "Copy branch fix/macos-dock-icon-safe-area",
+      })
+    ).toHaveClass("path-copy-target");
+
+    const pullRequest = screen.getByRole("button", {
+      name: /Open pwrdrvr\/PwrAgent#1918 .* in browser/,
+    });
+    expect(pullRequest).toHaveAttribute("data-pr-chip");
+    fireEvent.focus(pullRequest);
+
+    expect(screen.getByText("Pull request")).toBeInTheDocument();
+    expect(
+      screen.getByText("Keep the dock icon inside its safe area")
+    ).toBeInTheDocument();
+    expect(screen.getByText("ready for review · checks passing")).toBeInTheDocument();
   });
 
   it("treats a remote-qualified target as the pull request's own base", () => {
@@ -266,7 +323,9 @@ describe("TranscriptReview provenance", () => {
     renderReview({ context: unchecked });
 
     expect(screen.queryByText("no PR at review time")).not.toBeInTheDocument();
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Open .* in browser/ })
+    ).not.toBeInTheDocument();
   });
 
   it("renders no row for a review that predates the capture", () => {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -11569,9 +11569,96 @@ describe("useThreadSessionState", () => {
         projectLabel: "PwrAgent",
         gitBranch: "fix/dock-icon",
         baseBranch: "origin/main",
-        pullRequest: { number: 1918, baseRefName: "main" },
+        pullRequest: {
+          number: 1918,
+          baseRefName: "main",
+        },
       },
       reviewer: { backend: "codex", model: "gpt-5.6-sol" },
+    });
+  });
+
+  it("does not drop replay provenance when a matching live review omits it", async () => {
+    let agentEventHandler:
+      | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+      | undefined;
+    const context = {
+      workspacePath: "/Users/dev/pwrdrvr/PwrAgent",
+      projectLabel: "PwrAgent",
+      gitBranch: "fix/dock-icon",
+      baseBranch: "origin/main",
+      pullRequest: {
+        provider: "github.com",
+        org: "pwrdrvr",
+        repo: "PwrAgent",
+        number: 1918,
+        url: "https://github.com/pwrdrvr/PwrAgent/pull/1918",
+      },
+    };
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (listener) => {
+        agentEventHandler = listener;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "review",
+              id: "review-start",
+              review: "Review changes against origin/main",
+              displayText: "Review changes against origin/main",
+              context,
+              turn: {
+                id: "turn-review",
+                status: "in_progress",
+              },
+            },
+          ],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-review",
+            item: {
+              id: "review-start-live",
+              type: "enteredReviewMode",
+              review: "Review changes against origin/main",
+            },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.entries).toHaveLength(1);
+      expect(result.current.entries[0]).toMatchObject({
+        type: "review",
+        context,
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -11578,7 +11578,10 @@ describe("useThreadSessionState", () => {
     });
   });
 
-  it("does not drop replay provenance when a matching live review omits it", async () => {
+  it.each([
+    ["semantic review match", "review-start-live"],
+    ["exact item-ID replacement", "review-start"],
+  ])("does not drop replay provenance during a %s", async (_case, liveItemId) => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
       | undefined;
@@ -11644,7 +11647,7 @@ describe("useThreadSessionState", () => {
             threadId: "thread-1",
             turnId: "turn-review",
             item: {
-              id: "review-start-live",
+              id: liveItemId,
               type: "enteredReviewMode",
               review: "Review changes against origin/main",
             },

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -415,6 +415,28 @@ function hasOptimisticTurnUsageForEntry(
   return Boolean(entry.turn?.id && optimisticTurnUsageIds.has(entry.turn.id));
 }
 
+function preserveReviewMetadata(
+  existingEntry: AppServerThreadEntry | undefined,
+  replacementEntry: AppServerThreadEntry,
+): AppServerThreadEntry {
+  if (
+    existingEntry?.type !== "review"
+    || replacementEntry.type !== "review"
+  ) {
+    return replacementEntry;
+  }
+
+  return {
+    ...replacementEntry,
+    ...(replacementEntry.context ?? existingEntry.context
+      ? { context: replacementEntry.context ?? existingEntry.context }
+      : {}),
+    ...(replacementEntry.reviewer ?? existingEntry.reviewer
+      ? { reviewer: replacementEntry.reviewer ?? existingEntry.reviewer }
+      : {}),
+  };
+}
+
 function mergeTranscriptEntries(
   responseEntries: AppServerThreadEntry[],
   optimisticEntries: AppServerThreadEntry[]
@@ -516,7 +538,10 @@ function mergeTranscriptEntries(
   for (const optimisticEntry of optimisticEntries) {
     const existingIndex = mergedEntryIndexById.get(optimisticEntry.id) ?? -1;
     if (existingIndex !== -1) {
-      merged[existingIndex] = optimisticEntry;
+      merged[existingIndex] = preserveReviewMetadata(
+        merged[existingIndex],
+        optimisticEntry,
+      );
       if (typeof optimisticEntry.createdAt === "number") {
         greatestCreatedAt = Math.max(
           greatestCreatedAt ?? optimisticEntry.createdAt,
@@ -560,18 +585,10 @@ function mergeTranscriptEntries(
           && reviewEntriesMatch(entry, optimisticEntry)
       );
       if (matchingReviewIndex !== -1) {
-        const matched = merged[matchingReviewIndex];
-        merged[matchingReviewIndex] = matched?.type === "review"
-          ? {
-              ...optimisticEntry,
-              ...(optimisticEntry.context ?? matched.context
-                ? { context: optimisticEntry.context ?? matched.context }
-                : {}),
-              ...(optimisticEntry.reviewer ?? matched.reviewer
-                ? { reviewer: optimisticEntry.reviewer ?? matched.reviewer }
-                : {}),
-            }
-          : optimisticEntry;
+        merged[matchingReviewIndex] = preserveReviewMetadata(
+          merged[matchingReviewIndex],
+          optimisticEntry,
+        );
         rebuildAppendIndexes();
         continue;
       }

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -560,7 +560,18 @@ function mergeTranscriptEntries(
           && reviewEntriesMatch(entry, optimisticEntry)
       );
       if (matchingReviewIndex !== -1) {
-        merged[matchingReviewIndex] = optimisticEntry;
+        const matched = merged[matchingReviewIndex];
+        merged[matchingReviewIndex] = matched?.type === "review"
+          ? {
+              ...optimisticEntry,
+              ...(optimisticEntry.context ?? matched.context
+                ? { context: optimisticEntry.context ?? matched.context }
+                : {}),
+              ...(optimisticEntry.reviewer ?? matched.reviewer
+                ? { reviewer: optimisticEntry.reviewer ?? matched.reviewer }
+                : {}),
+            }
+          : optimisticEntry;
         rebuildAppendIndexes();
         continue;
       }

--- a/apps/desktop/src/renderer/src/styles/__tests__/review-provenance-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/review-provenance-contract.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+describe("review provenance shrink contract", () => {
+  it("keeps a long pull-request chip inside the review copy column", () => {
+    const body = ruleBody(".transcript-review__provenance > .pr-chip");
+    expect(body).toMatch(/min-width:\s*0/);
+    expect(body).toMatch(/max-width:\s*100%/);
+  });
+
+  it("ellipsizes the pull-request identity after the chip shrinks", () => {
+    const body = ruleBody(".transcript-review__provenance .pr-chip__label");
+    expect(body).toMatch(/min-width:\s*0/);
+    expect(body).toMatch(/overflow:\s*hidden/);
+    expect(body).toMatch(/text-overflow:\s*ellipsis/);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20773,6 +20773,20 @@ a.transcript-message__messaging-origin:focus-visible {
   margin-top: 8px;
 }
 
+/* The shared PR chip has to shrink inside the review copy column just like the
+   path chips below. Keep this constraint local: sidebar PR identities should
+   retain their existing intrinsic width. */
+.transcript-review__provenance > .pr-chip {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.transcript-review__provenance .pr-chip__label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .review-chip {
   display: inline-flex;
   align-items: center;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -20822,13 +20822,6 @@ a.transcript-message__messaging-origin:focus-visible {
   outline: none;
 }
 
-.review-chip--pull-request:hover,
-.review-chip--pull-request:focus-visible {
-  border-color: var(--accent-border);
-  background: var(--bg-panel-hover);
-  outline: none;
-}
-
 /* "no PR at review time" is an answer, not a control. Dashed and muted so it
    reads as a recorded absence rather than something to click. */
 .review-chip--empty {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -6,6 +6,7 @@ import type {
   AppServerThreadActivityDetail,
   AppServerThreadActivityEntry,
   AppServerThreadImagePart,
+  AppServerReviewContext,
   AppServerThreadReviewEntry,
   AppServerThreadStatus,
   AppServerThreadSummary,
@@ -340,6 +341,12 @@ export type ThreadSubAgentSummary = {
   preferredFastMode?: boolean;
   monitorThreadId?: ThreadIdentifier;
   monitorTurnId?: ThreadIdentifier;
+  /**
+   * Frozen workspace, branch, and pull-request context for a code review.
+   * Present only on `review:` summaries. The provider transcript does not
+   * retain this metadata, so thread replay reattaches it by `monitorTurnId`.
+   */
+  reviewContext?: AppServerReviewContext;
   /**
    * The parent turn this sub-agent ran inside. Set for Token Miser gates so
    * the Pricing rail can nest a gate under the turn it happened in — the gate's


### PR DESCRIPTION
## Summary

- persist frozen review workspace, branch, and pull-request identity in the durable review summary and restore it during replay
- preserve review context and reviewer metadata when optimistic entries reconcile with backend history
- render the branch as a copyable chip and the pull request with the canonical live-status chip and tooltip

## Testing

- pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-review.test.tsx apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
- pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/review-provenance.test.ts
- pnpm typecheck
- pnpm lint:eslint
- pnpm lint:colors
- pnpm lint:boundaries