### PR TITLE
test(tests): eliminate per-file Vitest process forks

### DIFF
--- a/apps/desktop/src/main/__tests__/standard-test-process-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/standard-test-process-budget.test.ts
@@ -18,6 +18,12 @@ const EXPECTED_PROJECTS = [
   "shared",
 ];
 const OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE = 0;
+const EXPECTED_POOLS = {
+  "desktop-main": process.platform === "win32" ? "forks" : "threads",
+  "desktop-renderer": "threads",
+  messaging: "threads",
+  shared: "threads",
+} as const;
 
 type ConfiguredProject = {
   test?: {
@@ -27,7 +33,7 @@ type ConfiguredProject = {
 };
 
 describe("standard test process budget", () => {
-  it("keeps every project on an in-process worker pool", () => {
+  it("keeps every project on its production-equivalent worker pool", () => {
     const projects = configuredProjects();
 
     expect(projects.map((project) => project.test?.name).sort()).toEqual(
@@ -35,19 +41,32 @@ describe("standard test process budget", () => {
     );
     expect(projects).toHaveLength(EXPECTED_PROJECTS.length);
     expect(
-      projects.map((project) => ({
-        name: project.test?.name,
-        osWorkerProcessesPerTestFile:
-          project.test?.pool === "threads" ? 0 : 1,
-      })),
-    ).toEqual(
-      EXPECTED_PROJECTS.map((name) => ({
-        name,
-        osWorkerProcessesPerTestFile:
-          OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE,
-      })),
-    );
+      Object.fromEntries(
+        projects.map((project) => [project.test?.name, project.test?.pool]),
+      ),
+    ).toEqual(EXPECTED_POOLS);
   });
+
+  it.runIf(process.platform !== "win32")(
+    "keeps the POSIX OS worker process budget at zero per test file",
+    () => {
+      const projects = configuredProjects();
+
+      expect(
+        projects.map((project) => ({
+          name: project.test?.name,
+          osWorkerProcessesPerTestFile:
+            project.test?.pool === "threads" ? 0 : 1,
+        })),
+      ).toEqual(
+        EXPECTED_PROJECTS.map((name) => ({
+          name,
+          osWorkerProcessesPerTestFile:
+            OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE,
+        })),
+      );
+    },
+  );
 });
 
 function configuredProjects(): ConfiguredProject[] {

--- a/apps/desktop/src/main/__tests__/standard-test-process-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/standard-test-process-budget.test.ts
@@ -1,0 +1,64 @@
+// Regression budget for standard Vitest worker-process churn.
+//
+// Vitest 4 defaults to the `forks` pool. In this workspace that produced one
+// fresh Node OS process per test file: 356 fork-worker execs for desktop-main
+// alone. Ten concurrent worktrees therefore multiply ordinary test discovery
+// into thousands of executable provenance events on macOS.
+//
+// `threads` keeps Vitest's default file isolation but does not exec an OS
+// process for each file. Keep the budget explicit so a pool default change or
+// a newly added project cannot quietly restore per-file process scaling.
+import { describe, expect, it } from "vitest";
+import workspaceConfig from "../../../../../vitest.workspace";
+
+const EXPECTED_PROJECTS = [
+  "desktop-main",
+  "desktop-renderer",
+  "messaging",
+  "shared",
+];
+const OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE = 0;
+
+type ConfiguredProject = {
+  test?: {
+    name?: string;
+    pool?: string;
+  };
+};
+
+describe("standard test process budget", () => {
+  it("keeps every project on an in-process worker pool", () => {
+    const projects = configuredProjects();
+
+    expect(projects.map((project) => project.test?.name).sort()).toEqual(
+      EXPECTED_PROJECTS,
+    );
+    expect(projects).toHaveLength(EXPECTED_PROJECTS.length);
+    expect(
+      projects.map((project) => ({
+        name: project.test?.name,
+        osWorkerProcessesPerTestFile:
+          project.test?.pool === "threads" ? 0 : 1,
+      })),
+    ).toEqual(
+      EXPECTED_PROJECTS.map((name) => ({
+        name,
+        osWorkerProcessesPerTestFile:
+          OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE,
+      })),
+    );
+  });
+});
+
+function configuredProjects(): ConfiguredProject[] {
+  return (workspaceConfig.test?.projects ?? [])
+    .filter(
+      (project): project is ConfiguredProject =>
+        typeof project === "object"
+        && project !== null
+        && typeof (project as ConfiguredProject).test?.name === "string",
+    )
+    .sort((left, right) =>
+      (left.test?.name ?? "").localeCompare(right.test?.name ?? ""),
+    );
+}

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -35,6 +35,12 @@ export default defineConfig({
       {
         test: {
           name: "messaging",
+          // Vitest 4 defaults to forks, which execs a fresh Node process for
+          // every test file. With hundreds of files and many concurrent
+          // worktrees, that executable churn overwhelms macOS provenance
+          // checks. Threads retain Vitest's default per-file isolation without
+          // creating an OS process per file.
+          pool: "threads",
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
           environment: "node",
@@ -44,6 +50,7 @@ export default defineConfig({
       {
         test: {
           name: "shared",
+          pool: "threads",
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
           environment: "node",
@@ -53,6 +60,7 @@ export default defineConfig({
       {
         test: {
           name: "desktop-main",
+          pool: "threads",
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
           hookTimeout: HOOK_TIMEOUT_MS,
@@ -93,6 +101,7 @@ export default defineConfig({
       {
         test: {
           name: "desktop-renderer",
+          pool: "threads",
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
           environment: "jsdom",

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -8,6 +8,12 @@ import { defineConfig } from "vitest/config";
 const TEST_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 5_000;
 const HOOK_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 10_000;
 
+// A Windows worker thread's process.env is case-sensitive, unlike the real
+// Electron main process and a forked Node process on Windows. Keep desktop-main
+// on forks there so PATH/Path behavior remains production-equivalent. POSIX
+// uses threads to avoid one OS process exec per test file.
+const DESKTOP_MAIN_POOL = process.platform === "win32" ? "forks" : "threads";
+
 // Where the desktop suites resolve the PwrAgent root to. `resolvePwragentRoot`
 // falls back to `~/.pwragent` — the operator's live application state — and
 // only about a dozen main tests override it themselves, so every other test
@@ -60,7 +66,7 @@ export default defineConfig({
       {
         test: {
           name: "desktop-main",
-          pool: "threads",
+          pool: DESKTOP_MAIN_POOL,
           globals: true,
           testTimeout: TEST_TIMEOUT_MS,
           hookTimeout: HOOK_TIMEOUT_MS,


### PR DESCRIPTION
## Summary

- run all four standard Vitest projects on worker threads on POSIX instead of Vitest 4's fork pool
- preserve Vitest's default per-file isolation while removing one Node OS-process exec per test file on macOS and Linux
- keep Windows `desktop-main` on forks because worker-thread environment keys are case-sensitive there, unlike Electron's real main-process environment
- add deterministic project/pool and POSIX zero-OS-worker-process-per-test-file budgets

## Evidence

The same passing, instrumented `desktop-main` partition ran 357 files / 5,234 tests under both profiles. The measurement-only runs used a 15-second timeout so profiler overhead could not turn existing 5-second timing flakes into failures; the checked-in timeout is unchanged.

| Metric | Forks (before) | Threads (after) | Delta |
|---|---:|---:|---:|
| Vitest worker Node execs | 357 | 0 | -357 (-100%) |
| Observed Node PIDs | 404 | 47 | -357 (-88.4%) |
| Node executable launches | 362 | 5 | -357 (-98.6%) |
| All child spawn attempts | 2,539 | 2,182 | -357 (-14.1%) |
| Unique launched executable inodes | 24 | 24 | 0 |
| Temporary executable inodes | 74 | 74 | 0 |
| Temporary executable apparent bytes | 22,835 | 22,835 | 0 |
| Temporary executable allocated bytes | 253,952 | 253,952 | 0 |
| Wall time | 29.66s | 26.79s | -2.87s (-9.7%) |

This intentionally avoids no on-disk executable bytes or inodes: it removes 357 repeated process launches of the existing Node executable. On macOS, the expected impact is 357 fewer executable provenance/process events for this one project per worktree. At 10 concurrent worktrees that is 3,570 fewer Node execs for `desktop-main`; the other three projects receive the same per-file protection.

The original fork baseline showed 356 worker execs before the budget test was added; the final comparable runs show 357 before and zero after, exactly one avoided OS process per file.

## Safety and isolation

- Vitest's default per-file isolation remains enabled; only the worker transport changes.
- No standard unit test calls `process.chdir`, which Node disallows from worker threads.
- Windows CI exposed a production-equivalence boundary: worker-thread `process.env` keys are case-sensitive on Windows, while the real Electron main process and forked Node processes use case-insensitive keys. `desktop-main` therefore keeps forks only on Windows; Windows renderer, messaging, and shared projects remain on threads.
- Focused checks covered project config, disposable `PWRAGENT_HOME`, the real-agent CLI guard, SQLite/native-backed state tests, messaging, shared, and renderer/jsdom behavior.
- The complete uninstrumented standard suite passed under threads: 663 files, 9,769 tests passed, 6 skipped.
- A prior full run had one 5-second `codex-environment-runtime.test.ts` timeout. That file then passed alone (31/31), passed in its process/stdio partition (61/61), and the complete rerun passed.

## Managed runtime/download audit

Standard Vitest performed no real managed Codex, Grok, or ripgrep download. The suite-wide outbound-fetch and real-agent-CLI guards remained enabled and passed. Managed-runtime tests use injected fake fetch, archive extraction, and version-probe seams. No guard was widened or changed. Replay E2E was not run and already disables managed Grok.

## Verification

- focused `desktop-main`: 4 files, 50 tests passed
- focused messaging: 1 file, 121 tests passed
- focused shared: 1 file, 4 tests passed
- focused renderer: 1 file, 299 tests passed
- focused process/stdio partition: 4 files, 61 tests passed
- CI-repair focus: process budget + ACP stdio transport, 2 files / 14 tests passed
- `pnpm test --reporter=dot`: 663 files, 9,769 passed, 6 skipped
- passing instrumented before/after `desktop-main` measurements: 357 files, 5,228 passed, 6 skipped in each profile

## Remaining limitations / top churn sources

This ASAP fix targets the dominant standard-test worker multiplier only. In the measured `desktop-main` partition, test-owned churn remains unchanged:

- Git: 1,923 launches
- `/usr/bin/which`: 108 launches
- SSH: 21 launches
- Bash: 13 launches
- `/bin/sh`: 11 launches
- `/bin/zsh`: 9 launches
- temporary executable fixtures: 74 unique inodes, 22,835 apparent bytes / 253,952 allocated bytes

Those sources need separate ownership/fixture work and are not masked with worker caps, retries, longer checked-in timeouts, or serial lanes. Active development Electron instances and headed E2E were outside this measurement.
