### PR TITLE
fix(desktop): consolidate turn usage transcript rows

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25478,12 +25478,12 @@ command = "pnpm dev"
         turn: {
           id: "turn-1",
           status: "completed",
-          completedAt: 4_000,
+          completedAt: 1_800_000_004_000,
           output: [],
         },
       },
     });
-    await codexClient.emit({
+    const lateUsageNotification: AppServerNotification = {
       method: "thread/tokenUsage/updated",
       params: {
         threadId: "thread-1",
@@ -25495,16 +25495,11 @@ command = "pnpm dev"
             reasoningOutputTokens: 10,
             totalTokens: 2_040,
           },
-          total: {
-            inputTokens: 3_000,
-            cachedInputTokens: 1_900,
-            outputTokens: 50,
-            reasoningOutputTokens: 15,
-            totalTokens: 3_065,
-          },
         },
       },
-    });
+    };
+    await codexClient.emit(lateUsageNotification);
+    await codexClient.emit(lateUsageNotification);
 
     const pricing = await overlayStore.readThreadPricing({
       backend: "codex",
@@ -25513,7 +25508,7 @@ command = "pnpm dev"
     expect(pricing.lines).toHaveLength(1);
     expect(pricing.lines[0]).toMatchObject({
       cachedInputTokens: 1_900,
-      completedAt: 4_000,
+      completedAt: 1_800_000_004_000,
       inputTokens: 3_000,
       outputTokens: 50,
       reasoningOutputTokens: 15,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25429,6 +25429,104 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("attributes turnless usage emitted after completion to the completed turn", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-5.5",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          last: {
+            inputTokens: 1_000,
+            cachedInputTokens: 100,
+            outputTokens: 20,
+            reasoningOutputTokens: 5,
+            totalTokens: 1_025,
+          },
+          total: {
+            inputTokens: 1_000,
+            cachedInputTokens: 100,
+            outputTokens: 20,
+            reasoningOutputTokens: 5,
+            totalTokens: 1_025,
+          },
+        },
+      },
+    });
+    await codexClient.emit({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          completedAt: 4_000,
+          output: [],
+        },
+      },
+    });
+    await codexClient.emit({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        tokenUsage: {
+          last: {
+            inputTokens: 2_000,
+            cachedInputTokens: 1_800,
+            outputTokens: 30,
+            reasoningOutputTokens: 10,
+            totalTokens: 2_040,
+          },
+          total: {
+            inputTokens: 3_000,
+            cachedInputTokens: 1_900,
+            outputTokens: 50,
+            reasoningOutputTokens: 15,
+            totalTokens: 3_065,
+          },
+        },
+      },
+    });
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cachedInputTokens: 1_900,
+      completedAt: 4_000,
+      inputTokens: 3_000,
+      outputTokens: 50,
+      reasoningOutputTokens: 15,
+      totalTokens: 3_065,
+      turnId: "turn-1",
+      turnUsageAttributed: true,
+      uncachedInputTokens: 1_100,
+      usageLineId: "codex:thread-1:turn-1:live-token-usage",
+    });
+
+    await registry.close();
+  });
+
   it("folds final and peak protocol context observations into the existing usage row", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -439,54 +439,57 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
-  it("keeps an attributed live turn aggregate when hydration only has request usage", async () => {
-    await store.upsertThreadUsageLine({
-      line: buildUsageLine({
-        cachedInputTokens: 24_545_792,
+  it.each(["latest-request", "total"] as const)(
+    "keeps an attributed live turn aggregate when hydration only has %s usage",
+    async (scope) => {
+      await store.upsertThreadUsageLine({
+        line: buildUsageLine({
+          cachedInputTokens: 24_545_792,
+          inputTokens: 25_139_426,
+          outputTokens: 66_567,
+          reasoningOutputTokens: 24_064,
+          scope: "turn",
+          source: "live",
+          status: "pending",
+          totalTokens: 25_205_993,
+          turnUsageAttributed: true,
+          uncachedInputTokens: 593_634,
+          usageLineId: "codex:thread-1:turn-1:live-token-usage",
+        }),
+      });
+
+      await store.upsertThreadUsageLine({
+        line: buildUsageLine({
+          cachedInputTokens: 111_232,
+          completedAt: 55_000,
+          inputTokens: 112_017,
+          outputTokens: 319,
+          reasoningOutputTokens: 90,
+          scope,
+          source: "hydration",
+          status: "finalized",
+          totalTokens: 112_426,
+          uncachedInputTokens: 785,
+          usageLineId: `codex:thread-1:turn-1:${scope}:item-9`,
+        }),
+      });
+
+      const pricing = await store.readThreadPricing({
+        backend: "codex",
+        threadId: "thread-1",
+      });
+
+      expect(pricing.lines).toHaveLength(1);
+      expect(pricing.lines[0]).toMatchObject({
+        completedAt: 55_000,
         inputTokens: 25_139_426,
-        outputTokens: 66_567,
-        reasoningOutputTokens: 24_064,
         scope: "turn",
         source: "live",
-        status: "pending",
-        totalTokens: 25_205_993,
-        turnUsageAttributed: true,
-        uncachedInputTokens: 593_634,
         usageLineId: "codex:thread-1:turn-1:live-token-usage",
-      }),
-    });
-
-    await store.upsertThreadUsageLine({
-      line: buildUsageLine({
-        cachedInputTokens: 111_232,
-        completedAt: 55_000,
-        inputTokens: 112_017,
-        outputTokens: 319,
-        reasoningOutputTokens: 90,
-        scope: "latest-request",
-        source: "hydration",
-        status: "finalized",
-        totalTokens: 112_426,
-        uncachedInputTokens: 785,
-        usageLineId: "codex:thread-1:turn-1:latest-request:item-9",
-      }),
-    });
-
-    const pricing = await store.readThreadPricing({
-      backend: "codex",
-      threadId: "thread-1",
-    });
-
-    expect(pricing.lines).toHaveLength(1);
-    expect(pricing.lines[0]).toMatchObject({
-      completedAt: 55_000,
-      inputTokens: 25_139_426,
-      scope: "turn",
-      source: "live",
-      usageLineId: "codex:thread-1:turn-1:live-token-usage",
-    });
-    expect(pricing.summaries[0]?.usageLineCount).toBe(1);
-  });
+      });
+      expect(pricing.summaries[0]?.usageLineCount).toBe(1);
+    },
+  );
 
   it("keeps the original usage line timestamp when live usage is updated", async () => {
     await store.upsertThreadUsageLine({

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -439,6 +439,55 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("keeps an attributed live turn aggregate when hydration only has request usage", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cachedInputTokens: 24_545_792,
+        inputTokens: 25_139_426,
+        outputTokens: 66_567,
+        reasoningOutputTokens: 24_064,
+        scope: "turn",
+        source: "live",
+        status: "pending",
+        totalTokens: 25_205_993,
+        turnUsageAttributed: true,
+        uncachedInputTokens: 593_634,
+        usageLineId: "codex:thread-1:turn-1:live-token-usage",
+      }),
+    });
+
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cachedInputTokens: 111_232,
+        completedAt: 55_000,
+        inputTokens: 112_017,
+        outputTokens: 319,
+        reasoningOutputTokens: 90,
+        scope: "latest-request",
+        source: "hydration",
+        status: "finalized",
+        totalTokens: 112_426,
+        uncachedInputTokens: 785,
+        usageLineId: "codex:thread-1:turn-1:latest-request:item-9",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      completedAt: 55_000,
+      inputTokens: 25_139_426,
+      scope: "turn",
+      source: "live",
+      usageLineId: "codex:thread-1:turn-1:live-token-usage",
+    });
+    expect(pricing.summaries[0]?.usageLineCount).toBe(1);
+  });
+
   it("keeps the original usage line timestamp when live usage is updated", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4164,6 +4164,45 @@ function subtractTaskMonitorTokenUsage(
   return Object.keys(result).length > 0 ? result : undefined;
 }
 
+function addTaskMonitorTokenUsage(
+  first: TaskMonitorTokenUsageBreakdown,
+  second: TaskMonitorTokenUsageBreakdown,
+): TaskMonitorTokenUsageBreakdown | undefined {
+  const result: TaskMonitorTokenUsageBreakdown = {};
+  for (const key of [
+    "cachedInputTokens",
+    "inputTokens",
+    "uncachedInputTokens",
+    "outputTokens",
+    "reasoningOutputTokens",
+    "totalTokens",
+  ] as const) {
+    const firstValue = first[key];
+    const secondValue = second[key];
+    if (typeof firstValue === "number" || typeof secondValue === "number") {
+      result[key] = (firstValue ?? 0) + (secondValue ?? 0);
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function taskMonitorTokenUsageEqual(
+  first: TaskMonitorTokenUsageBreakdown | undefined,
+  second: TaskMonitorTokenUsageBreakdown | undefined,
+): boolean {
+  if (!first || !second) {
+    return false;
+  }
+  return (
+    first.cachedInputTokens === second.cachedInputTokens
+    && first.inputTokens === second.inputTokens
+    && first.uncachedInputTokens === second.uncachedInputTokens
+    && first.outputTokens === second.outputTokens
+    && first.reasoningOutputTokens === second.reasoningOutputTokens
+    && first.totalTokens === second.totalTokens
+  );
+}
+
 function canSubtractTaskMonitorTokenUsage(
   total: TaskMonitorTokenUsageBreakdown,
   baseline: TaskMonitorTokenUsageBreakdown,
@@ -7587,6 +7626,17 @@ type LiveThreadUsageEmitWork = {
   threadId: string;
 };
 
+type RecentlyCompletedThreadUsageTurn = {
+  completedAt?: number;
+  startedAt?: number;
+  turnId: string;
+};
+
+type LiveThreadUsageAggregate = {
+  latestUsage?: TaskMonitorTokenUsageBreakdown;
+  usage: TaskMonitorTokenUsageBreakdown;
+};
+
 type DerivedLiveThreadTokenUsage = {
   // Whether turnTokenUsage is a real measurement of this turn — a per-turn
   // delta or a per-request "last" snapshot — vs a fallback to a whole-thread
@@ -7852,6 +7902,14 @@ export class DesktopBackendRegistry {
       turnId: string;
       usage: TaskMonitorTokenUsageBreakdown;
     }
+  >();
+  private readonly liveThreadUsageAggregates = new Map<
+    string,
+    LiveThreadUsageAggregate
+  >();
+  private readonly recentlyCompletedThreadUsageTurns = new Map<
+    string,
+    RecentlyCompletedThreadUsageTurn
   >();
   // Per-turn tally of observed context replays (key: backend:threadId:turnId).
   private readonly liveThreadReplayObservations = new Map<
@@ -23817,6 +23875,7 @@ export class DesktopBackendRegistry {
   }
 
   private deriveLiveThreadTokenUsage(params: {
+    appendLatestUsage?: boolean;
     backend: AppServerBackendKind;
     observationSequence?: number;
     threadId: string;
@@ -23828,7 +23887,7 @@ export class DesktopBackendRegistry {
       return { attributed: false, turnTokenUsage: params.tokenUsage };
     }
 
-    if (!records.totalUsage || !params.turnId) {
+    if (!params.turnId) {
       return {
         // A "last" snapshot is this request's own usage; anything else here is
         // a bare/whole payload we can't attribute to the turn.
@@ -23845,6 +23904,36 @@ export class DesktopBackendRegistry {
       params.turnId,
       "live-token-usage",
     ].join(":");
+    if (!records.totalUsage) {
+      const currentUsage = records.latestUsage ?? records.currentUsage;
+      if (!currentUsage) {
+        return { attributed: false, turnTokenUsage: params.tokenUsage };
+      }
+      const previousAggregate = this.liveThreadUsageAggregates.get(key);
+      const turnTokenUsage =
+        params.appendLatestUsage
+        && records.latestUsage
+        && previousAggregate
+          ? taskMonitorTokenUsageEqual(
+              previousAggregate.latestUsage,
+              records.latestUsage,
+            )
+            ? previousAggregate.usage
+            : addTaskMonitorTokenUsage(
+                previousAggregate.usage,
+                records.latestUsage,
+              ) ?? records.latestUsage
+          : currentUsage;
+      this.liveThreadUsageAggregates.set(key, {
+        ...(records.latestUsage ? { latestUsage: records.latestUsage } : {}),
+        usage: turnTokenUsage,
+      });
+      return {
+        attributed: Boolean(records.latestUsage),
+        turnTokenUsage,
+      };
+    }
+
     let baseline = this.liveThreadUsageBaselines.get(key);
     let seededBaselineTokenUsage: TaskMonitorTokenUsageBreakdown | undefined;
     const cumulativeKey = [params.backend, params.threadId].join(":");
@@ -23900,19 +23989,24 @@ export class DesktopBackendRegistry {
       });
     }
 
-    const turnTokenUsage = baseline
+    const derivedTurnUsage = baseline
       ? subtractTaskMonitorTokenUsage(records.totalUsage, baseline)
       : undefined;
+    const turnTokenUsage =
+      derivedTurnUsage
+      ?? records.latestUsage
+      ?? records.currentUsage
+      ?? records.totalUsage;
+    this.liveThreadUsageAggregates.set(key, {
+      ...(records.latestUsage ? { latestUsage: records.latestUsage } : {}),
+      usage: turnTokenUsage,
+    });
     return {
       // Attributed when we computed a per-turn delta or have this request's
       // "last" snapshot; not when we fall back to the whole cumulative total.
-      attributed: Boolean(turnTokenUsage) || Boolean(records.latestUsage),
+      attributed: Boolean(derivedTurnUsage) || Boolean(records.latestUsage),
       cumulativeTokenUsage: records.totalUsage,
-      turnTokenUsage:
-        turnTokenUsage ??
-        records.latestUsage ??
-        records.currentUsage ??
-        records.totalUsage,
+      turnTokenUsage,
       ...(seededBaselineTokenUsage ? { seededBaselineTokenUsage } : {}),
     };
   }
@@ -24222,6 +24316,16 @@ export class DesktopBackendRegistry {
       this.finishLiveThreadUsageDerivation(work);
       return;
     }
+    const explicitTurnId = notification.params.turnId ?? undefined;
+    const rememberedCompletedTurn = this.recentlyCompletedThreadUsageTurns.get(
+      [event.backend, threadId].join(":"),
+    );
+    const recentlyCompletedTurn =
+      rememberedCompletedTurn
+      && (!explicitTurnId || explicitTurnId === rememberedCompletedTurn.turnId)
+      ? rememberedCompletedTurn
+      : undefined;
+    const turnId = explicitTurnId ?? recentlyCompletedTurn?.turnId;
     await work.precedingDerivation;
     let derivedUsage: DerivedLiveThreadTokenUsage | undefined;
     let contextDrop: ObservedContextWindowDrop | undefined;
@@ -24245,11 +24349,11 @@ export class DesktopBackendRegistry {
       ) {
         return;
       }
-      if (notification.params.turnId) {
+      if (turnId) {
         const reviewKey = buildReviewSubAgentKey(
           event.backend,
           threadId,
-          notification.params.turnId,
+          turnId,
         );
         if (
           this.activeReviewSubAgents.has(reviewKey)
@@ -24261,11 +24365,12 @@ export class DesktopBackendRegistry {
 
       const tokenUsage = notification.params.tokenUsage;
       derivedUsage = this.deriveLiveThreadTokenUsage({
+        appendLatestUsage: Boolean(recentlyCompletedTurn),
         backend: event.backend,
         observationSequence: work.observationSequence,
         threadId,
         tokenUsage,
-        turnId: notification.params.turnId ?? undefined,
+        turnId,
       });
       contextDrop = detectObservedContextWindowDrop({
         cursor: this.liveThreadReplayInputCursor.get(
@@ -24277,13 +24382,13 @@ export class DesktopBackendRegistry {
         backend: event.backend,
         threadId,
         tokenUsage,
-        turnId: notification.params.turnId ?? undefined,
+        turnId,
       });
       contextWindow = this.observeLiveThreadContextWindow({
         backend: event.backend,
         threadId,
         tokenUsage,
-        turnId: notification.params.turnId ?? undefined,
+        turnId,
       });
     } finally {
       // Publish the cumulative cursor before any overlay or sqlite await lets
@@ -24298,7 +24403,7 @@ export class DesktopBackendRegistry {
         backend: event.backend,
         contextDrop,
         threadId,
-        turnId: notification.params.turnId ?? undefined,
+        turnId,
       });
     }
 
@@ -24327,10 +24432,21 @@ export class DesktopBackendRegistry {
         "effort",
       ]) ??
       overlay?.reasoningEffort;
-    const usageTiming = resolveLiveThreadUsageTiming({
+    const resolvedUsageTiming = resolveLiveThreadUsageTiming({
       overlay,
-      turnId: notification.params.turnId ?? undefined,
+      turnId,
     });
+    const usageTiming = {
+      ...resolvedUsageTiming,
+      ...(recentlyCompletedTurn?.completedAt !== undefined
+        && resolvedUsageTiming.completedAt === undefined
+          ? { completedAt: recentlyCompletedTurn.completedAt }
+          : {}),
+      ...(recentlyCompletedTurn?.startedAt !== undefined
+        && resolvedUsageTiming.startedAt === undefined
+          ? { startedAt: recentlyCompletedTurn.startedAt }
+          : {}),
+    };
     const line = buildLiveThreadUsageLine({
       attributed: derivedUsage.attributed,
       backend: event.backend,
@@ -24344,7 +24460,7 @@ export class DesktopBackendRegistry {
       serviceTier,
       threadId,
       tokenUsage: derivedUsage.turnTokenUsage,
-      turnId: notification.params.turnId ?? undefined,
+      turnId,
     });
     if (!line) {
       return;
@@ -24368,7 +24484,7 @@ export class DesktopBackendRegistry {
           overlay,
           serviceTier,
           threadId,
-          turnId: notification.params.turnId ?? undefined,
+          turnId,
           usageTiming,
         });
       } catch (error) {
@@ -36216,7 +36332,50 @@ export class DesktopBackendRegistry {
     } as AgentEvent);
   }
 
+  private trackRecentThreadUsageTurn(event: AgentEvent): void {
+    if (event.notification.method === "turn/started") {
+      const threadId = event.notification.params.threadId;
+      const key = [event.backend, threadId].join(":");
+      const completedTurn = this.recentlyCompletedThreadUsageTurns.get(key);
+      if (completedTurn) {
+        this.liveThreadUsageAggregates.delete([
+          event.backend,
+          threadId,
+          completedTurn.turnId,
+          "live-token-usage",
+        ].join(":"));
+      }
+      this.recentlyCompletedThreadUsageTurns.delete(key);
+      return;
+    }
+    if (
+      event.notification.method !== "turn/completed"
+      && event.notification.method !== "turn/failed"
+      && event.notification.method !== "turn/cancelled"
+    ) {
+      return;
+    }
+    const turnId = turnIdFromTerminalNotification(event.notification);
+    if (!turnId) {
+      return;
+    }
+    const turn = readRecord(event.notification.params.turn);
+    const completedAt = completedAtFromTerminalNotification(event.notification);
+    const startedAt = normalizeNotificationTimestamp(
+      turn?.startedAt ?? turn?.started_at,
+    );
+    this.recentlyCompletedThreadUsageTurns.set(
+      [event.backend, event.notification.params.threadId].join(":"),
+      {
+        turnId,
+        ...(typeof completedAt === "number" ? { completedAt } : {}),
+        ...(typeof startedAt === "number" ? { startedAt } : {}),
+      },
+    );
+  }
+
   private emit(event: AgentEvent): Promise<void> {
+    this.trackRecentThreadUsageTurn(event);
     const isLiveThreadUsage =
       event.notification.method === "thread/tokenUsage/updated";
     if (isLiveThreadUsage && this.closed) {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1331,7 +1331,66 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       if (existing) {
         line = mergeThreadUsageLineForUpsert(line, existing);
       }
-      if (
+      // Codex hydration records expose either the last request or the
+      // thread-cumulative total. Neither can replace an already-attributed
+      // live turn aggregate without undercounting or charging prior turns.
+      // Keep the turn line authoritative while still letting the hydration
+      // write refresh shared turn timing and settings below.
+      const preservedLiveTurnAggregate =
+        (line.source === "hydration" || line.source === "backfill") &&
+        line.turnId &&
+        line.scope !== "turn"
+          ? this.stateDb.raw
+              .prepare(
+                `SELECT usage_line_id
+                 FROM thread_usage_lines
+                 WHERE provider = ?
+                   AND backend = ?
+                   AND thread_id = ?
+                   AND turn_id = ?
+                   AND source = 'live'
+                   AND scope = 'turn'
+                   AND (turn_usage_attributed IS NULL OR turn_usage_attributed = 1)
+                 ORDER BY updated_at DESC
+                 LIMIT 1`,
+              )
+              .get(
+                line.provider,
+                line.backend,
+                line.threadId,
+                line.turnId,
+              ) as { usage_line_id: string } | undefined
+          : undefined;
+      if (preservedLiveTurnAggregate) {
+        this.stateDb.raw
+          .prepare(
+            `UPDATE thread_usage_lines
+             SET status = CASE
+                   WHEN usage_line_id = ? THEN 'pending'
+                   ELSE 'superseded'
+                 END,
+                 updated_at = ?
+             WHERE provider = ?
+               AND backend = ?
+               AND thread_id = ?
+               AND turn_id = ?
+               AND (
+                 usage_line_id = ?
+                 OR source = 'hydration'
+                 OR source = 'backfill'
+               )`,
+          )
+          .run(
+            preservedLiveTurnAggregate.usage_line_id,
+            now,
+            line.provider,
+            line.backend,
+            line.threadId,
+            line.turnId,
+            preservedLiveTurnAggregate.usage_line_id,
+          );
+        line = { ...line, status: "superseded" };
+      } else if (
         (line.source === "hydration" || line.source === "backfill") &&
         line.turnId
       ) {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -2,6 +2,7 @@ import {
   estimateTokenUsageCost,
   formatSearchCommandActionLabel,
   formatTokenUsagePriceFactor,
+  formatTokenUsageMicrosAsUsd,
   formatTokenUsageStandardRateSuffix,
   formatTokenUsageUsd,
   formatTokenUsageUsdPerMillion,
@@ -14,6 +15,7 @@ import {
   type AppServerThreadImagePart,
   type AppServerThreadSubAgentCallDetail,
   type AppServerThreadTurnMetadata,
+  type ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
   formatDynamicToolOutput,
@@ -377,9 +379,11 @@ type NormalizedTokenUsage = {
 };
 
 export function buildTokenUsageActivityEntry(params: {
+  createdAt?: number;
   fastMode?: boolean;
   id: string;
   model?: string;
+  pricingAt?: number;
   serviceTier?: string;
   summaryPrefix?: string;
   tokenUsage: unknown;
@@ -397,6 +401,7 @@ export function buildTokenUsageActivityEntry(params: {
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const cost = estimateTokenUsageCost({
+    at: params.pricingAt,
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,
@@ -503,11 +508,103 @@ export function buildTokenUsageActivityEntry(params: {
   return {
     type: "activity",
     id: params.id,
-    createdAt: Date.now(),
+    createdAt: params.createdAt ?? Date.now(),
     summary: `${summaryPrefix}: ${summaryParts.join(" · ")}`,
     status: "completed",
     details,
     ...(params.turn ? { turn: params.turn } : {}),
+  };
+}
+
+export function buildTurnUsageActivityEntryFromLine(params: {
+  line: ThreadUsageLineRecord;
+  turn: AppServerThreadTurnMetadata;
+}): AppServerThreadActivityEntry | undefined {
+  const { line, turn } = params;
+  if (!line.turnId) {
+    return undefined;
+  }
+
+  const id = `live-turn-usage-${line.turnId}`;
+  const entry = buildTokenUsageActivityEntry({
+    createdAt: line.completedAt ?? turn.completedAt ?? line.createdAt,
+    fastMode: line.fastMode,
+    id,
+    model: line.model,
+    pricingAt: line.createdAt,
+    serviceTier: line.serviceTier,
+    summaryPrefix: "Turn usage",
+    tokenUsage: {
+      total: {
+        cachedInputTokens: line.cachedInputTokens,
+        inputTokens: line.inputTokens,
+        outputTokens: line.outputTokens,
+        reasoningOutputTokens: line.reasoningOutputTokens,
+        totalTokens: line.totalTokens,
+      },
+    },
+    turn,
+  });
+  if (!entry) {
+    return undefined;
+  }
+
+  const summaryParts = [
+    `${formatTokenCount(line.uncachedInputTokens)} uncached in`,
+    `${formatTokenCount(line.cachedInputTokens)} cached`,
+    line.reasoningOutputTokens > 0
+      ? `${formatTokenCount(line.outputTokens)} out (${formatTokenCount(
+          line.reasoningOutputTokens,
+        )} reasoning)`
+      : `${formatTokenCount(line.outputTokens)} out`,
+    line.priceStatus === "priced"
+      ? `${formatTokenUsageMicrosAsUsd(line.totalCostMicros)} list price`
+      : undefined,
+  ].filter((part): part is string => Boolean(part));
+  const exactCostsByDetailId = new Map([
+    [`${id}-uncached-input-cost`, line.uncachedInputCostMicros],
+    [`${id}-cached-input-cost`, line.cachedInputCostMicros],
+    [`${id}-output-cost`, line.outputCostMicros],
+  ]);
+  const details = entry.details.map((detail) => {
+    const exactCostMicros = exactCostsByDetailId.get(detail.id);
+    if (exactCostMicros !== undefined && detail.label.includes(" = ")) {
+      return {
+        ...detail,
+        label: detail.label.replace(
+          / = [^=]+$/,
+          ` = ${formatTokenUsageMicrosAsUsd(exactCostMicros)}`,
+        ),
+      };
+    }
+    if (detail.id === `${id}-cost`) {
+      return {
+        ...detail,
+        label: detail.label.replace(
+          /^Cost: .*? list price/,
+          `Cost: ${formatTokenUsageMicrosAsUsd(line.totalCostMicros)} list price`,
+        ),
+      };
+    }
+    return detail;
+  });
+  if (
+    line.priceStatus === "priced"
+    && !details.some((detail) => detail.id === `${id}-cost`)
+  ) {
+    details.push({
+      id: `${id}-cost`,
+      kind: "read",
+      label: `Cost: ${formatTokenUsageMicrosAsUsd(line.totalCostMicros)} list price`,
+      status: "completed",
+    });
+  }
+
+  return {
+    ...entry,
+    details,
+    summary: `Turn usage: ${summaryParts.join(" · ")}`,
+    usageLine: line,
   };
 }
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8759,6 +8759,7 @@ describe("useThreadSessionState", () => {
         },
       });
     });
+
     act(() => {
       agentEventHandler?.({
         backend: "codex",
@@ -8815,6 +8816,22 @@ describe("useThreadSessionState", () => {
         },
       });
     });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Ran final checks",
+      "message:Done.",
+      "activity:Turn usage: 593,634 uncached in · 24,545,792 cached · 66,567 out (24,064 reasoning) · $14.01 list price",
+    ]);
+    expect(result.current.entries.at(-1)).toMatchObject({
+      id: "live-turn-usage-turn-1",
+      createdAt: 4_000,
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        completedAt: 4_000,
+      },
+    });
+
     act(() => {
       agentEventHandler?.({
         backend: "codex",
@@ -8947,6 +8964,105 @@ describe("useThreadSessionState", () => {
       usageLine: {
         usageLineId: "codex:thread-1:turn-1:live-token-usage",
       },
+    });
+  });
+
+  it("reconciles completed usage inside an older history page", async () => {
+    const turn = {
+      id: "turn-1",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 4_000,
+    };
+    const initialTail = readThreadResponse({
+      entries: [messageEntry({
+        id: "newer-message",
+        role: "user",
+        text: "Next prompt",
+        createdAt: 5_000,
+      })],
+      hasPreviousPage: true,
+      previousCursor: "newer-message",
+    });
+    const olderPage = {
+      ...readThreadResponse({
+        entries: [
+          {
+            type: "activity" as const,
+            id: "late-final-checks",
+            createdAt: 3_500,
+            summary: "Ran final checks",
+            status: "completed" as const,
+            details: [],
+            turn,
+          },
+          {
+            type: "message" as const,
+            id: "assistant-turn-1",
+            role: "assistant" as const,
+            phase: "final" as const,
+            text: "Done.",
+            createdAt: 4_000,
+            turn,
+          },
+          {
+            type: "activity" as const,
+            id: "live-turn-usage-turn-1",
+            createdAt: 3_900,
+            summary:
+              "Turn usage: 592,849 uncached in · 24,434,560 cached · 66,248 out (23,974 reasoning) · $13.95 list price",
+            status: "completed" as const,
+            details: [],
+            turn,
+          },
+          {
+            type: "activity" as const,
+            id: "live-token-usage-turn-1",
+            createdAt: 3_950,
+            summary:
+              "Latest request usage: 785 uncached in · 111,232 cached · 319 out (90 reasoning) · $0.056 list price",
+            status: "completed" as const,
+            details: [],
+            turn,
+          },
+        ],
+        hasPreviousPage: false,
+      }),
+      pricing: {
+        lines: [authoritativeTurnUsageLine()],
+        summaries: [],
+      },
+    };
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(initialTail)
+      .mockResolvedValueOnce(olderPage);
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        initialHistoryLimit: DEFAULT_INITIAL_THREAD_HISTORY_TURN_LIMIT,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Ran final checks",
+      "message:Done.",
+      "activity:Turn usage: 593,634 uncached in · 24,545,792 cached · 66,567 out (24,064 reasoning) · $14.01 list price",
+      "message:Next prompt",
+    ]);
+    expect(result.current.entries[2]).toMatchObject({
+      id: "live-turn-usage-turn-1",
+      createdAt: 4_000,
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -8659,6 +8659,178 @@ describe("useThreadSessionState", () => {
     expect(result.current.runningTurnUsageText).toBeUndefined();
   });
 
+  it("consolidates trailing request usage into one authoritative turn-end row", async () => {
+    let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback;
+        return () => undefined;
+      },
+      readThread: async ({ backend, threadId }) => ({
+        backend: backend ?? "codex",
+        fetchedAt: Date.now(),
+        threadId,
+        pricing: {
+          lines: [],
+          summaries: [],
+        },
+        replay: {
+          entries: [],
+          messages: [],
+          pagination: {
+            supportsPagination: false,
+            hasPreviousPage: false,
+          },
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: {
+          ...buildThread({ id: "thread-1", updatedAt: 1_000 }),
+          model: "gpt-5.6-sol",
+        },
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    act(() => {
+      result.current.setActiveTurnId("turn-1");
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 25_027_409,
+                cached_input_tokens: 24_434_560,
+                output_tokens: 66_248,
+                reasoning_output_tokens: 23_974,
+                total_tokens: 25_117_631,
+              },
+              total_token_usage: {
+                input_tokens: 25_027_409,
+                cached_input_tokens: 24_434_560,
+                output_tokens: 66_248,
+                reasoning_output_tokens: 23_974,
+                total_tokens: 25_117_631,
+              },
+            },
+          },
+        },
+      });
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "turn/completed",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            turn: {
+              id: "turn-1",
+              status: "completed",
+              startedAt: 1_000,
+              completedAt: 4_000,
+              output: [{ type: "text", text: "Done." }],
+            },
+          },
+        },
+      });
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 112_017,
+                cached_input_tokens: 111_232,
+                output_tokens: 319,
+                reasoning_output_tokens: 90,
+                total_tokens: 112_426,
+              },
+            },
+          },
+        },
+      });
+    });
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/pricing/updated",
+          params: {
+            threadId: "thread-1",
+            pricing: {
+              lines: [
+                {
+                  backend: "codex",
+                  cachedInputCostMicros: 9_818_317,
+                  cachedInputTokens: 24_545_792,
+                  completedAt: 4_000,
+                  createdAt: 1_000,
+                  currency: "USD",
+                  inputTokens: 25_139_426,
+                  model: "gpt-5.6-sol",
+                  outputCostMicros: 1_812_620,
+                  outputTokens: 66_567,
+                  priceStatus: "priced",
+                  provider: "openai",
+                  reasoningOutputTokens: 24_064,
+                  scope: "turn",
+                  serviceTier: "standard",
+                  source: "live",
+                  status: "pending",
+                  threadId: "thread-1",
+                  totalCostMicros: 14_005_473,
+                  totalTokens: 25_205_993,
+                  turnId: "turn-1",
+                  turnUsageAttributed: true,
+                  uncachedInputCostMicros: 2_374_536,
+                  uncachedInputTokens: 593_634,
+                  usageLineId: "codex:thread-1:turn-1:live-token-usage",
+                },
+              ],
+              summaries: [],
+            },
+          },
+        },
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:Done.",
+      "activity:Turn usage: 593,634 uncached in · 24,545,792 cached · 66,567 out (24,064 reasoning) · $14.01 list price",
+    ]);
+    expect(result.current.entries.at(-1)).toMatchObject({
+      id: "live-turn-usage-turn-1",
+      createdAt: 4_000,
+      turn: {
+        id: "turn-1",
+        status: "completed",
+        completedAt: 4_000,
+      },
+      usageLine: {
+        usageLineId: "codex:thread-1:turn-1:live-token-usage",
+        totalCostMicros: 14_005_473,
+      },
+    });
+  });
+
   it("prices finalized active-turn usage from the token usage notification model", async () => {
     let agentEventHandler: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] | undefined;
     const desktopApi: DesktopApi = {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -1837,7 +1837,6 @@ describe("useThreadSessionState", () => {
         },
       });
     });
-
     expect(transcriptLabels(result.current.entries)).toEqual([
       "message:Older history",
       "message:Earlier prompt",
@@ -8772,7 +8771,7 @@ describe("useThreadSessionState", () => {
               id: "turn-1",
               status: "completed",
               startedAt: 1_000,
-              completedAt: 4_000,
+              completedAt: 1_800_000_004_000,
               output: [{ type: "text", text: "Done." }],
             },
           },
@@ -8791,7 +8790,28 @@ describe("useThreadSessionState", () => {
           id: "turn-1",
           status: "completed",
           startedAt: 1_000,
-          completedAt: 4_000,
+          completedAt: 1_800_000_004_000,
+        },
+      });
+    });
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 112_017,
+                cached_input_tokens: 111_232,
+                output_tokens: 319,
+                reasoning_output_tokens: 90,
+                total_tokens: 112_426,
+              },
+            },
+          },
         },
       });
     });
@@ -8824,11 +8844,11 @@ describe("useThreadSessionState", () => {
     ]);
     expect(result.current.entries.at(-1)).toMatchObject({
       id: "live-turn-usage-turn-1",
-      createdAt: 4_000,
+      createdAt: 1_800_000_004_000,
       turn: {
         id: "turn-1",
         status: "completed",
-        completedAt: 4_000,
+        completedAt: 1_800_000_004_000,
       },
     });
 
@@ -8840,7 +8860,10 @@ describe("useThreadSessionState", () => {
           params: {
             threadId: "thread-1",
             pricing: {
-              lines: [authoritativeTurnUsageLine()],
+              lines: [{
+                ...authoritativeTurnUsageLine(),
+                completedAt: 1_800_000_004_000,
+              }],
               summaries: [],
             },
           },
@@ -8855,11 +8878,11 @@ describe("useThreadSessionState", () => {
     ]);
     expect(result.current.entries.at(-1)).toMatchObject({
       id: "live-turn-usage-turn-1",
-      createdAt: 4_000,
+      createdAt: 1_800_000_004_000,
       turn: {
         id: "turn-1",
         status: "completed",
-        completedAt: 4_000,
+        completedAt: 1_800_000_004_000,
       },
       usageLine: {
         usageLineId: "codex:thread-1:turn-1:live-token-usage",

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -10,6 +10,7 @@ import type {
   AppServerThreadMessageEntry,
   AppServerThreadReviewEntry,
   NavigationThreadSummary,
+  ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -51,6 +52,36 @@ function transcriptLabels(entries: AppServerThreadEntry[]): string[] {
         ? `activity:${entry.summary}`
         : entry.type
   );
+}
+
+function authoritativeTurnUsageLine(): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 9_818_317,
+    cachedInputTokens: 24_545_792,
+    completedAt: 4_000,
+    createdAt: 1_000,
+    currency: "USD",
+    inputTokens: 25_139_426,
+    model: "gpt-5.6-sol",
+    outputCostMicros: 1_812_620,
+    outputTokens: 66_567,
+    priceStatus: "priced",
+    provider: "openai",
+    reasoningOutputTokens: 24_064,
+    scope: "turn",
+    serviceTier: "standard",
+    source: "live",
+    status: "pending",
+    threadId: "thread-1",
+    totalCostMicros: 14_005_473,
+    totalTokens: 25_205_993,
+    turnId: "turn-1",
+    turnUsageAttributed: true,
+    uncachedInputCostMicros: 2_374_536,
+    uncachedInputTokens: 593_634,
+    usageLineId: "codex:thread-1:turn-1:live-token-usage",
+  };
 }
 
 function messageEntry(params: {
@@ -8747,6 +8778,22 @@ describe("useThreadSessionState", () => {
         },
       });
     });
+    act(() => {
+      result.current.upsertLiveTranscriptEntry({
+        type: "activity",
+        id: "late-final-checks",
+        createdAt: 3_500,
+        summary: "Ran final checks",
+        status: "completed",
+        details: [],
+        turn: {
+          id: "turn-1",
+          status: "completed",
+          startedAt: 1_000,
+          completedAt: 4_000,
+        },
+      });
+    });
 
     act(() => {
       agentEventHandler?.({
@@ -8776,35 +8823,7 @@ describe("useThreadSessionState", () => {
           params: {
             threadId: "thread-1",
             pricing: {
-              lines: [
-                {
-                  backend: "codex",
-                  cachedInputCostMicros: 9_818_317,
-                  cachedInputTokens: 24_545_792,
-                  completedAt: 4_000,
-                  createdAt: 1_000,
-                  currency: "USD",
-                  inputTokens: 25_139_426,
-                  model: "gpt-5.6-sol",
-                  outputCostMicros: 1_812_620,
-                  outputTokens: 66_567,
-                  priceStatus: "priced",
-                  provider: "openai",
-                  reasoningOutputTokens: 24_064,
-                  scope: "turn",
-                  serviceTier: "standard",
-                  source: "live",
-                  status: "pending",
-                  threadId: "thread-1",
-                  totalCostMicros: 14_005_473,
-                  totalTokens: 25_205_993,
-                  turnId: "turn-1",
-                  turnUsageAttributed: true,
-                  uncachedInputCostMicros: 2_374_536,
-                  uncachedInputTokens: 593_634,
-                  usageLineId: "codex:thread-1:turn-1:live-token-usage",
-                },
-              ],
+              lines: [authoritativeTurnUsageLine()],
               summaries: [],
             },
           },
@@ -8813,6 +8832,7 @@ describe("useThreadSessionState", () => {
     });
 
     expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Ran final checks",
       "message:Done.",
       "activity:Turn usage: 593,634 uncached in · 24,545,792 cached · 66,567 out (24,064 reasoning) · $14.01 list price",
     ]);
@@ -8827,6 +8847,105 @@ describe("useThreadSessionState", () => {
       usageLine: {
         usageLineId: "codex:thread-1:turn-1:live-token-usage",
         totalCostMicros: 14_005_473,
+      },
+    });
+    const usageEntry = result.current.entries.at(-1);
+    expect(usageEntry?.type === "activity" ? usageEntry.details : []).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          label:
+            "Input: 25,139,426 tokens (593,634 uncached, 24,545,792 cached)",
+        }),
+        expect.objectContaining({
+          label: "Output: 66,567 tokens, including 24,064 reasoning",
+        }),
+        expect.objectContaining({
+          label: expect.stringContaining("Cost: $14.01 list price"),
+        }),
+      ]),
+    );
+  });
+
+  it("reconciles hydrated usage snapshots at the completed turn boundary", async () => {
+    const turn = {
+      id: "turn-1",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 4_000,
+    };
+    const response = readThreadResponse({
+      entries: [
+        {
+          type: "activity",
+          id: "live-token-usage-turn-1",
+          createdAt: 1_000,
+          summary:
+            "Latest request usage: 785 uncached in · 111,232 cached · 319 out (90 reasoning) · $0.056 list price",
+          status: "completed",
+          details: [],
+          turn,
+        },
+        {
+          type: "activity",
+          id: "late-final-checks",
+          createdAt: 3_500,
+          summary: "Ran final checks",
+          status: "completed",
+          details: [],
+          turn,
+        },
+        {
+          type: "message",
+          id: "assistant-turn-1",
+          role: "assistant",
+          phase: "final",
+          text: "Done.",
+          createdAt: 4_000,
+          turn,
+        },
+        {
+          type: "activity",
+          id: "live-turn-usage-turn-1",
+          createdAt: 3_900,
+          summary:
+            "Turn usage: 592,849 uncached in · 24,434,560 cached · 66,248 out (23,974 reasoning) · $13.95 list price",
+          status: "completed",
+          details: [],
+          turn,
+        },
+      ],
+      hasPreviousPage: false,
+    });
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread: async () => ({
+        ...response,
+        pricing: {
+          lines: [authoritativeTurnUsageLine()],
+          summaries: [],
+        },
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Ran final checks",
+      "message:Done.",
+      "activity:Turn usage: 593,634 uncached in · 24,545,792 cached · 66,567 out (24,064 reasoning) · $14.01 list price",
+    ]);
+    expect(result.current.entries.at(-1)).toMatchObject({
+      id: "live-turn-usage-turn-1",
+      createdAt: 4_000,
+      usageLine: {
+        usageLineId: "codex:thread-1:turn-1:live-token-usage",
       },
     });
   });

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -146,7 +146,14 @@ type TokenUsageBreakdown = {
 
 type TurnUsageAccumulator = {
   baseline?: TokenUsageBreakdown;
+  latestUsage?: TokenUsageBreakdown;
   turnId: string;
+  usage?: TokenUsageBreakdown;
+};
+
+type RecentlyCompletedTurnUsage = {
+  accumulator?: TurnUsageAccumulator;
+  turn: AppServerThreadTurnMetadata;
 };
 
 type ThreadSessionEntry = {
@@ -173,7 +180,7 @@ type ThreadSessionEntry = {
   // keeps only its observable revision/count so one append stays O(1).
   retainedLiveEntryCount: number;
   retainedLiveEntryVersion: number;
-  recentlyCompletedTurnUsage?: AppServerThreadTurnMetadata;
+  recentlyCompletedTurnUsage?: RecentlyCompletedTurnUsage;
   optimisticEntries: AppServerThreadEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingUsageActivityEntry?: AppServerThreadActivityEntry;
@@ -273,10 +280,12 @@ function transcriptMessagesForEntries(
 
 function mergeFinalizedUsageEntry(
   olderItems: AppServerThreadEntry[],
-  usageEntry: AppServerThreadActivityEntry
+  usageEntry: AppServerThreadActivityEntry,
+  options: { replaceCompleted?: boolean } = {},
 ): AppServerThreadEntry[] {
   const existingEntry = olderItems.find((entry) => entry.id === usageEntry.id);
   if (
+    !options.replaceCompleted &&
     existingEntry &&
     existingEntry.type === "activity" &&
     isTokenUsageActivityEntry(existingEntry) &&
@@ -417,6 +426,7 @@ function reconcileCompletedTurnUsageEntries(params: {
   activeTurnId?: string;
   entries: AppServerThreadEntry[];
   lines?: ThreadUsageLineRecord[];
+  requireExistingTurnUsage?: boolean;
 }): AppServerThreadEntry[] {
   const contentTurnById = new Map<string, AppServerThreadTurnMetadata>();
   const existingTurnUsageByTurnId = new Map<
@@ -470,6 +480,9 @@ function reconcileCompletedTurnUsageEntries(params: {
   const replacementByTurnId = new Map<string, AppServerThreadActivityEntry>();
   for (const [turnId, contentTurn] of contentTurnById) {
     const existingUsage = existingTurnUsageByTurnId.get(turnId);
+    if (params.requireExistingTurnUsage && !existingUsage) {
+      continue;
+    }
     const line = authoritativeLineByTurnId.get(turnId);
     const completedAt =
       line?.completedAt
@@ -2578,6 +2591,51 @@ function subtractTokenField(
   return Math.max(0, total - baseline);
 }
 
+function addTokenBreakdowns(
+  first: TokenUsageBreakdown,
+  second: TokenUsageBreakdown,
+): TokenUsageBreakdown | undefined {
+  const addField = (
+    firstValue: number | undefined,
+    secondValue: number | undefined,
+  ): number | undefined => {
+    if (typeof firstValue !== "number" && typeof secondValue !== "number") {
+      return undefined;
+    }
+    return (firstValue ?? 0) + (secondValue ?? 0);
+  };
+  const result: TokenUsageBreakdown = {
+    cachedInputTokens: addField(
+      first.cachedInputTokens,
+      second.cachedInputTokens,
+    ),
+    inputTokens: addField(first.inputTokens, second.inputTokens),
+    outputTokens: addField(first.outputTokens, second.outputTokens),
+    reasoningOutputTokens: addField(
+      first.reasoningOutputTokens,
+      second.reasoningOutputTokens,
+    ),
+    totalTokens: addField(first.totalTokens, second.totalTokens),
+  };
+  return hasTokenBreakdownValue(result) ? result : undefined;
+}
+
+function tokenBreakdownsEqual(
+  first: TokenUsageBreakdown | undefined,
+  second: TokenUsageBreakdown | undefined,
+): boolean {
+  if (!first || !second) {
+    return false;
+  }
+  return (
+    first.cachedInputTokens === second.cachedInputTokens
+    && first.inputTokens === second.inputTokens
+    && first.outputTokens === second.outputTokens
+    && first.reasoningOutputTokens === second.reasoningOutputTokens
+    && first.totalTokens === second.totalTokens
+  );
+}
+
 function hasTokenBreakdownValue(tokens: TokenUsageBreakdown): boolean {
   return (
     typeof tokens.cachedInputTokens === "number" ||
@@ -2621,6 +2679,7 @@ function deriveTurnUsageBaseline(params: {
 }
 
 function buildPendingTurnUsage(params: {
+  appendLatestUsage?: boolean;
   contextWindow?: ThreadContextWindowState;
   existing?: TurnUsageAccumulator;
   fastMode?: boolean;
@@ -2635,25 +2694,38 @@ function buildPendingTurnUsage(params: {
   const turnId = params.turn?.id;
   const usageRecords = readTokenUsageRecords(params.tokenUsage);
   const totalUsage = usageRecords?.totalUsage;
-  if (!turnId || !totalUsage) {
+  if (!turnId || !usageRecords) {
+    return {};
+  }
+  if (!totalUsage && !params.appendLatestUsage) {
     return {};
   }
 
   const existing = params.existing?.turnId === turnId ? params.existing : undefined;
   const baseline =
     existing?.baseline ??
-    deriveTurnUsageBaseline({
-      contextWindow: params.contextWindow,
-      latestUsage: usageRecords.latestUsage,
-      totalUsage,
-    });
+    (totalUsage
+      ? deriveTurnUsageBaseline({
+          contextWindow: params.contextWindow,
+          latestUsage: usageRecords.latestUsage,
+          totalUsage,
+        })
+      : undefined);
+  const turnUsage = totalUsage
+    ? baseline
+      ? subtractTokenBreakdowns(totalUsage, baseline)
+      : usageRecords.latestUsage ?? totalUsage
+    : params.appendLatestUsage && existing?.usage && usageRecords.latestUsage
+      ? tokenBreakdownsEqual(existing.latestUsage, usageRecords.latestUsage)
+        ? existing.usage
+        : addTokenBreakdowns(existing.usage, usageRecords.latestUsage)
+      : usageRecords.latestUsage ?? usageRecords.currentUsage;
   const accumulator: TurnUsageAccumulator = {
     turnId,
     ...(baseline ? { baseline } : {}),
+    ...(usageRecords.latestUsage ? { latestUsage: usageRecords.latestUsage } : {}),
+    ...(turnUsage ? { usage: turnUsage } : existing?.usage ? { usage: existing.usage } : {}),
   };
-  const turnUsage = baseline
-    ? subtractTokenBreakdowns(totalUsage, baseline)
-    : usageRecords.latestUsage;
   const entry = turnUsage
     ? buildTokenUsageActivityEntry({
         fastMode: params.fastMode,
@@ -6036,7 +6108,10 @@ export function useThreadSessionState(params: {
                 : current.pendingTurnUsage,
               recentlyCompletedTurnUsage:
                 completedTurnMatchesActive && completedTurn
-                  ? completedTurn
+                  ? {
+                      accumulator: current.pendingTurnUsage,
+                      turn: completedTurn,
+                    }
                   : current.recentlyCompletedTurnUsage,
               pendingUserInput: completedTurnMatchesActive
                 ? undefined
@@ -6272,7 +6347,10 @@ export function useThreadSessionState(params: {
               : current.pendingTurnUsage,
             recentlyCompletedTurnUsage:
               completedTurnMatchesActive && completedTurn
-                ? completedTurn
+                ? {
+                    accumulator: current.pendingTurnUsage,
+                    turn: completedTurn,
+                  }
                 : current.recentlyCompletedTurnUsage,
             pendingUserInput: completedTurnMatchesActive
               ? undefined
@@ -6468,7 +6546,7 @@ export function useThreadSessionState(params: {
           const resolvedTurnId =
             notificationTurnId
             ?? current.activeTurnId
-            ?? recentlyCompletedTurnUsage?.id;
+            ?? recentlyCompletedTurnUsage?.turn.id;
           const knownTurnUsage = findKnownTurnUsageMetadata(current, resolvedTurnId);
           const usageBelongsToActiveTurn = Boolean(
             current.activeTurnId &&
@@ -6479,13 +6557,13 @@ export function useThreadSessionState(params: {
             fallbackStartedAt:
               resolvedTurnId && resolvedTurnId !== current.activeTurnId
                 ? knownTurnUsage.turn?.startedAt
-                  ?? recentlyCompletedTurnUsage?.startedAt
+                  ?? recentlyCompletedTurnUsage?.turn.startedAt
                 : current.activeTurnStartedAt,
             fallbackStatus:
               knownTurnUsage.turn?.status ??
-              recentlyCompletedTurnUsage?.status ??
+              recentlyCompletedTurnUsage?.turn.status ??
               (usageBelongsToActiveTurn ? "in_progress" : "completed"),
-            turn: knownTurnUsage.turn ?? recentlyCompletedTurnUsage,
+            turn: knownTurnUsage.turn ?? recentlyCompletedTurnUsage?.turn,
           });
           const model = resolveTokenUsageModel({
             backend: event.backend,
@@ -6510,7 +6588,7 @@ export function useThreadSessionState(params: {
               resolvedTurnId !== current.activeTurnId &&
               (knownTurnUsage.isTurnUsage || recentlyCompletedTurnUsage) &&
               isTerminalTurnMetadata(
-                knownTurnUsage.turn ?? recentlyCompletedTurnUsage,
+                knownTurnUsage.turn ?? recentlyCompletedTurnUsage?.turn,
               )
           );
           const usageEntryId = knownCompletedTurnUsage
@@ -6554,6 +6632,29 @@ export function useThreadSessionState(params: {
             pendingTurnUsage = turnUsage.accumulator ?? current.pendingTurnUsage;
             usageEntry = turnUsage.entry ?? usageEntry;
           }
+          let nextRecentlyCompletedTurnUsage = current.recentlyCompletedTurnUsage;
+          const trailingCompletedTurnUsage = Boolean(
+            usageEntry && recentlyCompletedTurnUsage && turn?.id,
+          );
+          if (trailingCompletedTurnUsage && recentlyCompletedTurnUsage && turn) {
+            const completedUsage = buildPendingTurnUsage({
+              appendLatestUsage: true,
+              contextWindow: current.contextWindow,
+              existing: recentlyCompletedTurnUsage.accumulator,
+              fastMode,
+              model,
+              serviceTier,
+              tokenUsage: event.notification.params.tokenUsage,
+              turn,
+            });
+            usageEntry = completedUsage.entry ?? usageEntry;
+            nextRecentlyCompletedTurnUsage = {
+              accumulator:
+                completedUsage.accumulator
+                ?? recentlyCompletedTurnUsage.accumulator,
+              turn: recentlyCompletedTurnUsage.turn,
+            };
+          }
           if (!contextWindow && !usageEntry) {
             return current;
           }
@@ -6590,7 +6691,11 @@ export function useThreadSessionState(params: {
             optimisticEntries: usageEntry && !holdUsageUntilTurnCompletes
               ? suppressUsageEntry
                 ? current.optimisticEntries
-                : mergeFinalizedUsageEntry(current.optimisticEntries, usageEntry)
+                : mergeFinalizedUsageEntry(
+                    current.optimisticEntries,
+                    usageEntry,
+                    { replaceCompleted: trailingCompletedTurnUsage },
+                  )
               : current.optimisticEntries,
             pendingUsageActivityEntry: holdUsageUntilTurnCompletes
               ? usageEntry
@@ -6598,6 +6703,7 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: holdUsageUntilTurnCompletes
               ? pendingTurnUsage
               : current.pendingTurnUsage,
+            recentlyCompletedTurnUsage: nextRecentlyCompletedTurnUsage,
           };
         }
 
@@ -6647,6 +6753,27 @@ export function useThreadSessionState(params: {
         before: selectedPagination.previousCursor,
         limit: THREAD_HISTORY_PAGE_LIMIT,
       });
+      const hasAuthoritativeTurnUsage = olderResponse.pricing?.lines.some(
+        (line) =>
+          Boolean(line.turnId)
+          && line.scope === "turn"
+          && line.status !== "superseded"
+          && line.turnUsageAttributed !== false,
+      );
+      const reconciledOlderResponse = hasAuthoritativeTurnUsage
+        ? {
+            ...olderResponse,
+            replay: {
+              ...olderResponse.replay,
+              entries: reconcileCompletedTurnUsageEntries({
+                activeTurnId: selectedSession?.activeTurnId,
+                entries: olderResponse.replay.entries,
+                lines: olderResponse.pricing?.lines,
+                requireExistingTurnUsage: true,
+              }),
+            },
+          }
+        : olderResponse;
 
       if ((requestVersionsRef.current[threadKey] ?? 0) !== requestVersion) {
         return;
@@ -6666,7 +6793,7 @@ export function useThreadSessionState(params: {
             ...current,
             lastTouchedAt: Date.now(),
             loadingMore: false,
-            response: olderResponse,
+            response: reconciledOlderResponse,
           };
         }
 
@@ -6676,7 +6803,7 @@ export function useThreadSessionState(params: {
           appendedHistory = prependTranscriptHistoryPage({
             history: current.loadedHistory,
             index: historyIndex,
-            page: olderResponse,
+            page: reconciledOlderResponse,
             tailEntries: current.response.replay.entries,
           });
         }
@@ -6702,6 +6829,7 @@ export function useThreadSessionState(params: {
   }, [
     desktopApi,
     selectedPagination,
+    selectedSession?.activeTurnId,
     selectedSession?.loadingMore,
     thread,
     threadKey,

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -21,6 +21,7 @@ import type {
   MessagingChannelKind,
   MessagingConversationKind,
   NavigationThreadSummary,
+  ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { isAppServerBackendKind, isCelestialIconId } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
@@ -49,6 +50,7 @@ import {
   buildMcpProgressDetail,
   buildTaskMonitorUsageActivityEntry,
   buildTokenUsageActivityEntry,
+  buildTurnUsageActivityEntryFromLine,
   formatChangedFileSummary,
   getNotificationItem,
   mergeActivityDetails,
@@ -171,6 +173,7 @@ type ThreadSessionEntry = {
   // keeps only its observable revision/count so one append stays O(1).
   retainedLiveEntryCount: number;
   retainedLiveEntryVersion: number;
+  recentlyCompletedTurnUsage?: AppServerThreadTurnMetadata;
   optimisticEntries: AppServerThreadEntry[];
   pendingAssistantMessage?: AppServerThreadMessageEntry;
   pendingUsageActivityEntry?: AppServerThreadActivityEntry;
@@ -365,6 +368,206 @@ function tokenUsageActivityScope(
     return "latest-request";
   }
   return undefined;
+}
+
+function isTerminalTurnMetadata(
+  turn: AppServerThreadTurnMetadata | undefined,
+): boolean {
+  return Boolean(
+    turn
+    && (
+      turn.status === "completed"
+      || turn.status === "failed"
+      || turn.status === "cancelled"
+      || turn.status === "interrupted"
+      || typeof turn.completedAt === "number"
+    )
+  );
+}
+
+function preferTurnUsageLine(
+  current: ThreadUsageLineRecord | undefined,
+  candidate: ThreadUsageLineRecord,
+): ThreadUsageLineRecord {
+  if (!current) {
+    return candidate;
+  }
+  if (candidate.source === "live" && current.source !== "live") {
+    return candidate;
+  }
+  if (candidate.turnUsageAttributed === true && current.turnUsageAttributed !== true) {
+    return candidate;
+  }
+  const currentAt = current.completedAt ?? current.createdAt;
+  const candidateAt = candidate.completedAt ?? candidate.createdAt;
+  return candidateAt >= currentAt ? candidate : current;
+}
+
+/**
+ * Treat completed turn usage as one terminal transcript projection.
+ *
+ * The renderer can briefly own three views of the same accounting: a live
+ * per-request row, the turn-total placeholder frozen by turn/completed, and
+ * the main-process pricing line after its last async usage observation. Keep
+ * the pricing line authoritative, remove the narrower rows it supersedes, and
+ * anchor the result after every loaded entry from that turn. This stays
+ * linear in the loaded transcript and does not disturb incremental collection.
+ */
+function reconcileCompletedTurnUsageEntries(params: {
+  activeTurnId?: string;
+  entries: AppServerThreadEntry[];
+  lines?: ThreadUsageLineRecord[];
+}): AppServerThreadEntry[] {
+  const contentTurnById = new Map<string, AppServerThreadTurnMetadata>();
+  const existingTurnUsageByTurnId = new Map<
+    string,
+    AppServerThreadActivityEntry
+  >();
+
+  for (const entry of params.entries) {
+    const turnId =
+      entry.turn?.id
+      ?? (entry.type === "activity" ? entry.usageLine?.turnId : undefined);
+    if (!turnId || turnId === params.activeTurnId) {
+      continue;
+    }
+    if (
+      entry.type === "activity"
+      && tokenUsageActivityScope(entry) === "turn"
+    ) {
+      existingTurnUsageByTurnId.set(turnId, entry);
+      continue;
+    }
+    if (
+      entry.type === "activity"
+      && tokenUsageActivityScope(entry) !== undefined
+    ) {
+      continue;
+    }
+    if (entry.turn) {
+      contentTurnById.set(turnId, entry.turn);
+    }
+  }
+
+  const authoritativeLineByTurnId = new Map<string, ThreadUsageLineRecord>();
+  for (const line of params.lines ?? []) {
+    if (
+      !line.turnId
+      || line.turnId === params.activeTurnId
+      || line.scope !== "turn"
+      || line.status === "superseded"
+      || line.turnUsageAttributed === false
+      || !contentTurnById.has(line.turnId)
+    ) {
+      continue;
+    }
+    authoritativeLineByTurnId.set(
+      line.turnId,
+      preferTurnUsageLine(authoritativeLineByTurnId.get(line.turnId), line),
+    );
+  }
+
+  const replacementByTurnId = new Map<string, AppServerThreadActivityEntry>();
+  for (const [turnId, contentTurn] of contentTurnById) {
+    const existingUsage = existingTurnUsageByTurnId.get(turnId);
+    const line = authoritativeLineByTurnId.get(turnId);
+    const completedAt =
+      line?.completedAt
+      ?? contentTurn.completedAt
+      ?? existingUsage?.turn?.completedAt;
+    const terminal = typeof completedAt === "number"
+      || isTerminalTurnMetadata(contentTurn)
+      || isTerminalTurnMetadata(existingUsage?.turn);
+    if (!terminal) {
+      continue;
+    }
+
+    const startedAt =
+      contentTurn.startedAt
+      ?? line?.startedAt
+      ?? existingUsage?.turn?.startedAt;
+    const interruptedStatus =
+      contentTurn.status === "failed"
+      || contentTurn.status === "cancelled"
+      || contentTurn.status === "interrupted"
+        ? contentTurn.status
+        : existingUsage?.turn?.status === "failed"
+          || existingUsage?.turn?.status === "cancelled"
+          || existingUsage?.turn?.status === "interrupted"
+          ? existingUsage.turn.status
+          : undefined;
+    const turn: AppServerThreadTurnMetadata = {
+      ...contentTurn,
+      id: turnId,
+      status: interruptedStatus ?? "completed",
+      ...(typeof startedAt === "number" ? { startedAt } : {}),
+      ...(typeof completedAt === "number" ? { completedAt } : {}),
+      ...(typeof (contentTurn.durationMs ?? existingUsage?.turn?.durationMs) === "number"
+        ? {
+            durationMs:
+              contentTurn.durationMs ?? existingUsage?.turn?.durationMs,
+          }
+        : typeof startedAt === "number" && typeof completedAt === "number"
+          ? { durationMs: Math.max(0, completedAt - startedAt) }
+          : {}),
+    };
+    const authoritativeEntry = line
+      ? buildTurnUsageActivityEntryFromLine({ line, turn })
+      : undefined;
+    if (authoritativeEntry) {
+      replacementByTurnId.set(turnId, authoritativeEntry);
+      continue;
+    }
+    if (existingUsage) {
+      replacementByTurnId.set(
+        turnId,
+        typeof completedAt === "number"
+          ? { ...existingUsage, createdAt: completedAt, turn }
+          : { ...existingUsage, turn },
+      );
+    }
+  }
+
+  if (replacementByTurnId.size === 0) {
+    return params.entries;
+  }
+
+  const filteredEntries: AppServerThreadEntry[] = [];
+  const lastEntryIndexByTurnId = new Map<string, number>();
+  for (const entry of params.entries) {
+    const usageTurnId = entry.type === "activity"
+      ? entry.turn?.id ?? entry.usageLine?.turnId
+      : undefined;
+    const scope = entry.type === "activity"
+      ? tokenUsageActivityScope(entry)
+      : undefined;
+    if (
+      usageTurnId
+      && replacementByTurnId.has(usageTurnId)
+      && (scope === "latest-request" || scope === "total" || scope === "turn")
+    ) {
+      continue;
+    }
+
+    const index = filteredEntries.length;
+    filteredEntries.push(entry);
+    if (entry.turn?.id && replacementByTurnId.has(entry.turn.id)) {
+      lastEntryIndexByTurnId.set(entry.turn.id, index);
+    }
+  }
+
+  const replacementAfterIndex = new Map<number, AppServerThreadActivityEntry>();
+  for (const [turnId, replacement] of replacementByTurnId) {
+    const anchorIndex = lastEntryIndexByTurnId.get(turnId);
+    if (anchorIndex !== undefined) {
+      replacementAfterIndex.set(anchorIndex, replacement);
+    }
+  }
+
+  return filteredEntries.flatMap((entry, index) => {
+    const replacement = replacementAfterIndex.get(index);
+    return replacement ? [entry, replacement] : [entry];
+  });
 }
 
 function hasTurnUsageForEntry(
@@ -5831,6 +6034,10 @@ export function useThreadSessionState(params: {
               pendingTurnUsage: completedTurnMatchesActive
                 ? undefined
                 : current.pendingTurnUsage,
+              recentlyCompletedTurnUsage:
+                completedTurnMatchesActive && completedTurn
+                  ? completedTurn
+                  : current.recentlyCompletedTurnUsage,
               pendingUserInput: completedTurnMatchesActive
                 ? undefined
                 : current.pendingUserInput,
@@ -6063,6 +6270,10 @@ export function useThreadSessionState(params: {
             pendingTurnUsage: completedTurnMatchesActive
               ? undefined
               : current.pendingTurnUsage,
+            recentlyCompletedTurnUsage:
+              completedTurnMatchesActive && completedTurn
+                ? completedTurn
+                : current.recentlyCompletedTurnUsage,
             pendingUserInput: completedTurnMatchesActive
               ? undefined
               : current.pendingUserInput,
@@ -6112,6 +6323,7 @@ export function useThreadSessionState(params: {
             pendingRequest: undefined,
             pendingUsageActivityEntry: undefined,
             pendingTurnUsage: undefined,
+            recentlyCompletedTurnUsage: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
           };
@@ -6147,6 +6359,7 @@ export function useThreadSessionState(params: {
             pendingRequest: undefined,
             pendingUsageActivityEntry: undefined,
             pendingTurnUsage: undefined,
+            recentlyCompletedTurnUsage: undefined,
             pendingUserInput: undefined,
             pendingStatusText: undefined,
           };
@@ -6248,21 +6461,31 @@ export function useThreadSessionState(params: {
             typeof event.notification.params.turnId === "string"
               ? event.notification.params.turnId
               : undefined;
-          const knownTurnUsage = findKnownTurnUsageMetadata(current, notificationTurnId);
+          const recentlyCompletedTurnUsage =
+            !notificationTurnId && !current.activeTurnId
+              ? current.recentlyCompletedTurnUsage
+              : undefined;
+          const resolvedTurnId =
+            notificationTurnId
+            ?? current.activeTurnId
+            ?? recentlyCompletedTurnUsage?.id;
+          const knownTurnUsage = findKnownTurnUsageMetadata(current, resolvedTurnId);
           const usageBelongsToActiveTurn = Boolean(
             current.activeTurnId &&
               (!notificationTurnId || notificationTurnId === current.activeTurnId)
           );
           const turn = buildTurnMetadata({
-            fallbackId: notificationTurnId ?? current.activeTurnId,
+            fallbackId: resolvedTurnId,
             fallbackStartedAt:
-              notificationTurnId && notificationTurnId !== current.activeTurnId
+              resolvedTurnId && resolvedTurnId !== current.activeTurnId
                 ? knownTurnUsage.turn?.startedAt
+                  ?? recentlyCompletedTurnUsage?.startedAt
                 : current.activeTurnStartedAt,
             fallbackStatus:
               knownTurnUsage.turn?.status ??
+              recentlyCompletedTurnUsage?.status ??
               (usageBelongsToActiveTurn ? "in_progress" : "completed"),
-            turn: knownTurnUsage.turn,
+            turn: knownTurnUsage.turn ?? recentlyCompletedTurnUsage,
           });
           const model = resolveTokenUsageModel({
             backend: event.backend,
@@ -6283,10 +6506,12 @@ export function useThreadSessionState(params: {
             threadId: notificationThreadId,
           });
           const knownCompletedTurnUsage = Boolean(
-            notificationTurnId &&
-              notificationTurnId !== current.activeTurnId &&
-              knownTurnUsage.isTurnUsage &&
-              knownTurnUsage.turn?.status === "completed"
+            resolvedTurnId &&
+              resolvedTurnId !== current.activeTurnId &&
+              (knownTurnUsage.isTurnUsage || recentlyCompletedTurnUsage) &&
+              isTerminalTurnMetadata(
+                knownTurnUsage.turn ?? recentlyCompletedTurnUsage,
+              )
           );
           const usageEntryId = knownCompletedTurnUsage
             ? `live-turn-usage-${turn?.id ?? notificationThreadId}`
@@ -6646,6 +6871,7 @@ export function useThreadSessionState(params: {
         interacted: Boolean(turnId) || current.interacted,
         lastTouchedAt: Date.now(),
         pendingTurnUsage: undefined,
+        recentlyCompletedTurnUsage: undefined,
       }));
     },
     [threadKey, updateSession]
@@ -6897,6 +7123,18 @@ export function useThreadSessionState(params: {
     ),
     [selectedSession?.response?.replay.entries, visibleOptimisticEntries],
   );
+  const reconciledTailEntries = useMemo(
+    () => reconcileCompletedTurnUsageEntries({
+      activeTurnId: selectedSession?.activeTurnId,
+      entries: mergedTailEntries,
+      lines: selectedSession?.response?.pricing?.lines,
+    }),
+    [
+      mergedTailEntries,
+      selectedSession?.activeTurnId,
+      selectedSession?.response?.pricing?.lines,
+    ],
+  );
   const mergedTailMessages = useMemo(
     () => mergeTranscriptMessages(
       selectedSession?.response?.replay.messages ?? [],
@@ -6910,12 +7148,12 @@ export function useThreadSessionState(params: {
     () => createTranscriptReviewPresentation({
       history: selectedSession?.loadedHistory,
       index: selectedHistoryIndex,
-      tailEntries: mergedTailEntries,
+      tailEntries: reconciledTailEntries,
       tailMessages: mergedTailMessages,
     }),
     [
-      mergedTailEntries,
       mergedTailMessages,
+      reconciledTailEntries,
       selectedHistoryIndex,
       selectedSession?.loadedHistory,
     ],


### PR DESCRIPTION
## Summary

- I consolidate completed turn accounting into one terminal transcript row instead of leaving a frozen turn total beside a trailing per-request row.
- I reconcile that row from the main-process pricing ledger, use the turn completion timestamp, and anchor it after all loaded content for the turn.
- I preserve incremental transcript performance by limiting reconciliation to the bounded tail, reconciling each older page once at ingestion, and associating turnless trailing usage with a bounded recently completed turn.
- I keep attributed live turn totals authoritative when hydration exposes only `latest-request` or thread-cumulative `total` rows, while still refreshing shared turn timing and settings.
- I append request-only late usage idempotently in both the renderer and pricing ledger, so a duplicate notification cannot double-count the turn.
- I added regression coverage for the live completion race, turnless main-process accounting, hydration supersession, older history pages, expanded cost details, placement, and the retained-history scan budget.

## Verification

- `pnpm lint`
- `pnpm test` (661 files passed; 9,764 tests passed; 6 skipped)
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts` (780 tests passed)
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts` (198 tests passed)
- `pnpm test apps/desktop/src/main/__tests__/thread-replay-pagination.test.ts apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx` (312 tests passed)

## Notes

- The regression fixture mirrors the reported split exactly: `$13.95` plus a trailing `$0.056` request now renders as the pricing ledger's single `$14.01` turn total.
- All branch commits have valid SSH signatures.
