### PR TITLE
fix(desktop): harden provider configuration lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3489,6 +3489,89 @@ describe("AcpBackendAdapter", () => {
     expect(secondDispose).toHaveBeenCalledOnce();
   });
 
+  it("blocks new ACP launches after config invalidation without stranding an existing session", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    let currentFingerprint = "gemini-one";
+    const firstAgent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      configDependencyFingerprint: currentFingerprint,
+      activeCommand: "/path/gemini-one",
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local",
+        command: "/path/gemini-one",
+        args: ["--acp", "--skip-trust"],
+        env: {},
+      },
+    };
+    const replacementAgent: AcpInstalledAgentRecord = {
+      ...firstAgent,
+      configDependencyFingerprint: "gemini-two",
+      activeCommand: "/path/gemini-two",
+      launchDescriptor: {
+        ...firstAgent.launchDescriptor!,
+        command: "/path/gemini-two",
+      },
+    };
+    let discovered = firstAgent;
+    const firstClient = {
+      dispose: vi.fn(async () => undefined),
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasRetainableSessions: () => true,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: (sessionId: string) => sessionId === "session-1",
+      supportsSessionLoad: () => false,
+    };
+    const secondClient = {
+      dispose: vi.fn(async () => undefined),
+      hasActiveOperations: () => false,
+      hasActiveTurns: () => false,
+      hasRetainableSessions: () => false,
+      initialize: vi.fn(async () => undefined),
+      ownsSession: () => false,
+      supportsSessionLoad: () => false,
+    };
+    const createAcpClient = vi
+      .fn()
+      .mockReturnValueOnce(firstClient)
+      .mockReturnValueOnce(secondClient);
+    const adapter = createTestAcpBackendAdapter({
+      acpAgentStore: null,
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [discovered],
+      resolveProviderDependencyFingerprint: () => currentFingerprint,
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+
+    await adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    await expect(adapter.getClient(backendId)).resolves.toBe(firstClient);
+    currentFingerprint = "gemini-two";
+    adapter.invalidateRuntimeSelections(["gemini"]);
+
+    await expect(adapter.getClient(backendId)).rejects.toThrow(
+      "Refresh this provider in Settings before starting new work",
+    );
+    await expect(
+      adapter.getClientForSession(backendId, "session-1"),
+    ).resolves.toBe(firstClient);
+    expect(firstClient.dispose).not.toHaveBeenCalled();
+
+    discovered = replacementAgent;
+    await adapter.discoverAvailableAgents(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    await expect(adapter.getClient(backendId)).resolves.toBe(secondClient);
+    expect(createAcpClient).toHaveBeenNthCalledWith(2, replacementAgent);
+
+    await adapter.close();
+  });
+
   it("adopts a newer durable launch identity over stale local discovery", async () => {
     const backendId = "acp:kimi" as AcpBackendId;
     const firstAgent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6587,6 +6587,50 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("invalidates only the provider changed by an external config reload", async () => {
+    const tempRoot = await mkdtemp(
+      path.join(os.tmpdir(), "pwragent-backend-registry-"),
+    );
+    const configPath = path.join(tempRoot, "config.toml");
+    await writeFile(
+      configPath,
+      "[acp_agents.gemini]\ncli_path = \"/path/gemini-one\"\n",
+    );
+    const configStore = new DesktopConfigStore({ configPath });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+      configStore,
+      discoverLocalAcpAgents: async () => [],
+    });
+    const invalidate = vi
+      .spyOn(registry, "invalidateProviderRuntimeSelections")
+      .mockResolvedValue();
+
+    try {
+      await writeFile(
+        configPath,
+        "[acp_agents.gemini]\ncli_path = \"/path/gemini-two\"\n",
+      );
+      configStore.reloadFromDisk("watch");
+
+      await vi.waitFor(() => {
+        expect(invalidate).toHaveBeenCalledExactlyOnceWith({
+          acp: true,
+          acpRegistryIds: ["gemini"],
+          codex: false,
+        });
+      });
+      await registry.synchronizeProviderRuntimeSelections();
+      expect(invalidate).toHaveBeenCalledTimes(1);
+    } finally {
+      await registry.close();
+      configStore.dispose();
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+
   it("omits disabled persisted ACP agents from backend pickers", async () => {
     const tempRoot = await mkdtemp(
       path.join(os.tmpdir(), "pwragent-backend-registry-"),
@@ -14610,6 +14654,51 @@ script = "echo setup"
       label: "GPT-5.6-Sol",
     });
     expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
+
+    await registry.close();
+  });
+
+  it("keeps a working Codex catalog after an explicit refresh fails", async () => {
+    const modelListErrors: Error[] = [];
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/start", "turn/start"],
+      },
+      modelListErrors,
+      models: [
+        {
+          id: "gpt-5.6-sol",
+          label: "GPT-5.6-Sol",
+          supportsReasoning: true,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    const permit = issueProviderDiscoveryPermit("settings-user-action");
+
+    const first = await registry.listBackends(
+      { includeUnavailable: true, refreshModels: "codex" },
+      permit,
+    );
+    modelListErrors.push(new Error("temporary model refresh failure"));
+
+    await expect(
+      registry.listBackends(
+        { includeUnavailable: true, refreshModels: "codex" },
+        permit,
+      ),
+    ).rejects.toThrow("temporary model refresh failure");
+    const cached = await registry.listBackends({ includeUnavailable: true });
+
+    expect(cached.backends[0]).toEqual(first.backends[0]);
+    expect(cached.backends[0]?.available).toBe(true);
+    expect(cached.backends[0]?.launchpadOptions?.models).toEqual([
+      expect.objectContaining({ id: "gpt-5.6-sol" }),
+    ]);
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/desktop-config-store.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-store.test.ts
@@ -260,6 +260,43 @@ cli_path = "/opt/qwen-one"
     );
   });
 
+  it("restores matching last-known-good state when provider config is reverted", async () => {
+    const fixture = createFixture(`
+[acp_agents.qwen]
+cli_path = "/opt/qwen-one"
+`);
+    const discoverProvider = vi.fn(async ({ projection }) => ({
+      candidates: [],
+      selectedCommand: projection.configured.commandOverride,
+      selectedVersion: "1.0.0",
+    }));
+    const store = fixture.createStore({ discoverProvider });
+    await store.refreshProvider(
+      "qwen",
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    fs.writeFileSync(
+      fixture.configPath,
+      "[acp_agents.qwen]\ncli_path = \"/opt/qwen-two\"\n",
+      "utf8",
+    );
+    store.reloadFromDisk("watch");
+    expect(store.read("providers").qwen.validation.state).toBe("stale");
+
+    fs.writeFileSync(
+      fixture.configPath,
+      "[acp_agents.qwen]\ncli_path = \"/opt/qwen-one\"\n",
+      "utf8",
+    );
+    store.reloadFromDisk("watch");
+
+    const restored = store.read("providers").qwen;
+    expect(restored.validation.state).toBe("valid");
+    expect(providerLastKnownGoodMatchesConfig(restored)).toBe(true);
+    expect(restored.lastKnownGood?.selectedCommand).toBe("/opt/qwen-one");
+    expect(discoverProvider).toHaveBeenCalledOnce();
+  });
+
   it("does not let a stale provider completion overwrite a newer fingerprint", async () => {
     const fixture = createFixture(`
 [acp_agents.qwen]
@@ -446,6 +483,29 @@ cli_path = "/opt/qwen-one"
 
     expect(store.fileStatus().kind).toBe("valid");
     expect(store.read("general").appearance.theme).toBe("light");
+  });
+
+  it("publishes config status changes when normalized domains do not change", () => {
+    const source = "[general.appearance]\ntheme = \"dark\"\n";
+    const fixture = createFixture(source);
+    const store = fixture.createStore();
+    const listener = vi.fn();
+    store.subscribeUpdates(listener);
+    fs.writeFileSync(fixture.configPath, "[general\n", "utf8");
+
+    store.reloadFromDisk("watch");
+
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({
+      changedDomains: [],
+      configFile: expect.objectContaining({ kind: "invalid" }),
+    }));
+    fs.writeFileSync(fixture.configPath, source, "utf8");
+    store.reloadFromDisk("watch");
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({
+      changedDomains: [],
+      configFile: expect.objectContaining({ kind: "valid" }),
+    }));
   });
 
   it("observes an atomic external config replacement", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-config-store.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-config-store.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { DesktopConfigStore } from "../settings/config-store/desktop-config-store";
 import { issueProviderDiscoveryPermit } from "../settings/provider-discovery-permit";
 import {
+  providerLastKnownGoodMatchesConfig,
   resolvePrAutomationConfig,
   resolveSpendAlertPolicy,
   resolveToolOutputAlertPolicy,
@@ -165,6 +166,10 @@ theme = "dark"
     expect(firstResult.lastKnownGood?.selectedCommand).toBe(
       "/opt/pwragent/codex",
     );
+    expect(firstResult.lastKnownGood?.dependencyFingerprint).toBe(
+      firstResult.dependencyFingerprint,
+    );
+    expect(providerLastKnownGoodMatchesConfig(firstResult)).toBe(true);
 
     const persisted = fixture.db.raw
       .prepare("SELECT payload FROM provider_discovery_snapshots WHERE provider_id = ?")
@@ -247,6 +252,9 @@ cli_path = "/opt/qwen-one"
       "/opt/qwen-one",
     );
     expect(store.read("providers").qwen.validation.state).toBe("stale");
+    expect(
+      providerLastKnownGoodMatchesConfig(store.read("providers").qwen),
+    ).toBe(false);
     expect(store.read("providers").codex.dependencyFingerprint).toBe(
       codexFingerprint,
     );

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -587,10 +587,14 @@ describe("DesktopSettingsService", () => {
     const configPath = path.join(root, "config.toml");
     const secretStore = new MemoryDesktopSecretStore();
     const service = new DesktopSettingsService({ configPath, env: {}, secretStore });
+    const beforeCreation = await service.readSettingsProjection();
+    expect(beforeCreation.federation.noiseStaticPrivateKey.configured).toBe(false);
 
     const first = await service.getOrCreateFederationNoiseStaticKeyPair();
     expect(first.privateKeyBase64.length).toBeGreaterThan(0);
     expect(Buffer.from(first.publicKeyBase64, "base64").length).toBe(32);
+    const afterCreation = await service.readSettingsProjection();
+    expect(afterCreation.federation.noiseStaticPrivateKey.configured).toBe(true);
 
     // A fresh service over the same secret store reuses the persisted key.
     const reopened = new DesktopSettingsService({ configPath, env: {}, secretStore });
@@ -2786,7 +2790,7 @@ describe("DesktopSettingsService", () => {
     expect(service.resolveGhCommandPreference()).toBe("/custom/bin/gh");
   });
 
-  it("caches secret metadata without decrypting stored values", async () => {
+  it("rereads secret metadata without decrypting stored values", async () => {
     const getSecret = vi.fn(async () => {
       throw new Error("secret values should not be decrypted for settings snapshots");
     });
@@ -2825,7 +2829,7 @@ describe("DesktopSettingsService", () => {
       snapshot.messaging.telegram.botToken,
     );
     expect(hasSecret).toHaveBeenCalledWith("telegramBotToken");
-    expect(hasSecret).toHaveBeenCalledTimes(secretMetadataReads);
+    expect(hasSecret).toHaveBeenCalledTimes(secretMetadataReads * 2);
     expect(getSecret).not.toHaveBeenCalled();
     expect(getSecretSync).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -2786,7 +2786,7 @@ describe("DesktopSettingsService", () => {
     expect(service.resolveGhCommandPreference()).toBe("/custom/bin/gh");
   });
 
-  it("reads secret metadata without decrypting stored values", async () => {
+  it("caches secret metadata without decrypting stored values", async () => {
     const getSecret = vi.fn(async () => {
       throw new Error("secret values should not be decrypted for settings snapshots");
     });
@@ -2813,13 +2813,19 @@ describe("DesktopSettingsService", () => {
     });
 
     const snapshot = await service.readSettingsProjection();
+    const secretMetadataReads = hasSecret.mock.calls.length;
+    const repeatedSnapshot = await service.readSettingsProjection();
 
     expect(snapshot.messaging.telegram.botToken).toMatchObject({
       configured: true,
       source: "keychain",
       writable: true,
     });
+    expect(repeatedSnapshot.messaging.telegram.botToken).toEqual(
+      snapshot.messaging.telegram.botToken,
+    );
     expect(hasSecret).toHaveBeenCalledWith("telegramBotToken");
+    expect(hasSecret).toHaveBeenCalledTimes(secretMetadataReads);
     expect(getSecret).not.toHaveBeenCalled();
     expect(getSecretSync).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -151,7 +151,7 @@ const setFederatedThreadMessageHandlerMock = vi.fn();
 const setFederatedThreadInspectionHandlerMock = vi.fn();
 const setFederatedThreadMutationHandlerMock = vi.fn();
 const setFederatedThreadControlHandlerMock = vi.fn();
-const invalidateProviderRuntimeSelectionsMock = vi.fn(async () => undefined);
+const synchronizeProviderRuntimeSelectionsMock = vi.fn(async () => undefined);
 const listThreadsMock = vi.fn<(request?: unknown) => Promise<unknown[]>>();
 const refreshProvidersAtStartupMock = vi.fn<() => Promise<void>>(
   async () => undefined,
@@ -543,7 +543,7 @@ const runtimeFederationLeaseCoordinatorMock = {
 
 vi.mock("../app-server/backend-registry", () => ({
   getDesktopBackendRegistry: vi.fn(() => ({
-    invalidateProviderRuntimeSelections: invalidateProviderRuntimeSelectionsMock,
+    synchronizeProviderRuntimeSelections: synchronizeProviderRuntimeSelectionsMock,
     listThreads: listThreadsMock,
     refreshProvidersAtStartup: refreshProvidersAtStartupMock,
     setMessagingAgentToolService: setMessagingAgentToolServiceMock,
@@ -760,8 +760,8 @@ describe("bootstrapApp", () => {
     setFederatedThreadInspectionHandlerMock.mockReset();
     setFederatedThreadMutationHandlerMock.mockReset();
     setFederatedThreadControlHandlerMock.mockReset();
-    invalidateProviderRuntimeSelectionsMock.mockReset();
-    invalidateProviderRuntimeSelectionsMock.mockResolvedValue(undefined);
+    synchronizeProviderRuntimeSelectionsMock.mockReset();
+    synchronizeProviderRuntimeSelectionsMock.mockResolvedValue(undefined);
     listThreadsMock.mockReset();
     listThreadsMock.mockResolvedValue([]);
     refreshProvidersAtStartupMock.mockReset();
@@ -899,7 +899,7 @@ describe("bootstrapApp", () => {
     expect(setApplicationMenuMock).toHaveBeenCalledTimes(1);
   });
 
-  it("invalidates live provider runtimes after executable settings change", async () => {
+  it("synchronizes live provider runtimes after executable settings change", async () => {
     startupProfilerInstance.start.mockResolvedValue();
     await import("../index");
     await flushMicrotasks();
@@ -919,14 +919,7 @@ describe("bootstrapApp", () => {
       acpAgents: { kimi: { cliPath: "/replacement/kimi" } },
     });
 
-    expect(invalidateProviderRuntimeSelectionsMock).toHaveBeenNthCalledWith(1, {
-      acp: false,
-      codex: true,
-    });
-    expect(invalidateProviderRuntimeSelectionsMock).toHaveBeenNthCalledWith(2, {
-      acp: true,
-      codex: false,
-    });
+    expect(synchronizeProviderRuntimeSelectionsMock).toHaveBeenCalledTimes(2);
   });
 
   it("does not infer a boot failure when the main window is slow to show", async () => {

--- a/apps/desktop/src/main/acp/acp-registry-types.ts
+++ b/apps/desktop/src/main/acp/acp-registry-types.ts
@@ -104,6 +104,9 @@ export type AcpInstalledAgentRecord = {
   allowlistRuleId: string;
   installedAt: number;
   updatedAt: number;
+  /** Provider-config fingerprint under which this launch record was
+   * discovered. Missing only on durable rows created by older builds. */
+  configDependencyFingerprint?: string;
   launchDescriptor?: AcpLaunchDescriptor;
   capabilities?: AcpAgentCapabilities;
   runtimeCapabilities?: BackendAcpRuntimeCapabilities;

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -59,6 +59,7 @@ import {
   acpProviderCommandOverrideFromSnapshot,
   acpProviderEnabledFromSnapshot,
   managedGrokBuildsEnabledFromSnapshot,
+  providerProjectionForRegistryId,
 } from "../settings/config-store/provider-runtime-config";
 import {
   AcpLiveToolUpdateResolver,
@@ -216,7 +217,18 @@ export function createLocalAcpAgentDiscovery(params: {
       ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
       ...(env ? { env } : {}),
     });
-    return records;
+    return records.map((record) => {
+      const configDependencyFingerprint = providerProjectionForRegistryId(
+        providers,
+        record.registryId,
+      )?.dependencyFingerprint;
+      return {
+        ...record,
+        ...(configDependencyFingerprint
+          ? { configDependencyFingerprint }
+          : {}),
+      };
+    });
   };
 }
 
@@ -269,6 +281,9 @@ export type AcpBackendAdapterOptions = {
    */
   discoverLocalAcpAgents: LocalAcpDiscovery;
   isAcpAgentEnabled?: (registryId: string) => boolean;
+  resolveProviderDependencyFingerprint?: (
+    registryId: string,
+  ) => string | undefined;
   checkGrokCliUpdate?: typeof checkGrokCliUpdate | null;
   resolveMcpConnectionServers?: (context: {
     backendId: AcpBackendId;
@@ -1074,6 +1089,9 @@ export class AcpBackendAdapter {
   private readonly createAcpTransport?: AcpTransportFactory;
   private readonly discoverLocalAcpAgents: LocalAcpDiscovery;
   private readonly isAcpAgentEnabled?: (registryId: string) => boolean;
+  private readonly resolveProviderDependencyFingerprint?: (
+    registryId: string,
+  ) => string | undefined;
   private readonly resolveMcpConnectionServers?: AcpBackendAdapterOptions["resolveMcpConnectionServers"];
   private readonly emit: (event: AgentEvent) => Promise<void>;
   private readonly handleServerRequest: (
@@ -1106,6 +1124,7 @@ export class AcpBackendAdapter {
   private localAcpAgentsRevision = 0;
   private localAcpAgentsPromise?: Promise<AcpInstalledAgentRecord[]>;
   private localAgentSnapshot: AcpInstalledAgentRecord[] = [];
+  private readonly invalidatedProviderRegistryIds = new Set<string>();
 
   constructor(options: AcpBackendAdapterOptions) {
     this.captureStores = options.captureStores;
@@ -1145,6 +1164,8 @@ export class AcpBackendAdapter {
             : undefined);
     this.discoverLocalAcpAgents = options.discoverLocalAcpAgents;
     this.isAcpAgentEnabled = options.isAcpAgentEnabled;
+    this.resolveProviderDependencyFingerprint =
+      options.resolveProviderDependencyFingerprint;
     this.createAcpTransport = options.createAcpTransport;
     this.createAcpClient =
       options.createAcpClient ?? ((agent) => this.createDefaultClient(agent));
@@ -1315,6 +1336,13 @@ export class AcpBackendAdapter {
   invalidateLocalAgentDiscovery(): void {
     this.localAcpAgentsRevision += 1;
     this.localAcpAgentsPromise = undefined;
+  }
+
+  invalidateRuntimeSelections(registryIds: readonly string[]): void {
+    this.invalidateLocalAgentDiscovery();
+    for (const registryId of registryIds) {
+      this.invalidatedProviderRegistryIds.add(registryId);
+    }
   }
 
   listSessions(
@@ -1940,6 +1968,19 @@ export class AcpBackendAdapter {
     );
     if (!agent) {
       throw new Error(`ACP backend is not installed: ${backend}`);
+    }
+    if (this.invalidatedProviderRegistryIds.has(agent.registryId)) {
+      const currentFingerprint =
+        this.resolveProviderDependencyFingerprint?.(agent.registryId);
+      if (
+        !currentFingerprint
+        || agent.configDependencyFingerprint !== currentFingerprint
+      ) {
+        throw new Error(
+          `ACP provider configuration changed for ${backend}. Refresh this provider in Settings before starting new work.`,
+        );
+      }
+      this.invalidatedProviderRegistryIds.delete(agent.registryId);
     }
     if (agent.installStatus !== "installed") {
       throw new Error(`ACP backend is not installed: ${backend}`);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -553,10 +553,17 @@ import {
   type ProviderDiscoveryPermit,
 } from "../settings/provider-discovery-permit";
 import {
+  PROVIDER_IDS,
+  providerLastKnownGoodMatchesConfig,
   resolveSpendAlertPolicy,
   resolveToolOutputAlertPolicy,
+  type ConfigDomainMap,
+  type ProviderId,
 } from "../settings/config-store/config-domains";
-import { acpProviderEnabledFromSnapshot } from "../settings/config-store/provider-runtime-config";
+import {
+  acpProviderEnabledFromSnapshot,
+  providerProjectionForRegistryId,
+} from "../settings/config-store/provider-runtime-config";
 import {
   ONBOARDING_CODEX_GATE_ENABLED,
   type ManagedCodexSelectionChange,
@@ -7622,6 +7629,17 @@ function buildCodexInvalidIdRecoveryCooldownMessage(
   );
 }
 
+function readProviderRuntimeFingerprints(
+  providers: ConfigDomainMap["providers"],
+): Readonly<Record<ProviderId, string>> {
+  return Object.fromEntries(
+    PROVIDER_IDS.map((provider) => [
+      provider,
+      providers[provider].dependencyFingerprint,
+    ]),
+  ) as Record<ProviderId, string>;
+}
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly configStore?: Pick<
@@ -7629,6 +7647,8 @@ export class DesktopBackendRegistry {
     "read" | "subscribe"
   >;
   private codexBackendSummary?: BackendSummary;
+  private providerRuntimeFingerprints?: Readonly<Record<ProviderId, string>>;
+  private providerRuntimeInvalidationPromise?: Promise<void>;
   private readonly overlayStore: BackendRegistryOverlayStoreLike;
   private readonly gitDirectoryService: GitDirectoryService;
   private readonly gitWorkingStateService: GitWorkingStateService;
@@ -8870,6 +8890,13 @@ export class DesktopBackendRegistry {
                 : true;
             }
           : undefined),
+      resolveProviderDependencyFingerprint: options?.configStore
+        ? (registryId) =>
+            providerProjectionForRegistryId(
+              options.configStore!.read("providers"),
+              registryId,
+            )?.dependencyFingerprint
+        : undefined,
       emit: async (event) => {
         this.rememberAcpAvailableCommands(event);
         await this.emit(event);
@@ -8891,6 +8918,23 @@ export class DesktopBackendRegistry {
         options?.automationInspectionMcpCommand ??
         resolveAutomationInspectionMcpCommand(),
     });
+    if (this.configStore) {
+      this.providerRuntimeFingerprints = readProviderRuntimeFingerprints(
+        this.configStore.read("providers"),
+      );
+      this.unsubscribers.push(
+        this.configStore.subscribe(["providers"], () => {
+          void this.synchronizeProviderRuntimeSelections().catch((error) => {
+            backendRegistryLog.warn(
+              "provider runtime config invalidation failed",
+              {
+                error: error instanceof Error ? error.message : String(error),
+              },
+            );
+          });
+        }),
+      );
+    }
     this.messagingStore = options?.messagingStore;
     this.messagingArchiveCleaner = options?.messagingArchiveCleaner;
     this.appManagementHandler = options?.appManagementHandler ?? undefined;
@@ -9675,10 +9719,14 @@ export class DesktopBackendRegistry {
 
   async invalidateProviderRuntimeSelections(params: {
     acp: boolean;
+    acpRegistryIds?: readonly string[];
     codex: boolean;
   }): Promise<void> {
     if (params.acp) {
-      this.acpBackend.invalidateLocalAgentDiscovery();
+      this.acpBackend.invalidateRuntimeSelections(
+        params.acpRegistryIds
+        ?? PROVIDER_IDS.filter((provider) => provider !== "codex"),
+      );
     }
     if (!params.codex) return;
     // A settings write is authority to stop using the obsolete executable,
@@ -9689,6 +9737,42 @@ export class DesktopBackendRegistry {
     this.modelCatalog.invalidate("codex");
     this.codexRuntimeRestartPending = true;
     await this.maybeRestartCodexForManagedRuntimeChange();
+  }
+
+  async synchronizeProviderRuntimeSelections(): Promise<void> {
+    const providers = this.configStore?.read("providers");
+    if (!providers) return;
+    const previous = this.providerRuntimeFingerprints;
+    const next = readProviderRuntimeFingerprints(providers);
+    this.providerRuntimeFingerprints = next;
+    if (!previous) return;
+
+    const changed = PROVIDER_IDS.filter(
+      (provider) => previous[provider] !== next[provider],
+    );
+    if (changed.length === 0) {
+      await this.providerRuntimeInvalidationPromise;
+      return;
+    }
+    const acpRegistryIds = changed.filter((provider) => provider !== "codex");
+    const prior = this.providerRuntimeInvalidationPromise;
+    const attempt = Promise.resolve(prior).catch(() => undefined).then(
+      async () => {
+        await this.invalidateProviderRuntimeSelections({
+          acp: acpRegistryIds.length > 0,
+          acpRegistryIds,
+          codex: changed.includes("codex"),
+        });
+      },
+    );
+    this.providerRuntimeInvalidationPromise = attempt;
+    try {
+      await attempt;
+    } finally {
+      if (this.providerRuntimeInvalidationPromise === attempt) {
+        this.providerRuntimeInvalidationPromise = undefined;
+      }
+    }
   }
 
   /**
@@ -23493,7 +23577,10 @@ export class DesktopBackendRegistry {
       return this.codexBackendSummary;
     }
     const provider = this.configStore?.read("providers").codex;
-    const lastKnownGood = provider?.lastKnownGood;
+    const lastKnownGood = provider
+      && providerLastKnownGoodMatchesConfig(provider)
+      ? provider.lastKnownGood
+      : undefined;
     const available = Boolean(lastKnownGood?.selectedCommand);
     const methods: string[] = [];
     const capabilities = buildCapabilities(methods, "codex");
@@ -23537,6 +23624,7 @@ export class DesktopBackendRegistry {
     permit: ProviderDiscoveryPermit,
   ): Promise<BackendSummary> {
     assertProviderDiscoveryPermit(permit);
+    const previousSummary = this.readCodexBackendSummary();
     const [
       initializeResult,
       defaultModelsResult,
@@ -23561,6 +23649,21 @@ export class DesktopBackendRegistry {
           ? initializeResult.reason.message
           : String(initializeResult.reason)
         : "";
+    const modelRefreshError =
+      defaultModelsResult.status === "rejected"
+        ? defaultModelsResult.reason instanceof Error
+          ? defaultModelsResult.reason.message
+          : String(defaultModelsResult.reason)
+        : "";
+    if (previousSummary.available && (!available || modelRefreshError)) {
+      // A force refresh can fail because a healthy binary was temporarily
+      // unavailable or model listing failed. Keep the current/durable summary
+      // and reject so Settings surfaces the attempt without caching a sticky
+      // unavailable backend or empty model catalog.
+      throw new Error(
+        unavailableReason || modelRefreshError || "Codex unavailable",
+      );
+    }
     const capabilities = buildCapabilities(methods, "codex");
     if (
       this.resolveManagedReviewEnabledFn()

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7635,7 +7635,7 @@ function readProviderRuntimeFingerprints(
   return Object.fromEntries(
     PROVIDER_IDS.map((provider) => [
       provider,
-      providers[provider].dependencyFingerprint,
+      providers[provider]?.dependencyFingerprint ?? "",
     ]),
   ) as Record<ProviderId, string>;
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1322,14 +1322,11 @@ export function bootstrapApp(): void {
     registerQuitBlockerIpcHandlers();
     registerSettingsIpcHandlers(undefined, {
       onConfigPatchWritten: async (patch) => {
-        const codexRuntimeChanged = patch.models?.codex?.path !== undefined;
-        const acpRuntimeChanged = patch.acpAgents !== undefined;
-        if (codexRuntimeChanged || acpRuntimeChanged) {
-          await getDesktopBackendRegistry().invalidateProviderRuntimeSelections({
-            acp: acpRuntimeChanged,
-            codex: codexRuntimeChanged,
-          });
-        }
+        // The registry observes the normalized provider domain, including
+        // external file replacements. Await the same deduplicated invalidation
+        // here so a direct Settings write cannot return ahead of its runtime
+        // ownership boundary.
+        await getDesktopBackendRegistry().synchronizeProviderRuntimeSelections();
         if (patch.federation !== undefined) {
           // Store subscriptions also cover external config-file edits. Keep
           // direct settings writes awaiting the same single-flight restart so

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -85,6 +85,7 @@ import {
   acpProviderCommandOverrideFromSnapshot,
   acpProviderEnabledFromSnapshot,
   managedGrokBuildsEnabledFromSnapshot,
+  providerProjectionForRegistryId,
 } from "../settings/config-store/provider-runtime-config";
 import {
   getDesktopBackendRegistry,
@@ -166,10 +167,10 @@ function invalidateAcpRefreshCacheAfterWrite(
 }
 
 // Coalesces concurrent ACP refreshes. A refresh runs cheap local discovery and
-// may launch agents to probe capabilities; React StrictMode double-fires the
-// settings-pane mount effect (dev) and users can double-click "Discover new",
-// so without this two passes would launch the same agents in parallel. Pure
-// cache reads (refresh === false) never launch and are not coalesced.
+// may launch agents to probe capabilities; users can double-click an explicit
+// refresh or trigger overlapping setup and Settings actions, so without this
+// two passes would launch the same agents in parallel. Pure cache reads
+// (refresh === false) never launch and are not coalesced.
 //
 // We track provider scope so narrower requests can ride an in-flight superset.
 // Force bypasses old durable capability freshness; it never justifies launching
@@ -519,7 +520,7 @@ async function listInstalledAndLocalAcpAgents(
           preferences[registryId] = { overridePath: override };
         }
       }
-      discovered = await discoverLocalAcpAgentRecords({
+      discovered = (await discoverLocalAcpAgentRecords({
         enabledRegistryIds: discoveryRegistryIds,
         managedGrok: {
           enabled:
@@ -537,6 +538,17 @@ async function listInstalledAndLocalAcpAgents(
         },
         ...(Object.keys(preferences).length > 0 ? { preferences } : {}),
         ...(options?.env ? { env: options.env } : {}),
+      })).map((record) => {
+        const configDependencyFingerprint = providerProjectionForRegistryId(
+          providers,
+          record.registryId,
+        )?.dependencyFingerprint;
+        return {
+          ...record,
+          ...(configDependencyFingerprint
+            ? { configDependencyFingerprint }
+            : {}),
+        };
       });
       const discoveryCwd = await ensureAcpRuntimeDiscoveryWorkspace();
       const now = Date.now();

--- a/apps/desktop/src/main/settings/config-store/config-domains.ts
+++ b/apps/desktop/src/main/settings/config-store/config-domains.ts
@@ -73,6 +73,9 @@ export type ProviderProjection = Readonly<{
     managedBuilds?: boolean;
   }>;
   lastKnownGood?: Readonly<{
+    /** Configuration dependency fingerprint this observation verified. Older
+     * durable rows omit it and are normalized from their enclosing row. */
+    dependencyFingerprint?: string;
     selectedCommand?: string;
     selectedVersion?: string;
     candidates: readonly ProviderCandidateSummary[];
@@ -191,7 +194,14 @@ export function normalizeConfigDomains(params: {
             : {}),
         },
         ...(previous?.lastKnownGood
-          ? { lastKnownGood: previous.lastKnownGood }
+          ? {
+              lastKnownGood: {
+                ...previous.lastKnownGood,
+                dependencyFingerprint:
+                  previous.lastKnownGood.dependencyFingerprint
+                  ?? previous.dependencyFingerprint,
+              },
+            }
           : {}),
         validation:
           previous?.dependencyFingerprint === dependencyFingerprint
@@ -240,6 +250,17 @@ export function normalizeConfigDomains(params: {
     integratedTerminal: config.integratedTerminal ?? {},
     imageUploads: config.imageUploads ?? {},
   });
+}
+
+export function providerLastKnownGoodMatchesConfig(
+  provider: ProviderProjection,
+): boolean {
+  const lastKnownGood = provider.lastKnownGood;
+  if (!lastKnownGood) return false;
+  return (
+    lastKnownGood.dependencyFingerprint ?? provider.dependencyFingerprint
+  ) === provider.dependencyFingerprint
+    && provider.validation.state !== "stale";
 }
 
 export function providerDependencyFingerprint(params: {

--- a/apps/desktop/src/main/settings/config-store/config-domains.ts
+++ b/apps/desktop/src/main/settings/config-store/config-domains.ts
@@ -182,6 +182,16 @@ export function normalizeConfigDomains(params: {
         provider,
       });
       const previous = params.previousProviders?.[provider];
+      const lastKnownGood = previous?.lastKnownGood
+        ? {
+            ...previous.lastKnownGood,
+            dependencyFingerprint:
+              previous.lastKnownGood.dependencyFingerprint
+              ?? previous.dependencyFingerprint,
+          }
+        : undefined;
+      const restoredLastKnownGood =
+        lastKnownGood?.dependencyFingerprint === dependencyFingerprint;
       const projection: ProviderProjection = {
         provider,
         dependencyFingerprint,
@@ -193,22 +203,20 @@ export function normalizeConfigDomains(params: {
             ? { managedBuilds: config.acpAgents.grok.managedBuilds }
             : {}),
         },
-        ...(previous?.lastKnownGood
-          ? {
-              lastKnownGood: {
-                ...previous.lastKnownGood,
-                dependencyFingerprint:
-                  previous.lastKnownGood.dependencyFingerprint
-                  ?? previous.dependencyFingerprint,
-              },
-            }
+        ...(lastKnownGood
+          ? { lastKnownGood }
           : {}),
         validation:
           previous?.dependencyFingerprint === dependencyFingerprint
             ? previous.validation
-            : {
-                state: previous?.lastKnownGood ? "stale" : "unknown",
-              },
+            : restoredLastKnownGood
+              ? {
+                  state: "valid",
+                  lastAttemptAt: lastKnownGood.validatedAt,
+                }
+              : {
+                  state: previous?.lastKnownGood ? "stale" : "unknown",
+                },
       };
       return [provider, projection];
     }),
@@ -259,8 +267,7 @@ export function providerLastKnownGoodMatchesConfig(
   if (!lastKnownGood) return false;
   return (
     lastKnownGood.dependencyFingerprint ?? provider.dependencyFingerprint
-  ) === provider.dependencyFingerprint
-    && provider.validation.state !== "stale";
+  ) === provider.dependencyFingerprint;
 }
 
 export function providerDependencyFingerprint(params: {

--- a/apps/desktop/src/main/settings/config-store/desktop-config-store.ts
+++ b/apps/desktop/src/main/settings/config-store/desktop-config-store.ts
@@ -44,6 +44,13 @@ export type ConfigDomainChange<K extends keyof ConfigDomainMap> = Readonly<{
   values: Readonly<Pick<ConfigDomainMap, K>>;
 }>;
 
+export type ConfigStoreUpdate = Readonly<{
+  version: number;
+  configRevision: string;
+  configFile: ConfigFileStatus;
+  changedDomains: readonly (keyof ConfigDomainMap)[];
+}>;
+
 export type ConfigStoreDiagnosticEvent = Readonly<{
   operation:
     | "config-parse"
@@ -80,6 +87,9 @@ export class DesktopConfigStore {
   private readonly durable?: DurableConfigSnapshotStore;
   private readonly now: () => number;
   private readonly subscriptions = new Set<Subscription>();
+  private readonly updateSubscriptions = new Set<
+    (event: ConfigStoreUpdate) => void
+  >();
   private diagnosticEventCount = 0;
   private readonly diagnosticOperationCounts: Record<
     ConfigStoreDiagnosticEvent["operation"],
@@ -215,6 +225,16 @@ export class DesktopConfigStore {
     this.subscriptions.add(subscription);
     return () => {
       this.subscriptions.delete(subscription);
+    };
+  }
+
+  subscribeUpdates(listener: (event: ConfigStoreUpdate) => void): () => void {
+    // Unlike a domain subscription, this observes invalid/repair publications
+    // whose normalized values are unchanged. It is notification only and
+    // carries no provider discovery authority.
+    this.updateSubscriptions.add(listener);
+    return () => {
+      this.updateSubscriptions.delete(listener);
     };
   }
 
@@ -505,6 +525,7 @@ export class DesktopConfigStore {
     this.watcher = undefined;
     this.providerRefresh?.dispose();
     this.subscriptions.clear();
+    this.updateSubscriptions.clear();
   }
 
   private publish(params: {
@@ -572,6 +593,14 @@ export class DesktopConfigStore {
     changedDomains: readonly (keyof ConfigDomainMap)[],
     snapshot: ConfigStoreSnapshot,
   ): void {
+    for (const listener of this.updateSubscriptions) {
+      listener({
+        version: snapshot.version,
+        configRevision: snapshot.configRevision,
+        configFile: snapshot.configFile,
+        changedDomains,
+      });
+    }
     if (changedDomains.length === 0) {
       return;
     }

--- a/apps/desktop/src/main/settings/config-store/desktop-config-store.ts
+++ b/apps/desktop/src/main/settings/config-store/desktop-config-store.ts
@@ -479,6 +479,7 @@ export class DesktopConfigStore {
           ...current,
           lastKnownGood: {
             candidates: observation.candidates,
+            dependencyFingerprint: current.dependencyFingerprint,
             ...(observation.executableIdentity
               ? { executableIdentity: observation.executableIdentity }
               : {}),

--- a/apps/desktop/src/main/settings/config-store/provider-refresh.ts
+++ b/apps/desktop/src/main/settings/config-store/provider-refresh.ts
@@ -91,6 +91,7 @@ export class ProviderRefreshCoordinator {
         ...latest,
         lastKnownGood: {
           ...result,
+          dependencyFingerprint: current.dependencyFingerprint,
           validatedAt: (this.options.now ?? Date.now)(),
         },
         validation: {

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -503,10 +503,6 @@ export class DesktopSettingsService {
   private readonly configPath: string;
   private readonly configStore: DesktopConfigStore;
   private readonly configWriteListeners = new Set<() => void>();
-  private readonly secretStates = new Map<
-    DesktopSettingsSecretName,
-    DesktopSettingsSecretState
-  >();
   private readonly now: () => number;
   private readonly startupCodexHome?: string;
   private loggedObsoleteComposerConfig = false;
@@ -3340,10 +3336,10 @@ export class DesktopSettingsService {
     envKey: string | undefined,
     storageAvailable: boolean,
   ): Promise<DesktopSettingsSecretState> {
-    const cached = this.secretStates.get(secret);
-    if (cached) return cached;
+    // The profile database is shared by processes. Sample presence for every
+    // projection so a secret created outside Settings cannot stay cached as
+    // absent; secret values themselves are never read here.
     const state = await this.loadSecretState(secret, envKey, storageAvailable);
-    this.secretStates.set(secret, state);
     this.configStore.recordSecretPresence(secret, state);
     return state;
   }
@@ -3394,13 +3390,11 @@ export class DesktopSettingsService {
   private async readAndPublishSecretState(
     secret: DesktopSettingsSecretName,
   ): Promise<DesktopSettingsSecretState> {
-    this.secretStates.delete(secret);
-    const state = await this.readSecretState(
+    return await this.readSecretState(
       secret,
       secretEnvironmentKey(secret),
       this.options.secretStore.describe().available,
     );
-    return state;
   }
 
   private resolveSecretSync(

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -218,6 +218,7 @@ import {
   assertProviderDiscoveryPermit,
   type ProviderDiscoveryPermit,
 } from "./provider-discovery-permit";
+import { providerLastKnownGoodMatchesConfig } from "./config-store/config-domains";
 import type {
   ManagedCodexCheckMode,
   ManagedCodexRuntime,
@@ -328,7 +329,10 @@ function providerConfigSection(provider: ProviderProjection): {
 function codexDiscoveryFromProvider(
   provider: ProviderProjection,
 ): DesktopCodexDiscoverySnapshot {
-  const selectedCommand = provider.lastKnownGood?.selectedCommand;
+  const lastKnownGood = providerLastKnownGoodMatchesConfig(provider)
+    ? provider.lastKnownGood
+    : undefined;
+  const selectedCommand = lastKnownGood?.selectedCommand;
   const sourceIsValid = (
     source: string,
   ): source is DesktopCodexCandidateSource =>
@@ -336,7 +340,7 @@ function codexDiscoveryFromProvider(
     || source === "config"
     || source === "path"
     || source === "application";
-  const candidates = (provider.lastKnownGood?.candidates ?? [])
+  const candidates = (lastKnownGood?.candidates ?? [])
     .filter((candidate) => sourceIsValid(candidate.source))
     .map((candidate) => ({
       command: candidate.command,
@@ -499,6 +503,10 @@ export class DesktopSettingsService {
   private readonly configPath: string;
   private readonly configStore: DesktopConfigStore;
   private readonly configWriteListeners = new Set<() => void>();
+  private readonly secretStates = new Map<
+    DesktopSettingsSecretName,
+    DesktopSettingsSecretState
+  >();
   private readonly now: () => number;
   private readonly startupCodexHome?: string;
   private loggedObsoleteComposerConfig = false;
@@ -3332,6 +3340,19 @@ export class DesktopSettingsService {
     envKey: string | undefined,
     storageAvailable: boolean,
   ): Promise<DesktopSettingsSecretState> {
+    const cached = this.secretStates.get(secret);
+    if (cached) return cached;
+    const state = await this.loadSecretState(secret, envKey, storageAvailable);
+    this.secretStates.set(secret, state);
+    this.configStore.recordSecretPresence(secret, state);
+    return state;
+  }
+
+  private async loadSecretState(
+    secret: DesktopSettingsSecretName,
+    envKey: string | undefined,
+    storageAvailable: boolean,
+  ): Promise<DesktopSettingsSecretState> {
     if (envKey && readEnvString(this.env, envKey)) {
       return {
         configured: true,
@@ -3373,12 +3394,12 @@ export class DesktopSettingsService {
   private async readAndPublishSecretState(
     secret: DesktopSettingsSecretName,
   ): Promise<DesktopSettingsSecretState> {
+    this.secretStates.delete(secret);
     const state = await this.readSecretState(
       secret,
       secretEnvironmentKey(secret),
       this.options.secretStore.describe().available,
     );
-    this.configStore.recordSecretPresence(secret, state);
     return state;
   }
 

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -15,7 +15,6 @@ import {
   disposeDesktopConfigStore,
   getDesktopConfigStore,
 } from "./config-store/desktop-config-store-singleton";
-import { CONFIG_DOMAIN_KEYS } from "./config-store/config-domains";
 import { resolveDesktopConfigPath } from "./desktop-config";
 
 let desktopSettingsService: DesktopSettingsService | undefined;
@@ -76,12 +75,11 @@ export function getDesktopSettingsService(): DesktopSettingsService {
     configStore.subscribe(["general"], ({ values }) => {
       broadcastAppearanceChange(values.general.appearance);
     });
-    configStore.subscribe(
-      CONFIG_DOMAIN_KEYS,
-      ({ version, changedDomains }) => {
+    configStore.subscribeUpdates(
+      ({ version, configRevision, changedDomains }) => {
         const payload = {
           version,
-          configRevision: configStore.configRevision(),
+          configRevision,
           changedDomains,
         };
         for (const webContents of subscribersForChannel(

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -15,6 +15,7 @@ import {
   disposeDesktopConfigStore,
   getDesktopConfigStore,
 } from "./config-store/desktop-config-store-singleton";
+import { CONFIG_DOMAIN_KEYS } from "./config-store/config-domains";
 import { resolveDesktopConfigPath } from "./desktop-config";
 
 let desktopSettingsService: DesktopSettingsService | undefined;
@@ -75,6 +76,21 @@ export function getDesktopSettingsService(): DesktopSettingsService {
     configStore.subscribe(["general"], ({ values }) => {
       broadcastAppearanceChange(values.general.appearance);
     });
+    configStore.subscribe(
+      CONFIG_DOMAIN_KEYS,
+      ({ version, changedDomains }) => {
+        const payload = {
+          version,
+          configRevision: configStore.configRevision(),
+          changedDomains,
+        };
+        for (const webContents of subscribersForChannel(
+          SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL,
+        )) {
+          webContents.send(SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL, payload);
+        }
+      },
+    );
   }
   return desktopSettingsService;
 }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -361,6 +361,7 @@ import type {
   WriteStarMapWorkspaceRequest,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
+  DesktopSettingsRuntimeChangedEvent,
   ReadDesktopConfigBootstrapResponse,
   ReadDesktopFullAccessPolicyResponse,
   ReadDesktopMessagingSettingsResponse,
@@ -2232,8 +2233,13 @@ const desktopApi = Object.freeze({
       ipcRenderer.off(APPEARANCE_CHANGED_EVENT_CHANNEL, listener);
     };
   },
-  onSettingsRuntimeChanged: (callback: () => void): (() => void) => {
-    const listener = () => callback();
+  onSettingsRuntimeChanged: (
+    callback: (event?: DesktopSettingsRuntimeChangedEvent) => void,
+  ): (() => void) => {
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload?: DesktopSettingsRuntimeChangedEvent,
+    ) => callback(payload);
     ipcRenderer.on(SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL, listener);
     return () => {
       ipcRenderer.off(SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL, listener);

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -95,6 +95,9 @@ export function AcpAgentsSettings(props: {
           : {}),
         refresh: refreshRegistry,
         ...(force ? { force: true } : {}),
+        ...(refreshRegistry && props.only
+          ? { registryIds: [props.only] }
+          : {}),
       });
       setEntries(response.entries);
       setError(response.error);
@@ -111,10 +114,10 @@ export function AcpAgentsSettings(props: {
     }
   }
 
-  // Run the initial load exactly once. Mount renders cached agents immediately
-  // (refresh(false) — pure cache read, no launches), then a registry refresh
-  // that only probes undiscovered/stale agents. The ref guards React StrictMode
-  // double-invoking this effect in dev (main also coalesces refreshes).
+  // Run the initial cache read exactly once. Mounting or focusing a provider
+  // must never probe or launch it; the row's Refresh/Save actions own that
+  // provider-scoped discovery budget. The ref only collapses StrictMode's
+  // double-invoked mount effect.
   const didInitialLoad = useRef(false);
   useEffect(() => {
     if (didInitialLoad.current) {
@@ -125,7 +128,7 @@ export function AcpAgentsSettings(props: {
       return;
     }
     didInitialLoad.current = true;
-    void refresh(false).then(() => refresh(true));
+    void refresh(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
 

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -211,8 +211,9 @@ export function ModelsSettings(props: {
   };
 
   useEffect(() => {
-    void refreshCatalog(false, true);
-    // The settings surface is itself a catalog refresh boundary.
+    void refreshCatalog();
+    // Mount is a cache-only read. Provider discovery belongs to the explicit
+    // all-provider Refresh action below, not navigation into Settings.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.desktopApi]);
 
@@ -239,13 +240,9 @@ export function ModelsSettings(props: {
     void props.onSaveCodexPath(path.trim());
   };
 
-  // Names and status for the hub index + focused-screen titles. The
-  // registry probe runs from the hub and the Codex screen (which mounts
-  // no AcpAgentsSettings); focused ACP screens probe via their own
-  // AcpAgentsSettings mount.
-  const acpCatalog = useAcpAgentCatalog(props.desktopApi, {
-    probe: props.focus === undefined || props.focus === "codex",
-  });
+  // Names and status for the hub index + focused-screen titles. This is a
+  // cache-only catalog read; explicit Refresh/Verify actions own discovery.
+  const acpCatalog = useAcpAgentCatalog(props.desktopApi);
   const orderedAcpEntries = displayOrderedAcpEntries(acpCatalog.entries);
   const focusedAcpEntry =
     props.focus && props.focus !== "codex"
@@ -1001,7 +998,7 @@ function ProviderModelDefaultsSettings(props: {
                 type="button"
                 onClick={() => void props.onRefresh()}
               >
-                {props.refreshing ? "Refreshing…" : "Refresh models"}
+                {props.refreshing ? "Refreshing…" : "Refresh all providers"}
               </button>
             }
           />
@@ -1011,7 +1008,7 @@ function ProviderModelDefaultsSettings(props: {
             sub={
               props.error
                 ? `Last refresh failed: ${props.error}`
-                : "Refresh after installing or upgrading a provider CLI."
+                : "Refresh every provider after installing or upgrading a CLI."
             }
             control={
               <button
@@ -1020,7 +1017,7 @@ function ProviderModelDefaultsSettings(props: {
                 type="button"
                 onClick={() => void props.onRefresh()}
               >
-                {props.refreshing ? "Refreshing…" : "Refresh models"}
+                {props.refreshing ? "Refreshing…" : "Refresh all providers"}
               </button>
             }
           />

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -171,7 +171,7 @@ export function ModelsSettings(props: {
 
   const refreshCatalog = async (
     force = false,
-    refreshModels = false,
+    refreshModels: true | "codex" | false = false,
   ): Promise<void> => {
     if (!props.desktopApi?.listBackends) {
       setCatalogError("Provider model discovery is unavailable in this build.");
@@ -188,12 +188,15 @@ export function ModelsSettings(props: {
         });
         acpRegistryRefreshed = true;
       }
+      const requestedModelRefresh = force ? true : refreshModels;
       const response = await props.desktopApi.listBackends({
         ...((force || refreshModels)
           ? { discoveryIntent: "settings-user-action" as const }
           : {}),
         includeUnavailable: true,
-        ...(force || refreshModels ? { refreshModels: true } : {}),
+        ...(requestedModelRefresh
+          ? { refreshModels: requestedModelRefresh }
+          : {}),
       });
       setBackends(response.backends);
       setCatalogError(undefined);
@@ -330,27 +333,42 @@ export function ModelsSettings(props: {
             sub="Detected on this machine. The newest supported version is used automatically."
             source={codexSource}
             control={
-              <div
-                className="settings-paths"
-                aria-label="Codex discovery"
-                data-codex-path-actions
-              >
-                {autoCandidates.length === 0 ? (
-                  <p className="settings-empty">No Codex candidates found.</p>
-                ) : (
-                  autoCandidates.map((candidate) => (
-                    <CodexCandidateRow
-                      key={`${candidate.source}:${candidate.command}`}
-                      candidate={candidate}
-                      disabled={props.saving || envForced}
-                      onUse={(command) => {
-                        setCodexPath(command);
-                        saveCodexPath(command);
-                      }}
-                    />
-                  ))
-                )}
-              </div>
+              <>
+                <div
+                  className="settings-paths"
+                  aria-label="Codex discovery"
+                  data-codex-path-actions
+                >
+                  {autoCandidates.length === 0 ? (
+                    <p className="settings-empty">No Codex candidates found.</p>
+                  ) : (
+                    autoCandidates.map((candidate) => (
+                      <CodexCandidateRow
+                        key={`${candidate.source}:${candidate.command}`}
+                        candidate={candidate}
+                        disabled={props.saving || envForced}
+                        onUse={(command) => {
+                          setCodexPath(command);
+                          saveCodexPath(command);
+                        }}
+                      />
+                    ))
+                  )}
+                </div>
+                <div
+                  className="settings-inline-actions"
+                  data-codex-path-actions
+                >
+                  <button
+                    className="button button--secondary"
+                    disabled={refreshingCatalog || props.saving}
+                    type="button"
+                    onClick={() => void refreshCatalog(false, "codex")}
+                  >
+                    {refreshingCatalog ? "Refreshing…" : "Refresh Codex"}
+                  </button>
+                </div>
+              </>
             }
           />
           <SettingsField

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -128,6 +128,7 @@ describe("AcpAgentsSettings", () => {
 
     render(<AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />);
 
+    fireEvent.click(await screen.findByRole("button", { name: "Refresh" }));
     await waitFor(() => {
       expect(onBackendSummariesRefresh).toHaveBeenCalledTimes(1);
     });
@@ -137,7 +138,7 @@ describe("AcpAgentsSettings", () => {
     );
   });
 
-  it("keeps cached ACP agents visible while background discovery refreshes", async () => {
+  it("keeps cached ACP agents visible while explicit discovery refreshes", async () => {
     const dispatchEvent = vi.spyOn(window, "dispatchEvent");
     let resolveRefresh:
       | ((value: { fetchedAt: number; entries: AcpAgentSettingsEntry[] }) => void)
@@ -200,9 +201,11 @@ describe("AcpAgentsSettings", () => {
     render(<AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />);
 
     expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
     await waitFor(() => {
       expect(listAcpAgents).toHaveBeenCalledWith({
         discoveryIntent: "settings-user-action",
+        force: true,
         refresh: true,
       });
     });
@@ -618,6 +621,17 @@ describe("AcpAgentsSettings", () => {
 
     expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
     expect(screen.queryByText("Grok")).not.toBeInTheDocument();
+    expect(listAcpAgents).toHaveBeenCalledExactlyOnceWith({ refresh: false });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenLastCalledWith({
+        discoveryIntent: "settings-user-action",
+        force: true,
+        refresh: true,
+        registryIds: ["gemini"],
+      });
+    });
   });
 
   it("says the provider is unavailable when the focused agent is missing", async () => {
@@ -791,7 +805,7 @@ describe("AcpAgentsSettings", () => {
     );
   });
 
-  it("loads exactly once under StrictMode's double-invoked mount effect", async () => {
+  it("performs one cache-only read under StrictMode's double-invoked mount effect", async () => {
     const listAcpAgents = vi.fn(
       async (_request?: { refresh?: boolean; force?: boolean }) => ({
         fetchedAt: 1000,
@@ -807,12 +821,9 @@ describe("AcpAgentsSettings", () => {
 
     expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
     // StrictMode runs the mount effect twice in dev; the did-initial-load ref
-    // must collapse that into a single gated registry refresh (one
-    // refresh: true), not two parallel discovery passes that storm the agents.
+    // collapses it into one cache read and must never turn mount into discovery.
     await waitFor(() => {
-      expect(
-        listAcpAgents.mock.calls.filter((call) => call[0]?.refresh === true),
-      ).toHaveLength(1);
+      expect(listAcpAgents).toHaveBeenCalledExactlyOnceWith({ refresh: false });
     });
   });
 
@@ -840,10 +851,7 @@ describe("AcpAgentsSettings", () => {
     rerender(<AcpAgentsSettings desktopApi={{ listAcpAgents } as DesktopApi} />);
     expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
     await waitFor(() => {
-      expect(listAcpAgents).toHaveBeenCalledWith({
-        discoveryIntent: "settings-user-action",
-        refresh: true,
-      });
+      expect(listAcpAgents).toHaveBeenCalledExactlyOnceWith({ refresh: false });
     });
     expect(
       screen.queryByText(

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -789,6 +789,43 @@ describe("SettingsScreen", () => {
     });
   });
 
+  it("refreshes only Codex from the focused Codex screen", async () => {
+    const listBackends = vi.fn<NonNullable<DesktopApi["listBackends"]>>(
+      async () => ({ fetchedAt: 1000, backends: [] }),
+    );
+    const listAcpAgents = vi.fn<NonNullable<DesktopApi["listAcpAgents"]>>(
+      async () => ({ fetchedAt: 1000, entries: [] }),
+    );
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listAcpAgents, listBackends }}
+        initialSection="models"
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    const nav = screen.getByRole("navigation", { name: "Settings sections" });
+    fireEvent.click(within(nav).getByRole("button", { name: "Codex" }));
+    const refresh = await screen.findByRole("button", {
+      name: "Refresh Codex",
+    });
+    await waitFor(() => expect(listBackends).toHaveBeenCalled());
+    listBackends.mockClear();
+    listAcpAgents.mockClear();
+    fireEvent.click(refresh);
+
+    await waitFor(() => {
+      expect(listBackends).toHaveBeenCalledExactlyOnceWith({
+        discoveryIntent: "settings-user-action",
+        includeUnavailable: true,
+        refreshModels: "codex",
+      });
+    });
+    expect(listAcpAgents).not.toHaveBeenCalled();
+  });
+
   it("names the active PwrAgent Codex path environment override", () => {
     const base = createSnapshot();
     const snapshot = createSnapshot({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -22,6 +22,7 @@ import type {
   MessagingPairingEntry,
   WorktreeSnapshotSummary,
 } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
 import { SettingsScreen } from "../SettingsScreen";
 import type { DesktopSettingsState } from "../useDesktopSettings";
 
@@ -613,7 +614,7 @@ function createArchivedSnapshot(
 }
 
 describe("SettingsScreen", () => {
-  it("renders cached provider models and locks ACP paths while refreshing the catalog", async () => {
+  it("renders cached provider models and keeps mount-only catalog reads passive", async () => {
     const cachedBackends: BackendSummary[] = [
       {
         kind: "codex",
@@ -647,10 +648,10 @@ describe("SettingsScreen", () => {
         },
       },
     ];
-    const listBackends = vi.fn(
+    const listBackends = vi.fn<NonNullable<DesktopApi["listBackends"]>>(
       async () => await new Promise<never>(() => undefined),
     );
-    const listAcpAgents = vi.fn(async () => ({
+    const listAcpAgents = vi.fn<NonNullable<DesktopApi["listAcpAgents"]>>(async () => ({
       fetchedAt: 1000,
       entries: [
         {
@@ -698,17 +699,20 @@ describe("SettingsScreen", () => {
       .not.toBeInTheDocument();
     await waitFor(() => {
       expect(listBackends).toHaveBeenCalledWith({
-        discoveryIntent: "settings-user-action",
         includeUnavailable: true,
-        refreshModels: true,
       });
     });
     await waitFor(() => {
-      expect(listAcpAgents).toHaveBeenCalledWith({
-        discoveryIntent: "settings-user-action",
-        refresh: true,
-      });
+      expect(listAcpAgents).toHaveBeenCalled();
     });
+    expect(
+      listAcpAgents.mock.calls.every(([request]) => request?.refresh === false),
+    ).toBe(true);
+    expect(
+      listBackends.mock.calls.every(
+        ([request]) => request?.refreshModels === undefined,
+      ),
+    ).toBe(true);
     fireEvent.click(
       await screen.findByRole("button", { name: "Open Grok settings" }),
     );
@@ -739,8 +743,49 @@ describe("SettingsScreen", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: "Refresh models" }))
+      expect(screen.getByRole("button", { name: "Refresh all providers" }))
         .toBeDisabled();
+    });
+  });
+
+  it("keeps the Models hub refresh explicitly all-provider", async () => {
+    const listBackends = vi.fn(async () => ({
+      fetchedAt: 1000,
+      backends: [],
+    }));
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1000,
+      entries: [],
+    }));
+
+    render(
+      <SettingsScreen
+        desktopApi={{ listAcpAgents, listBackends }}
+        initialSection="models"
+        settings={createSettingsState()}
+        onClose={() => undefined}
+      />,
+    );
+
+    const refresh = await screen.findByRole("button", {
+      name: "Refresh all providers",
+    });
+    await waitFor(() => expect(listBackends).toHaveBeenCalled());
+    listBackends.mockClear();
+    listAcpAgents.mockClear();
+    fireEvent.click(refresh);
+
+    await waitFor(() => {
+      expect(listAcpAgents).toHaveBeenCalledWith({
+        discoveryIntent: "settings-user-action",
+        force: true,
+        refresh: true,
+      });
+      expect(listBackends).toHaveBeenCalledWith({
+        discoveryIntent: "settings-user-action",
+        includeUnavailable: true,
+        refreshModels: true,
+      });
     });
   });
 

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx
@@ -64,6 +64,55 @@ describe("useDesktopSettings", () => {
     });
   });
 
+  it("discards an older settings read that resolves after a newer refresh", async () => {
+    type ReadResponse = Awaited<ReturnType<
+      NonNullable<DesktopApi["readSettings"]>
+    >>;
+    let runtimeChanged:
+      | Parameters<NonNullable<DesktopApi["onSettingsRuntimeChanged"]>>[0]
+      | undefined;
+    const resolveReads: Array<(response: ReadResponse) => void> = [];
+    const readSettings = vi
+      .fn<NonNullable<DesktopApi["readSettings"]>>()
+      .mockImplementation(async () => await new Promise((resolve) => {
+        resolveReads.push(resolve);
+      }));
+    const desktopApi: DesktopApi = {
+      onSettingsRuntimeChanged: (callback) => {
+        runtimeChanged = callback;
+        return () => {
+          runtimeChanged = undefined;
+        };
+      },
+      readSettings,
+    };
+    const { result } = renderHook(() => useDesktopSettings(desktopApi));
+    await vi.waitFor(() => {
+      expect(readSettings).toHaveBeenCalledOnce();
+      expect(runtimeChanged).toBeDefined();
+    });
+
+    act(() => runtimeChanged?.({
+      version: 2,
+      configRevision: "newer",
+      changedDomains: ["providers"],
+    }));
+    await vi.waitFor(() => expect(readSettings).toHaveBeenCalledTimes(2));
+    await act(async () => {
+      resolveReads[1]?.({ snapshot: {
+        fetchedAt: 2,
+      } as DesktopSettingsSnapshot });
+    });
+    expect(result.current.snapshot?.fetchedAt).toBe(2);
+
+    await act(async () => {
+      resolveReads[0]?.({ snapshot: {
+        fetchedAt: 1,
+      } as DesktopSettingsSnapshot });
+    });
+    expect(result.current.snapshot?.fetchedAt).toBe(2);
+  });
+
   it("coalesces its own config event while preserving a newer external edit", async () => {
     let runtimeChanged:
       | Parameters<NonNullable<DesktopApi["onSettingsRuntimeChanged"]>>[0]

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/use-desktop-settings.test.tsx
@@ -28,6 +28,118 @@ describe("useDesktopSettings", () => {
     await vi.waitFor(() => expect(readSettings).toHaveBeenCalledTimes(2));
   });
 
+  it("observes normalized config changes published by another process", async () => {
+    let runtimeChanged:
+      | Parameters<NonNullable<DesktopApi["onSettingsRuntimeChanged"]>>[0]
+      | undefined;
+    const firstSnapshot = {} as DesktopSettingsSnapshot;
+    const externalSnapshot = {
+      models: { codex: { path: { value: "/external/codex" } } },
+    } as unknown as DesktopSettingsSnapshot;
+    const readSettings = vi
+      .fn<NonNullable<DesktopApi["readSettings"]>>()
+      .mockResolvedValueOnce({ snapshot: firstSnapshot })
+      .mockResolvedValueOnce({ snapshot: externalSnapshot });
+    const desktopApi: DesktopApi = {
+      onSettingsRuntimeChanged: (callback) => {
+        runtimeChanged = callback;
+        return () => {
+          runtimeChanged = undefined;
+        };
+      },
+      readSettings,
+    };
+    const { result } = renderHook(() => useDesktopSettings(desktopApi));
+    await vi.waitFor(() => expect(result.current.snapshot).toBe(firstSnapshot));
+
+    act(() => runtimeChanged?.({
+      version: 2,
+      configRevision: "external",
+      changedDomains: ["providers"],
+    }));
+
+    await vi.waitFor(() => {
+      expect(readSettings).toHaveBeenCalledTimes(2);
+      expect(result.current.snapshot).toBe(externalSnapshot);
+    });
+  });
+
+  it("coalesces its own config event while preserving a newer external edit", async () => {
+    let runtimeChanged:
+      | Parameters<NonNullable<DesktopApi["onSettingsRuntimeChanged"]>>[0]
+      | undefined;
+    let resolveWrite:
+      | ((value: Awaited<ReturnType<
+        NonNullable<DesktopApi["writeSettingsConfig"]>
+      >>) => void)
+      | undefined;
+    const initialSnapshot = {} as DesktopSettingsSnapshot;
+    const writtenSnapshot = {
+      models: { codex: { path: { value: "/written/codex" } } },
+    } as unknown as DesktopSettingsSnapshot;
+    const externalSnapshot = {
+      models: { codex: { path: { value: "/external/codex" } } },
+    } as unknown as DesktopSettingsSnapshot;
+    const readSettings = vi
+      .fn<NonNullable<DesktopApi["readSettings"]>>()
+      .mockResolvedValueOnce({ snapshot: initialSnapshot })
+      .mockResolvedValueOnce({ snapshot: externalSnapshot });
+    const writeSettingsConfig = vi
+      .fn<NonNullable<DesktopApi["writeSettingsConfig"]>>()
+      .mockImplementation(async () => await new Promise((resolve) => {
+        resolveWrite = resolve;
+      }));
+    const desktopApi: DesktopApi = {
+      onSettingsRuntimeChanged: (callback) => {
+        runtimeChanged = callback;
+        return () => {
+          runtimeChanged = undefined;
+        };
+      },
+      readSettings,
+      writeSettingsConfig,
+    };
+    const { result } = renderHook(() => useDesktopSettings(desktopApi));
+    await vi.waitFor(() => expect(result.current.snapshot).toBe(initialSnapshot));
+
+    const write = result.current.writeConfig({
+      models: { codex: { path: "/written/codex" } },
+    });
+    await vi.waitFor(() => expect(writeSettingsConfig).toHaveBeenCalledOnce());
+    act(() => {
+      runtimeChanged?.({
+        version: 2,
+        configRevision: "written",
+        changedDomains: ["providers"],
+      });
+      runtimeChanged?.({
+        version: 3,
+        configRevision: "external",
+        changedDomains: ["providers"],
+      });
+    });
+    await act(async () => {
+      resolveWrite?.({
+        update: {
+          version: 2,
+          configRevision: "written",
+          changedDomains: ["providers"],
+          normalizedPatch: {
+            models: { codex: { path: "/written/codex" } },
+          },
+          scheduledProviderRefreshes: [],
+        },
+        snapshot: writtenSnapshot,
+      });
+      await write;
+    });
+
+    await vi.waitFor(() => {
+      expect(readSettings).toHaveBeenCalledTimes(2);
+      expect(result.current.snapshot).toBe(externalSnapshot);
+    });
+  });
+
   it("refreshes backend summaries after ACP provider settings change", async () => {
     const onRefresh = vi.fn();
     const normalizedSnapshot = {

--- a/apps/desktop/src/renderer/src/features/settings/useAcpAgentCatalog.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useAcpAgentCatalog.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import type {
   AcpAgentSettingsEntry,
   DesktopSettingsSnapshot,
@@ -45,28 +45,17 @@ export type AcpAgentCatalogState = {
 /**
  * Light read of the ACP agent catalog for surfaces that need names and
  * status but do not own the full per-agent editing flow: the settings
- * nav sub-items and the AI Providers hub index. Reads the cached
- * catalog immediately; with `probe` it then asks the registry to
- * refresh stale agents once per mount (the main process coalesces
- * concurrent refreshes) and re-reads when any surface announces new
- * summaries.
+ * nav sub-items and the AI Providers hub index. Reads only the cached
+ * catalog and re-reads when an explicit Settings/setup action announces new
+ * summaries. Mounting navigation or a provider screen is never authority to
+ * probe or launch an agent.
  */
 export function useAcpAgentCatalog(
   desktopApi: DesktopApi | undefined,
-  options?: { probe?: boolean },
 ): AcpAgentCatalogState {
   const [entries, setEntries] = useState<AcpAgentSettingsEntry[]>([]);
   const [loaded, setLoaded] = useState(false);
   const [error, setError] = useState<string | undefined>();
-  const probe = options?.probe === true;
-  // The probe runs once per mounted consumer, not once per effect run —
-  // `probe` flips with hub↔focused navigation and re-probing (plus the
-  // event fan-out it triggers) on every hop is pure churn.
-  const probedRef = useRef(false);
-  // Set just before this instance dispatches the refresh event so its
-  // own listener can skip the echo — the dispatching read already holds
-  // the fresh response.
-  const selfAnnouncedRef = useRef(false);
   const listAcpAgents = desktopApi?.listAcpAgents;
 
   useEffect(() => {
@@ -74,23 +63,11 @@ export function useAcpAgentCatalog(
       return;
     }
     let disposed = false;
-    const read = async (refresh: boolean): Promise<void> => {
+    const read = async (): Promise<void> => {
       try {
         const response = await listAcpAgents({
-          refresh,
-          ...(refresh
-            ? { discoveryIntent: "settings-user-action" as const }
-            : {}),
+          refresh: false,
         });
-        if (refresh) {
-          // The main-process cache refreshed even if this consumer was
-          // cleaned up mid-flight (hub→focused navigation), so always
-          // announce — other catalog consumers have no push channel.
-          if (!disposed) {
-            selfAnnouncedRef.current = true;
-          }
-          window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
-        }
         if (disposed) {
           return;
         }
@@ -109,22 +86,13 @@ export function useAcpAgentCatalog(
       }
     };
     const onSummariesRefreshed = (): void => {
-      if (selfAnnouncedRef.current) {
-        selfAnnouncedRef.current = false;
-        return;
-      }
-      void read(false);
+      void read();
     };
     window.addEventListener(
       BACKEND_SUMMARIES_REFRESH_EVENT,
       onSummariesRefreshed,
     );
-    if (probe && !probedRef.current) {
-      probedRef.current = true;
-      void read(false).then(() => read(true));
-    } else {
-      void read(false);
-    }
+    void read();
     return () => {
       disposed = true;
       window.removeEventListener(
@@ -132,7 +100,7 @@ export function useAcpAgentCatalog(
         onSummariesRefreshed,
       );
     };
-  }, [listAcpAgents, probe]);
+  }, [listAcpAgents]);
 
   return { entries, loaded, error, unavailable: listAcpAgents === undefined };
 }

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -38,6 +38,7 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
+  const readGenerationRef = useRef(0);
   const configWriteInFlightRef = useRef(false);
   const pendingRuntimeRefreshVersionRef = useRef<number | null | undefined>(
     undefined,
@@ -48,15 +49,24 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
       return;
     }
 
+    const generation = ++readGenerationRef.current;
     setLoading(true);
     setError(undefined);
     try {
       const response = await desktopApi.readSettings({});
-      setSnapshot(response.snapshot);
+      if (readGenerationRef.current === generation) {
+        setSnapshot(response.snapshot);
+      }
     } catch (readError) {
-      setError(readError instanceof Error ? readError.message : String(readError));
+      if (readGenerationRef.current === generation) {
+        setError(
+          readError instanceof Error ? readError.message : String(readError),
+        );
+      }
     } finally {
-      setLoading(false);
+      if (readGenerationRef.current === generation) {
+        setLoading(false);
+      }
     }
   }, [desktopApi]);
 
@@ -66,6 +76,9 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
 
   useEffect(() => {
     void read();
+    return () => {
+      readGenerationRef.current += 1;
+    };
   }, [read]);
 
   useEffect(() => {
@@ -90,6 +103,8 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         return false;
       }
 
+      readGenerationRef.current += 1;
+      setLoading(false);
       setSaving(true);
       configWriteInFlightRef.current = true;
       setError(undefined);
@@ -98,6 +113,11 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         const request: WriteDesktopSettingsConfigRequest = { patch };
         const response = await desktopApi.writeSettingsConfig(request);
         appliedVersion = response.update.version;
+        // The write response is authoritative over any cache read that began
+        // before it completed. A queued newer config event starts a fresh read
+        // below after this snapshot is adopted.
+        readGenerationRef.current += 1;
+        setLoading(false);
         setSnapshot(response.snapshot);
         if (
           patch.models?.codex?.path !== undefined
@@ -193,6 +213,8 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
 
   const applySnapshot = useCallback(
     (nextSnapshot: DesktopSettingsSnapshot): void => {
+      readGenerationRef.current += 1;
+      setLoading(false);
       setSnapshot(nextSnapshot);
     },
     [],

--- a/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
+++ b/apps/desktop/src/renderer/src/features/settings/useDesktopSettings.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   ClearDesktopSettingsSecretRequest,
   DesktopChatReplyComposer,
@@ -38,6 +38,10 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string>();
+  const configWriteInFlightRef = useRef(false);
+  const pendingRuntimeRefreshVersionRef = useRef<number | null | undefined>(
+    undefined,
+  );
 
   const read = useCallback(async (): Promise<void> => {
     if (!desktopApi?.readSettings) {
@@ -65,7 +69,16 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
   }, [read]);
 
   useEffect(() => {
-    return desktopApi?.onSettingsRuntimeChanged?.(() => {
+    return desktopApi?.onSettingsRuntimeChanged?.((event) => {
+      if (configWriteInFlightRef.current) {
+        const pending = pendingRuntimeRefreshVersionRef.current;
+        pendingRuntimeRefreshVersionRef.current = event
+          ? pending === null
+            ? null
+            : Math.max(pending ?? 0, event.version)
+          : null;
+        return;
+      }
       void read();
     });
   }, [desktopApi, read]);
@@ -78,10 +91,13 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
       }
 
       setSaving(true);
+      configWriteInFlightRef.current = true;
       setError(undefined);
+      let appliedVersion: number | undefined;
       try {
         const request: WriteDesktopSettingsConfigRequest = { patch };
         const response = await desktopApi.writeSettingsConfig(request);
+        appliedVersion = response.update.version;
         setSnapshot(response.snapshot);
         if (
           patch.models?.codex?.path !== undefined
@@ -94,10 +110,23 @@ export function useDesktopSettings(desktopApi?: DesktopApi): DesktopSettingsStat
         setError(writeError instanceof Error ? writeError.message : String(writeError));
         return false;
       } finally {
+        configWriteInFlightRef.current = false;
         setSaving(false);
+        const pendingVersion = pendingRuntimeRefreshVersionRef.current;
+        pendingRuntimeRefreshVersionRef.current = undefined;
+        if (
+          pendingVersion !== undefined
+          && (
+            pendingVersion === null
+            || appliedVersion === undefined
+            || pendingVersion > appliedVersion
+          )
+        ) {
+          void read();
+        }
       }
     },
-    [desktopApi],
+    [desktopApi, read],
   );
 
   const replaceSecret = useCallback(

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -389,6 +389,7 @@ import type {
   OpenDesktopPwrAgentProfileResponse,
   ReadDesktopSettingsRequest,
   ReadDesktopSettingsResponse,
+  DesktopSettingsRuntimeChangedEvent,
   ReadDesktopConfigBootstrapResponse,
   ReadDesktopFullAccessPolicyResponse,
   ReadDesktopMessagingSettingsResponse,
@@ -1205,7 +1206,9 @@ export type DesktopApi = {
       transcriptTextSize: DesktopTextSize;
     }) => void,
   ) => () => void;
-  onSettingsRuntimeChanged?: (callback: () => void) => () => void;
+  onSettingsRuntimeChanged?: (
+    callback: (event?: DesktopSettingsRuntimeChangedEvent) => void,
+  ) => () => void;
   onCodexEnvironmentSetupProgress?: (
     callback: (event: CodexEnvironmentSetupProgressEvent) => void,
   ) => () => void;

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1476,6 +1476,15 @@ export type DesktopSettingsConfigUpdate = {
   scheduledProviderRefreshes: readonly string[];
 };
 
+/** Main-to-renderer notification that the normalized in-memory config store
+ * advanced. The renderer re-reads the cache-backed Settings projection; the
+ * notification itself carries no secrets and grants no discovery authority. */
+export type DesktopSettingsRuntimeChangedEvent = {
+  version: number;
+  configRevision: string;
+  changedDomains: readonly DesktopConfigDomainKey[];
+};
+
 export type DesktopSettingsWriteResponse = {
   update: DesktopSettingsConfigUpdate;
   snapshot: DesktopSettingsSnapshot;


### PR DESCRIPTION
## Summary

- I made Models, Codex, and focused ACP Settings mounts cache-only. Discovery now requires an admitted startup, setup, or explicit operator action, and focused ACP refreshes carry only that provider's `registryIds`.
- I kept the Models hub refresh intentionally all-provider and relabeled it **Refresh all providers** so its scope is explicit.
- I added **Refresh Codex** to the focused Codex screen; it refreshes only Codex and never invokes ACP discovery.
- I propagate normalized config-store changes to open Settings windows and provider runtime owners, including atomic replacements and writes from another process sharing the profile, without granting discovery authority.
- I fingerprint verified provider results against their launch configuration. New ACP work cannot reuse a stale executable after a config change, active sessions retain their owning client, and failed explicit Codex refreshes preserve the working catalog.
- I restore matching last-known-good provider state after an A→B→A config revert, sample shared secret presence on every Settings projection, discard out-of-order renderer reads, and publish invalid/repair config-file status changes even when normalized values stay equal.

## Verification

- I ran `pnpm lint` successfully, including SQL, Codex-storage, color, Electron-version, license, ESLint, TypeScript, and dependency-boundary checks.
- I ran the full workspace test suite: 661 files passed, with 9,768 tests passed and 6 skipped.
- I also ran the focused review-regression suites: 218 tests passed.
- I verified both commits have good SSH signatures and that this assigned worktree contains the feature-branch HEAD based directly on current `origin/main`.

## Notes

- I preserved setup-wizard discovery and the private `ProviderDiscoveryPermit` boundary.
- I left compare-and-set optional. The observed issue was stale runtime/UI state after external normalized changes, not a demonstrated lost-update race; the store watcher, versioned renderer notification, and single-flight runtime invalidation address that failure without broad config reloads.
- This does not release or publish any product artifact.
