### PR TITLE
fix(messaging): dedupe turn start failures

### DIFF
--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -5263,6 +5263,173 @@ describe("MessagingController", () => {
     });
   });
 
+  it("does not double-report a default-agent start failure emitted by the backend", async () => {
+    const navigation = buildNavigationSnapshot();
+    const rawFailure = JSON.stringify({
+      type: "error",
+      error: {
+        message: "thread not found: thread-1",
+      },
+      status: 400,
+    });
+    const harness = await createHarness({
+      navigation,
+      getThreadAdmissionState: async (request) => ({
+        thread: {
+          ...navigation.threads[0]!,
+          id: request.threadId,
+          source: request.backend,
+          agent: {
+            name: "Provider Agent",
+            instructionLineCount: 1,
+            instructionsTooLong: false,
+            updatedAt: 1500,
+          },
+        },
+      }),
+    });
+    harness.startTurn.mockImplementationOnce(async (request) => {
+      await harness.controller.handleBackendEvent({
+        backend: request.backend,
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: request.threadId,
+            turnId: `pending:${request.threadId}`,
+            turn: {
+              id: `pending:${request.threadId}`,
+              status: "in_progress",
+            },
+          },
+        },
+      });
+      await harness.controller.handleBackendEvent({
+        backend: request.backend,
+        notification: {
+          method: "turn/failed",
+          params: {
+            threadId: request.threadId,
+            turnId: `pending:${request.threadId}`,
+            turn: {
+              id: `pending:${request.threadId}`,
+              status: "failed",
+              error: { message: rawFailure },
+            },
+          },
+        },
+      });
+      throw new Error(rawFailure);
+    });
+    const channel = buildTopicChannel("13125");
+    await harness.store.upsertDefaultAgentAssignment({
+      id: "default-agent:reported-start-failure",
+      scope: { kind: "conversation", channel },
+      target: { kind: "agent", backend: "codex", threadId: "thread-1" },
+      createdAt: 1000,
+      updatedAt: 1000,
+    });
+
+    await harness.controller.handleInboundEvent(
+      buildTextEvent("use the available Agent", { botMention: true, channel }),
+    );
+
+    await expect(
+      harness.store.getDefaultAgentAssignment("default-agent:reported-start-failure"),
+    ).resolves.toMatchObject({ revokedAt: expect.any(Number) });
+    const failureNotices = harness.delivered.filter(
+      (intent) =>
+        intent.kind === "error"
+        && (
+          intent.title === "Turn failed"
+          || intent.title === "Turn could not start"
+        ),
+    );
+    expect(failureNotices).toHaveLength(1);
+    expect(failureNotices[0]).toMatchObject({
+      title: "Turn failed",
+      body: "thread not found: thread-1",
+    });
+  });
+
+  it("waits for an asynchronously forwarded remote start failure before reporting it", async () => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0]!.federation = {
+      ref: buildFederatedThreadRef({
+        backend: "codex",
+        instanceId: "client_one",
+        threadId: "thread-1",
+      }),
+      instanceLabel: "Studio Mac",
+      peerStatus: "connected",
+    };
+    const harness = await createHarness({ navigation });
+    const event = buildTextEvent("remote request");
+    await harness.store.upsertBinding({
+      id: "binding:remote-start-failure",
+      authorizedActorIds: ["user-1"],
+      backend: "codex",
+      channel: event.channel,
+      createdAt: 1000,
+      federatedThread: navigation.threads[0]!.federation.ref,
+      routingState: event.routingState,
+      targetKind: "thread",
+      threadId: "thread-1",
+      updatedAt: 1000,
+    });
+    const failureLookupStarted = createDeferred<void>();
+    const releaseFailureLookup = createDeferred<void>();
+    const findActiveBindingsForThread =
+      harness.store.findActiveBindingsForThread.bind(harness.store);
+    vi.spyOn(harness.store, "findActiveBindingsForThread")
+      .mockImplementationOnce(async (request) => {
+        failureLookupStarted.resolve();
+        await releaseFailureLookup.promise;
+        return await findActiveBindingsForThread(request);
+      });
+    let failureHandling: Promise<void> | undefined;
+    harness.startTurn.mockImplementationOnce(async (request) => {
+      failureHandling = harness.controller.handleBackendEvent({
+        backend: request.backend,
+        federationTarget: request.federationTarget,
+        notification: {
+          method: "turn/failed",
+          params: {
+            threadId: request.threadId,
+            turnId: `pending:${request.threadId}`,
+            turn: {
+              id: `pending:${request.threadId}`,
+              status: "failed",
+              error: { message: "remote start failed" },
+            },
+          },
+        },
+      });
+      await failureLookupStarted.promise;
+      throw new Error("remote start failed");
+    });
+
+    const inboundHandling = harness.controller.handleInboundEvent(event);
+    await failureLookupStarted.promise;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    releaseFailureLookup.resolve();
+    await inboundHandling;
+    await failureHandling;
+
+    const failureNotices = harness.delivered.filter(
+      (intent) =>
+        intent.kind === "error"
+        && (
+          intent.title === "Turn failed"
+          || intent.title === "Turn could not start"
+        ),
+    );
+    expect(failureNotices).toHaveLength(1);
+    expect(failureNotices[0]).toMatchObject({
+      title: "Turn failed",
+      body: "remote start failed",
+    });
+  });
+
   it("preserves the messaging location for queued Agent-thread turns", async () => {
     const harness = await createHarness();
     harness.startTurn.mockImplementation(async (request: StartTurnRequest) => {

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -499,6 +499,7 @@ type ActiveAgentMessagingOrigin = {
   event: MessagingInboundEvent;
   privateReplyContinuationBindingId?: string;
   privateResponseRequested?: boolean;
+  reportedStartFailureText?: string;
 };
 
 type AgentMessagingOriginResolution =
@@ -1030,6 +1031,10 @@ export class MessagingController {
     string,
     ActiveAgentMessagingOrigin
   >();
+  private readonly pendingTurnFailureHandlersByThreadKey = new Map<
+    string,
+    Set<Promise<void>>
+  >();
   private readonly privateReplyCompletionTurnKeys = new Set<string>();
   private readonly terminalPrivateResponseTurnKeys = new Set<string>();
   private readonly privateResponseFallbackTurnKeys = new Set<string>();
@@ -1435,7 +1440,30 @@ export class MessagingController {
     };
   }
 
-  async handleBackendEvent(event: AgentEvent): Promise<void> {
+  handleBackendEvent(event: AgentEvent): Promise<void> {
+    const handling = this.handleBackendEventNow(event);
+    const threadId = threadIdForBackendEvent(event);
+    if (!threadId || event.notification.method !== "turn/failed") {
+      return handling;
+    }
+    const threadKey = threadKeyForBackendEvent(event, threadId);
+    let pending = this.pendingTurnFailureHandlersByThreadKey.get(threadKey);
+    if (!pending) {
+      pending = new Set();
+      this.pendingTurnFailureHandlersByThreadKey.set(threadKey, pending);
+    }
+    pending.add(handling);
+    const removePending = (): void => {
+      pending.delete(handling);
+      if (pending.size === 0) {
+        this.pendingTurnFailureHandlersByThreadKey.delete(threadKey);
+      }
+    };
+    void handling.then(removePending, removePending);
+    return handling;
+  }
+
+  private async handleBackendEventNow(event: AgentEvent): Promise<void> {
     const threadId = threadIdForBackendEvent(event);
     if (!threadId && event.notification.method === "account/updated") {
       await this.refreshStatusSurfacesForBackend(
@@ -4979,12 +5007,19 @@ export class MessagingController {
       if (isMissingTurnTargetStartError(error, params.binding)) {
         await this.revokeDefaultAgentRouteForFailedStart(params.binding);
       }
+      await this.waitForPendingTurnFailureHandlers(params.binding);
+      const errorMessage = parseCodexTurnErrorMessage(
+        error instanceof Error ? error.message : String(error),
+      );
+      if (startingOrigin?.reportedStartFailureText === errorMessage) {
+        return "failed";
+      }
       await this.deliver(
         buildErrorIntent({
           id: this.newIntentId("turn-start-failed"),
           createdAt: this.now(),
           title: "Turn could not start",
-          body: error instanceof Error ? error.message : String(error),
+          body: errorMessage,
           recoverable: true,
         }),
         params.binding,
@@ -5027,6 +5062,17 @@ export class MessagingController {
       admissionState.activeTurn
       || admissionState.threadStatus === "active",
     );
+  }
+
+  private async waitForPendingTurnFailureHandlers(
+    binding: MessagingBindingRecord,
+  ): Promise<void> {
+    const pending = this.pendingTurnFailureHandlersByThreadKey.get(
+      this.threadKeyForBinding(binding),
+    );
+    if (pending?.size) {
+      await Promise.allSettled([...pending]);
+    }
   }
 
   private async adoptStartedTurn(params: {
@@ -7550,6 +7596,17 @@ export class MessagingController {
     if (!this.markAssistantMessageDelivered(event, binding, `turn-failed:${text}`)) {
       return;
     }
+    const startingOrigin = this.startingAgentMessagingOriginsByThreadKey.get(
+      agentMessagingThreadKey(event.backend, binding.threadId),
+    );
+    const startingDeliveryBinding = startingOrigin?.deliveryBinding
+      ?? startingOrigin?.binding;
+    if (startingOrigin && startingDeliveryBinding?.id === binding.id) {
+      // Some backends publish a synthetic failed-turn lifecycle before their
+      // startTurn promise rejects. Correlate that report to the in-flight
+      // messaging origin so the rejection handler does not post it again.
+      startingOrigin.reportedStartFailureText = text;
+    }
     this.logger.debug?.(
       `messaging turn-failure deliver thread=${binding.threadId} binding=${binding.id} preview="${compactLogPreview(text)}"`,
     );
@@ -7722,6 +7779,7 @@ export class MessagingController {
     this.completedTaskMonitorTurns.clear();
     this.activeAgentMessagingOriginsByTurnKey.clear();
     this.startingAgentMessagingOriginsByThreadKey.clear();
+    this.pendingTurnFailureHandlersByThreadKey.clear();
     this.privateReplyCompletionTurnKeys.clear();
     this.terminalPrivateResponseTurnKeys.clear();
     this.privateResponseFallbackTurnKeys.clear();
@@ -21029,6 +21087,21 @@ function agentMessagingThreadKey(
   threadId: ThreadIdentifier,
 ): string {
   return buildThreadIdentityKey(backend, threadId);
+}
+
+function threadKeyForBackendEvent(
+  event: AgentEvent,
+  threadId: ThreadIdentifier,
+): string {
+  return event.federationTarget?.scope === "remote"
+    ? federatedThreadIdentityKey(
+        buildFederatedThreadRef({
+          backend: event.backend,
+          instanceId: event.federationTarget.instanceId,
+          threadId,
+        }),
+      )
+    : buildThreadIdentityKey(event.backend, threadId);
 }
 
 function agentMessagingQueueKey(


### PR DESCRIPTION
## Summary

- correlate backend-emitted turn failures with the in-flight messaging start
- normalize start rejection envelopes through the same parser used by lifecycle failures
- coordinate pending local and federated turn-failure handlers before posting a start rejection
- suppress the duplicate notice when the same failure was already delivered
- preserve missing Default Agent route revocation before deduplication
- add regressions for serialized Codex errors and asynchronously forwarded remote failures

## Testing

- pnpm test apps/desktop/src/main/__tests__/messaging-controller.test.ts (438 passed)
- pnpm --filter @pwragent/desktop typecheck
- pnpm exec eslint apps/desktop/src/main/messaging/core/messaging-controller.ts apps/desktop/src/main/__tests__/messaging-controller.test.ts
- git diff --check