### PR TITLE
fix(agent-core): add Sky Computer Use dev workaround

### DIFF
--- a/docs/solutions/sky-computer-use-managed-codex-signing.md
+++ b/docs/solutions/sky-computer-use-managed-codex-signing.md
@@ -66,7 +66,14 @@ registration automatically if the update fails. It does not read Codex-owned
 configuration files directly. Before changing a non-trampoline launcher, it
 records only that launcher's command and arguments under `~/.pwragent/local/`;
 environment values remain in Codex's registration and are not copied into the
-backup.
+backup. Reapplying with a different ChatGPT application or PwrAgent root moves
+that original-launcher backup instead of replacing it with the old trampoline.
+
+The helper refuses to mutate a registration with non-default fields that
+`codex mcp add` cannot reproduce, including working directories, inherited
+environment-variable names, enablement, tool filters, and timeouts. It also
+redacts child-process command lines from errors because those arguments can
+contain MCP environment values.
 
 Inspect without changing anything:
 

--- a/docs/solutions/sky-computer-use-managed-codex-signing.md
+++ b/docs/solutions/sky-computer-use-managed-codex-signing.md
@@ -1,0 +1,115 @@
+# Sky Computer Use with the managed Codex runtime
+
+## Status
+
+This is a developer-only macOS workaround recorded on September 2, 2026. It
+must not become packaged PwrAgent behavior. It depends on private paths and
+signing behavior in the installed ChatGPT application.
+
+## Symptom
+
+Sky Computer Use failed in a PwrAgent thread backed by the managed PwrAgent
+Codex runtime:
+
+```text
+Sky Computer Use native pipe startup failed
+```
+
+The failure happened after this import succeeded:
+
+```js
+globalThis.sky = (await import("@oai/sky")).sky;
+```
+
+Changing the working directory or adding a `node_modules` symlink does not
+address the failure.
+
+## Evidence
+
+The observed runtime was:
+
+- PwrAgent Codex `0.149.0-pwragent.2`, signed by PwrDrvr LLC team
+  `T44CNHC4UH`.
+- ChatGPT Codex `0.150.0-alpha.8`, `node`, and `node_repl`, signed by OpenAI
+  team `2DC432GLL2`.
+- Codex Computer Use `26.819.1000816`, signed by OpenAI team `2DC432GLL2`.
+
+The Computer Use service logged `Sender process is not authenticated` for the
+failing native-pipe connection. An A/B probe used the same OpenAI `node_repl`
+binary and environment in both cases:
+
+| Parent chain | Result |
+|---|---|
+| Ordinary or PwrAgent-signed parent → OpenAI `node_repl` | Native-pipe authentication failed |
+| OpenAI-signed `node` → OpenAI `node_repl` | Native-pipe connection succeeded |
+
+The successful probe then reached MCP form elicitation. That later failure was
+expected because the minimal probe client did not advertise form-elicitation
+support. The important distinction was that the native-pipe authentication
+error was gone.
+
+## Local workaround
+
+The helper changes the configured `node_repl` stdio command from a direct
+launch to this chain:
+
+```text
+managed Codex
+  → ChatGPT's OpenAI-signed cua_node/bin/node
+    → ~/.pwragent/local/openai-node-repl-trampoline.cjs
+      → ChatGPT's OpenAI-signed cua_node/bin/node_repl
+```
+
+It uses the public `codex mcp` CLI, preserves every existing `node_repl`
+environment value, verifies the replacement, and restores the original
+registration automatically if the update fails. It does not read Codex-owned
+configuration files directly. Before changing a non-trampoline launcher, it
+records only that launcher's command and arguments under `~/.pwragent/local/`;
+environment values remain in Codex's registration and are not copied into the
+backup.
+
+Inspect without changing anything:
+
+```bash
+pnpm dev:sky-computer-use -- --status
+```
+
+Install the workaround:
+
+```bash
+pnpm dev:sky-computer-use -- --apply
+```
+
+Then fully restart PwrAgent or reload its Codex MCP servers. Already-running
+`node_repl` processes keep their original parent chain.
+
+Restore the direct launcher:
+
+```bash
+pnpm dev:sky-computer-use -- --restore
+```
+
+When an original-launcher backup exists, `--restore` uses it. Otherwise it
+restores ChatGPT's bundled `node_repl` directly.
+
+For a nonstandard ChatGPT installation or PwrAgent root, pass
+`--chatgpt-app <path>` or `--pwragent-root <path>`. Pass `--codex <path>` to
+select the Codex CLI used for the public `mcp get`, `remove`, and `add`
+operations.
+
+## Why this must remain developer-only
+
+- `/Applications/ChatGPT.app/Contents/Resources/cua_node` is not a public
+  PwrAgent runtime contract.
+- ChatGPT updates can replace the Node REPL, Sky package, service, and protocol
+  independently of PwrAgent.
+- The workaround changes a machine-wide Codex MCP registration.
+- A symlink does not change the responsible process or its signing identity.
+- The next compatibility boundary may be form elicitation in the managed Codex
+  fork.
+
+A durable product fix needs a supported OpenAI authentication/broker contract
+for third-party Codex hosts or a Computer Use service that explicitly accepts
+the PwrDrvr signing identity. Codex documents MCP command and argument settings
+in the [official configuration reference](https://learn.chatgpt.com/docs/config-file/config-reference),
+but Sky's native-pipe authentication is not a public integration surface.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:dev": "pnpm --filter @pwragent/desktop dev:dev",
     "dev:no-messaging": "PWRAGENT_DISABLE_MESSAGING=1 pnpm --filter @pwragent/desktop dev -- --disable-messaging",
     "dev:op": "node ./scripts/op-run.mjs dev",
+    "dev:sky-computer-use": "node ./scripts/configure-sky-computer-use-workaround.mjs",
     "op:dev": "node ./scripts/op-run.mjs dev",
     "op:run": "node ./scripts/op-run.mjs run",
     "licenses:allowlist": "node ./scripts/check-third-party-license-allowlist.mjs",

--- a/scripts/configure-sky-computer-use-workaround.mjs
+++ b/scripts/configure-sky-computer-use-workaround.mjs
@@ -1,0 +1,351 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCallback);
+
+export const DEFAULT_CHATGPT_APP = "/Applications/ChatGPT.app";
+export const LAUNCHER_BACKUP_FILENAME = "node-repl-launcher-before-sky-trampoline.json";
+export const NODE_REPL_SERVER_NAME = "node_repl";
+export const TRAMPOLINE_FILENAME = "openai-node-repl-trampoline.cjs";
+
+function readOptionValue(args, index, option) {
+  const value = args[index + 1];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+export function parseArgs(args) {
+  let mode = "status";
+  let modeSelected = false;
+  let chatgptApp = DEFAULT_CHATGPT_APP;
+  let codexCommand;
+  let pwragentRoot;
+
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--") {
+      continue;
+    }
+    if (argument === "--apply" || argument === "--restore" || argument === "--status") {
+      if (modeSelected) {
+        throw new Error("Select exactly one of --apply, --restore, or --status");
+      }
+      modeSelected = true;
+      mode = argument.slice(2);
+      continue;
+    }
+    if (argument === "--chatgpt-app") {
+      chatgptApp = readOptionValue(args, index, argument);
+      index += 1;
+      continue;
+    }
+    if (argument === "--codex") {
+      codexCommand = readOptionValue(args, index, argument);
+      index += 1;
+      continue;
+    }
+    if (argument === "--pwragent-root") {
+      pwragentRoot = readOptionValue(args, index, argument);
+      index += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${argument}`);
+  }
+
+  return {
+    chatgptApp: path.resolve(chatgptApp),
+    codexCommand: codexCommand ? path.resolve(codexCommand) : undefined,
+    mode,
+    pwragentRoot: pwragentRoot ? path.resolve(pwragentRoot) : undefined,
+  };
+}
+
+function readStringRecord(value, label) {
+  if (value === undefined) {
+    return {};
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+
+  const result = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") {
+      throw new Error(`${label}.${key} must be a string`);
+    }
+    result[key] = entry;
+  }
+  return result;
+}
+
+export function readNodeReplRegistration(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Codex returned an invalid node_repl registration");
+  }
+  const transport = value.transport;
+  if (!transport || typeof transport !== "object" || Array.isArray(transport)) {
+    throw new Error("Codex node_repl registration has no transport");
+  }
+  if (transport.type !== "stdio") {
+    throw new Error(`Codex node_repl transport must be stdio, got ${String(transport.type)}`);
+  }
+  if (typeof transport.command !== "string" || !transport.command.trim()) {
+    throw new Error("Codex node_repl registration has no command");
+  }
+  if (!Array.isArray(transport.args) || !transport.args.every((entry) => typeof entry === "string")) {
+    throw new Error("Codex node_repl registration has invalid arguments");
+  }
+
+  return {
+    args: [...transport.args],
+    command: transport.command,
+    env: readStringRecord(transport.env, "node_repl environment"),
+  };
+}
+
+export function readLauncherBackup(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("The node_repl launcher backup is invalid");
+  }
+  if (value.version !== 1) {
+    throw new Error(`Unsupported node_repl launcher backup version: ${String(value.version)}`);
+  }
+  if (typeof value.command !== "string" || !value.command.trim()) {
+    throw new Error("The node_repl launcher backup has no command");
+  }
+  if (!Array.isArray(value.args) || !value.args.every((entry) => typeof entry === "string")) {
+    throw new Error("The node_repl launcher backup has invalid arguments");
+  }
+  return {
+    args: [...value.args],
+    command: value.command,
+  };
+}
+
+export function buildMcpAddArgs(registration, command, args) {
+  const commandArgs = ["mcp", "add"];
+  for (const [key, value] of Object.entries(registration.env)) {
+    commandArgs.push("--env", `${key}=${value}`);
+  }
+  commandArgs.push(NODE_REPL_SERVER_NAME, "--", command, ...args);
+  return commandArgs;
+}
+
+export function renderTrampoline(nodeReplPath) {
+  return `"use strict";
+
+const { spawn } = require("node:child_process");
+
+const nodeReplPath = ${JSON.stringify(nodeReplPath)};
+const child = spawn(nodeReplPath, process.argv.slice(2), {
+  env: process.env,
+  stdio: "inherit",
+});
+
+let exiting = false;
+
+function forwardSignal(signal) {
+  if (!exiting) {
+    child.kill(signal);
+  }
+}
+
+for (const signal of ["SIGINT", "SIGHUP", "SIGTERM"]) {
+  process.on(signal, () => forwardSignal(signal));
+}
+
+child.on("error", (error) => {
+  console.error(\`Failed to launch the bundled node_repl: \${error.message}\`);
+  process.exitCode = 1;
+});
+
+child.on("exit", (code, signal) => {
+  exiting = true;
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exitCode = code ?? 1;
+});
+`;
+}
+
+export function registrationsMatch(left, right) {
+  return left.command === right.command
+    && JSON.stringify(left.args) === JSON.stringify(right.args)
+    && Object.keys(left.env).length === Object.keys(right.env).length
+    && Object.entries(left.env).every(([key, value]) => right.env[key] === value);
+}
+
+async function readRegistration(codexCommand) {
+  const { stdout } = await execFile(
+    codexCommand,
+    ["mcp", "get", NODE_REPL_SERVER_NAME, "--json"],
+    { maxBuffer: 1024 * 1024 },
+  );
+  return readNodeReplRegistration(JSON.parse(stdout));
+}
+
+async function removeRegistration(codexCommand) {
+  await execFile(codexCommand, ["mcp", "remove", NODE_REPL_SERVER_NAME]);
+}
+
+async function addRegistration(codexCommand, registration, command, args) {
+  await execFile(
+    codexCommand,
+    buildMcpAddArgs(registration, command, args),
+    { maxBuffer: 1024 * 1024 },
+  );
+}
+
+async function readLauncherBackupFile(backupPath) {
+  try {
+    return readLauncherBackup(JSON.parse(await readFile(backupPath, "utf8")));
+  } catch (error) {
+    if (error && typeof error === "object" && error.code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function replaceRegistration({
+  codexCommand,
+  current,
+  desiredArgs,
+  desiredCommand,
+}) {
+  await removeRegistration(codexCommand);
+  try {
+    await addRegistration(codexCommand, current, desiredCommand, desiredArgs);
+    const updated = await readRegistration(codexCommand);
+    const desired = {
+      args: desiredArgs,
+      command: desiredCommand,
+      env: current.env,
+    };
+    if (!registrationsMatch(updated, desired)) {
+      throw new Error("Codex did not preserve the requested node_repl registration");
+    }
+    return updated;
+  } catch (error) {
+    try {
+      await removeRegistration(codexCommand);
+    } catch {
+      // The failed add may have left no registration to remove.
+    }
+    try {
+      await addRegistration(codexCommand, current, current.command, current.args);
+    } catch (restoreError) {
+      throw new AggregateError(
+        [error, restoreError],
+        "Updating node_repl failed and the original registration could not be restored",
+      );
+    }
+    throw error;
+  }
+}
+
+function printStatus(registration, expected) {
+  const applied = registration.command === expected.command
+    && JSON.stringify(registration.args) === JSON.stringify(expected.args);
+  console.log(JSON.stringify({
+    applied,
+    args: registration.args,
+    command: registration.command,
+    environmentVariableCount: Object.keys(registration.env).length,
+  }, null, 2));
+}
+
+export async function main(args = process.argv.slice(2), runtime = {}) {
+  const options = parseArgs(args);
+  if ((runtime.platform ?? process.platform) !== "darwin") {
+    throw new Error("The Sky Computer Use signing workaround is macOS-only");
+  }
+
+  const resources = path.join(options.chatgptApp, "Contents", "Resources");
+  const signedNode = path.join(resources, "cua_node", "bin", "node");
+  const nodeRepl = path.join(resources, "cua_node", "bin", "node_repl");
+  const codexCommand = options.codexCommand ?? path.join(resources, "codex");
+  const pwragentRoot = options.pwragentRoot
+    ?? process.env.PWRAGENT_HOME?.trim()
+    ?? path.join(os.homedir(), ".pwragent");
+  const localRoot = path.join(pwragentRoot, "local");
+  const backupPath = path.join(localRoot, LAUNCHER_BACKUP_FILENAME);
+  const trampoline = path.join(localRoot, TRAMPOLINE_FILENAME);
+
+  await Promise.all([
+    access(codexCommand, fsConstants.X_OK),
+    access(signedNode, fsConstants.X_OK),
+    access(nodeRepl, fsConstants.X_OK),
+  ]);
+
+  const current = await readRegistration(codexCommand);
+  const expected = {
+    args: [trampoline],
+    command: signedNode,
+    env: current.env,
+  };
+
+  if (options.mode === "status") {
+    printStatus(current, expected);
+    return;
+  }
+
+  if (options.mode === "restore") {
+    const backup = await readLauncherBackupFile(backupPath);
+    const restored = await replaceRegistration({
+      codexCommand,
+      current,
+      desiredArgs: backup?.args ?? [],
+      desiredCommand: backup?.command ?? nodeRepl,
+    });
+    printStatus(restored, expected);
+    console.log("Restored the direct node_repl launcher. Restart Codex MCP servers to apply it.");
+    return;
+  }
+
+  await mkdir(localRoot, { recursive: true });
+  await writeFile(trampoline, renderTrampoline(nodeRepl), {
+    encoding: "utf8",
+    mode: 0o644,
+  });
+
+  if (!registrationsMatch(current, expected)) {
+    await writeFile(backupPath, `${JSON.stringify({
+      args: current.args,
+      command: current.command,
+      version: 1,
+    }, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  }
+
+  const updated = registrationsMatch(current, expected)
+    ? current
+    : await replaceRegistration({
+        codexCommand,
+        current,
+        desiredArgs: expected.args,
+        desiredCommand: expected.command,
+      });
+  printStatus(updated, expected);
+  console.log("Installed the signed-node trampoline. Restart Codex MCP servers to apply it.");
+}
+
+const isMain = process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  });
+}

--- a/scripts/configure-sky-computer-use-workaround.mjs
+++ b/scripts/configure-sky-computer-use-workaround.mjs
@@ -8,6 +8,25 @@ import { promisify } from "node:util";
 
 const execFile = promisify(execFileCallback);
 
+const EXPECTED_REGISTRATION_KEYS = new Set([
+  "disabled_reason",
+  "disabled_tools",
+  "enabled",
+  "enabled_tools",
+  "name",
+  "startup_timeout_sec",
+  "tool_timeout_sec",
+  "transport",
+]);
+const EXPECTED_TRANSPORT_KEYS = new Set([
+  "args",
+  "command",
+  "cwd",
+  "env",
+  "env_vars",
+  "type",
+]);
+
 export const DEFAULT_CHATGPT_APP = "/Applications/ChatGPT.app";
 export const LAUNCHER_BACKUP_FILENAME = "node-repl-launcher-before-sky-trampoline.json";
 export const NODE_REPL_SERVER_NAME = "node_repl";
@@ -103,6 +122,51 @@ export function readNodeReplRegistration(value) {
     throw new Error("Codex node_repl registration has invalid arguments");
   }
 
+  const unsupportedSettings = [];
+  for (const key of Object.keys(value)) {
+    if (!EXPECTED_REGISTRATION_KEYS.has(key)) {
+      unsupportedSettings.push(key);
+    }
+  }
+  for (const key of Object.keys(transport)) {
+    if (!EXPECTED_TRANSPORT_KEYS.has(key)) {
+      unsupportedSettings.push(`transport.${key}`);
+    }
+  }
+  if (value.name !== undefined && value.name !== NODE_REPL_SERVER_NAME) {
+    unsupportedSettings.push("name");
+  }
+  if (value.enabled !== undefined && value.enabled !== true) {
+    unsupportedSettings.push("enabled");
+  }
+  for (const key of [
+    "disabled_reason",
+    "disabled_tools",
+    "enabled_tools",
+    "startup_timeout_sec",
+    "tool_timeout_sec",
+  ]) {
+    if (value[key] !== undefined && value[key] !== null) {
+      unsupportedSettings.push(key);
+    }
+  }
+  if (transport.cwd !== undefined && transport.cwd !== null) {
+    unsupportedSettings.push("transport.cwd");
+  }
+  if (
+    transport.env_vars !== undefined
+    && (!Array.isArray(transport.env_vars) || transport.env_vars.length > 0)
+  ) {
+    unsupportedSettings.push("transport.env_vars");
+  }
+  if (unsupportedSettings.length > 0) {
+    throw new Error(
+      `Codex node_repl registration has unsupported settings: ${[
+        ...new Set(unsupportedSettings),
+      ].sort().join(", ")}`,
+    );
+  }
+
   return {
     args: [...transport.args],
     command: transport.command,
@@ -138,6 +202,23 @@ export function buildMcpAddArgs(registration, command, args) {
   return commandArgs;
 }
 
+export function createSafeCodexCommandError(action, error) {
+  const details = [];
+  const code = error && typeof error === "object" ? error.code : undefined;
+  const signal = error && typeof error === "object" ? error.signal : undefined;
+  if (
+    typeof code === "number"
+    || (typeof code === "string" && /^[A-Z0-9_-]+$/.test(code))
+  ) {
+    details.push(`code ${code}`);
+  }
+  if (typeof signal === "string" && /^[A-Z0-9_-]+$/.test(signal)) {
+    details.push(`signal ${signal}`);
+  }
+  const suffix = details.length > 0 ? ` (${details.join(", ")})` : "";
+  return new Error(`Codex ${action} failed${suffix}`);
+}
+
 export function renderTrampoline(nodeReplPath) {
   return `"use strict";
 
@@ -150,6 +231,7 @@ const child = spawn(nodeReplPath, process.argv.slice(2), {
 });
 
 let exiting = false;
+const signalHandlers = new Map();
 
 function forwardSignal(signal) {
   if (!exiting) {
@@ -158,7 +240,15 @@ function forwardSignal(signal) {
 }
 
 for (const signal of ["SIGINT", "SIGHUP", "SIGTERM"]) {
-  process.on(signal, () => forwardSignal(signal));
+  const handler = () => forwardSignal(signal);
+  signalHandlers.set(signal, handler);
+  process.on(signal, handler);
+}
+
+function removeSignalHandlers() {
+  for (const [signal, handler] of signalHandlers) {
+    process.off(signal, handler);
+  }
 }
 
 child.on("error", (error) => {
@@ -168,6 +258,7 @@ child.on("error", (error) => {
 
 child.on("exit", (code, signal) => {
   exiting = true;
+  removeSignalHandlers();
   if (signal) {
     process.kill(process.pid, signal);
     return;
@@ -184,24 +275,74 @@ export function registrationsMatch(left, right) {
     && Object.entries(left.env).every(([key, value]) => right.env[key] === value);
 }
 
+export function isManagedTrampolineRegistration(registration) {
+  const expectedNodeSuffix = path.join(
+    "Contents",
+    "Resources",
+    "cua_node",
+    "bin",
+    "node",
+  );
+  return registration.args.length === 1
+    && path.basename(registration.args[0]) === TRAMPOLINE_FILENAME
+    && path.normalize(registration.command).endsWith(expectedNodeSuffix);
+}
+
+export function originalLauncherForApply(current, expected, backup) {
+  if (registrationsMatch(current, expected)) {
+    return undefined;
+  }
+  if (isManagedTrampolineRegistration(current)) {
+    if (!backup) {
+      throw new Error(
+        "The installed Sky trampoline has no original-launcher backup; restore it before migrating paths",
+      );
+    }
+    return backup;
+  }
+  return {
+    args: current.args,
+    command: current.command,
+  };
+}
+
+export function resolvePwragentRoot(explicitRoot, environmentRoot, homeDir) {
+  const configuredRoot = explicitRoot ?? environmentRoot?.trim();
+  return configuredRoot
+    ? path.resolve(configuredRoot)
+    : path.join(homeDir, ".pwragent");
+}
+
+async function runCodexCommand(codexCommand, args, action) {
+  try {
+    return await execFile(codexCommand, args, { maxBuffer: 1024 * 1024 });
+  } catch (error) {
+    throw createSafeCodexCommandError(action, error);
+  }
+}
+
 async function readRegistration(codexCommand) {
-  const { stdout } = await execFile(
+  const { stdout } = await runCodexCommand(
     codexCommand,
     ["mcp", "get", NODE_REPL_SERVER_NAME, "--json"],
-    { maxBuffer: 1024 * 1024 },
+    "mcp get node_repl",
   );
   return readNodeReplRegistration(JSON.parse(stdout));
 }
 
 async function removeRegistration(codexCommand) {
-  await execFile(codexCommand, ["mcp", "remove", NODE_REPL_SERVER_NAME]);
+  await runCodexCommand(
+    codexCommand,
+    ["mcp", "remove", NODE_REPL_SERVER_NAME],
+    "mcp remove node_repl",
+  );
 }
 
 async function addRegistration(codexCommand, registration, command, args) {
-  await execFile(
+  await runCodexCommand(
     codexCommand,
     buildMcpAddArgs(registration, command, args),
-    { maxBuffer: 1024 * 1024 },
+    "mcp add node_repl",
   );
 }
 
@@ -274,9 +415,11 @@ export async function main(args = process.argv.slice(2), runtime = {}) {
   const signedNode = path.join(resources, "cua_node", "bin", "node");
   const nodeRepl = path.join(resources, "cua_node", "bin", "node_repl");
   const codexCommand = options.codexCommand ?? path.join(resources, "codex");
-  const pwragentRoot = options.pwragentRoot
-    ?? process.env.PWRAGENT_HOME?.trim()
-    ?? path.join(os.homedir(), ".pwragent");
+  const pwragentRoot = resolvePwragentRoot(
+    options.pwragentRoot,
+    process.env.PWRAGENT_HOME,
+    os.homedir(),
+  );
   const localRoot = path.join(pwragentRoot, "local");
   const backupPath = path.join(localRoot, LAUNCHER_BACKUP_FILENAME);
   const trampoline = path.join(localRoot, TRAMPOLINE_FILENAME);
@@ -300,7 +443,10 @@ export async function main(args = process.argv.slice(2), runtime = {}) {
   }
 
   if (options.mode === "restore") {
-    const backup = await readLauncherBackupFile(backupPath);
+    const installedBackupPath = isManagedTrampolineRegistration(current)
+      ? path.join(path.dirname(current.args[0]), LAUNCHER_BACKUP_FILENAME)
+      : backupPath;
+    const backup = await readLauncherBackupFile(installedBackupPath);
     const restored = await replaceRegistration({
       codexCommand,
       current,
@@ -313,21 +459,31 @@ export async function main(args = process.argv.slice(2), runtime = {}) {
   }
 
   await mkdir(localRoot, { recursive: true });
-  await writeFile(trampoline, renderTrampoline(nodeRepl), {
-    encoding: "utf8",
-    mode: 0o644,
-  });
-
-  if (!registrationsMatch(current, expected)) {
+  const installedBackupPath = isManagedTrampolineRegistration(current)
+    ? path.join(path.dirname(current.args[0]), LAUNCHER_BACKUP_FILENAME)
+    : undefined;
+  const installedBackup = installedBackupPath
+    ? await readLauncherBackupFile(installedBackupPath)
+    : undefined;
+  const originalLauncher = originalLauncherForApply(
+    current,
+    expected,
+    installedBackup,
+  );
+  if (originalLauncher) {
     await writeFile(backupPath, `${JSON.stringify({
-      args: current.args,
-      command: current.command,
+      args: originalLauncher.args,
+      command: originalLauncher.command,
       version: 1,
     }, null, 2)}\n`, {
       encoding: "utf8",
       mode: 0o600,
     });
   }
+  await writeFile(trampoline, renderTrampoline(nodeRepl), {
+    encoding: "utf8",
+    mode: 0o644,
+  });
 
   const updated = registrationsMatch(current, expected)
     ? current

--- a/scripts/configure-sky-computer-use-workaround.test.mjs
+++ b/scripts/configure-sky-computer-use-workaround.test.mjs
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMcpAddArgs,
+  parseArgs,
+  readLauncherBackup,
+  readNodeReplRegistration,
+  registrationsMatch,
+  renderTrampoline,
+} from "./configure-sky-computer-use-workaround.mjs";
+
+describe("configure Sky Computer Use workaround", () => {
+  it("defaults to a status check", () => {
+    expect(parseArgs([])).toEqual({
+      chatgptApp: "/Applications/ChatGPT.app",
+      codexCommand: undefined,
+      mode: "status",
+      pwragentRoot: undefined,
+    });
+  });
+
+  it("accepts pnpm's argument separator", () => {
+    expect(parseArgs(["--", "--status"]).mode).toBe("status");
+  });
+
+  it("accepts one mutation mode and path overrides", () => {
+    expect(parseArgs([
+      "--apply",
+      "--chatgpt-app",
+      "/Volumes/Tools/ChatGPT.app",
+      "--codex",
+      "/opt/codex",
+      "--pwragent-root",
+      "/tmp/pwragent",
+    ])).toEqual({
+      chatgptApp: "/Volumes/Tools/ChatGPT.app",
+      codexCommand: "/opt/codex",
+      mode: "apply",
+      pwragentRoot: "/tmp/pwragent",
+    });
+  });
+
+  it("rejects ambiguous modes", () => {
+    expect(() => parseArgs(["--apply", "--restore"]))
+      .toThrow("Select exactly one");
+  });
+
+  it("reads a stdio registration without exposing Codex storage", () => {
+    expect(readNodeReplRegistration({
+      transport: {
+        args: ["--example"],
+        command: "/path/to/node_repl",
+        env: { A: "one", B: "two" },
+        type: "stdio",
+      },
+    })).toEqual({
+      args: ["--example"],
+      command: "/path/to/node_repl",
+      env: { A: "one", B: "two" },
+    });
+  });
+
+  it("validates the launcher backup without persisting environment values", () => {
+    expect(readLauncherBackup({
+      args: ["--example"],
+      command: "/original/node_repl",
+      version: 1,
+    })).toEqual({
+      args: ["--example"],
+      command: "/original/node_repl",
+    });
+    expect(() => readLauncherBackup({
+      args: [],
+      command: "/original/node_repl",
+      version: 2,
+    })).toThrow("Unsupported");
+  });
+
+  it("preserves every environment value in the replacement command", () => {
+    expect(buildMcpAddArgs(
+      {
+        args: [],
+        command: "/old/node_repl",
+        env: {
+          NODE_REPL_TRUSTED_SERVICES: "{\"sky\":\"@oai/sky/service\"}",
+          SKY_CUA_SERVICE_PATH: "/path with spaces/Codex Computer Use.app",
+        },
+      },
+      "/signed/node",
+      ["/path/to/trampoline.cjs"],
+    )).toEqual([
+      "mcp",
+      "add",
+      "--env",
+      "NODE_REPL_TRUSTED_SERVICES={\"sky\":\"@oai/sky/service\"}",
+      "--env",
+      "SKY_CUA_SERVICE_PATH=/path with spaces/Codex Computer Use.app",
+      "node_repl",
+      "--",
+      "/signed/node",
+      "/path/to/trampoline.cjs",
+    ]);
+  });
+
+  it("renders the node_repl path as a safe JavaScript string", () => {
+    const trampoline = renderTrampoline("/path/with \"quotes\"/node_repl");
+    expect(trampoline).toContain(
+      'const nodeReplPath = "/path/with \\"quotes\\"/node_repl";',
+    );
+    expect(trampoline).toContain('stdio: "inherit"');
+  });
+
+  it("compares the complete command, args, and environment", () => {
+    const registration = {
+      args: ["/trampoline.cjs"],
+      command: "/signed/node",
+      env: { A: "one", B: "two" },
+    };
+    expect(registrationsMatch(registration, registration)).toBe(true);
+    expect(registrationsMatch(registration, {
+      ...registration,
+      env: { B: "two", A: "one" },
+    })).toBe(true);
+    expect(registrationsMatch(registration, {
+      ...registration,
+      env: { A: "two" },
+    })).toBe(false);
+  });
+});

--- a/scripts/configure-sky-computer-use-workaround.test.mjs
+++ b/scripts/configure-sky-computer-use-workaround.test.mjs
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   buildMcpAddArgs,
@@ -11,7 +12,7 @@ import {
 describe("configure Sky Computer Use workaround", () => {
   it("defaults to a status check", () => {
     expect(parseArgs([])).toEqual({
-      chatgptApp: "/Applications/ChatGPT.app",
+      chatgptApp: path.resolve("/Applications/ChatGPT.app"),
       codexCommand: undefined,
       mode: "status",
       pwragentRoot: undefined,
@@ -32,10 +33,10 @@ describe("configure Sky Computer Use workaround", () => {
       "--pwragent-root",
       "/tmp/pwragent",
     ])).toEqual({
-      chatgptApp: "/Volumes/Tools/ChatGPT.app",
-      codexCommand: "/opt/codex",
+      chatgptApp: path.resolve("/Volumes/Tools/ChatGPT.app"),
+      codexCommand: path.resolve("/opt/codex"),
       mode: "apply",
-      pwragentRoot: "/tmp/pwragent",
+      pwragentRoot: path.resolve("/tmp/pwragent"),
     });
   });
 

--- a/scripts/configure-sky-computer-use-workaround.test.mjs
+++ b/scripts/configure-sky-computer-use-workaround.test.mjs
@@ -1,12 +1,20 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  TRAMPOLINE_FILENAME,
   buildMcpAddArgs,
+  createSafeCodexCommandError,
+  isManagedTrampolineRegistration,
+  originalLauncherForApply,
   parseArgs,
   readLauncherBackup,
   readNodeReplRegistration,
   registrationsMatch,
   renderTrampoline,
+  resolvePwragentRoot,
 } from "./configure-sky-computer-use-workaround.mjs";
 
 describe("configure Sky Computer Use workaround", () => {
@@ -60,6 +68,41 @@ describe("configure Sky Computer Use workaround", () => {
     });
   });
 
+  it("rejects MCP settings that codex mcp add cannot preserve", () => {
+    const registration = {
+      disabled_reason: null,
+      disabled_tools: null,
+      enabled: true,
+      enabled_tools: null,
+      name: "node_repl",
+      startup_timeout_sec: null,
+      tool_timeout_sec: null,
+      transport: {
+        args: [],
+        command: "/path/to/node_repl",
+        cwd: null,
+        env: {},
+        env_vars: [],
+        type: "stdio",
+      },
+    };
+    const unsupported = [
+      { enabled: false },
+      { enabled_tools: ["js"] },
+      { startup_timeout_sec: 30 },
+      { unexpected: true },
+      { transport: { ...registration.transport, cwd: "/tmp" } },
+      { transport: { ...registration.transport, env_vars: ["TOKEN"] } },
+    ];
+
+    for (const override of unsupported) {
+      expect(() => readNodeReplRegistration({
+        ...registration,
+        ...override,
+      })).toThrow("unsupported settings");
+    }
+  });
+
   it("validates the launcher backup without persisting environment values", () => {
     expect(readLauncherBackup({
       args: ["--example"],
@@ -102,13 +145,51 @@ describe("configure Sky Computer Use workaround", () => {
     ]);
   });
 
+  it("redacts environment arguments from Codex command failures", () => {
+    const error = Object.assign(
+      new Error("codex mcp add --env TOKEN=super-secret node_repl"),
+      { code: 1, signal: "SIGTERM" },
+    );
+    const safeError = createSafeCodexCommandError("mcp add node_repl", error);
+
+    expect(safeError.message).toBe(
+      "Codex mcp add node_repl failed (code 1, signal SIGTERM)",
+    );
+    expect(safeError.message).not.toContain("super-secret");
+    expect(safeError.cause).toBeUndefined();
+  });
+
   it("renders the node_repl path as a safe JavaScript string", () => {
     const trampoline = renderTrampoline("/path/with \"quotes\"/node_repl");
     expect(trampoline).toContain(
       'const nodeReplPath = "/path/with \\"quotes\\"/node_repl";',
     );
     expect(trampoline).toContain('stdio: "inherit"');
+    expect(trampoline).toContain("process.off(signal, handler)");
   });
+
+  it.skipIf(process.platform === "win32")(
+    "propagates a child termination signal",
+    async () => {
+      const tempRoot = await mkdtemp(path.join(os.tmpdir(), "sky-trampoline-test-"));
+      const trampolinePath = path.join(tempRoot, TRAMPOLINE_FILENAME);
+      try {
+        await writeFile(trampolinePath, renderTrampoline(process.execPath));
+        const result = await new Promise((resolve, reject) => {
+          const trampoline = spawn(process.execPath, [
+            trampolinePath,
+            "-e",
+            'process.kill(process.pid, "SIGTERM")',
+          ]);
+          trampoline.once("error", reject);
+          trampoline.once("exit", (code, signal) => resolve({ code, signal }));
+        });
+        expect(result).toEqual({ code: null, signal: "SIGTERM" });
+      } finally {
+        await rm(tempRoot, { recursive: true });
+      }
+    },
+  );
 
   it("compares the complete command, args, and environment", () => {
     const registration = {
@@ -125,5 +206,48 @@ describe("configure Sky Computer Use workaround", () => {
       ...registration,
       env: { A: "two" },
     })).toBe(false);
+  });
+
+  it("retains the real original launcher when moving an installed trampoline", () => {
+    const current = {
+      args: [path.join("/old-root", "local", TRAMPOLINE_FILENAME)],
+      command: path.join(
+        "/old-chatgpt",
+        "Contents",
+        "Resources",
+        "cua_node",
+        "bin",
+        "node",
+      ),
+      env: { A: "one" },
+    };
+    const expected = {
+      args: [path.join("/new-root", "local", TRAMPOLINE_FILENAME)],
+      command: path.join(
+        "/new-chatgpt",
+        "Contents",
+        "Resources",
+        "cua_node",
+        "bin",
+        "node",
+      ),
+      env: current.env,
+    };
+    const backup = {
+      args: ["--original"],
+      command: "/original/node_repl",
+    };
+
+    expect(isManagedTrampolineRegistration(current)).toBe(true);
+    expect(originalLauncherForApply(current, expected, backup)).toEqual(backup);
+    expect(() => originalLauncherForApply(current, expected, undefined))
+      .toThrow("has no original-launcher backup");
+  });
+
+  it("treats an empty PWRAGENT_HOME as unset", () => {
+    const homeDir = path.resolve("/operator-home");
+    expect(resolvePwragentRoot(undefined, "   ", homeDir)).toBe(
+      path.join(homeDir, ".pwragent"),
+    );
   });
 });


### PR DESCRIPTION
## Summary

- add a developer-only status/apply/restore helper for the Sky Computer Use node_repl signing workaround
- preserve the existing MCP environment and back up the original launcher command and arguments
- document the native-pipe authentication evidence, limitations, and rollback path

## Why

The managed PwrAgent Codex runtime is signed by PwrDrvr LLC. Sky Computer Use rejects the resulting node_repl native-pipe connection as unauthenticated even though @oai/sky imports successfully. Launching node_repl through the OpenAI-signed Node binary crosses that authentication boundary.

This remains developer-only because it depends on private paths and signing behavior inside ChatGPT.app.

## Validation

- `pnpm test scripts/configure-sky-computer-use-workaround.test.mjs`
- `pnpm lint:codex-storage`
- `pnpm lint:eslint`
- `pnpm typecheck`
- real `--restore` → `--apply` → `--status` rehearsal preserving all 15 node_repl environment values
- live PwrAgent Computer Use test pending after an MCP/PwrAgent restart
