### PR TITLE
fix(desktop): limit stale native sub-agents

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -21,6 +21,7 @@ import {
   buildFederatedThreadRef,
   buildNavigationSnapshot,
   buildThreadIdentityKey,
+  CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS,
   MAX_THREAD_READ_EVALUATION_PRICING_SUMMARIES,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
   PWRSNAP_MCP_CONNECTION_ID,
@@ -1895,7 +1896,6 @@ class MockBackendClient {
   async listNativeSubAgentThreads(params?: {
     filter?: string;
     limit?: number;
-    maxPages?: number;
   }): Promise<AppServerThreadSummary[]> {
     this.listNativeSubAgentThreadsCallCount += 1;
     this.lastListNativeSubAgentThreadsParams = params;
@@ -13049,7 +13049,6 @@ script = "echo setup"
     });
     expect(codexClient.lastListNativeSubAgentThreadsParams).toEqual({
       limit: 50,
-      maxPages: 1,
     });
     expect(codexClient.readThreadCalls).toEqual([]);
 
@@ -42051,6 +42050,7 @@ script = "printf setup"
   });
 
   it("groups native Codex workers below their ordinary parent without making rows", async () => {
+    const now = Date.now();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [
@@ -42070,8 +42070,8 @@ script = "printf setup"
           titleSource: "explicit",
           linkedDirectories: [],
           source: "codex",
-          createdAt: 30,
-          updatedAt: 30,
+          createdAt: now - CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS - 2,
+          updatedAt: now - CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS - 1,
           threadStatus: "idle",
           codexNativeSubAgent: {
             parentThreadId: "thread-parent",
@@ -42086,8 +42086,8 @@ script = "printf setup"
           titleSource: "explicit",
           linkedDirectories: [],
           source: "codex",
-          createdAt: 20,
-          updatedAt: 20,
+          createdAt: now - (2 * CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS),
+          updatedAt: now - (2 * CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS),
           threadStatus: "active",
           codexNativeSubAgent: {
             parentThreadId: "thread-worker-a",
@@ -42102,8 +42102,8 @@ script = "printf setup"
           titleSource: "explicit",
           linkedDirectories: [],
           source: "codex",
-          createdAt: 10,
-          updatedAt: 10,
+          createdAt: now - 20,
+          updatedAt: now - 10,
           threadStatus: "idle",
           codexNativeSubAgent: {
             parentThreadId: "thread-parent",
@@ -42127,8 +42127,8 @@ script = "printf setup"
       {
         threadId: "thread-worker-a",
         title: "Draft release notes",
-        createdAt: 10,
-        updatedAt: 10,
+        createdAt: now - 20,
+        updatedAt: now - 10,
         threadStatus: "idle",
         depth: 1,
         agentNickname: "release-writer",
@@ -42137,22 +42137,12 @@ script = "printf setup"
       {
         threadId: "thread-worker-a-child",
         title: "Check release links",
-        createdAt: 20,
-        updatedAt: 20,
+        createdAt: now - (2 * CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS),
+        updatedAt: now - (2 * CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS),
         threadStatus: "active",
         depth: 2,
         agentNickname: "link-checker",
         agentRole: "researcher",
-      },
-      {
-        threadId: "thread-worker-b",
-        title: "Review release notes",
-        createdAt: 30,
-        updatedAt: 30,
-        threadStatus: "idle",
-        depth: 1,
-        agentNickname: "release-reviewer",
-        agentRole: "reviewer",
       },
     ]);
     expect(codexClient.listNativeSubAgentThreadsCallCount).toBe(1);
@@ -42166,9 +42156,9 @@ script = "printf setup"
       )?.subAgents,
     ).toEqual([
       expect.objectContaining({
-        monitorId: "codex-native:thread-worker-b",
-        monitorThreadId: "thread-worker-b",
-        agentName: "release-reviewer",
+        monitorId: "codex-native:thread-worker-a",
+        monitorThreadId: "thread-worker-a",
+        agentName: "release-writer",
         status: "success",
       }),
       expect.objectContaining({
@@ -42177,12 +42167,6 @@ script = "printf setup"
         agentName: "link-checker",
         status: "running",
       }),
-      expect.objectContaining({
-        monitorId: "codex-native:thread-worker-a",
-        monitorThreadId: "thread-worker-a",
-        agentName: "release-writer",
-        status: "success",
-      }),
     ]);
 
     await registry.close();
@@ -42190,6 +42174,7 @@ script = "printf setup"
 
   it("backfills native Codex cards and pricing from durable child turn usage", async () => {
     const nativeThreadId = "thread-epicurus";
+    const now = Date.now();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [
@@ -42209,8 +42194,8 @@ script = "printf setup"
           titleSource: "explicit",
           linkedDirectories: [],
           source: "codex",
-          createdAt: 20,
-          updatedAt: 40,
+          createdAt: now - 40,
+          updatedAt: now - 20,
           threadStatus: "idle",
           codexNativeSubAgent: {
             parentThreadId: "thread-parent",
@@ -42342,6 +42327,7 @@ script = "printf setup"
   it("repairs missing native Codex pricing from an existing card usage snapshot", async () => {
     const nativeThreadId = "thread-epicurus";
     const monitorId = `codex-native:${nativeThreadId}`;
+    const now = Date.now();
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/list"] },
       threads: [
@@ -42361,8 +42347,8 @@ script = "printf setup"
           titleSource: "explicit",
           linkedDirectories: [],
           source: "codex",
-          createdAt: 20,
-          updatedAt: 40,
+          createdAt: now - 40,
+          updatedAt: now - 20,
           threadStatus: "idle",
           codexNativeSubAgent: {
             parentThreadId: "thread-parent",

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -191,6 +191,7 @@ class MockTransport implements JsonRpcTransport {
     dailyUsageBuckets: [],
   };
   static unfilteredThreadListResult: unknown[] | undefined;
+  static threadListNextCursor: string | undefined;
   static threadListResultBySearchTerm = new Map<string, unknown[]>();
   static turnInterruptResponseMode: "success" | "timeout" = "success";
   static threadResumeError:
@@ -270,6 +271,7 @@ class MockTransport implements JsonRpcTransport {
             id: payload.id,
             result: {
               data: params.params?.archived ? [] : threadListOverride,
+              nextCursor: MockTransport.threadListNextCursor,
             },
           }),
         );
@@ -1374,6 +1376,7 @@ describe("CodexAppServerClient", () => {
       dailyUsageBuckets: [],
     };
     MockTransport.unfilteredThreadListResult = undefined;
+    MockTransport.threadListNextCursor = undefined;
     MockTransport.threadListResultBySearchTerm.clear();
     MockTransport.turnInterruptResponseMode = "success";
     MockTransport.threadResumeError = undefined;
@@ -1876,6 +1879,7 @@ describe("CodexAppServerClient", () => {
   });
 
   it("keeps spawned agents out of navigation and exposes them for parent disclosure", async () => {
+    MockTransport.threadListNextCursor = "older-native-subagents";
     MockTransport.threadListResultBySearchTerm.set("native-subagent-source", [
       {
         id: "thread-parent",
@@ -1930,6 +1934,7 @@ describe("CodexAppServerClient", () => {
     const threads = await client.listThreads({ filter: "native-subagent-source" });
     const nativeSubAgentThreads = await client.listNativeSubAgentThreads({
       filter: "native-subagent-source",
+      limit: 1_000,
     });
 
     expect(threads.map((thread) => thread.id)).toEqual(["thread-parent"]);
@@ -1949,18 +1954,29 @@ describe("CodexAppServerClient", () => {
     const threadListRequests = transport!.sentMessages
       .map((message) => JSON.parse(message) as {
         method?: string;
-        params?: { sourceKinds?: string[] };
+        params?: {
+          limit?: number;
+          sortKey?: string;
+          sourceKinds?: string[];
+          useStateDbOnly?: boolean;
+        };
       })
       .filter((message) => message.method === "thread/list");
     expect(threadListRequests).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           params: expect.objectContaining({
+            limit: 100,
+            sortKey: "updated_at",
             sourceKinds: ["subAgentThreadSpawn"],
+            useStateDbOnly: true,
           }),
         }),
       ]),
     );
+    expect(threadListRequests.filter(
+      (request) => request.params?.sourceKinds?.includes("subAgentThreadSpawn"),
+    )).toHaveLength(1);
 
     await client.close();
   });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -74,6 +74,7 @@ import {
   buildThreadUrl,
   estimateTokenUsageCost,
   formatTokenUsageUsd,
+  isCodexNativeSubAgentVisibleInNavigation,
   isToolManagedWorktreePath,
   normalizeRenamedTitleSource,
   resolveOpenAiPricingServiceTier,
@@ -731,7 +732,6 @@ type BackendClient = {
     params?: {
       filter?: string;
       limit?: number;
-      maxPages?: number;
     },
     diagnostics?: { callerReason?: string; ownerId?: string },
   ): Promise<AppServerThreadSummary[]>;
@@ -2898,6 +2898,7 @@ function codexNativeSubAgentId(threadId: string): string {
  */
 function groupCodexNativeSubAgents(params: {
   nativeThreads: AppServerThreadSummary[];
+  now: number;
   parentThreads: AppServerThreadSummary[];
 }): AppServerThreadSummary[] {
   const childrenByParentThreadId = new Map<string, AppServerThreadSummary[]>();
@@ -2939,7 +2940,7 @@ function groupCodexNativeSubAgents(params: {
         }
         emittedThreadIds.add(child.id);
         const provenance = child.codexNativeSubAgent;
-        nativeSubAgents.push({
+        const summary: CodexNativeSubAgentSummary = {
           threadId: child.id,
           title: child.title,
           createdAt: child.createdAt,
@@ -2948,7 +2949,10 @@ function groupCodexNativeSubAgents(params: {
           depth: provenance?.depth ?? inferredDepth,
           agentNickname: provenance?.agentNickname,
           agentRole: provenance?.agentRole,
-        });
+        };
+        if (isCodexNativeSubAgentVisibleInNavigation(summary, params.now)) {
+          nativeSubAgents.push(summary);
+        }
         appendChildren(child.id, inferredDepth + 1);
       }
     };
@@ -22915,7 +22919,6 @@ export class DesktopBackendRegistry {
       this.codexClient.listNativeSubAgentThreads
         ? await this.codexClient.listNativeSubAgentThreads({
             ...(params.limit !== undefined ? { limit: params.limit } : {}),
-            ...(params.maxPages !== undefined ? { maxPages: params.maxPages } : {}),
           }, diagnostics).catch((error) => {
             backendRegistryLog.debug("native Codex sub-agent discovery failed", {
               error: error instanceof Error ? error.message : String(error),
@@ -22925,6 +22928,7 @@ export class DesktopBackendRegistry {
         : [];
     const groupedThreads = groupCodexNativeSubAgents({
       nativeThreads: nativeSubAgentThreads,
+      now: Date.now(),
       parentThreads: defaultThreads,
     });
     // The sidebar deliberately flattens nested native workers below their

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -6076,6 +6076,8 @@ function buildThreadDiscoveryPayloads(
   ];
 }
 
+const CODEX_NATIVE_SUBAGENT_DISCOVERY_LIMIT = 100;
+
 function threadTitleSourcePriority(
   titleSource: AppServerThreadTitleSource
 ): number {
@@ -7994,11 +7996,14 @@ export class CodexAppServerClient {
   /**
    * Lists native Codex `spawn_agent` workers for parent-scoped disclosure.
    * Callers must not add these summaries to ordinary navigation.
+   *
+   * Discovery is deliberately one newest-first state-DB page. Its cost stays
+   * fixed as native worker history grows; the navigation projection applies
+   * the shorter display horizon after grouping nested workers.
    */
   async listNativeSubAgentThreads(params?: {
     filter?: string;
     limit?: number;
-    maxPages?: number;
   }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
@@ -8007,8 +8012,14 @@ export class CodexAppServerClient {
       client: this.connection,
       diagnostics,
       filter: params?.filter,
-      limit: params?.limit,
-      maxPages: params?.maxPages,
+      limit: Math.max(
+        1,
+        Math.min(
+          Math.floor(params?.limit ?? CODEX_NATIVE_SUBAGENT_DISCOVERY_LIMIT),
+          CODEX_NATIVE_SUBAGENT_DISCOVERY_LIMIT,
+        ),
+      ),
+      maxPages: 1,
       requestTimeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       sourceKinds: ["subAgentThreadSpawn"],
     });

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -608,6 +608,7 @@ describe("ThreadContextPanel", () => {
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {
+    const now = Date.now();
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     (window as Window & { pwragent?: unknown }).pwragent = {
       openSubAgentTranscriptWindow,
@@ -622,9 +623,9 @@ describe("ThreadContextPanel", () => {
             monitorId: "codex-native:019ed7df-5876-7882-9b75-7fd647372da7",
             task: "Check PR status",
             status: "success",
-            createdAt: 2000,
-            completedAt: 3000,
-            updatedAt: 2500,
+            createdAt: now - 2000,
+            completedAt: now - 1000,
+            updatedAt: now - 1000,
             agentName: "Peirce",
             lastMessage: "PR #783 is open and all required checks are passing.",
             monitorThreadId: "019ed7df-5876-7882-9b75-7fd647372da7",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -223,6 +223,7 @@ describe("SubAgentsPanel", () => {
 
     expect(screen.queryByText("Stale native worker")).not.toBeInTheDocument();
     expect(screen.getByText("Active native worker")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("tab", { name: "PwrAgent 1" }));
     expect(screen.getByText("Managed monitor history")).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -186,6 +186,46 @@ describe("SubAgentsPanel", () => {
     expect(screen.queryByText("Gate noisy output")).not.toBeInTheDocument();
   });
 
+  it("limits completed native workers while preserving current and managed monitors", () => {
+    const now = Date.now();
+    render(
+      <SubAgentsPanel
+        thread={{
+          ...thread,
+          subAgents: [
+            {
+              monitorId: "codex-native:stale-worker",
+              task: "Stale native worker",
+              status: "success",
+              createdAt: now - (2 * 24 * 60 * 60 * 1000),
+              updatedAt: now - (2 * 24 * 60 * 60 * 1000),
+              completedAt: now - (2 * 24 * 60 * 60 * 1000),
+            },
+            {
+              monitorId: "codex-native:active-worker",
+              task: "Active native worker",
+              status: "running",
+              createdAt: 1,
+              updatedAt: 1,
+            },
+            {
+              monitorId: "monitor:managed-history",
+              task: "Managed monitor history",
+              status: "success",
+              createdAt: 1,
+              updatedAt: 1,
+              completedAt: 1,
+            },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Stale native worker")).not.toBeInTheDocument();
+    expect(screen.getByText("Active native worker")).toBeInTheDocument();
+    expect(screen.getByText("Managed monitor history")).toBeInTheDocument();
+  });
+
   it("shows Token Miser's per-gate cost equation", () => {
     render(
       <SubAgentsPanel

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/useSubAgents.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/useSubAgents.ts
@@ -2,6 +2,7 @@ import type {
   NavigationThreadSummary,
   ThreadSubAgentSummary,
 } from "@pwragent/shared";
+import { isThreadSubAgentVisibleInPanel } from "@pwragent/shared";
 
 export type UseSubAgentsResult = {
   subAgents: ThreadSubAgentSummary[];
@@ -15,10 +16,11 @@ export type UseSubAgentsResult = {
  * the persisted thread overlay projected onto the navigation snapshot.
  */
 export function useSubAgents(thread: NavigationThreadSummary): UseSubAgentsResult {
+  const now = Date.now();
   return {
-    subAgents: [...(thread.subAgents ?? [])].sort(
-      (left, right) => right.createdAt - left.createdAt,
-    ),
+    subAgents: (thread.subAgents ?? [])
+      .filter((subAgent) => isThreadSubAgentVisibleInPanel(subAgent, now))
+      .sort((left, right) => right.createdAt - left.createdAt),
     loading: false,
     supported: true,
   };

--- a/packages/shared/src/__tests__/subagent-visibility.test.ts
+++ b/packages/shared/src/__tests__/subagent-visibility.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import type {
+  CodexNativeSubAgentSummary,
+  ThreadSubAgentSummary,
+} from "../index";
+import {
+  CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS,
+  CODEX_NATIVE_SUBAGENT_PANEL_RETENTION_MS,
+  isCodexNativeSubAgentVisibleInNavigation,
+  isThreadSubAgentVisibleInPanel,
+} from "../subagent-visibility";
+
+const NOW = 1_800_000_000_000;
+
+function nativeSummary(
+  overrides: Partial<CodexNativeSubAgentSummary> = {},
+): CodexNativeSubAgentSummary {
+  return {
+    threadId: "native-worker",
+    title: "Native worker",
+    threadStatus: "idle",
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function panelSummary(
+  overrides: Partial<ThreadSubAgentSummary> = {},
+): ThreadSubAgentSummary {
+  return {
+    monitorId: "codex-native:native-worker",
+    task: "Native worker",
+    status: "success",
+    createdAt: NOW,
+    updatedAt: NOW,
+    completedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe("Codex native sub-agent visibility", () => {
+  it("keeps active and recently active workers in navigation", () => {
+    expect(isCodexNativeSubAgentVisibleInNavigation(nativeSummary({
+      threadStatus: "active",
+      updatedAt: NOW - (14 * 24 * 60 * 60 * 1000),
+    }), NOW)).toBe(true);
+    expect(isCodexNativeSubAgentVisibleInNavigation(nativeSummary({
+      updatedAt: NOW - CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS,
+    }), NOW)).toBe(true);
+  });
+
+  it("hides stale idle workers from navigation", () => {
+    expect(isCodexNativeSubAgentVisibleInNavigation(nativeSummary({
+      updatedAt: NOW - CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS - 1,
+    }), NOW)).toBe(false);
+  });
+
+  it("keeps workers whose age cannot be established", () => {
+    expect(isCodexNativeSubAgentVisibleInNavigation(nativeSummary({
+      createdAt: undefined,
+      updatedAt: undefined,
+    }), NOW)).toBe(true);
+  });
+
+  it("keeps native workers in the selected-thread panel for one day", () => {
+    expect(isThreadSubAgentVisibleInPanel(panelSummary({
+      completedAt: NOW - CODEX_NATIVE_SUBAGENT_PANEL_RETENTION_MS,
+    }), NOW)).toBe(true);
+    expect(isThreadSubAgentVisibleInPanel(panelSummary({
+      completedAt: NOW - CODEX_NATIVE_SUBAGENT_PANEL_RETENTION_MS - 1,
+    }), NOW)).toBe(false);
+  });
+
+  it("does not age out active native workers or other monitor kinds", () => {
+    expect(isThreadSubAgentVisibleInPanel(panelSummary({
+      completedAt: undefined,
+      outcome: undefined,
+      status: "running",
+      updatedAt: 1,
+    }), NOW)).toBe(true);
+    expect(isThreadSubAgentVisibleInPanel(panelSummary({
+      monitorId: "monitor:pwragent",
+      completedAt: 1,
+      updatedAt: 1,
+    }), NOW)).toBe(true);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -43,6 +43,7 @@ export * from "./pending-request-response";
 export * from "./path-display";
 export * from "./renderer-payload-boundary";
 export * from "./review-branches";
+export * from "./subagent-visibility";
 export * from "./subthreads";
 export * from "./thread-jump-match";
 export * from "./thread-pins";

--- a/packages/shared/src/subagent-visibility.ts
+++ b/packages/shared/src/subagent-visibility.ts
@@ -1,0 +1,59 @@
+import type {
+  CodexNativeSubAgentSummary,
+} from "./contracts/normalized-app-server";
+import type { ThreadSubAgentSummary } from "./contracts/navigation";
+
+export const CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS = 60 * 60 * 1000;
+export const CODEX_NATIVE_SUBAGENT_PANEL_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+function latestActivityAt(
+  subAgent: Pick<CodexNativeSubAgentSummary, "createdAt" | "updatedAt">,
+): number | undefined {
+  return subAgent.updatedAt ?? subAgent.createdAt;
+}
+
+/**
+ * Keep the repeated navigation disclosure focused on live or newly finished
+ * native workers. Missing timestamps stay visible because their age cannot be
+ * established safely.
+ */
+export function isCodexNativeSubAgentVisibleInNavigation(
+  subAgent: CodexNativeSubAgentSummary,
+  now: number,
+): boolean {
+  if (subAgent.threadStatus === "active") {
+    return true;
+  }
+  const activityAt = latestActivityAt(subAgent);
+  return activityAt === undefined
+    || activityAt >= now - CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS;
+}
+
+function hasTerminalEvidence(subAgent: ThreadSubAgentSummary): boolean {
+  return (
+    subAgent.status === "success"
+    || subAgent.status === "failure"
+    || subAgent.status === "cancelled"
+    || subAgent.completedAt !== undefined
+    || subAgent.outcome !== undefined
+    || subAgent.completionSource !== undefined
+  );
+}
+
+/**
+ * The selected thread's panel retains completed native workers longer than
+ * navigation does. Other monitor kinds keep their existing durable history.
+ */
+export function isThreadSubAgentVisibleInPanel(
+  subAgent: ThreadSubAgentSummary,
+  now: number,
+): boolean {
+  if (!subAgent.monitorId.startsWith("codex-native:")) {
+    return true;
+  }
+  if (!hasTerminalEvidence(subAgent)) {
+    return true;
+  }
+  const activityAt = subAgent.completedAt ?? subAgent.updatedAt;
+  return activityAt >= now - CODEX_NATIVE_SUBAGENT_PANEL_RETENTION_MS;
+}


### PR DESCRIPTION
## Summary

- cap Codex-native sub-agent discovery at one newest-first state-DB page of at most 100 workers
- show repeated navigation disclosures only for active workers or workers updated within the last hour
- retain completed native worker cards for 24 hours in the selected thread panel while leaving active and PwrAgent-managed monitors unchanged

## Verification

- `pnpm test packages/shared/src/__tests__/subagent-visibility.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx` (791 passed)
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `pnpm lint:sql`