### PR TITLE
feat(desktop): add sub-agent ownership lenses

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -18,6 +18,8 @@ import { RailStatusChip } from "./RailStatusChip";
 import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
 import { SubAgentDetailsModal } from "./SubAgentDetailsModal";
 import {
+  type SubAgentLens,
+  subAgentLens,
   subAgentOriginSentence,
   subAgentUsageLabel,
 } from "./subagent-kind";
@@ -32,10 +34,47 @@ type SubAgentsPanelProps = {
   thread: NavigationThreadSummary;
 };
 
+const SUB_AGENT_LENSES: Array<{
+  id: SubAgentLens;
+  label: string;
+}> = [
+  { id: "harness", label: "Harness" },
+  { id: "token-miser", label: "Token Miser" },
+  { id: "pwragent", label: "PwrAgent" },
+];
+
 /** Sub-Agents tab: durable task-monitor cards spawned from this thread. */
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
   const { onDetailsModalOpenChange } = props;
+  const [requestedLens, setRequestedLens] = useState<SubAgentLens>("harness");
+  const lensCounts = SUB_AGENT_LENSES.reduce<Record<SubAgentLens, number>>(
+    (counts, lens) => ({
+      ...counts,
+      [lens.id]: subAgents.filter(
+        (subAgent) => subAgentLens(subAgent) === lens.id,
+      ).length,
+    }),
+    {
+      harness: 0,
+      "token-miser": 0,
+      pwragent: 0,
+    },
+  );
+  const availableLenses = SUB_AGENT_LENSES.filter(
+    (lens) => lensCounts[lens.id] > 0,
+  );
+  const preferredLens =
+    availableLenses.find((lens) => lens.id === "harness")?.id
+    ?? availableLenses.find((lens) => lens.id === "pwragent")?.id
+    ?? availableLenses[0]?.id
+    ?? "harness";
+  const activeLens = lensCounts[requestedLens] > 0
+    ? requestedLens
+    : preferredLens;
+  const visibleSubAgents = subAgents.filter(
+    (subAgent) => subAgentLens(subAgent) === activeLens,
+  );
   // Track the open dialog by id, not by the summary object: the snapshot the
   // Details button was clicked with goes stale the moment the sub-agent
   // streams another update, and the dialog would sit on frozen status, timing,
@@ -116,8 +155,44 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
       {loading ? (
         <p className="context-empty">Loading sub-agents…</p>
       ) : subAgents.length > 0 ? (
-        <ul className="context-list context-list--cards">
-          {subAgents.map((subAgent) => {
+        <>
+          {availableLenses.length > 1 ? (
+            <div
+              aria-label="Sub-agent ownership"
+              className="subagent-lens-switch"
+              role="tablist"
+            >
+              {availableLenses.map((lens) => (
+                <button
+                  aria-label={`${lens.label} ${lensCounts[lens.id]}`}
+                  aria-controls="subagent-lens-panel"
+                  aria-selected={activeLens === lens.id}
+                  className="subagent-lens-switch__button"
+                  id={`subagent-lens-${lens.id}`}
+                  key={lens.id}
+                  role="tab"
+                  type="button"
+                  onClick={() => setRequestedLens(lens.id)}
+                >
+                  <span>{lens.label}</span>
+                  <span className="subagent-lens-switch__count">
+                    {lensCounts[lens.id]}
+                  </span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+          <ul
+            aria-labelledby={
+              availableLenses.length > 1
+                ? `subagent-lens-${activeLens}`
+                : undefined
+            }
+            className="context-list context-list--cards"
+            id="subagent-lens-panel"
+            role={availableLenses.length > 1 ? "tabpanel" : undefined}
+          >
+          {visibleSubAgents.map((subAgent) => {
             const tone = subAgentTone(subAgent.status);
             const originSentence = subAgentOriginSentence(subAgent);
             const backend = subAgent.backend ?? props.thread.source;
@@ -224,7 +299,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
               </li>
             );
           })}
-        </ul>
+          </ul>
+        </>
       ) : (
         <p className="context-empty">
           No sub-agents yet. Delegated monitors, reviews, and observed native

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -1,4 +1,9 @@
-import { useEffect, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useState,
+  type KeyboardEvent,
+} from "react";
 import type {
   NavigationThreadSummary,
   ThreadSubAgentSummary,
@@ -47,6 +52,10 @@ const SUB_AGENT_LENSES: Array<{
 export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
   const { onDetailsModalOpenChange } = props;
+  const lensControlId = useId();
+  const lensPanelId = `${lensControlId}-panel`;
+  const lensTabId = (lens: SubAgentLens): string =>
+    `${lensControlId}-${lens}`;
   const [requestedLens, setRequestedLens] = useState<SubAgentLens>("harness");
   const lensCounts = SUB_AGENT_LENSES.reduce<Record<SubAgentLens, number>>(
     (counts, lens) => ({
@@ -114,6 +123,46 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
     onDetailsModalOpenChange?.(false);
   };
 
+  // Horizontal tablist roving focus (WAI-ARIA tabs pattern). Keep activation
+  // manual so arrowing through ownership choices does not replace the card
+  // list until the operator presses Enter or Space.
+  const handleLensKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (
+      event.key !== "ArrowRight"
+      && event.key !== "ArrowLeft"
+      && event.key !== "Home"
+      && event.key !== "End"
+    ) {
+      return;
+    }
+    const tabs = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>('[role="tab"]'),
+    );
+    if (tabs.length === 0) {
+      return;
+    }
+    const current = tabs.indexOf(document.activeElement as HTMLElement);
+    let next: number;
+    switch (event.key) {
+      case "ArrowRight":
+        next = current < 0 ? 0 : (current + 1) % tabs.length;
+        break;
+      case "ArrowLeft":
+        next = current < 0
+          ? tabs.length - 1
+          : (current - 1 + tabs.length) % tabs.length;
+        break;
+      case "Home":
+        next = 0;
+        break;
+      default:
+        next = tabs.length - 1;
+        break;
+    }
+    event.preventDefault();
+    tabs[next]?.focus();
+  };
+
   const stopSubAgent = async (subAgent: ThreadSubAgentSummary): Promise<void> => {
     if (!props.desktopApi?.stopSubAgent) {
       return;
@@ -159,18 +208,21 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
           {availableLenses.length > 1 ? (
             <div
               aria-label="Sub-agent ownership"
+              aria-orientation="horizontal"
               className="subagent-lens-switch"
               role="tablist"
+              onKeyDown={handleLensKeyDown}
             >
               {availableLenses.map((lens) => (
                 <button
                   aria-label={`${lens.label} ${lensCounts[lens.id]}`}
-                  aria-controls="subagent-lens-panel"
+                  aria-controls={lensPanelId}
                   aria-selected={activeLens === lens.id}
                   className="subagent-lens-switch__button"
-                  id={`subagent-lens-${lens.id}`}
+                  id={lensTabId(lens.id)}
                   key={lens.id}
                   role="tab"
+                  tabIndex={activeLens === lens.id ? 0 : -1}
                   type="button"
                   onClick={() => setRequestedLens(lens.id)}
                 >
@@ -185,11 +237,11 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
           <ul
             aria-labelledby={
               availableLenses.length > 1
-                ? `subagent-lens-${activeLens}`
+                ? lensTabId(activeLens)
                 : undefined
             }
             className="context-list context-list--cards"
-            id="subagent-lens-panel"
+            id={lensPanelId}
             role={availableLenses.length > 1 ? "tabpanel" : undefined}
           >
           {visibleSubAgents.map((subAgent) => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -49,6 +49,73 @@ const thread: NavigationThreadSummary = {
 };
 
 describe("SubAgentsPanel", () => {
+  it("separates harness, Token Miser, and PwrAgent sub-agents", () => {
+    render(
+      <SubAgentsPanel
+        thread={{
+          ...thread,
+          subAgents: [
+            {
+              monitorId: "system:token-miser:gate-1",
+              task: "Gate noisy output",
+              status: "success",
+              createdAt: 1_800_000_000_200,
+              updatedAt: 1_800_000_000_300,
+            },
+            {
+              monitorId: "codex-native:child-1",
+              task: "Inspect native worker",
+              status: "running",
+              createdAt: 1_800_000_000_100,
+              updatedAt: 1_800_000_000_100,
+            },
+            ...thread.subAgents!,
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "Harness 1" }))
+      .toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Inspect native worker")).toBeInTheDocument();
+    expect(screen.queryByText("Gate noisy output")).not.toBeInTheDocument();
+    expect(screen.queryByText("Watch the deployment")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "Token Miser 1" }));
+    expect(screen.getByText("Gate noisy output")).toBeInTheDocument();
+    expect(screen.queryByText("Inspect native worker")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("tab", { name: "PwrAgent 2" }));
+    expect(screen.getByText("Watch the deployment")).toBeInTheDocument();
+    expect(screen.getByText("Finished work")).toBeInTheDocument();
+    expect(screen.queryByText("Gate noisy output")).not.toBeInTheDocument();
+  });
+
+  it("prefers PwrAgent when a thread has no harness-managed sub-agents", () => {
+    render(
+      <SubAgentsPanel
+        thread={{
+          ...thread,
+          subAgents: [
+            {
+              monitorId: "system:token-miser:gate-1",
+              task: "Gate noisy output",
+              status: "success",
+              createdAt: 1_800_000_000_200,
+              updatedAt: 1_800_000_000_300,
+            },
+            ...thread.subAgents!,
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("tab", { name: "PwrAgent 2" }))
+      .toHaveAttribute("aria-selected", "true");
+    expect(screen.getByText("Watch the deployment")).toBeInTheDocument();
+    expect(screen.queryByText("Gate noisy output")).not.toBeInTheDocument();
+  });
+
   it("shows Token Miser's per-gate cost equation", () => {
     render(
       <SubAgentsPanel

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -48,29 +48,31 @@ const thread: NavigationThreadSummary = {
   ],
 };
 
+const mixedSubAgents = [
+  {
+    monitorId: "system:token-miser:gate-1",
+    task: "Gate noisy output",
+    status: "success" as const,
+    createdAt: 1_800_000_000_200,
+    updatedAt: 1_800_000_000_300,
+  },
+  {
+    monitorId: "codex-native:child-1",
+    task: "Inspect native worker",
+    status: "running" as const,
+    createdAt: 1_800_000_000_100,
+    updatedAt: 1_800_000_000_100,
+  },
+  ...thread.subAgents!,
+];
+
 describe("SubAgentsPanel", () => {
   it("separates harness, Token Miser, and PwrAgent sub-agents", () => {
     render(
       <SubAgentsPanel
         thread={{
           ...thread,
-          subAgents: [
-            {
-              monitorId: "system:token-miser:gate-1",
-              task: "Gate noisy output",
-              status: "success",
-              createdAt: 1_800_000_000_200,
-              updatedAt: 1_800_000_000_300,
-            },
-            {
-              monitorId: "codex-native:child-1",
-              task: "Inspect native worker",
-              status: "running",
-              createdAt: 1_800_000_000_100,
-              updatedAt: 1_800_000_000_100,
-            },
-            ...thread.subAgents!,
-          ],
+          subAgents: mixedSubAgents,
         }}
       />,
     );
@@ -89,6 +91,74 @@ describe("SubAgentsPanel", () => {
     expect(screen.getByText("Watch the deployment")).toBeInTheDocument();
     expect(screen.getByText("Finished work")).toBeInTheDocument();
     expect(screen.queryByText("Gate noisy output")).not.toBeInTheDocument();
+  });
+
+  it("uses roving focus and horizontal tablist keyboard navigation", () => {
+    render(
+      <SubAgentsPanel
+        thread={{
+          ...thread,
+          subAgents: mixedSubAgents,
+        }}
+      />,
+    );
+
+    const tablist = screen.getByRole("tablist", {
+      name: "Sub-agent ownership",
+    });
+    const harness = screen.getByRole("tab", { name: "Harness 1" });
+    const tokenMiser = screen.getByRole("tab", { name: "Token Miser 1" });
+    const pwrAgent = screen.getByRole("tab", { name: "PwrAgent 2" });
+
+    expect(tablist).toHaveAttribute("aria-orientation", "horizontal");
+    expect(harness).toHaveAttribute("tabindex", "0");
+    expect(tokenMiser).toHaveAttribute("tabindex", "-1");
+    expect(pwrAgent).toHaveAttribute("tabindex", "-1");
+
+    harness.focus();
+    fireEvent.keyDown(harness, { key: "ArrowRight" });
+    expect(tokenMiser).toHaveFocus();
+    expect(harness).toHaveAttribute("aria-selected", "true");
+
+    fireEvent.keyDown(tokenMiser, { key: "End" });
+    expect(pwrAgent).toHaveFocus();
+    fireEvent.keyDown(pwrAgent, { key: "ArrowRight" });
+    expect(harness).toHaveFocus();
+    fireEvent.keyDown(harness, { key: "ArrowLeft" });
+    expect(pwrAgent).toHaveFocus();
+    fireEvent.keyDown(pwrAgent, { key: "Home" });
+    expect(harness).toHaveFocus();
+  });
+
+  it("uses unique tab relationships for each mounted panel", () => {
+    render(
+      <>
+        <SubAgentsPanel
+          thread={{ ...thread, subAgents: mixedSubAgents }}
+        />
+        <SubAgentsPanel
+          thread={{ ...thread, id: "second-thread", subAgents: mixedSubAgents }}
+        />
+      </>,
+    );
+
+    const tablists = screen.getAllByRole("tablist", {
+      name: "Sub-agent ownership",
+    });
+    const firstHarness = within(tablists[0]!).getByRole("tab", {
+      name: "Harness 1",
+    });
+    const secondHarness = within(tablists[1]!).getByRole("tab", {
+      name: "Harness 1",
+    });
+    const panels = screen.getAllByRole("tabpanel");
+
+    expect(firstHarness.id).not.toBe(secondHarness.id);
+    expect(panels[0]!.id).not.toBe(panels[1]!.id);
+    expect(firstHarness).toHaveAttribute("aria-controls", panels[0]!.id);
+    expect(secondHarness).toHaveAttribute("aria-controls", panels[1]!.id);
+    expect(panels[0]).toHaveAttribute("aria-labelledby", firstHarness.id);
+    expect(panels[1]).toHaveAttribute("aria-labelledby", secondHarness.id);
   });
 
   it("prefers PwrAgent when a thread has no harness-managed sub-agents", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/subagent-kind.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/subagent-kind.test.ts
@@ -2,6 +2,7 @@ import type { ThreadSubAgentSummary } from "@pwragent/shared";
 import { describe, expect, it } from "vitest";
 import {
   isTokenMiserSubAgent,
+  subAgentLens,
   subAgentOriginLabel,
   subAgentPricingUsageTitle,
   subAgentUsageLabel,
@@ -17,5 +18,20 @@ describe("Token Miser sub-agent presentation", () => {
     expect(subAgentOriginLabel(subAgent)).toBe("PwrAgent Token Miser gate");
     expect(subAgentUsageLabel(subAgent)).toBe("Gate");
     expect(subAgentPricingUsageTitle(subAgent)).toBe("Token Miser gate");
+  });
+
+  it("groups sub-agents by lifecycle owner", () => {
+    expect(subAgentLens({
+      monitorId: "codex-native:child-1",
+    } as ThreadSubAgentSummary)).toBe("harness");
+    expect(subAgentLens({
+      monitorId: "system:token-miser:gate-1",
+    } as ThreadSubAgentSummary)).toBe("token-miser");
+    expect(subAgentLens({
+      monitorId: "review:review-1",
+    } as ThreadSubAgentSummary)).toBe("pwragent");
+    expect(subAgentLens({
+      monitorId: "monitor-1",
+    } as ThreadSubAgentSummary)).toBe("pwragent");
   });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/subagent-kind.ts
@@ -1,5 +1,7 @@
 import type { ThreadSubAgentSummary } from "@pwragent/shared";
 
+export type SubAgentLens = "harness" | "token-miser" | "pwragent";
+
 export function isCodexNativeSubAgent(subAgent: ThreadSubAgentSummary): boolean {
   return subAgent.monitorId.startsWith("codex-native:");
 }
@@ -14,6 +16,21 @@ export function isTokenMiserSubAgent(
   subAgent: ThreadSubAgentSummary,
 ): boolean {
   return subAgent.monitorId.startsWith("system:token-miser:");
+}
+
+/**
+ * Groups sub-agents by the system that owns their lifecycle. The harness lens
+ * is intentionally provider-neutral even though Codex is the only harness
+ * that projects native workers today.
+ */
+export function subAgentLens(subAgent: ThreadSubAgentSummary): SubAgentLens {
+  if (isTokenMiserSubAgent(subAgent)) {
+    return "token-miser";
+  }
+  if (isCodexNativeSubAgent(subAgent)) {
+    return "harness";
+  }
+  return "pwragent";
 }
 
 export function subAgentOriginLabel(

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -22362,7 +22362,7 @@ a.transcript-message__messaging-origin:focus-visible {
 .subagent-lens-switch__button[aria-selected="true"] {
   background: var(--bg-panel-elevated);
   color: var(--text-primary);
-  box-shadow: 0 1px 2px var(--shadow-color);
+  box-shadow: 0 1px 3px var(--shadow-tint-soft);
 }
 
 .subagent-lens-switch__button:focus-visible {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -22326,6 +22326,63 @@ a.transcript-message__messaging-origin:focus-visible {
   border-top: 1px solid var(--border-subtle);
 }
 
+.subagent-lens-switch {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
+  gap: 2px;
+  margin: 10px 0 0;
+  padding: 2px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 6px;
+  background: var(--bg-input);
+}
+
+.subagent-lens-switch__button {
+  display: inline-flex;
+  min-width: 0;
+  height: 26px;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  padding: 0 6px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.subagent-lens-switch__button:hover {
+  color: var(--text-primary);
+}
+
+.subagent-lens-switch__button[aria-selected="true"] {
+  background: var(--bg-panel-elevated);
+  color: var(--text-primary);
+  box-shadow: 0 1px 2px var(--shadow-color);
+}
+
+.subagent-lens-switch__button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.subagent-lens-switch__button > span:first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.subagent-lens-switch__count {
+  flex: 0 0 auto;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Edits panel fills the tab as a flex column: a fixed `.edits-panel__header`
    over an internally scrolling `.edits-panel__body`. Overrides the default
    section padding (the header + body own their own insets) so the body's


### PR DESCRIPTION
## Summary

- split the Sub-agents rail into Harness, Token Miser, and PwrAgent ownership lenses
- prefer Harness by default, then PwrAgent, so Token Miser gate volume does not bury operator-relevant workers and monitors
- retain Token Miser lifecycle/details in Sub-agents while Pricing remains the cost-focused view
- hide empty categories and omit the switch when only one category exists

## Verification

- pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/subagent-kind.test.ts
- pnpm typecheck
- pnpm lint:eslint
- pnpm lint:colors
- pnpm lint:boundaries

## Notes

- The Harness label is intentionally provider-neutral. Codex is the only native harness source projected today, but the UI taxonomy leaves room for other harness-managed workers.
- Workspace ESLint completed with 43 existing warnings and no errors.