### PR TITLE
fix(desktop): prevent composer mention draft loss

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -2869,6 +2869,7 @@ export function Composer(props: ComposerProps) {
           pullRequestLinks,
         );
   const activeComposerScopeKeyRef = useRef(composerScopeKey);
+  const [editorScopeKey, setEditorScopeKey] = useState(composerScopeKey);
   const pasteScopeRef = useRef({ key: composerScopeKey, version: 0 });
   const pendingDraftRetargetRef = useRef<
     | {
@@ -4837,6 +4838,7 @@ export function Composer(props: ComposerProps) {
     }
 
     activeComposerScopeKeyRef.current = composerScopeKey;
+    setEditorScopeKey(composerScopeKey);
     const current = pasteScopeRef.current;
     if (retargetingDraft && current.key === previousScopeKey) {
       current.key = composerScopeKey;
@@ -10864,6 +10866,7 @@ export function Composer(props: ComposerProps) {
           </fieldset>
         ) : (
           <ComposerTiptapInput
+            key={editorScopeKey}
             ref={inputRef}
             id="thread-composer"
             ariaActiveDescendant={activeAutocompleteOptionId}

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1421,7 +1421,10 @@ function appendMarkdownBlock(
       .map((line) => `> ${line}`)
       .join("\n");
     quotedState.skillTokens.forEach((token) => {
-      state.skillTokens.push({ ...token, index: quoteStart + token.index + 2 });
+      state.skillTokens.push({
+        ...token,
+        index: quoteStart + getQuotedDraftOffset(quotedState.value, token.index),
+      });
     });
     return;
   }

--- a/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/ComposerTiptapInput.tsx
@@ -1849,15 +1849,64 @@ function getMarkdownBlockPrefixLength(
   return 0;
 }
 
-function getDraftIndexAtPosition(
-  editor: NonNullable<ReturnType<typeof useEditor>>,
+function getBlockquoteInnerMarkdown(node: ProseMirrorNode): string {
+  const state: TiptapReadState = { skillTokens: [], value: "" };
+  node.forEach((child, _offset, childIndex) => {
+    appendMarkdownBlock(child, state, childIndex);
+  });
+  return state.value;
+}
+
+function getQuotedMarkdownLength(innerMarkdown: string): number {
+  let lineCount = 1;
+  for (const character of innerMarkdown) {
+    if (character === "\n") {
+      lineCount += 1;
+    }
+  }
+  return innerMarkdown.length + lineCount * 2;
+}
+
+function getQuotedDraftOffset(
+  innerMarkdown: string,
+  innerOffset: number,
+): number {
+  let quotedOffset = 2;
+  const boundedInnerOffset = Math.min(innerOffset, innerMarkdown.length);
+  for (let index = 0; index < boundedInnerOffset; index += 1) {
+    quotedOffset += innerMarkdown[index] === "\n" ? 3 : 1;
+  }
+  return quotedOffset;
+}
+
+function getInnerDraftOffset(
+  innerMarkdown: string,
+  quotedOffset: number,
+): number {
+  if (quotedOffset <= 2) {
+    return 0;
+  }
+
+  let currentQuotedOffset = 2;
+  for (let index = 0; index < innerMarkdown.length; index += 1) {
+    const width = innerMarkdown[index] === "\n" ? 3 : 1;
+    if (quotedOffset <= currentQuotedOffset + width) {
+      return index + 1;
+    }
+    currentQuotedOffset += width;
+  }
+  return innerMarkdown.length;
+}
+
+export function getDraftIndexAtDocumentPosition(
+  doc: ProseMirrorNode,
   position: number,
   mode: TiptapReadMode,
 ): number {
   let index = 0;
   let found = false;
 
-  editor.state.doc.descendants((node, pos, parent, childIndex) => {
+  doc.descendants((node, pos, parent, childIndex) => {
     if (found) {
       return false;
     }
@@ -1869,6 +1918,24 @@ function getDraftIndexAtPosition(
       }
       if (childIndex > 0) {
         index += mode === "markdown" ? 2 : 1;
+      }
+      if (mode === "markdown" && node.type.name === "blockquote") {
+        const innerMarkdown = getBlockquoteInnerMarkdown(node);
+        const nodeEnd = pos + node.nodeSize;
+        if (position >= nodeEnd) {
+          index += getQuotedMarkdownLength(innerMarkdown);
+          return false;
+        }
+        const innerDoc = node.type.schema.topNodeType.create(null, node.content);
+        const innerPosition = Math.max(1, position - pos - 1);
+        const innerOffset = getDraftIndexAtDocumentPosition(
+          innerDoc,
+          innerPosition,
+          mode,
+        );
+        index += getQuotedDraftOffset(innerMarkdown, innerOffset);
+        found = true;
+        return false;
       }
       if (mode === "markdown" && node.type.name === "horizontalRule") {
         const nodeEnd = pos + node.nodeSize;
@@ -1901,7 +1968,7 @@ function getDraftIndexAtPosition(
         node,
         parent,
         childIndex,
-        editor.state.doc,
+        doc,
         pos,
       );
       if (prefixLength > 0) {
@@ -1957,16 +2024,24 @@ function getDraftIndexAtPosition(
   return index;
 }
 
-function getPositionAtDraftIndex(
+function getDraftIndexAtPosition(
   editor: NonNullable<ReturnType<typeof useEditor>>,
+  position: number,
+  mode: TiptapReadMode,
+): number {
+  return getDraftIndexAtDocumentPosition(editor.state.doc, position, mode);
+}
+
+export function getPositionAtDocumentDraftIndex(
+  doc: ProseMirrorNode,
   draftIndex: number,
   mode: TiptapReadMode,
 ): number {
   let index = 0;
-  let position = editor.state.doc.content.size;
+  let position = doc.content.size;
   let found = false;
 
-  editor.state.doc.descendants((node, pos, parent, childIndex) => {
+  doc.descendants((node, pos, parent, childIndex) => {
     if (found) {
       return false;
     }
@@ -1980,6 +2055,26 @@ function getPositionAtDraftIndex(
           return false;
         }
         index += separatorLength;
+      }
+      if (mode === "markdown" && node.type.name === "blockquote") {
+        const innerMarkdown = getBlockquoteInnerMarkdown(node);
+        const quotedMarkdownLength = getQuotedMarkdownLength(innerMarkdown);
+        if (draftIndex > index + quotedMarkdownLength) {
+          index += quotedMarkdownLength;
+          return false;
+        }
+        const innerDoc = node.type.schema.topNodeType.create(null, node.content);
+        const innerOffset = getInnerDraftOffset(
+          innerMarkdown,
+          Math.max(0, draftIndex - index),
+        );
+        position = pos + 1 + getPositionAtDocumentDraftIndex(
+          innerDoc,
+          innerOffset,
+          mode,
+        );
+        found = true;
+        return false;
       }
       if (mode === "markdown" && node.type.name === "codeBlock") {
         const codeBlock = getCodeBlockMarkdownParts(node);
@@ -2014,7 +2109,7 @@ function getPositionAtDraftIndex(
         node,
         parent,
         childIndex,
-        editor.state.doc,
+        doc,
         pos,
       );
       if (prefixLength > 0) {
@@ -2067,6 +2162,14 @@ function getPositionAtDraftIndex(
   });
 
   return Math.max(1, position);
+}
+
+function getPositionAtDraftIndex(
+  editor: NonNullable<ReturnType<typeof useEditor>>,
+  draftIndex: number,
+  mode: TiptapReadMode,
+): number {
+  return getPositionAtDocumentDraftIndex(editor.state.doc, draftIndex, mode);
 }
 
 function getSkillSummary(attrs: Record<string, unknown>): AppServerSkillSummary {
@@ -2778,9 +2881,9 @@ export const ComposerTiptapInput = forwardRef<
       return;
     }
 
-    const current = readTiptapContent(editor, readMode);
-    const currentSignature = getContentSignature(current);
-    const currentEditorDocumentSignature = JSON.stringify(editor.getJSON());
+    let current = readTiptapContent(editor, readMode);
+    let currentSignature = getContentSignature(current);
+    let currentEditorDocumentSignature = JSON.stringify(editor.getJSON());
     const nextEditorDocumentSignature = props.editorDocument
       ? JSON.stringify(props.editorDocument)
       : undefined;
@@ -2794,6 +2897,7 @@ export const ComposerTiptapInput = forwardRef<
       }
     }
 
+    let loadedEditorDocument = false;
     if (
       nextEditorDocumentSignature &&
       currentEditorDocumentSignature !== nextEditorDocumentSignature
@@ -2805,24 +2909,51 @@ export const ComposerTiptapInput = forwardRef<
       editor.commands.setContent(props.editorDocument!, { emitUpdate: false });
       closeEditorHistory(editor);
       applySelectionRequest(editor, props.selectionRequest);
+      current = readTiptapContent(editor, readMode);
+      currentSignature = getContentSignature(current);
+      currentEditorDocumentSignature = JSON.stringify(editor.getJSON());
+      loadedEditorDocument = true;
+      if (currentSignature === propsSignature) {
+        pendingExternalSignatureRef.current = undefined;
+        return;
+      }
+    }
+
+    pendingExternalSignatureRef.current = propsSignature;
+    if (!loadedEditorDocument) {
+      pushControlledUndoEntry(editor);
+      controlledRedoStackRef.current = [];
+    }
+    const inserted = applyExternalSkillInsertion({
+      current,
+      editor,
+      nextSkillTokens: props.skillTokens,
+      nextValue: props.value,
+      readMode,
+      selectionIndex: selectionIndexRef.current,
+    });
+    const insertedSignature = inserted
+      ? getContentSignature(readTiptapContent(editor, readMode))
+      : undefined;
+    if (inserted && insertedSignature === propsSignature) {
+      pendingSelectionIndexRef.current = undefined;
       pendingExternalSignatureRef.current = undefined;
       return;
     }
 
-    pendingExternalSignatureRef.current = propsSignature;
-    pushControlledUndoEntry(editor);
-    controlledRedoStackRef.current = [];
-    if (
-      applyExternalSkillInsertion({
-        current,
-        editor,
-        nextSkillTokens: props.skillTokens,
-        nextValue: props.value,
-        readMode,
-        selectionIndex: selectionIndexRef.current,
-      })
-    ) {
-      pendingSelectionIndexRef.current = undefined;
+    pendingExternalSignatureRef.current = undefined;
+    if (nextEditorDocumentSignature && loadedEditorDocument) {
+      if (JSON.stringify(editor.getJSON()) !== nextEditorDocumentSignature) {
+        closeEditorHistory(editor);
+        editor.commands.setContent(props.editorDocument!, { emitUpdate: false });
+        closeEditorHistory(editor);
+      }
+      const restored = readTiptapContent(editor, readMode);
+      const restoredEditorDocument = editor.getJSON();
+      propsRef.current.onChange(restored.value, restored.skillTokens, {
+        editorDocument: restoredEditorDocument,
+      });
+      applySelectionRequest(editor, props.selectionRequest);
       return;
     }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -322,6 +322,68 @@ describe("ComposerTiptapInput", () => {
     ).toBe(value.length);
   });
 
+  it("maps a mention token on the second quoted line past every quote prefix", async () => {
+    const value = "> First line\n> ";
+    const token: ComposerSkillToken = {
+      id: "grok-build:fixture",
+      index: value.length,
+      kind: "directory",
+      name: "grok-build",
+      path: "/Users/example/pwrdrvr/grok-build",
+    };
+    const editorDocument: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [
+                { type: "text", text: "First line" },
+                { type: "hardBreak" },
+                {
+                  type: "mention",
+                  attrs: {
+                    description: null,
+                    id: token.id,
+                    kind: token.kind,
+                    name: token.name,
+                    path: token.path,
+                    prChipModifiers: null,
+                    shortDescription: null,
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const onChange = vi.fn();
+
+    render(
+      <ComposerTiptapInput
+        id="reply"
+        label="Reply"
+        editorDocument={editorDocument}
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value=""
+      />,
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        value,
+        [token],
+        { editorDocument: expect.any(Object) },
+      );
+    });
+  });
+
   it("maps the quoted Markdown line end to the end of blockquote text", async () => {
     const value = "> Context:";
     const editorDocument: JSONContent = {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx
@@ -1,8 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createRef, useState } from "react";
+import type { JSONContent } from "@tiptap/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { ComposerTiptapInput } from "../ComposerTiptapInput";
+import {
+  ComposerTiptapInput,
+  getDraftIndexAtDocumentPosition,
+  getPositionAtDocumentDraftIndex,
+} from "../ComposerTiptapInput";
 import type { ComposerInputHandle, ComposerSkillToken } from "../ComposerInputTypes";
 
 afterEach(() => {
@@ -10,6 +15,7 @@ afterEach(() => {
 });
 
 function renderTiptapInput(props?: {
+  editorDocument?: JSONContent;
   markdownConversion?: boolean;
   value?: string;
 }) {
@@ -23,6 +29,7 @@ function renderTiptapInput(props?: {
       <ComposerTiptapInput
         id="reply"
         label="Reply"
+        editorDocument={props?.editorDocument}
         markdownConversion={props?.markdownConversion ?? true}
         onChange={(nextValue, nextSkillTokens = []) => {
           onChange(nextValue, nextSkillTokens);
@@ -169,6 +176,245 @@ const pastedCatalogSql = [
 ].join("\n");
 
 describe("ComposerTiptapInput", () => {
+  it("recovers a persisted mention mismatch from the visible editor document", async () => {
+    const editorValue = [
+      "> 1. Notarize the custom Codex release.",
+      "",
+      "We have both @grok",
+    ].join("\n");
+    const tokenIndex = editorValue.indexOf("@grok");
+    const value = `${editorValue.slice(0, tokenIndex)} ${editorValue.slice(tokenIndex + 3)}`;
+    const token: ComposerSkillToken = {
+      id: "grok-build:fixture",
+      index: tokenIndex,
+      kind: "directory",
+      name: "grok-build",
+      path: "/Users/example/pwrdrvr/grok-build",
+    };
+    const editorDocument: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "orderedList",
+              attrs: { start: 1, type: null },
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        {
+                          type: "text",
+                          text: "Notarize the custom Codex release.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "We have both @grok" }],
+        },
+      ],
+    };
+    const onChange = vi.fn();
+
+    const result = render(
+      <ComposerTiptapInput
+        id="reply"
+        label="Reply"
+        editorDocument={{
+          type: "doc",
+          content: [{ type: "paragraph" }],
+        }}
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value=""
+      />,
+    );
+    onChange.mockClear();
+    result.rerender(
+      <ComposerTiptapInput
+        id="reply"
+        label="Reply"
+        editorDocument={editorDocument}
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[token]}
+        value={value}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Reply" })).toHaveTextContent(
+      "We have both @grok",
+    );
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        editorValue,
+        [],
+        { editorDocument },
+      );
+    });
+  });
+
+  it("counts blockquote prefixes when mapping the native caret to Markdown", async () => {
+    const value = [
+      "> 1. Notarize the custom Codex release.",
+      "",
+      "We have both @grok",
+    ].join("\n");
+    const editorDocument: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "orderedList",
+              attrs: { start: 1, type: null },
+              content: [
+                {
+                  type: "listItem",
+                  content: [
+                    {
+                      type: "paragraph",
+                      content: [
+                        {
+                          type: "text",
+                          text: "Notarize the custom Codex release.",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "We have both @grok" }],
+        },
+      ],
+    };
+    renderTiptapInput({ editorDocument, value });
+
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    const doc = (
+      textbox as HTMLElement & {
+        pmViewDesc?: { node?: Parameters<typeof getDraftIndexAtDocumentPosition>[0] };
+      }
+    ).pmViewDesc?.node;
+    expect(doc).toBeDefined();
+    expect(
+      getDraftIndexAtDocumentPosition(doc!, doc!.content.size, "markdown"),
+    ).toBe(value.length);
+  });
+
+  it("maps the quoted Markdown line end to the end of blockquote text", async () => {
+    const value = "> Context:";
+    const editorDocument: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "blockquote",
+          content: [
+            {
+              type: "paragraph",
+              content: [{ type: "text", text: "Context:" }],
+            },
+          ],
+        },
+      ],
+    };
+    renderTiptapInput({ editorDocument, value });
+
+    const textbox = await screen.findByRole("textbox", { name: "Reply" });
+    const doc = (
+      textbox as HTMLElement & {
+        pmViewDesc?: { node?: Parameters<typeof getDraftIndexAtDocumentPosition>[0] };
+      }
+    ).pmViewDesc?.node;
+    expect(doc).toBeDefined();
+    const position = getPositionAtDocumentDraftIndex(
+      doc!,
+      value.length,
+      "markdown",
+    );
+    expect(position).toBe(doc!.child(0).nodeSize - 2);
+    expect(getDraftIndexAtDocumentPosition(doc!, position, "markdown"))
+      .toBe(value.length);
+  });
+
+  it("promotes a restored editor document instead of suppressing later edits", async () => {
+    const onChange = vi.fn();
+    const result = render(
+      <ComposerTiptapInput
+        id="reply"
+        label="Reply"
+        editorDocument={{
+          type: "doc",
+          content: [{ type: "paragraph" }],
+        }}
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value=""
+      />,
+    );
+    onChange.mockClear();
+    const restoredEditorDocument: JSONContent = {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "The sentences visible in the editor are newer.",
+            },
+          ],
+        },
+      ],
+    };
+
+    result.rerender(
+      <ComposerTiptapInput
+        id="reply"
+        label="Reply"
+        editorDocument={restoredEditorDocument}
+        markdownConversion
+        onChange={onChange}
+        placeholder="Ask anything"
+        skillTokens={[]}
+        value="Stale controlled draft"
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Reply" })).toHaveTextContent(
+      "The sentences visible in the editor are newer.",
+    );
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        "The sentences visible in the editor are newer.",
+        [],
+        { editorDocument: restoredEditorDocument },
+      );
+    });
+  });
+
   it("keeps Alt+Enter inside the editor instead of routing it to the composer", async () => {
     const onKeyDown = vi.fn();
     render(
@@ -271,7 +517,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Context:".length);
+    setComposerSelection(textbox, "> Context:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -516,7 +762,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Query:".length);
+    setComposerSelection(textbox, "> Query:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -576,7 +822,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Source:".length);
+    setComposerSelection(textbox, "> Source:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -640,7 +886,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Release notes:".length);
+    setComposerSelection(textbox, "> Release notes:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -718,7 +964,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Checklist:".length);
+    setComposerSelection(textbox, "> Checklist:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -782,7 +1028,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Tasks:".length);
+    setComposerSelection(textbox, "> Tasks:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -855,7 +1101,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Source:".length);
+    setComposerSelection(textbox, "> Source:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {
@@ -963,7 +1209,7 @@ describe("ComposerTiptapInput", () => {
       />,
     );
     const textbox = await screen.findByRole("textbox", { name: "Reply" });
-    setComposerSelection(textbox, "Table:".length);
+    setComposerSelection(textbox, "> Table:".length);
 
     fireEvent.paste(textbox, {
       clipboardData: {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2594,6 +2594,57 @@ describe("Composer", () => {
     expect(screen.queryByText("No command")).not.toBeInTheDocument();
   });
 
+  it("opens hash autocomplete below a multiline blockquote", async () => {
+    const currentThread: NavigationThreadSummary = {
+      id: "thread-current",
+      title: "Current thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const targetThread: NavigationThreadSummary = {
+      id: "019fbbbe-ad52-77c2-b7f7-28182d9a6f83",
+      title: "Bob's Best Thread 3000",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+
+    render(
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        skills={[]}
+        thread={currentThread}
+        threads={[currentThread, targetThread]}
+      />,
+    );
+
+    const textbox = screen.getByRole("textbox", { name: "Reply" });
+    fireEvent.change(textbox, {
+      target: {
+        value: [
+          "Warnings:",
+          "",
+          "> First warning",
+          ">",
+          "> Second warning",
+          "",
+          "Investigate #Bob",
+        ].join("\n"),
+      },
+    });
+
+    const listbox = await screen.findByRole("listbox", {
+      name: "Threads and pull requests",
+    });
+    expect(
+      within(listbox).getByRole("option", { name: /#Bob's Best Thread 3000/ }),
+    ).toBeInTheDocument();
+  });
+
   it("retires a `#` anchor that runs long with nothing to match", async () => {
     // `#` is the only trigger whose query spans spaces, so before this it
     // stayed armed for the whole rest of the line: every keystroke after a

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -2806,6 +2806,53 @@ describe("Composer", () => {
     expect(jumpSearchRemoteThreads).toHaveBeenCalledTimes(2);
   });
 
+  it("does not carry controlled undo history across thread switches", async () => {
+    const threadOne: NavigationThreadSummary = {
+      id: "thread-one",
+      title: "First thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const threadTwo: NavigationThreadSummary = {
+      id: "thread-two",
+      title: "Second thread",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    };
+    const draftStore = createComposerDraftStore();
+    const composer = (thread: NavigationThreadSummary) => (
+      <Composer
+        desktopApi={{ onAgentEvent: () => () => undefined }}
+        disabled={false}
+        draftStore={draftStore}
+        skills={[]}
+        thread={thread}
+        threads={[threadOne, threadTwo]}
+      />
+    );
+    const { rerender } = render(composer(threadOne));
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Reply" }), {
+      target: { value: "Private text from the first thread" },
+    });
+    rerender(composer(threadTwo));
+    const secondThreadInput = screen.getByRole("textbox", { name: "Reply" });
+    await waitFor(() => {
+      expect(secondThreadInput).toHaveValue("");
+    });
+
+    fireEvent.keyDown(secondThreadInput, { key: "z", metaKey: true });
+
+    expect(secondThreadInput).toHaveValue("");
+    expect(secondThreadInput).not.toHaveTextContent(
+      "Private text from the first thread",
+    );
+  });
+
   it("re-arms a cold `#` anchor once the query is short again", async () => {
     // The escape hatch. A retired anchor is keyed by the query's leading
     // run, so deleting back past that run yields a different (shorter)
@@ -15355,6 +15402,109 @@ describe("Composer", () => {
           undefined,
           undefined,
           ["/Users/example/Projects/catalog-portal"]
+        );
+      });
+    } finally {
+      delete (window as unknown as { __pwragentHomeDir?: string })
+        .__pwragentHomeDir;
+    }
+  });
+
+  it("replaces a directory trigger after quoted Markdown without losing later edits", async () => {
+    (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
+      "/Users/example";
+    try {
+      const launchpad: NavigationLaunchpadDraft = {
+        directoryKey: "directory:/repo",
+        directoryKind: "directory",
+        directoryLabel: "Repo",
+        directoryPath: "/repo",
+        backend: "codex",
+        executionMode: "default",
+        prompt: "",
+        workMode: "local",
+        branchName: "main",
+        createdAt: 1,
+        updatedAt: 1,
+      };
+      const repoDirectory: NavigationDirectorySummary = {
+        key: "directory:/repo",
+        kind: "directory",
+        label: "Repo",
+        path: "/repo",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 20,
+      };
+      const grokDirectory: NavigationDirectorySummary = {
+        key: "directory:/Users/example/pwrdrvr/grok-build",
+        kind: "directory",
+        label: "grok-build",
+        path: "/Users/example/pwrdrvr/grok-build",
+        threadKeys: [],
+        needsAttentionCount: 0,
+        latestUpdatedAt: 10,
+      };
+      const onMaterializeLaunchpad = vi.fn(async () => undefined);
+
+      render(
+        <Composer
+          backends={[backendSummary("codex")]}
+          directory={repoDirectory}
+          directories={[repoDirectory, grokDirectory]}
+          draftStore={createComposerDraftStore()}
+          launchpad={launchpad}
+          onMaterializeLaunchpad={onMaterializeLaunchpad}
+          onUpdateLaunchpad={async () => undefined}
+          skills={[]}
+        />
+      );
+
+      const beforeMention = [
+        "> 1. Notarize the custom Codex release; the current release workflow signs but contains no notarization step.",
+        "",
+        "Oh... I didn't know that would matter for this... we have both @grok",
+      ].join("\n");
+      const afterMention = [
+        "> 1. Notarize the custom Codex release; the current release workflow signs but contains no notarization step.",
+        "",
+        "Oh... I didn't know that would matter for this... we have both  ",
+      ].join("\n");
+      fireEvent.change(screen.getByLabelText("New thread"), {
+        target: { value: beforeMention },
+      });
+
+      const listbox = screen.getByRole("listbox", { name: "Directories" });
+      fireEvent.click(
+        within(listbox).getByRole("option", { name: /grok-build/ }),
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText("New thread")).toHaveValue(afterMention);
+      });
+      const richInput = screen.getByTestId("composer-tiptap-input");
+      expect(within(richInput).getByText("@grok-build")).toBeInTheDocument();
+      expect(richInput).not.toHaveTextContent("@g@grok-build");
+      expect(richInput).not.toHaveTextContent("@grok-buildok");
+
+      await clickButton("Start thread");
+
+      await waitFor(() => {
+        expect(onMaterializeLaunchpad).toHaveBeenCalledWith(
+          "directory:/repo",
+          [
+            {
+              type: "text",
+              text: [
+                "> 1. Notarize the custom Codex release; the current release workflow signs but contains no notarization step.",
+                "",
+                "Oh... I didn't know that would matter for this... we have both [@grok-build](~/pwrdrvr/grok-build)",
+              ].join("\n"),
+            },
+          ],
+          undefined,
+          undefined,
+          ["/Users/example/pwrdrvr/grok-build"],
         );
       });
     } finally {


### PR DESCRIPTION
## Summary

- count blockquote Markdown prefixes in both editor-position mapping directions so autocomplete commits replace the complete trigger
- reconcile a newly loaded editor document with controlled text and mention tokens instead of leaving the external-sync guard armed indefinitely
- remount the rich editor only after composer scope state changes, preventing undo history from leaking between threads
- add regressions based on the observed quoted-message, persisted-state mismatch, stale-send, and cross-thread undo failures

## Root cause

The rich editor serialized each quoted line with a `> ` prefix, but its position mapper did not count those two characters. A caret after quoted content was therefore reported two characters early per quoted line. Directory autocomplete could commit only part of an `@name` trigger, leaving suffix text behind and producing editor-document state that disagreed with the controlled draft and mention tokens.

When navigation later loaded that editor document, the synchronization effect returned without reconciling the disagreement. The pending external signature then suppressed subsequent editor updates, so visible edits could disappear on navigation and Send could transmit stale controlled state.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/ComposerTiptapInput.test.tsx` (40 passed)
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx` (301 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `git diff --check`