### PR TITLE
perf(desktop): bound Git working-state subprocesses

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -610,6 +610,36 @@ const refreshThreadGitWorkingStates = vi.fn(
     return { scheduledCount: worktreePaths.length };
   },
 );
+const pendingFocusedWorkingStatePaths = new Set<string>();
+const scheduleWorktreeGitWorkingStateRefresh = vi.fn((params: {
+  acceptedPushedCommitShas?: string[];
+  worktreePath: string;
+}): boolean => {
+  if (pendingFocusedWorkingStatePaths.has(params.worktreePath)) {
+    return false;
+  }
+  pendingFocusedWorkingStatePaths.add(params.worktreePath);
+  void (async () => {
+    try {
+      for await (const entry of readWorktreeWorkingStateEntries(
+        [params.worktreePath],
+        {
+          acceptedPushedCommitShasByWorktreePath: {
+            [params.worktreePath]: params.acceptedPushedCommitShas,
+          },
+        },
+      )) {
+        await rememberThreadGitWorkingStateCacheEntry({
+          ...entry,
+          fetchedAt: Date.now(),
+        });
+      }
+    } finally {
+      pendingFocusedWorkingStatePaths.delete(params.worktreePath);
+    }
+  })();
+  return true;
+});
 // Hold the result until the test releases it, so two concurrent IPC requests
 // overlap and exercise the in-flight dedup.
 let releaseEditCommitResolve: (() => void) | undefined;
@@ -1057,6 +1087,7 @@ vi.mock("../app-server/backend-registry", () => {
     readWorktreeWorkingStateEntries,
     hydrateThreadGitWorkingStates,
     refreshThreadGitWorkingStates,
+    scheduleWorktreeGitWorkingStateRefresh,
     getThreadGitWorkingStateCache,
     loadThreadGitWorkingStateCache,
     rememberThreadGitWorkingStateCacheEntry,
@@ -1198,6 +1229,8 @@ describe("app server ipc", () => {
     );
     refreshThreadGitWorkingStates.mockClear();
     threadGitWorkingStateRefreshRound = undefined;
+    scheduleWorktreeGitWorkingStateRefresh.mockClear();
+    pendingFocusedWorkingStatePaths.clear();
     threadGitWorkingStateCache.clear();
     threadGitWorkingStateCacheLoaded = false;
     getThreadGitWorkingStateCache.mockClear();

--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -20,6 +20,10 @@ import type {
   SetThreadParentRequest,
   ThreadGitWorkingState,
 } from "@pwragent/shared";
+import {
+  BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+  selectStaleWorktreeWorkingStatePaths,
+} from "../app-server/thread-working-state-refresh-policy";
 import { resolvePwragentRoot } from "../profile";
 
 // `resolveScratchProjectsRoots` anchors the first two workspace roots at the
@@ -531,6 +535,81 @@ const readWorktreeWorkingStateEntries = vi.fn(
     })(),
 );
 const invalidateWorktreeWorkingState = vi.fn((_worktreePath?: string) => undefined);
+let threadGitWorkingStateRefreshRound: Promise<void> | undefined;
+function resolveWorkingStatePath(
+  thread: AppServerThreadSummary,
+): string | undefined {
+  const projectKey = thread.projectKey?.trim();
+  if (projectKey) {
+    return projectKey;
+  }
+  for (const directory of thread.linkedDirectories) {
+    const worktreePath = directory.worktreePath?.trim();
+    if (worktreePath) {
+      return worktreePath;
+    }
+  }
+  return thread.linkedDirectories.find(
+    (directory) => directory.kind === "local" && directory.path.trim(),
+  )?.path.trim();
+}
+
+const refreshThreadGitWorkingStates = vi.fn(
+  async (threads: AppServerThreadSummary[]): Promise<{ scheduledCount: number }> => {
+    await loadThreadGitWorkingStateCache();
+    if (threadGitWorkingStateRefreshRound) {
+      return { scheduledCount: 0 };
+    }
+    const worktreePaths = selectStaleWorktreeWorkingStatePaths({
+      cache: threadGitWorkingStateCache,
+      limit: BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+      worktreePaths: threads.flatMap((thread) => {
+        const worktreePath = resolveWorkingStatePath(thread);
+        return worktreePath ? [worktreePath] : [];
+      }),
+    });
+    if (worktreePaths.length === 0) {
+      return { scheduledCount: 0 };
+    }
+
+    const overlayStates = await getThreadOverlayStates() as Record<
+      string,
+      { detachedPrs?: PrSummary[] }
+    >;
+    const acceptedPushedCommitShasByWorktreePath = Object.fromEntries(
+      worktreePaths.map((worktreePath) => {
+        const commitShas = threads
+          .filter((thread) => resolveWorkingStatePath(thread) === worktreePath)
+          .flatMap((thread) => [
+            ...((thread as AppServerThreadSummary & { prs?: PrSummary[] }).prs ?? []),
+            ...(overlayStates[thread.id]?.detachedPrs ?? []),
+          ])
+          .filter((pr) => pr.lifecycleState === "merged" || pr.state === "merged")
+          .flatMap((pr) => pr.commitShas ?? [])
+          .map((sha) => sha.trim().toLowerCase())
+          .filter((sha) => /^[0-9a-f]{40}$/.test(sha));
+        return [worktreePath, [...new Set(commitShas)].sort()];
+      }),
+    );
+    const round = (async () => {
+      for await (const entry of readWorktreeWorkingStateEntries(worktreePaths, {
+        acceptedPushedCommitShasByWorktreePath,
+      })) {
+        await rememberThreadGitWorkingStateCacheEntry({
+          ...entry,
+          fetchedAt: Date.now(),
+        });
+      }
+    })();
+    threadGitWorkingStateRefreshRound = round;
+    void round.finally(() => {
+      if (threadGitWorkingStateRefreshRound === round) {
+        threadGitWorkingStateRefreshRound = undefined;
+      }
+    });
+    return { scheduledCount: worktreePaths.length };
+  },
+);
 // Hold the result until the test releases it, so two concurrent IPC requests
 // overlap and exercise the in-flight dedup.
 let releaseEditCommitResolve: (() => void) | undefined;
@@ -977,6 +1056,7 @@ vi.mock("../app-server/backend-registry", () => {
     invalidateDirectoryStatus,
     readWorktreeWorkingStateEntries,
     hydrateThreadGitWorkingStates,
+    refreshThreadGitWorkingStates,
     getThreadGitWorkingStateCache,
     loadThreadGitWorkingStateCache,
     rememberThreadGitWorkingStateCacheEntry,
@@ -1116,6 +1196,8 @@ describe("app server ipc", () => {
     hydrateThreadGitWorkingStates.mockImplementation(
       async (threads: AppServerThreadSummary[]) => threads,
     );
+    refreshThreadGitWorkingStates.mockClear();
+    threadGitWorkingStateRefreshRound = undefined;
     threadGitWorkingStateCache.clear();
     threadGitWorkingStateCacheLoaded = false;
     getThreadGitWorkingStateCache.mockClear();
@@ -7280,11 +7362,7 @@ describe("app server ipc", () => {
     }
   });
 
-  it("reaches past a batch that is still in flight", async () => {
-    // In-flight worktrees are excluded before the cap, not after. Dropping
-    // them afterwards let a full batch of already-probing paths consume the
-    // cap and schedule nothing, so the stale one behind them waited for a
-    // round that had no reason to come.
+  it("coalesces navigation while a registry fleet batch is still in flight", async () => {
     const { NAVIGATION_SNAPSHOT_CHANNEL } = await import("../../shared/ipc");
     const threads = Array.from({ length: 9 }, (_unused, index) => ({
       id: `thread-${index}`,
@@ -7320,20 +7398,28 @@ describe("app server ipc", () => {
         threads.slice(0, 8).map((thread) => thread.projectKey),
       );
 
-      // Nothing has been written yet, so every worktree is still stale and a
-      // naive selection would pick the same first eight again.
+      // Nothing has been written yet, but serving-path frequency must not
+      // rotate into another fleet batch while the global round is active.
+      await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
+      expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(1);
+
+      releaseFirstProbe?.();
+      await vi.waitFor(() => {
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(8);
+      });
+
+      // A later snapshot starts the next bounded batch, so the tail still
+      // converges without overlapping automatic rounds.
       await handlers.get(NAVIGATION_SNAPSHOT_CHANNEL)?.({}, {});
       await vi.waitFor(() => {
         expect(readWorktreeWorkingStateEntries).toHaveBeenCalledTimes(2);
+        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(9);
       });
       expect(readWorktreeWorkingStateEntries.mock.calls[1]?.[0]).toEqual([
         threads[8]!.projectKey,
       ]);
     } finally {
       releaseFirstProbe?.();
-      await vi.waitFor(() => {
-        expect(writeThreadGitWorkingStateCacheEntry).toHaveBeenCalledTimes(9);
-      });
     }
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -3459,6 +3459,97 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("queues one focused refresh behind an automatic probe for the same worktree", async () => {
+    const worktreePath = "/worktrees/PwrAgnt";
+    const firstAcceptedPushedCommitSha = "a".repeat(40);
+    const latestAcceptedPushedCommitSha = "b".repeat(40);
+    const automaticState = { ...sampleGitWorkingState, dirtyFiles: 1 };
+    const focusedState = { ...sampleGitWorkingState, dirtyFiles: 2 };
+    let releaseAutomaticProbe: (() => void) | undefined;
+    const automaticProbeReleased = new Promise<void>((resolve) => {
+      releaseAutomaticProbe = resolve;
+    });
+    let activeProbes = 0;
+    let maxActiveProbes = 0;
+    const readWorkingStateEntries = vi.fn((paths: string[]) =>
+      (async function* () {
+        const call = readWorkingStateEntries.mock.calls.length;
+        activeProbes += 1;
+        maxActiveProbes = Math.max(maxActiveProbes, activeProbes);
+        try {
+          if (call === 1) {
+            await automaticProbeReleased;
+          }
+          yield {
+            worktreePath: paths[0]!,
+            gitWorkingState: call === 1 ? automaticState : focusedState,
+          };
+        } finally {
+          activeProbes -= 1;
+        }
+      })(),
+    );
+    const overlayStore = {
+      ...createOverlayStoreMock(),
+      readThreadGitWorkingStateCache: vi.fn(async () => ({})),
+      writeThreadGitWorkingStateCacheEntry: vi.fn(async () => undefined),
+    };
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      gitWorkingStateService: {
+        readWorkingStateEntries,
+      } as unknown as GitWorkingStateService,
+      overlayStore,
+    });
+
+    try {
+      await expect(
+        registry.refreshThreadGitWorkingStates([
+          multiProjectThread({ worktreePath }),
+        ]),
+      ).resolves.toEqual({ scheduledCount: 1 });
+      await expectEventually(
+        async () => readWorkingStateEntries.mock.calls.length,
+        1,
+      );
+
+      expect(registry.scheduleWorktreeGitWorkingStateRefresh({
+        worktreePath,
+        acceptedPushedCommitShas: [firstAcceptedPushedCommitSha],
+      })).toBe(true);
+      expect(registry.scheduleWorktreeGitWorkingStateRefresh({
+        worktreePath,
+        acceptedPushedCommitShas: [latestAcceptedPushedCommitSha],
+      })).toBe(false);
+      expect(readWorkingStateEntries).toHaveBeenCalledTimes(1);
+
+      releaseAutomaticProbe?.();
+      await expectEventually(
+        async () => readWorkingStateEntries.mock.calls.length,
+        2,
+      );
+      await expectEventually(
+        async () => overlayStore.writeThreadGitWorkingStateCacheEntry.mock.calls.length,
+        2,
+      );
+
+      expect(maxActiveProbes).toBe(1);
+      expect(readWorkingStateEntries.mock.calls[1]).toEqual([
+        [worktreePath],
+        {
+          acceptedPushedCommitShasByWorktreePath: {
+            [worktreePath]: [latestAcceptedPushedCommitSha],
+          },
+        },
+      ]);
+      expect(registry.getThreadGitWorkingStateCache().get(worktreePath))
+        .toMatchObject({ gitWorkingState: focusedState });
+    } finally {
+      releaseAutomaticProbe?.();
+      await registry.close();
+    }
+  });
+
   it("caps a background working-state round and rotates the oldest probe forward", async () => {
     // Navigation hands over a stable thread order. Without rotation the same
     // prefix would win every round and the tail would never converge.

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -98,6 +98,7 @@ import {
   type CodexEnvironmentCommandRunner,
 } from "../app-server/codex-environment-runtime";
 import { GitDirectoryService } from "../app-server/git-directory-service";
+import gitSubprocessBudgets from "./fixtures/git-subprocess-budgets.json";
 import type { ProviderThreadSnapshot } from "../app-server/provider-thread-snapshot-store";
 import type { GitWorkingStateService } from "../app-server/git-working-state-service";
 import type { OverlayStoreLike } from "../state/overlay-store-sqlite";
@@ -3565,7 +3566,7 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
-  it("coalesces a background working-state probe already in flight", async () => {
+  it("keeps repeated navigation inside the automatic fleet-round budget", async () => {
     const worktreePath = "/worktrees/PwrAgnt";
     let releaseProbe: (() => void) | undefined;
     const probeReleased = new Promise<void>((resolve) => {
@@ -3591,29 +3592,40 @@ describe("DesktopBackendRegistry", () => {
       } as unknown as GitWorkingStateService,
       overlayStore,
     });
-    const threads = [
-      multiProjectThread({ worktreePath }),
-      multiProjectThread({ worktreePath: `${worktreePath}-2` }),
-    ];
+    const worktreePaths = Array.from(
+      { length: gitSubprocessBudgets.automaticFleet.worktreeCount },
+      (_unused, index) => `${worktreePath}-${index}`,
+    );
+    const threads = worktreePaths.map((path) =>
+      multiProjectThread({ worktreePath: path }),
+    );
+    expect(Math.ceil(
+      worktreePaths.length / BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+    )).toBe(gitSubprocessBudgets.automaticFleet.baselineRoundsStarted);
 
     try {
       await expect(
-        registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
-      ).resolves.toEqual({ scheduledCount: 1 });
-      // The first worktree is in flight, so a capped round has to reach past
-      // it rather than re-selecting it and scheduling nothing.
-      await expect(
-        registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
-      ).resolves.toEqual({ scheduledCount: 1 });
-      await expect(
-        registry.refreshThreadGitWorkingStates(threads, { limit: 1 }),
-      ).resolves.toEqual({ scheduledCount: 0 });
+        registry.refreshThreadGitWorkingStates(threads),
+      ).resolves.toEqual({
+        scheduledCount: BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+      });
+      for (
+        let request = 1;
+        request < gitSubprocessBudgets.automaticFleet.navigationRequestsWhileInFlight;
+        request += 1
+      ) {
+        await expect(
+          registry.refreshThreadGitWorkingStates(threads),
+        ).resolves.toEqual({ scheduledCount: 0 });
+      }
       await expectEventually(
         async () => readWorkingStateEntries.mock.calls.length,
-        2,
+        gitSubprocessBudgets.automaticFleet.maxRoundsStarted,
       );
       expect(readWorkingStateEntries.mock.calls.map(([paths]) => paths))
-        .toEqual([[worktreePath], [`${worktreePath}-2`]]);
+        .toEqual([
+          worktreePaths.slice(0, BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE),
+        ]);
     } finally {
       releaseProbe?.();
       await registry.close();

--- a/apps/desktop/src/main/__tests__/fixtures/git-subprocess-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/git-subprocess-budgets.json
@@ -1,0 +1,13 @@
+{
+  "workingStateProbe": {
+    "candidateCount": 24,
+    "baselineGitCommands": 105,
+    "maxGitCommands": 10
+  },
+  "automaticFleet": {
+    "worktreeCount": 100,
+    "navigationRequestsWhileInFlight": 100,
+    "baselineRoundsStarted": 13,
+    "maxRoundsStarted": 1
+  }
+}

--- a/apps/desktop/src/main/__tests__/git-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/git-discovery.test.ts
@@ -223,7 +223,7 @@ describe("Git discovery", () => {
         ) => void,
       ) => {
         if (
-          command === "git"
+          (command === "git" || command === "/custom/bin/git")
           && args[0] === "--version"
           && options.env?.PATH === hydratedEnv.PATH
           && options.env?.ELECTRON_RENDERER_URL === undefined
@@ -242,6 +242,55 @@ describe("Git discovery", () => {
 
     await expect(resolveGitExecutable(hydratedEnv)).resolves.toBe(
       "/custom/bin/git",
+    );
+  });
+
+  it.skipIf(process.platform === "win32")("skips an executable PATH directory named git", async () => {
+    const directoryError = new Error("permission denied") as NodeJS.ErrnoException;
+    directoryError.code = "EACCES";
+    const missingError = new Error("missing") as NodeJS.ErrnoException;
+    missingError.code = "ENOENT";
+    const env = { PATH: "/bad/bin:/good/bin" } as NodeJS.ProcessEnv;
+    execFileMock.mockImplementation(
+      (
+        command: string,
+        args: string[],
+        _options: { env?: NodeJS.ProcessEnv },
+        callback: (
+          error: Error | null,
+          result?: { stdout: string; stderr?: string },
+        ) => void,
+      ) => {
+        if (command === "git" && args[0] === "--version") {
+          // PATH lookup skips the directory and reaches the real Git.
+          callback(null, { stdout: "git version 2.49.0\n" });
+          return;
+        }
+        if (command === "/bad/bin/git") {
+          callback(directoryError);
+          return;
+        }
+        if (command === "/good/bin/git") {
+          callback(null, { stdout: "git version 2.49.0\n" });
+          return;
+        }
+        callback(missingError);
+      },
+    );
+    const { resolveGitExecutable } = await import("../app-server/git-executable");
+
+    await expect(resolveGitExecutable(env)).resolves.toBe("/good/bin/git");
+    expect(execFileMock).toHaveBeenCalledWith(
+      "/bad/bin/git",
+      ["--version"],
+      expect.any(Object),
+      expect.any(Function),
+    );
+    expect(execFileMock).toHaveBeenCalledWith(
+      "/good/bin/git",
+      ["--version"],
+      expect.any(Object),
+      expect.any(Function),
     );
   });
 

--- a/apps/desktop/src/main/__tests__/git-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/git-discovery.test.ts
@@ -138,6 +138,12 @@ describe("Git discovery", () => {
       PATH: "/nix/profile/bin:/usr/bin",
       ELECTRON_RENDERER_URL: "http://localhost:5175",
     } as NodeJS.ProcessEnv;
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/nix/profile/bin/git") {
+        return undefined;
+      }
+      throw missingError;
+    });
     execFileMock.mockImplementation(
       (
         command: string,
@@ -149,7 +155,7 @@ describe("Git discovery", () => {
         ) => void,
       ) => {
         if (
-          command === "git"
+          (command === "git" || command === "/nix/profile/bin/git")
           && options.env?.PATH === hydratedEnv.PATH
           && options.env?.ELECTRON_RENDERER_URL === undefined
         ) {
@@ -178,7 +184,7 @@ describe("Git discovery", () => {
       expect.any(Function),
     );
     expect(execFileMock).toHaveBeenCalledWith(
-      "git",
+      "/nix/profile/bin/git",
       ["-C", "/repo", "status", "--short"],
       expect.objectContaining({
         env: expect.objectContaining({ PATH: hydratedEnv.PATH }),
@@ -200,6 +206,12 @@ describe("Git discovery", () => {
       PATH: "/custom/bin:/usr/bin:/bin",
       ELECTRON_RENDERER_URL: "http://localhost:5175",
     } as NodeJS.ProcessEnv;
+    accessMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "/custom/bin/git") {
+        return undefined;
+      }
+      throw missingError;
+    });
     execFileMock.mockImplementation(
       (
         command: string,
@@ -228,7 +240,9 @@ describe("Git discovery", () => {
       "Git executable unavailable",
     );
 
-    await expect(resolveGitExecutable(hydratedEnv)).resolves.toBe("git");
+    await expect(resolveGitExecutable(hydratedEnv)).resolves.toBe(
+      "/custom/bin/git",
+    );
   });
 
   it.skipIf(process.platform === "win32")("retries app-server git resolution after an initial failure", async () => {

--- a/apps/desktop/src/main/__tests__/git-executable.test.ts
+++ b/apps/desktop/src/main/__tests__/git-executable.test.ts
@@ -1,0 +1,16 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { resolveGitExecutable } from "../app-server/git-executable";
+
+describe("resolveGitExecutable", () => {
+  it("caches an absolute executable instead of a PATH command", async () => {
+    const env = { ...process.env };
+
+    const first = await resolveGitExecutable(env);
+    const second = await resolveGitExecutable(env);
+
+    expect(path.isAbsolute(first)).toBe(true);
+    expect(second).toBe(first);
+    expect(path.basename(first).toLowerCase()).toMatch(/^git(?:\.exe)?$/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-working-state-service.test.ts
@@ -8,6 +8,7 @@ import {
   GitWorkingStateService,
   probeWorktreeWorkingState,
 } from "../app-server/git-working-state-service";
+import gitSubprocessBudgets from "./fixtures/git-subprocess-budgets.json";
 
 const execFileAsync = promisify(execFile);
 
@@ -286,6 +287,63 @@ describe("probeWorktreeWorkingState", () => {
       baseAheadCommitCount: 5,
       isBehindBase: true,
     });
+  });
+
+  it("keeps cold base inference inside the fixed Git subprocess budget", async () => {
+    const headCommit = "a".repeat(40);
+    const baseCommit = "b".repeat(40);
+    const candidateNames = [
+      "main",
+      "master",
+      "develop",
+      "development",
+      "trunk",
+      ...Array.from(
+        { length: gitSubprocessBudgets.workingStateProbe.candidateCount - 5 },
+        (_unused, index) => `release/${index}`,
+      ),
+    ];
+    const { runGit, calls } = fakeGit((args) => {
+      if (args.includes("--numstat")) return "";
+      if (args.includes("status")) return "";
+      if (args[args.length - 1] === "remote") return "origin\n";
+      if (args.includes("rev-parse") && args.includes("--verify")) {
+        return `${headCommit}\n`;
+      }
+      if (args.includes("rev-parse") && args.includes("--abbrev-ref")) {
+        return "feature/fixed-budget\n";
+      }
+      if (args.includes("config")) return "";
+      if (args.includes("symbolic-ref")) return "origin/main\n";
+      if (args.includes("for-each-ref")) {
+        return candidateNames.map((name, index) => {
+          const ahead = name === "release/0" ? 1 : index + 10;
+          const behind = name === "release/0" ? 2 : index + 20;
+          return `origin/${name}\0${String(index + 1).padStart(40, "0")}\0${ahead} ${behind}`;
+        }).join("\n");
+      }
+      if (args.includes("merge-base")) return `${baseCommit}\n`;
+      if (args.includes("rev-list") && args.includes("--count")) return "0\n";
+      return undefined;
+    });
+
+    const state = await probeWorktreeWorkingState("/repo/wt", { runGit });
+
+    expect(state).toMatchObject({
+      baseBranch: "release/0",
+      baseCommit,
+      baseBehindCommitCount: 1,
+      baseAheadCommitCount: 2,
+    });
+    expect(candidateNames).toHaveLength(
+      gitSubprocessBudgets.workingStateProbe.candidateCount,
+    );
+    expect(
+      3 + 5 + (candidateNames.length * 4) + 1,
+    ).toBe(gitSubprocessBudgets.workingStateProbe.baselineGitCommands);
+    expect(calls).toHaveLength(
+      gitSubprocessBudgets.workingStateProbe.maxGitCommands,
+    );
   });
 
   it("does not infer a release base for an attached default branch checkout", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8095,7 +8095,19 @@ export class DesktopBackendRegistry {
     | undefined;
   private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
-  private readonly pendingThreadGitWorkingStateKeys = new Set<string>();
+  private readonly pendingThreadGitWorkingStateByPath = new Map<
+    string,
+    Promise<void>
+  >();
+  private readonly focusedThreadGitWorkingStateRefreshByPath = new Map<
+    string,
+    {
+      acceptedPushedCommitShas: string[] | undefined;
+      rerunRequested: boolean;
+      running: boolean;
+    }
+  >();
+  private readonly focusedThreadGitWorkingStateRefreshes = new Set<Promise<void>>();
   private threadGitWorkingStateRefreshRound: Promise<void> | undefined;
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestDetachHandler:
@@ -12438,16 +12450,13 @@ export class DesktopBackendRegistry {
     // Exclude in-flight worktrees before the cap, not after: a round whose
     // whole batch is already in flight must still reach the paths behind it.
     const worktreePaths = this.selectStaleThreadWorkingStatePaths(threads, {
-      exclude: this.pendingThreadGitWorkingStateKeys,
+      exclude: new Set(this.pendingThreadGitWorkingStateByPath.keys()),
       limit: options.limit ?? BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
     });
     if (worktreePaths.length === 0) {
       return { scheduledCount: 0 };
     }
 
-    for (const worktreePath of worktreePaths) {
-      this.pendingThreadGitWorkingStateKeys.add(worktreePath);
-    }
     // Carry only the threads behind this batch. The round outlives the
     // snapshot that scheduled it, and retaining every thread would hold a full
     // navigation snapshot for as long as the Git fleet runs.
@@ -12460,8 +12469,16 @@ export class DesktopBackendRegistry {
       probedThreads,
       worktreePaths,
     );
+    for (const worktreePath of worktreePaths) {
+      this.pendingThreadGitWorkingStateByPath.set(worktreePath, round);
+    }
     this.threadGitWorkingStateRefreshRound = round;
     void round.finally(() => {
+      for (const worktreePath of worktreePaths) {
+        if (this.pendingThreadGitWorkingStateByPath.get(worktreePath) === round) {
+          this.pendingThreadGitWorkingStateByPath.delete(worktreePath);
+        }
+      }
       if (this.threadGitWorkingStateRefreshRound === round) {
         this.threadGitWorkingStateRefreshRound = undefined;
       }
@@ -12479,10 +12496,100 @@ export class DesktopBackendRegistry {
         error: error instanceof Error ? error.message : String(error),
         worktreePaths,
       });
-    } finally {
-      for (const worktreePath of worktreePaths) {
-        this.pendingThreadGitWorkingStateKeys.delete(worktreePath);
+    }
+  }
+
+  /**
+   * Schedule one focused, user-triggered, or event-triggered refresh through
+   * the same per-worktree ownership map as the automatic fleet. If an older
+   * automatic probe is active, queue exactly one follow-up instead of racing
+   * it. Later requests update a queued probe, or request one bounded rerun
+   * when the focused probe has already started.
+   */
+  scheduleWorktreeGitWorkingStateRefresh(params: {
+    acceptedPushedCommitShas?: string[];
+    worktreePath: string;
+  }): boolean {
+    const worktreePath = params.worktreePath.trim();
+    if (this.closed || !worktreePath) {
+      return false;
+    }
+    const existingFocused =
+      this.focusedThreadGitWorkingStateRefreshByPath.get(worktreePath);
+    if (existingFocused) {
+      existingFocused.acceptedPushedCommitShas =
+        params.acceptedPushedCommitShas;
+      if (existingFocused.running) {
+        existingFocused.rerunRequested = true;
       }
+      return false;
+    }
+
+    const previous = this.pendingThreadGitWorkingStateByPath.get(worktreePath);
+    const focused = {
+      acceptedPushedCommitShas: params.acceptedPushedCommitShas,
+      rerunRequested: false,
+      running: false,
+    };
+    this.focusedThreadGitWorkingStateRefreshByPath.set(worktreePath, focused);
+    let refresh: Promise<void>;
+    refresh = (async () => {
+      if (previous) {
+        await previous;
+      }
+      do {
+        if (this.closed) {
+          return;
+        }
+        focused.rerunRequested = false;
+        focused.running = true;
+        try {
+          await this.probeFocusedWorktreeGitWorkingState(
+            worktreePath,
+            focused.acceptedPushedCommitShas,
+          );
+        } catch (error) {
+          backendRegistryLog.warn("focused working-state refresh failed", {
+            error: error instanceof Error ? error.message : String(error),
+            worktreePath,
+          });
+        } finally {
+          focused.running = false;
+        }
+      } while (focused.rerunRequested);
+    })().finally(() => {
+      if (
+        this.focusedThreadGitWorkingStateRefreshByPath.get(worktreePath)
+        === focused
+      ) {
+        this.focusedThreadGitWorkingStateRefreshByPath.delete(worktreePath);
+      }
+      if (this.pendingThreadGitWorkingStateByPath.get(worktreePath) === refresh) {
+        this.pendingThreadGitWorkingStateByPath.delete(worktreePath);
+      }
+      this.focusedThreadGitWorkingStateRefreshes.delete(refresh);
+    });
+    this.pendingThreadGitWorkingStateByPath.set(worktreePath, refresh);
+    this.focusedThreadGitWorkingStateRefreshes.add(refresh);
+    return true;
+  }
+
+  private async probeFocusedWorktreeGitWorkingState(
+    worktreePath: string,
+    acceptedPushedCommitShas: string[] | undefined,
+  ): Promise<void> {
+    for await (const entry of this.gitWorkingStateService.readWorkingStateEntries(
+      [worktreePath],
+      {
+        acceptedPushedCommitShasByWorktreePath: {
+          [worktreePath]: acceptedPushedCommitShas,
+        },
+      },
+    )) {
+      await this.rememberThreadGitWorkingStateCacheEntry({
+        ...entry,
+        fetchedAt: Date.now(),
+      });
     }
   }
 
@@ -20754,6 +20861,7 @@ export class DesktopBackendRegistry {
     if (this.threadGitWorkingStateRefreshRound) {
       await this.threadGitWorkingStateRefreshRound;
     }
+    await Promise.all([...this.focusedThreadGitWorkingStateRefreshes]);
     this.workingStateByWorktree.clear();
     this.workingStateCacheLoad = undefined;
     if (this.taskMonitorWatchdogTimer) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8096,7 +8096,7 @@ export class DesktopBackendRegistry {
   private directoryGitStatusWriter: DirectoryGitStatusWriter | undefined;
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
   private readonly pendingThreadGitWorkingStateKeys = new Set<string>();
-  private readonly threadGitWorkingStateRefreshRounds = new Set<Promise<void>>();
+  private threadGitWorkingStateRefreshRound: Promise<void> | undefined;
   private threadPrAutoDispatchHandler: ThreadPrAutoDispatchHandler | undefined;
   private threadPullRequestDetachHandler:
     | ThreadPullRequestDetachHandler
@@ -12423,6 +12423,13 @@ export class DesktopBackendRegistry {
     }
 
     await this.loadThreadGitWorkingStateCache();
+    // One registry-owned automatic fleet round spans every navigation
+    // surface. Before this gate, repeated renderer and messaging snapshots
+    // reached past the paths already in flight and started rotating batches
+    // concurrently. That turned serving-path frequency into Git fleet size.
+    if (this.threadGitWorkingStateRefreshRound) {
+      return { scheduledCount: 0 };
+    }
     // Staleness is decided in exactly one place: the cache. Filtering threads
     // on `gitWorkingState` here would read the field a serving path has just
     // hydrated from that same cache, so a worktree with any row — however old
@@ -12453,9 +12460,11 @@ export class DesktopBackendRegistry {
       probedThreads,
       worktreePaths,
     );
-    this.threadGitWorkingStateRefreshRounds.add(round);
+    this.threadGitWorkingStateRefreshRound = round;
     void round.finally(() => {
-      this.threadGitWorkingStateRefreshRounds.delete(round);
+      if (this.threadGitWorkingStateRefreshRound === round) {
+        this.threadGitWorkingStateRefreshRound = undefined;
+      }
     });
     return { scheduledCount: worktreePaths.length };
   }
@@ -20742,7 +20751,9 @@ export class DesktopBackendRegistry {
     // clears below final: `rememberThreadGitWorkingStateCacheEntry` reloads
     // the durable cache, so a late round would refill the map and write to a
     // store that is on its way out.
-    await Promise.all([...this.threadGitWorkingStateRefreshRounds]);
+    if (this.threadGitWorkingStateRefreshRound) {
+      await this.threadGitWorkingStateRefreshRound;
+    }
     this.workingStateByWorktree.clear();
     this.workingStateCacheLoad = undefined;
     if (this.taskMonitorWatchdogTimer) {

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -1,4 +1,6 @@
 import { execFile as execFileCallback } from "node:child_process";
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
@@ -86,6 +88,38 @@ async function resolveWindowsJobExecutable(
   return resolved;
 }
 
+async function resolvePosixExecutable(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  if (path.isAbsolute(command)) {
+    return path.normalize(command);
+  }
+  if (command.includes(path.sep)) {
+    return path.resolve(command);
+  }
+
+  for (const pathEntry of (readPathEnv(env) ?? "").split(path.delimiter)) {
+    const candidate = path.resolve(pathEntry || process.cwd(), command);
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep scanning the same PATH that made `canRunGit` succeed.
+    }
+  }
+  throw new Error(`Unable to resolve an absolute executable path for ${command}.`);
+}
+
+async function resolveExecutableAbsolutePath(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<string> {
+  return process.platform === "win32"
+    ? await resolveWindowsJobExecutable(command, env)
+    : await resolvePosixExecutable(command, env);
+}
+
 export async function resolveGitExecutable(
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
@@ -103,8 +137,9 @@ export async function resolveGitExecutable(
       for (const candidate of gitExecutableCandidates(childEnv)) {
         const result = await canRunGit(candidate, childEnv);
         if (result.ok) {
-          resolvedGitExecutableByEnv.set(cacheKey, candidate);
-          return candidate;
+          const absolute = await resolveExecutableAbsolutePath(candidate, childEnv);
+          resolvedGitExecutableByEnv.set(cacheKey, absolute);
+          return absolute;
         }
         failures.push(`${candidate}: ${result.error}`);
       }

--- a/apps/desktop/src/main/app-server/git-executable.ts
+++ b/apps/desktop/src/main/app-server/git-executable.ts
@@ -1,6 +1,4 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { constants } from "node:fs";
-import { access } from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
@@ -96,16 +94,19 @@ async function resolvePosixExecutable(
     return path.normalize(command);
   }
   if (command.includes(path.sep)) {
-    return path.resolve(command);
+    const absolute = path.resolve(command);
+    const result = await canRunGit(absolute, env);
+    if (result.ok) {
+      return absolute;
+    }
+    throw new Error(result.error);
   }
 
   for (const pathEntry of (readPathEnv(env) ?? "").split(path.delimiter)) {
     const candidate = path.resolve(pathEntry || process.cwd(), command);
-    try {
-      await access(candidate, constants.X_OK);
+    const result = await canRunGit(candidate, env);
+    if (result.ok) {
       return candidate;
-    } catch {
-      // Keep scanning the same PATH that made `canRunGit` succeed.
     }
   }
   throw new Error(`Unable to resolve an absolute executable path for ${command}.`);
@@ -137,9 +138,17 @@ export async function resolveGitExecutable(
       for (const candidate of gitExecutableCandidates(childEnv)) {
         const result = await canRunGit(candidate, childEnv);
         if (result.ok) {
-          const absolute = await resolveExecutableAbsolutePath(candidate, childEnv);
-          resolvedGitExecutableByEnv.set(cacheKey, absolute);
-          return absolute;
+          try {
+            const absolute = await resolveExecutableAbsolutePath(
+              candidate,
+              childEnv,
+            );
+            resolvedGitExecutableByEnv.set(cacheKey, absolute);
+            return absolute;
+          } catch (error) {
+            failures.push(`${candidate}: ${errorText(error)}`);
+            continue;
+          }
         }
         failures.push(`${candidate}: ${result.error}`);
       }

--- a/apps/desktop/src/main/app-server/git-working-state-service.ts
+++ b/apps/desktop/src/main/app-server/git-working-state-service.ts
@@ -70,6 +70,16 @@ type BaseBranchCandidate = {
   ref: string;
   label: string;
   sourceRank: number;
+  baseTipCommit?: string;
+  baseBehindCommitCount?: number;
+  baseAheadCommitCount?: number;
+};
+
+type BaseBranchRefState = {
+  ref: string;
+  baseTipCommit: string;
+  baseBehindCommitCount?: number;
+  baseAheadCommitCount?: number;
 };
 
 function buildAcceptedPushedCommitSet(
@@ -174,6 +184,31 @@ function parseGitLines(output: string | undefined): string[] {
     .filter(Boolean);
 }
 
+function parseBaseBranchRefStates(output: string | undefined): BaseBranchRefState[] {
+  return parseGitLines(output).flatMap((line) => {
+    const [rawRef, baseTipCommit, rawAheadBehind] = line.split("\0");
+    const ref = normalizeBaseBranchLabel(rawRef ?? "");
+    if (!ref) {
+      return [];
+    }
+    const [rawAhead, rawBehind] = (rawAheadBehind ?? "").trim().split(/\s+/);
+    const ahead = Number.parseInt(rawAhead ?? "", 10);
+    const behind = Number.parseInt(rawBehind ?? "", 10);
+    return [{
+      ref,
+      baseTipCommit: baseTipCommit?.trim() ?? "",
+      // `ahead-behind:HEAD` describes the candidate ref. A commit ahead of
+      // HEAD is one HEAD is behind, and vice versa.
+      ...(Number.isFinite(ahead) && Number.isFinite(behind)
+        ? {
+            baseBehindCommitCount: ahead,
+            baseAheadCommitCount: behind,
+          }
+        : {}),
+    }];
+  });
+}
+
 function normalizeBaseBranchLabel(refName: string): string {
   return refName
     .trim()
@@ -209,6 +244,7 @@ function addBaseBranchCandidate(
   seen: Set<string>,
   ref: string | undefined,
   sourceRank: number,
+  refStates: ReadonlyMap<string, BaseBranchRefState>,
 ): void {
   const normalizedRef = normalizeBaseBranchLabel(ref ?? "");
   const label = remoteAgnosticBranchName(normalizedRef);
@@ -216,7 +252,21 @@ function addBaseBranchCandidate(
     return;
   }
   seen.add(label);
-  candidates.push({ ref: normalizedRef, label, sourceRank });
+  const refState = refStates.get(normalizedRef);
+  candidates.push({
+    ref: normalizedRef,
+    label,
+    sourceRank,
+    ...(refState?.baseTipCommit
+      ? { baseTipCommit: refState.baseTipCommit }
+      : {}),
+    ...(refState?.baseBehindCommitCount === undefined
+      ? {}
+      : { baseBehindCommitCount: refState.baseBehindCommitCount }),
+    ...(refState?.baseAheadCommitCount === undefined
+      ? {}
+      : { baseAheadCommitCount: refState.baseAheadCommitCount }),
+  });
 }
 
 function isBetterBaseState(
@@ -276,19 +326,29 @@ async function resolveWorktreeBaseState(
       "refs/heads",
       "refs/remotes",
       "--sort=-committerdate",
-      "--format=%(refname:short)",
-    ]).catch(() => ""),
+      "--format=%(refname:short)%00%(objectname)%00%(ahead-behind:HEAD)",
+    ]).catch(() =>
+      runGitNoLocks([
+        "for-each-ref",
+        "refs/heads",
+        "refs/remotes",
+        "--sort=-committerdate",
+        "--format=%(refname:short)",
+      ]).catch(() => ""),
+    ),
   ]);
 
+  const refStates = parseBaseBranchRefStates(refsOutput);
+  const refStateByRef = new Map(refStates.map((state) => [state.ref, state]));
   const candidates: BaseBranchCandidate[] = [];
   const seen = new Set<string>();
-  addBaseBranchCandidate(candidates, seen, configuredBase, 0);
+  addBaseBranchCandidate(candidates, seen, configuredBase, 0, refStateByRef);
   if (!isCurrentBranchRef(remoteHead, currentBranch)) {
-    addBaseBranchCandidate(candidates, seen, remoteHead, 10);
+    addBaseBranchCandidate(candidates, seen, remoteHead, 10, refStateByRef);
   }
 
-  for (const ref of parseGitLines(refsOutput)) {
-    const label = normalizeBaseBranchLabel(ref);
+  for (const refState of refStates) {
+    const label = refState.ref;
     if (
       label === "origin/HEAD" ||
       isCurrentBranchRef(label, currentBranch) ||
@@ -296,7 +356,7 @@ async function resolveWorktreeBaseState(
     ) {
       continue;
     }
-    addBaseBranchCandidate(candidates, seen, label, 10);
+    addBaseBranchCandidate(candidates, seen, label, 10, refStateByRef);
     if (candidates.length >= MAX_BASE_BRANCH_CANDIDATES) {
       break;
     }
@@ -308,8 +368,9 @@ async function resolveWorktreeBaseState(
       })
     | undefined;
 
+  const ranked: Array<ResolvedWorktreeBaseState & { sourceRank: number }> = [];
   for (const candidate of candidates) {
-    const baseTipCommit = (
+    const baseTipCommit = candidate.baseTipCommit ?? (
       await runGitNoLocks([
         "rev-parse",
         "--verify",
@@ -320,25 +381,35 @@ async function resolveWorktreeBaseState(
       continue;
     }
 
-    const baseCommit = (
-      await runGitNoLocks(["merge-base", "HEAD", candidate.ref]).catch(() => "")
-    ).trim();
-    if (!baseCommit) {
-      continue;
+    let baseBehindCommitCount = candidate.baseBehindCommitCount;
+    let baseAheadCommitCount = candidate.baseAheadCommitCount;
+    let baseCommit = "";
+    if (
+      baseBehindCommitCount === undefined
+      || baseAheadCommitCount === undefined
+    ) {
+      // Compatibility for Git versions without the `ahead-behind` ref atom,
+      // and for a configured base that is not a branch ref. Current Git
+      // versions keep candidate evaluation in the single for-each-ref walk.
+      baseCommit = (
+        await runGitNoLocks(["merge-base", "HEAD", candidate.ref]).catch(() => "")
+      ).trim();
+      if (!baseCommit) {
+        continue;
+      }
+      const [baseBehindOutput, baseAheadOutput] = await Promise.all([
+        runGitNoLocks([
+          "rev-list",
+          "--count",
+          `${baseCommit}..${candidate.ref}`,
+        ]).catch(() => ""),
+        runGitNoLocks(["rev-list", "--count", `${baseCommit}..HEAD`]).catch(
+          () => "",
+        ),
+      ]);
+      baseBehindCommitCount = parseGitCount(baseBehindOutput);
+      baseAheadCommitCount = parseGitCount(baseAheadOutput);
     }
-
-    const [baseBehindOutput, baseAheadOutput] = await Promise.all([
-      runGitNoLocks([
-        "rev-list",
-        "--count",
-        `${baseCommit}..${candidate.ref}`,
-      ]).catch(() => ""),
-      runGitNoLocks(["rev-list", "--count", `${baseCommit}..HEAD`]).catch(
-        () => "",
-      ),
-    ]);
-    const baseBehindCommitCount = parseGitCount(baseBehindOutput);
-    const baseAheadCommitCount = parseGitCount(baseAheadOutput);
     const state: ResolvedWorktreeBaseState & { sourceRank: number } = {
       baseBranch: candidate.label,
       baseCommit,
@@ -352,10 +423,35 @@ async function resolveWorktreeBaseState(
     if (isBetterBaseState(state, best)) {
       best = state;
     }
+    ranked.push(state);
   }
 
   if (!best) {
     return undefined;
+  }
+  if (!best.baseCommit) {
+    // The ahead/behind atom gives every candidate's ranking in one Git
+    // process. Resolve the merge-base only for the winner. If a ref is
+    // disconnected, try the remaining ranked candidates in order without
+    // paying per-candidate processes in the normal connected case.
+    ranked.sort((left, right) => isBetterBaseState(left, right) ? -1 : 1);
+    for (const candidate of ranked) {
+      const candidateRef = candidates.find(
+        (entry) => entry.label === candidate.baseBranch,
+      )?.ref ?? candidate.baseBranch;
+      const baseCommit = (
+        await runGitNoLocks(["merge-base", "HEAD", candidateRef]).catch(
+          () => "",
+        )
+      ).trim();
+      if (baseCommit) {
+        best = { ...candidate, baseCommit };
+        break;
+      }
+    }
+    if (!best.baseCommit) {
+      return undefined;
+    }
   }
   const { sourceRank: _sourceRank, ...state } = best;
   return state;

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -193,7 +193,6 @@ import {
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
 import {
-  BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
   selectStaleWorktreeWorkingStatePaths,
 } from "../app-server/thread-working-state-refresh-policy";
 import { materializeTranscriptImageUrlsForRenderer } from "../transcript-image-protocol";
@@ -2310,10 +2309,16 @@ class DesktopAppServerService {
           this.applyCachedWorktreeWorkingState(thread),
         ),
       );
-    this.startWorktreeWorkingStateRefresh({
-      automatic: true,
-      worktreePaths: this.collectThreadWorktreePaths(canonicalSnapshot.threads),
-    });
+    // The registry owns the one automatic fleet round shared by renderer,
+    // messaging, and federated navigation. Focused, user, and event-driven
+    // refreshes still use this window's single-worktree lane below.
+    void getDesktopBackendRegistry()
+      .refreshThreadGitWorkingStates(canonicalSnapshot.threads)
+      .catch((error) => {
+        logDebug("worktreeWorkingStateRefresh:failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
 
     const remotePins = await this.mergePinnedRemoteThreads();
 
@@ -2616,19 +2621,6 @@ class DesktopAppServerService {
         maxBytes: request.maxBytes,
       },
     );
-  }
-
-  private collectThreadWorktreePaths(
-    threads: NavigationSnapshot["threads"],
-  ): string[] {
-    const paths = new Set<string>();
-    for (const thread of threads) {
-      const worktreePath = this.resolveThreadWorkingStatePath(thread);
-      if (worktreePath) {
-        paths.add(worktreePath);
-      }
-    }
-    return [...paths];
   }
 
   private rememberThreadWorktreePaths(
@@ -3325,7 +3317,6 @@ class DesktopAppServerService {
    * invalidation) bypasses freshness. Returns the number of worktrees scheduled.
    */
   private startWorktreeWorkingStateRefresh(params: {
-    automatic: boolean;
     worktreePaths: string[];
     force?: boolean;
   }): number {
@@ -3385,7 +3376,6 @@ class DesktopAppServerService {
     }
     return {
       scheduled: this.startWorktreeWorkingStateRefresh({
-        automatic: false,
         worktreePaths: [worktreePath],
         force,
       }) > 0,
@@ -3393,14 +3383,10 @@ class DesktopAppServerService {
   }
 
   /**
-   * Everything lane-specific about picking a batch: the automatic navigation
-   * lane sees the whole fleet and takes a capped, rotating slice, while the
-   * focused and user-triggered lanes name one worktree and want it now.
-   * Freshness and the rotation order are shared policy — see
-   * `app-server/thread-working-state-refresh-policy.ts`.
+   * Focused and user-triggered lanes name one worktree and want it now. The
+   * registry owns automatic fleet selection and coalescing.
    */
   private selectWorktreeWorkingStateRefreshCandidates(params: {
-    automatic: boolean;
     worktreePaths: string[];
     force?: boolean;
   }): string[] {
@@ -3408,9 +3394,6 @@ class DesktopAppServerService {
       cache: getDesktopBackendRegistry().getThreadGitWorkingStateCache(),
       exclude: this.pendingWorktreeWorkingStateKeys,
       ...(params.force ? { force: true } : {}),
-      ...(params.automatic
-        ? { limit: BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE }
-        : {}),
       worktreePaths: params.worktreePaths,
     });
   }
@@ -3504,7 +3487,6 @@ class DesktopAppServerService {
       getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
       void this.loadThreadGitWorkingStateCache().then(() => {
         this.startWorktreeWorkingStateRefresh({
-          automatic: false,
           worktreePaths: [worktreePath],
           force: true,
         });
@@ -5126,7 +5108,6 @@ class DesktopAppServerService {
       getDesktopBackendRegistry().invalidateWorktreeWorkingState(worktreePath);
       void this.loadThreadGitWorkingStateCache().then(() => {
         this.startWorktreeWorkingStateRefresh({
-          automatic: false,
           worktreePaths: [worktreePath],
           force: true,
         });

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1554,11 +1554,6 @@ class DesktopAppServerService {
   >();
   private readonly pendingDirectoryGitStatusRefreshes = new Map<string, Promise<void>>();
   private readonly pendingDirectoryGitStatusKeys = new Set<string>();
-  private readonly pendingWorktreeWorkingStateRefreshes = new Map<
-    string,
-    Promise<void>
-  >();
-  private readonly pendingWorktreeWorkingStateKeys = new Set<string>();
   // Maps a thread identity (`backend:threadId`) to its working directory so
   // a turn/command-completion event can refresh the right worktree's chips
   // without re-reading the navigation snapshot. Populated on every snapshot.
@@ -3310,54 +3305,32 @@ class DesktopAppServerService {
   }
 
   /**
-   * Schedule a background per-worktree working-state probe. Mirrors
-   * `startDirectoryGitStatusRefresh`: concurrent same-key requests coalesce
-   * through `pendingWorktreeWorkingStateKeys`, each automatic refresh obeys a
-   * bounded batch size + cache freshness, and `force` (event-driven
-   * invalidation) bypasses freshness. Returns the number of worktrees scheduled.
+   * Schedule focused, user-triggered, and event-triggered probes through the
+   * registry's shared per-worktree owner. Automatic and focused probes cannot
+   * race, and one fresh focused follow-up queues behind an older fleet probe.
    */
   private startWorktreeWorkingStateRefresh(params: {
     worktreePaths: string[];
     force?: boolean;
   }): number {
-    // In-flight paths are excluded during selection, not after it: dropping
-    // them afterwards let a full batch of already-probing worktrees consume
-    // the cap and schedule nothing, leaving the stale ones behind them for a
-    // later round.
     const worktreePaths =
       this.selectWorktreeWorkingStateRefreshCandidates(params);
     if (worktreePaths.length === 0) {
       return 0;
     }
 
-    const refreshKey = JSON.stringify({
-      worktreePaths,
-      force: params.force === true,
-    });
-    if (this.pendingWorktreeWorkingStateRefreshes.has(refreshKey)) {
-      return 0;
-    }
-
+    const registry = getDesktopBackendRegistry();
+    let scheduled = 0;
     for (const worktreePath of worktreePaths) {
-      this.pendingWorktreeWorkingStateKeys.add(worktreePath);
+      if (registry.scheduleWorktreeGitWorkingStateRefresh({
+        worktreePath,
+        acceptedPushedCommitShas:
+          this.getMergedPrCommitShasForWorktree(worktreePath),
+      })) {
+        scheduled += 1;
+      }
     }
-
-    const promise = this.refreshWorktreeWorkingStates(worktreePaths)
-      .catch((error) => {
-        logDebug("worktreeWorkingStateRefresh:failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      })
-      .finally(() => {
-        for (const worktreePath of worktreePaths) {
-          this.pendingWorktreeWorkingStateKeys.delete(worktreePath);
-        }
-        if (this.pendingWorktreeWorkingStateRefreshes.get(refreshKey) === promise) {
-          this.pendingWorktreeWorkingStateRefreshes.delete(refreshKey);
-        }
-      });
-    this.pendingWorktreeWorkingStateRefreshes.set(refreshKey, promise);
-    return worktreePaths.length;
+    return scheduled;
   }
 
   async refreshThreadGitWorkingState(
@@ -3392,42 +3365,9 @@ class DesktopAppServerService {
   }): string[] {
     return selectStaleWorktreeWorkingStatePaths({
       cache: getDesktopBackendRegistry().getThreadGitWorkingStateCache(),
-      exclude: this.pendingWorktreeWorkingStateKeys,
       ...(params.force ? { force: true } : {}),
       worktreePaths: params.worktreePaths,
     });
-  }
-
-  private async refreshWorktreeWorkingStates(
-    worktreePaths: string[],
-  ): Promise<void> {
-    const refreshable = worktreePaths.map((p) => p.trim()).filter(Boolean);
-    if (refreshable.length === 0) {
-      return;
-    }
-
-    for await (const entry of getDesktopBackendRegistry().readWorktreeWorkingStateEntries(
-      refreshable,
-      {
-        acceptedPushedCommitShasByWorktreePath: Object.fromEntries(
-          refreshable.map((worktreePath) => [
-            worktreePath,
-            this.getMergedPrCommitShasForWorktree(worktreePath),
-          ]),
-        ),
-      },
-    )) {
-      // The registry owns the monotonic stamp, the durable write, and the
-      // `navigation/threadGitWorkingState/updated` publish, so a probe from
-      // either lane reaches open surfaces the same way.
-      await getDesktopBackendRegistry().rememberThreadGitWorkingStateCacheEntry({
-        worktreePath: entry.worktreePath,
-        fetchedAt: Date.now(),
-        ...(entry.gitWorkingState
-          ? { gitWorkingState: entry.gitWorkingState }
-          : {}),
-      });
-    }
   }
 
   /**
@@ -7390,8 +7330,6 @@ class DesktopAppServerService {
     this.directoryGitStatusCacheLoaded = false;
     this.automaticDirectoryGitStatusRefreshesStarted = 0;
     this.lastDirectoriesByKey.clear();
-    this.pendingWorktreeWorkingStateRefreshes.clear();
-    this.pendingWorktreeWorkingStateKeys.clear();
     this.worktreePathByThreadKey.clear();
     this.prRefreshContextByThreadKey.clear();
     await disposeDesktopBackendRegistry();


### PR DESCRIPTION
## Summary

- make DesktopBackendRegistry the single owner of automatic Git working-state fleet rounds across renderer, messaging, and federated navigation
- coalesce navigation requests behind one active bounded fleet round while preserving later-batch convergence and focused, user, turn, branch, and PR invalidation refreshes
- replace four Git commands per base candidate with one for-each-ref ahead/behind traversal plus one merge-base for the selected candidate
- cache an absolute Git executable path on macOS, Linux, and Windows instead of caching the PATH command name
- add checked-in subprocess and scheduler budgets

## Measurements

Deterministic 24-candidate cold working-state probe:

- before: 105 Git commands per worktree
  - 3 dirty/status/remote probes
  - 5 base-discovery probes
  - 96 candidate probes, 4 for each candidate
  - 1 unpushed-count probe
- after: 10 Git commands per worktree
- reduction: 95 commands, or 90.5 percent
- bounded live probe in this worktree: 10 commands with main base selection and dirty/untracked/unpushed fields intact

Deterministic scheduling probe with 100 stale worktrees, 100 navigation requests, and the production batch size of 8:

- before: 13 automatic rounds could be started while earlier rounds were still active
- after: 1 active automatic fleet round
- after that round completes, a later snapshot starts the next bounded batch so the tail still converges

PATH behavior:

- before: executable resolution cached the string git, so every command repeated PATH lookup and failed spawn attempts
- after: this macOS worktree resolves and caches /opt/homebrew/bin/git
- after the one-time version discovery, working-state Git launches use the absolute path and perform zero per-command PATH searches

The measured process trace attributed 11,061 Git launches in 104 active seconds to PwrAgent. The command reduction and absolute launch path should substantially reduce syspolicyd executable validation and filesystem traversal. Remaining Git processes still require normal macOS code validation, so this does not claim to eliminate all syspolicyd work.

## Correctness

- base selection keeps configured-base precedence and the existing ahead, behind, and branch-name ranking
- dirty, untracked, and unpushed counts are unchanged
- merged PR head exclusions are still passed through the registry owner
- multi-project worktrees retain path-specific selection
- focused, user-triggered, turn-completion, branch-update, and PR-update invalidation remains immediate
- current Git versions use fixed-command base inference; Git versions without the ahead-behind ref atom retain the legacy compatibility fallback

## Verification

- focused desktop-main suites: 5 files, 796 tests passed
- Git discovery and absolute-resolution suites: 2 files, 7 tests passed
- full workspace suite: 9,774 passed, 6 skipped; one unrelated Settings protocol-capture timing test failed under full-suite load and passed in isolation
- full pnpm lint pipeline passed, including SQL, Codex-storage boundary, colors, Electron policy, licenses, ESLint, typecheck, and dependency boundaries
- git diff --check passed
