### PR TITLE
fix(desktop): preserve launch prompt during hydration

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1283,6 +1283,129 @@ describe("useThreadSessionState", () => {
     expect(liveEntryIdReads).toBeLessThanOrEqual(liveEntryCount * 12);
   });
 
+  it("does not rescan split-hydrated launch messages for every live update", async () => {
+    const historyMessageCount = 48;
+    const liveUpdateCount = 12;
+    const launchpadText = "Keep this prompt visible while the turn starts.";
+
+    async function measureMessageTextReads(
+      includeLaunchpadState: boolean,
+    ): Promise<number> {
+      let messageTextReads = 0;
+      const messageEntries: AppServerThreadMessageEntry[] = Array.from(
+        { length: historyMessageCount },
+        (_value, index) => ({
+          ...messageEntry({
+            id: `history-${index}`,
+            role: "user",
+            text: `Historical prompt ${index}`,
+            createdAt: index,
+          }),
+          turn: {
+            id: `history-turn-${index}`,
+            status: "completed" as const,
+          },
+        }),
+      );
+      const entries: AppServerThreadEntry[] = messageEntries;
+      const hydratedLaunchMessage: AppServerThreadMessage = {
+        id: "hydrated-launch",
+        role: "user",
+        text: launchpadText,
+        createdAt: 1_000,
+      };
+      const messages: AppServerThreadMessage[] = [
+        ...messageEntries.map(
+          ({ type: _type, turn: _turn, ...message }) => message,
+        ),
+        hydratedLaunchMessage,
+      ].map((message) => new Proxy(message, {
+        get(target, property, receiver) {
+          if (property === "text") {
+            messageTextReads += 1;
+          }
+          return Reflect.get(target, property, receiver);
+        },
+      }));
+      const desktopApi: DesktopApi = {
+        onAgentEvent: () => () => undefined,
+        readThread: async ({ backend, threadId }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries,
+            messages,
+            pagination: {
+              supportsPagination: true,
+              hasPreviousPage: false,
+            },
+          },
+        }),
+      };
+      const { result, rerender, unmount } = renderHook(
+        ({ showLaunchpadState }) =>
+          useThreadSessionState({
+            desktopApi,
+            thread: {
+              ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+              ...(showLaunchpadState
+                ? {
+                    optimisticUserMessage: {
+                      text: launchpadText,
+                      createdAt: 1_000,
+                    },
+                    optimisticActiveTurn: {
+                      id: "turn-1",
+                      statusText: "Thinking",
+                      startedAt: 1_000,
+                    },
+                  }
+                : {}),
+            },
+          }),
+        { initialProps: { showLaunchpadState: includeLaunchpadState } },
+      );
+
+      await waitForThreadHydration(result);
+      rerender({ showLaunchpadState: false });
+      await waitFor(() => {
+        expect(result.current.messages.at(-1)?.id).toBe("hydrated-launch");
+      });
+      messageTextReads = 0;
+
+      for (let index = 0; index < liveUpdateCount; index += 1) {
+        act(() => {
+          result.current.upsertLiveTranscriptEntry({
+            type: "activity",
+            id: `live-activity-${index}`,
+            summary: `Live activity ${index}`,
+            createdAt: 2_000 + index,
+            details: [],
+            turn: {
+              id: "turn-1",
+              status: "in_progress",
+              startedAt: 1_000,
+            },
+          });
+        });
+      }
+
+      const measuredReads = messageTextReads;
+      unmount();
+      return measuredReads;
+    }
+
+    const baselineReads = await measureMessageTextReads(false);
+    const launchpadReads = await measureMessageTextReads(true);
+
+    // Launch-message correlation may inspect the hydrated projection once,
+    // but live tail updates must not multiply that full-transcript scan.
+    expect(launchpadReads - baselineReads).toBeLessThanOrEqual(
+      (historyMessageCount + 1) * 2,
+    );
+  });
+
   it("coalesces reviews and suppresses duplicates across page-tail boundaries", async () => {
     const fullReview = [
       "Full review comments:",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3684,6 +3684,108 @@ describe("useThreadSessionState", () => {
     ).toHaveLength(1);
   });
 
+  it("keeps identical user messages from different turns in the message projection", async () => {
+    const launchpadText = "Run the same verification again.";
+    const desktopApi: DesktopApi = {
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "previous-user",
+              role: "user" as const,
+              text: launchpadText,
+              createdAt: 500,
+              turn: {
+                id: "turn-previous",
+                status: "completed" as const,
+              },
+            },
+            {
+              type: "message" as const,
+              id: "assistant-commentary",
+              role: "assistant" as const,
+              phase: "commentary" as const,
+              text: "I am starting the new verification.",
+              createdAt: 2_000,
+              turn: {
+                id: "turn-1",
+                status: "in_progress" as const,
+                startedAt: 1_000,
+              },
+            },
+          ],
+          messages: [
+            {
+              id: "previous-user",
+              role: "user" as const,
+              text: launchpadText,
+              createdAt: 500,
+            },
+            {
+              id: "assistant-commentary",
+              role: "assistant" as const,
+              phase: "commentary" as const,
+              text: "I am starting the new verification.",
+              createdAt: 2_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: true,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+    const { result, rerender } = renderHook(
+      ({ includeLaunchpadState }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: {
+            ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+            ...(includeLaunchpadState
+              ? {
+                  optimisticUserMessage: {
+                    text: launchpadText,
+                    createdAt: 1_000,
+                  },
+                  optimisticActiveTurn: {
+                    id: "turn-1",
+                    statusText: "Thinking",
+                    startedAt: 1_000,
+                  },
+                }
+              : {}),
+          },
+        }),
+      { initialProps: { includeLaunchpadState: true } },
+    );
+
+    await waitForThreadHydration(result);
+    rerender({ includeLaunchpadState: false });
+    await waitFor(() => {
+      expect(
+        result.current.entries
+          .filter((entry) => entry.type === "message" && entry.role === "user")
+          .map((entry) => entry.id)
+      ).toEqual([
+        "previous-user",
+        "optimistic-launchpad-codex:thread-1",
+      ]);
+    });
+    expect(
+      result.current.messages
+        .filter((message) => message.role === "user")
+        .map((message) => message.id)
+    ).toEqual([
+      "previous-user",
+      "optimistic-launchpad-codex:thread-1",
+    ]);
+  });
+
   it("keeps a duplicate optimistic user message when the launch item completes", async () => {
     const messageText = "Please update the TanStack Virtual lockfile.";
     let authoritativeEntries: AppServerThreadEntry[] = [];

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3603,6 +3603,87 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("keeps the launchpad prompt visible while messages hydrate ahead of entries", async () => {
+    const launchpadText = "Keep this prompt visible while the turn starts.";
+    const desktopApi: DesktopApi = {
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        replay: {
+          entries: [
+            {
+              type: "message" as const,
+              id: "assistant-commentary",
+              role: "assistant" as const,
+              phase: "commentary" as const,
+              text: "I am starting the investigation.",
+              createdAt: 2_000,
+            },
+          ],
+          messages: [
+            {
+              id: "hydrated-user",
+              role: "user" as const,
+              text: launchpadText,
+              createdAt: 1_000,
+            },
+            {
+              id: "assistant-commentary",
+              role: "assistant" as const,
+              phase: "commentary" as const,
+              text: "I am starting the investigation.",
+              createdAt: 2_000,
+            },
+          ],
+          pagination: {
+            supportsPagination: true,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+    const { result, rerender } = renderHook(
+      ({ includeLaunchpadState }) =>
+        useThreadSessionState({
+          desktopApi,
+          thread: {
+            ...buildThread({ id: "thread-1", updatedAt: 2_000 }),
+            ...(includeLaunchpadState
+              ? {
+                  optimisticUserMessage: {
+                    text: launchpadText,
+                    createdAt: 1_000,
+                  },
+                  optimisticActiveTurn: {
+                    id: "turn-1",
+                    statusText: "Thinking",
+                    startedAt: 1_000,
+                  },
+                }
+              : {}),
+          },
+        }),
+      { initialProps: { includeLaunchpadState: true } },
+    );
+
+    await waitForThreadHydration(result);
+    rerender({ includeLaunchpadState: false });
+    await waitFor(() => {
+      expect(
+        result.current.entries.map((entry) =>
+          entry.type === "message" ? `${entry.role}:${entry.text}` : entry.type
+        )
+      ).toEqual([
+        `user:${launchpadText}`,
+        "assistant:I am starting the investigation.",
+      ]);
+    });
+    expect(
+      result.current.messages.filter((message) => message.role === "user")
+    ).toHaveLength(1);
+  });
+
   it("keeps a duplicate optimistic user message when the launch item completes", async () => {
     const messageText = "Please update the TanStack Virtual lockfile.";
     let authoritativeEntries: AppServerThreadEntry[] = [];

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -6842,6 +6842,10 @@ export function useThreadSessionState(params: {
 
   const selectedRetainedLiveEntryVersion =
     selectedSession?.retainedLiveEntryVersion;
+  const selectedLaunchpadMessageCandidate =
+    threadKey && launchpadMessageCandidateRef.current?.threadKey === threadKey
+      ? launchpadMessageCandidateRef.current.candidate
+      : undefined;
   const selectedRetainedLiveEntries = useMemo(() => {
     if (!threadKey || selectedRetainedLiveEntryVersion === undefined) {
       return [];
@@ -6855,12 +6859,12 @@ export function useThreadSessionState(params: {
       threadKey
         ? reconciledLaunchpadMessageIdsRef.current[threadKey]
         : undefined,
-      launchpadMessageCandidate,
+      selectedLaunchpadMessageCandidate,
     ),
     [
-      launchpadMessageCandidate,
       selectedSession?.optimisticEntries,
       selectedSession?.response,
+      selectedLaunchpadMessageCandidate,
       threadKey,
     ],
   );
@@ -6897,14 +6901,36 @@ export function useThreadSessionState(params: {
     ),
     [selectedSession?.response?.replay.entries, visibleOptimisticEntries],
   );
+  const visibleOptimisticMessageEntries = useMemo(() => {
+    const authoritativeLaunchpadMessageExists = Boolean(
+      selectedLaunchpadMessageCandidate
+      && selectedSession?.response?.replay.messages.some((message) =>
+        matchesAuthoritativeLaunchpadMessage(
+          { type: "message", ...message },
+          selectedLaunchpadMessageCandidate,
+        )
+      )
+    );
+
+    return visibleOptimisticEntries.filter(
+      (entry): entry is AppServerThreadMessageEntry =>
+        entry.type === "message"
+        && !(
+          authoritativeLaunchpadMessageExists
+          && entry.id === selectedLaunchpadMessageCandidate?.entry.id
+        )
+    );
+  }, [
+    selectedLaunchpadMessageCandidate,
+    selectedSession?.response?.replay.messages,
+    visibleOptimisticEntries,
+  ]);
   const mergedTailMessages = useMemo(
     () => mergeTranscriptMessages(
       selectedSession?.response?.replay.messages ?? [],
-      visibleOptimisticEntries
-        .filter((entry): entry is AppServerThreadMessageEntry => entry.type === "message")
-        .map(({ type: _type, ...message }) => message),
+      visibleOptimisticMessageEntries.map(({ type: _type, ...message }) => message),
     ),
-    [selectedSession?.response?.replay.messages, visibleOptimisticEntries],
+    [selectedSession?.response?.replay.messages, visibleOptimisticMessageEntries],
   );
   const reviewPresentation = useMemo(
     () => createTranscriptReviewPresentation({

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -3253,6 +3253,55 @@ function matchesAuthoritativeLaunchpadMessage(
   });
 }
 
+function hasAuthoritativeLaunchpadMessageProjection(params: {
+  candidate: LaunchpadMessageCandidate;
+  entries: AppServerThreadEntry[];
+  messages: AppServerThreadMessage[];
+  reconciledMessageId?: string;
+}): boolean {
+  if (params.reconciledMessageId) {
+    return params.messages.some(
+      (message) => message.id === params.reconciledMessageId
+    );
+  }
+
+  const messageEntriesById = new Map<string, AppServerThreadMessageEntry>();
+  for (const entry of params.entries) {
+    if (entry.type === "message") {
+      messageEntriesById.set(entry.id, entry);
+    }
+  }
+
+  return params.messages.some((message) => {
+    if (
+      !messageMatchesOptimisticEntry(message, params.candidate.entry, {
+        allowImageUrlMismatch: true,
+      })
+    ) {
+      return false;
+    }
+
+    const matchingEntry = messageEntriesById.get(message.id);
+    if (!matchingEntry) {
+      // A message without its renderable entry is the split-hydration case
+      // this placeholder bridges. Once an entry exists, its turn disambiguates
+      // identical text submitted by a different turn.
+      return true;
+    }
+    if (
+      params.candidate.turnId
+      && matchingEntry.turn?.id !== params.candidate.turnId
+    ) {
+      return false;
+    }
+
+    return matchesAuthoritativeLaunchpadMessage(
+      matchingEntry,
+      params.candidate,
+    );
+  });
+}
+
 function mergeCompletedUserMessageWithOptimisticEntry(
   message: AppServerThreadMessageEntry,
   optimisticEntries: AppServerThreadEntry[]
@@ -6846,6 +6895,9 @@ export function useThreadSessionState(params: {
     threadKey && launchpadMessageCandidateRef.current?.threadKey === threadKey
       ? launchpadMessageCandidateRef.current.candidate
       : undefined;
+  const selectedReconciledLaunchpadMessageId = threadKey
+    ? reconciledLaunchpadMessageIdsRef.current[threadKey]
+    : undefined;
   const selectedRetainedLiveEntries = useMemo(() => {
     if (!threadKey || selectedRetainedLiveEntryVersion === undefined) {
       return [];
@@ -6856,16 +6908,14 @@ export function useThreadSessionState(params: {
     () => pruneOptimisticEntries(
       selectedSession?.optimisticEntries ?? [],
       selectedSession?.response,
-      threadKey
-        ? reconciledLaunchpadMessageIdsRef.current[threadKey]
-        : undefined,
+      selectedReconciledLaunchpadMessageId,
       selectedLaunchpadMessageCandidate,
     ),
     [
       selectedSession?.optimisticEntries,
       selectedSession?.response,
       selectedLaunchpadMessageCandidate,
-      threadKey,
+      selectedReconciledLaunchpadMessageId,
     ],
   );
   const visibleOptimisticEntries = useMemo(
@@ -6904,12 +6954,13 @@ export function useThreadSessionState(params: {
   const visibleOptimisticMessageEntries = useMemo(() => {
     const authoritativeLaunchpadMessageExists = Boolean(
       selectedLaunchpadMessageCandidate
-      && selectedSession?.response?.replay.messages.some((message) =>
-        matchesAuthoritativeLaunchpadMessage(
-          { type: "message", ...message },
-          selectedLaunchpadMessageCandidate,
-        )
-      )
+      && selectedSession?.response
+      && hasAuthoritativeLaunchpadMessageProjection({
+        candidate: selectedLaunchpadMessageCandidate,
+        entries: selectedSession.response.replay.entries,
+        messages: selectedSession.response.replay.messages,
+        reconciledMessageId: selectedReconciledLaunchpadMessageId,
+      })
     );
 
     return visibleOptimisticEntries.filter(
@@ -6922,7 +6973,8 @@ export function useThreadSessionState(params: {
     );
   }, [
     selectedLaunchpadMessageCandidate,
-    selectedSession?.response?.replay.messages,
+    selectedReconciledLaunchpadMessageId,
+    selectedSession?.response,
     visibleOptimisticEntries,
   ]);
   const mergedTailMessages = useMemo(

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -6951,18 +6951,37 @@ export function useThreadSessionState(params: {
     ),
     [selectedSession?.response?.replay.entries, visibleOptimisticEntries],
   );
-  const visibleOptimisticMessageEntries = useMemo(() => {
-    const authoritativeLaunchpadMessageExists = Boolean(
-      selectedLaunchpadMessageCandidate
-      && selectedSession?.response
+  const visibleLaunchpadMessageCandidate = useMemo(
+    () => selectedLaunchpadMessageCandidate
+      && visibleLocalOptimisticEntries.some(
+        (entry) => entry.id === selectedLaunchpadMessageCandidate.entry.id,
+      )
+      ? selectedLaunchpadMessageCandidate
+      : undefined,
+    [selectedLaunchpadMessageCandidate, visibleLocalOptimisticEntries],
+  );
+  const selectedResponseEntries = selectedSession?.response?.replay.entries;
+  const selectedResponseMessages = selectedSession?.response?.replay.messages;
+  const authoritativeLaunchpadMessageExists = useMemo(
+    () => Boolean(
+      visibleLaunchpadMessageCandidate
+      && selectedResponseEntries
+      && selectedResponseMessages
       && hasAuthoritativeLaunchpadMessageProjection({
-        candidate: selectedLaunchpadMessageCandidate,
-        entries: selectedSession.response.replay.entries,
-        messages: selectedSession.response.replay.messages,
+        candidate: visibleLaunchpadMessageCandidate,
+        entries: selectedResponseEntries,
+        messages: selectedResponseMessages,
         reconciledMessageId: selectedReconciledLaunchpadMessageId,
       })
-    );
-
+    ),
+    [
+      selectedReconciledLaunchpadMessageId,
+      selectedResponseEntries,
+      selectedResponseMessages,
+      visibleLaunchpadMessageCandidate,
+    ],
+  );
+  const visibleOptimisticMessageEntries = useMemo(() => {
     return visibleOptimisticEntries.filter(
       (entry): entry is AppServerThreadMessageEntry =>
         entry.type === "message"
@@ -6972,9 +6991,8 @@ export function useThreadSessionState(params: {
         )
     );
   }, [
+    authoritativeLaunchpadMessageExists,
     selectedLaunchpadMessageCandidate,
-    selectedReconciledLaunchpadMessageId,
-    selectedSession?.response,
     visibleOptimisticEntries,
   ]);
   const mergedTailMessages = useMemo(


### PR DESCRIPTION
## Summary

- I preserve the launchpad user prompt while the Codex message projection has hydrated but the renderable entry projection is still catching up.
- I keep the session-owned launch candidate after navigation drops its temporary optimistic fields, and I reconcile the message projection separately so it does not gain a duplicate user message.
- I disambiguate same-text messages with turn-bearing transcript entries so identical prompts from different turns remain visible.
- I cache and gate the launch-message correlation independently from live optimistic entries, preventing full historical scans on each streamed update.
- I added regressions for the disappearing prompt, identical cross-turn prompts, and repeated live-update projection scans.

## Verification

- I verified all 142 `useThreadSessionState` tests pass.
- I verified the performance regression fails on the unfixed implementation with 588 extra historical-message reads across 12 live updates, then passes with a budget of at most two complete correlation scans.
- I ran `pnpm lint:eslint` (0 errors; 43 existing warnings).
- I ran `pnpm typecheck`.
- I ran `pnpm lint:boundaries`.

## Notes

- The root cause was split hydration combined with transient launch metadata: `messages` could already contain the prompt while `entries` did not, and losing the launch candidate made ordinary optimistic pruning hide the only renderable user row.
- The correlation itself remains linear in the authoritative entry and message projections, and its memo is not invalidated as the live optimistic tail grows. This avoids adding cumulative O(n²) transcript work during streaming.
