### PR TITLE
fix(desktop): give the Savings lens back its results list

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -1,4 +1,12 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import type {
   AppServerBackendKind,
   FederationInstanceId,
@@ -24,6 +32,14 @@ import { useDesktopApi } from "../../lib/desktop-api";
 import { useDesktopSettings } from "../settings/useDesktopSettings";
 import { ThreadChip } from "./ThreadChip";
 import { detailMatchesInvocationItem } from "./tool-call-details";
+import {
+  clampDetailsHeight,
+  readStoredSavingsLayout,
+  SAVINGS_DETAILS_MIN_HEIGHT,
+  SAVINGS_RESULTS_MIN_HEIGHT,
+  writeStoredSavingsLayout,
+} from "./token-miser-savings-layout";
+import type { SavingsSectionKey } from "./token-miser-savings-layout";
 import {
   describeSameTrajectoryCostChange,
   TOKEN_MISER_PENDING_PRICING_CAPTION,
@@ -1107,6 +1123,262 @@ function SavingsConfidence(props: { savings: ThreadTokenMiserSavings }) {
   );
 }
 
+/**
+ * The three terms as shares of the unfiltered cost.
+ *
+ * Only drawn when the gate came out ahead. With negative savings the parts sum
+ * past the whole, and a bar overflowing its own track reads as a rendering
+ * fault rather than as an overspend — that case states itself in words above.
+ */
+function buildSavingsSplit(
+  savings: ThreadTokenMiserSavings,
+): { avoided: number; gate: number; revealed: number } | undefined {
+  const whole = savings.withoutGateCostMicros;
+  if (whole <= 0 || savings.savingsMicros <= 0) return undefined;
+  return {
+    avoided: savings.savingsMicros / whole * 100,
+    gate: savings.gateCostMicros / whole * 100,
+    revealed: savings.revealedCostMicros / whole * 100,
+  };
+}
+
+type SavingsDetailMeasurement = {
+  availableHeight: number;
+  detailsHeight: number;
+};
+
+const EMPTY_SAVINGS_MEASUREMENT: SavingsDetailMeasurement = {
+  availableHeight: 0,
+  detailsHeight: 0,
+};
+
+/**
+ * Per-machine view state for the lens: which reference rows are unfolded, and
+ * how tall the operator dragged the detail stack.
+ *
+ * Called before this component's early returns so the hook order never depends
+ * on whether a thread has gate decisions.
+ */
+function useSavingsLayout() {
+  const [layout, setLayout] = useState(readStoredSavingsLayout);
+  const [measurement, setMeasurement] = useState(EMPTY_SAVINGS_MEASUREMENT);
+  useEffect(() => {
+    writeStoredSavingsLayout(layout);
+  }, [layout]);
+  const toggleSection = useCallback(
+    (key: SavingsSectionKey, open: boolean) => {
+      setLayout((current) => ({
+        ...current,
+        openSections: open
+          ? current.openSections.includes(key)
+            ? current.openSections
+            : [...current.openSections, key]
+          : current.openSections.filter((entry) => entry !== key),
+      }));
+    },
+    [],
+  );
+  const resizeDetails = useCallback((height: number, available: number) => {
+    setLayout((current) => ({
+      ...current,
+      detailsHeight: clampDetailsHeight(height, available),
+    }));
+  }, []);
+  /* The stack measures itself after every render, so this has to return the
+     identical object when nothing moved — a fresh object each time would
+     re-render, re-measure, and never settle. */
+  const measure = useCallback((next: SavingsDetailMeasurement) => {
+    setMeasurement((current) =>
+      current.availableHeight === next.availableHeight
+        && current.detailsHeight === next.detailsHeight
+        ? current
+        : next);
+  }, []);
+  return { layout, measure, measurement, resizeDetails, toggleSection };
+}
+
+/**
+ * The folding reference rows, above the results list.
+ *
+ * `flex-shrink` is load-bearing: the operator's dragged height is a preference,
+ * not a floor, so a short window still gives the results list its three rows
+ * and lets this stack scroll instead.
+ */
+function SavingsDetailStack(props: {
+  children: ReactNode;
+  height: number | undefined;
+  onMeasure: (measurement: SavingsDetailMeasurement) => void;
+}) {
+  const stackRef = useRef<HTMLDivElement>(null);
+  const onMeasure = props.onMeasure;
+  useLayoutEffect(() => {
+    const node = stackRef.current;
+    if (!node) return;
+    onMeasure({
+      availableHeight: node.parentElement?.getBoundingClientRect().height ?? 0,
+      detailsHeight: node.getBoundingClientRect().height,
+    });
+  });
+  return (
+    <div
+      className="incident-explorer__savings-details"
+      ref={stackRef}
+      style={props.height === undefined
+        ? undefined
+        : { height: `${props.height}px` }}
+    >
+      {props.children}
+    </div>
+  );
+}
+
+/** How far the operator dragged the split, as the 0–100 a separator reports. */
+function savingsSplitShare(measurement: SavingsDetailMeasurement): number {
+  const ceiling = measurement.availableHeight - SAVINGS_RESULTS_MIN_HEIGHT;
+  const span = ceiling - SAVINGS_DETAILS_MIN_HEIGHT;
+  if (span <= 0) return 0;
+  const share =
+    (measurement.detailsHeight - SAVINGS_DETAILS_MIN_HEIGHT) / span * 100;
+  return Math.round(Math.min(100, Math.max(0, share)));
+}
+
+const SAVINGS_GRIP_KEY_STEP = 24;
+
+/**
+ * The handle between the reference rows and the results list.
+ *
+ * Reported as a percentage rather than pixels because a focusable separator
+ * with no `aria-valuemax` is read against the default 0–100, and the pixel
+ * ceiling moves with the window.
+ */
+function SavingsSplitGrip(props: {
+  measurement: SavingsDetailMeasurement;
+  onResize: (height: number, available: number) => void;
+}) {
+  const dragRef = useRef<{ startHeight: number; startY: number }>(undefined);
+  const measurement = props.measurement;
+  const onResize = props.onResize;
+  return (
+    <div
+      aria-label="Resize the Token Miser detail rows"
+      aria-orientation="horizontal"
+      aria-valuenow={savingsSplitShare(measurement)}
+      className="incident-explorer__savings-grip"
+      onKeyDown={(event) => {
+        const step = event.key === "ArrowUp"
+          ? -SAVINGS_GRIP_KEY_STEP
+          : event.key === "ArrowDown"
+            ? SAVINGS_GRIP_KEY_STEP
+            : undefined;
+        if (step === undefined) return;
+        event.preventDefault();
+        onResize(
+          measurement.detailsHeight + step,
+          measurement.availableHeight,
+        );
+      }}
+      onPointerDown={(event) => {
+        if (event.button !== 0) return;
+        event.preventDefault();
+        event.currentTarget.setPointerCapture(event.pointerId);
+        dragRef.current = {
+          startHeight: measurement.detailsHeight,
+          startY: event.clientY,
+        };
+      }}
+      onPointerMove={(event) => {
+        const drag = dragRef.current;
+        if (!drag) return;
+        onResize(
+          drag.startHeight + (event.clientY - drag.startY),
+          measurement.availableHeight,
+        );
+      }}
+      onPointerUp={(event) => {
+        dragRef.current = undefined;
+        if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+          event.currentTarget.releasePointerCapture(event.pointerId);
+        }
+      }}
+      role="separator"
+      tabIndex={0}
+    >
+      <span aria-hidden="true" />
+    </div>
+  );
+}
+
+/** One headline number on a folded row: bright value, muted label. */
+type SavingsFact = {
+  label: string;
+  value: string;
+  /**
+   * Dimmed, never hidden. A zero here is an answer — no compactions, nothing
+   * read back — and dropping the row would read as a missing measurement.
+   */
+  zero?: boolean;
+};
+
+type SavingsFigure = SavingsFact & { detail?: string };
+
+/**
+ * A reference section: one scannable line folded, a labelled grid unfolded.
+ *
+ * Built from the same disclosure primitive as the result rows below rather
+ * than `<details>`, so both stacks on this screen open the same way.
+ */
+function SavingsDetailSection(props: {
+  children?: ReactNode;
+  facts: SavingsFact[];
+  label: string;
+  onToggle: (key: SavingsSectionKey, open: boolean) => void;
+  open: boolean;
+  sectionKey: SavingsSectionKey;
+}) {
+  return (
+    <section
+      aria-label={props.label}
+      className="incident-explorer__savings-section"
+      data-open={props.open}
+    >
+      <button
+        aria-expanded={props.open}
+        className="incident-explorer__savings-section-row"
+        onClick={() => props.onToggle(props.sectionKey, !props.open)}
+        type="button"
+      >
+        <span aria-hidden="true" className="incident-explorer__savings-chevron" />
+        <span className="incident-explorer__savings-section-label">
+          {props.label}
+        </span>
+        <span className="incident-explorer__savings-facts">
+          {props.facts.map((fact) => (
+            <span data-zero={fact.zero === true} key={fact.label}>
+              <b>{fact.value}</b> {fact.label}
+            </span>
+          ))}
+        </span>
+      </button>
+      {props.open ? props.children : null}
+    </section>
+  );
+}
+
+function SavingsFigureGrid(props: { figures: SavingsFigure[] }) {
+  return (
+    <dl className="incident-explorer__savings-figures">
+      {props.figures.map((figure) => (
+        <div data-zero={figure.zero === true} key={figure.label}>
+          <dt>{figure.label}</dt>
+          <dd>
+            {figure.value}
+            {figure.detail ? <span>{figure.detail}</span> : null}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
 function TokenMiserSavingsLens(props: {
   comparison?: TokenMiserContextComparison;
   compactions: readonly ThreadCompactionRecord[];
@@ -1120,6 +1392,8 @@ function TokenMiserSavingsLens(props: {
   tokenMiser?: ThreadToolAccounting["tokenMiser"];
   usageLines: readonly ThreadUsageLineRecord[];
 }) {
+  const { layout, measure, measurement, resizeDetails, toggleSection } =
+    useSavingsLayout();
   const tokenMiser = props.tokenMiser;
   if (!tokenMiser) {
     return (
@@ -1134,16 +1408,23 @@ function TokenMiserSavingsLens(props: {
   if (!props.comparison) {
     return (
       <div className="incident-explorer__savings">
-        <TokenMiserContextTimeline
-          compactions={props.compactions}
-          usageLines={props.usageLines}
-        />
-        <TokenMiserCodeModeStats
-          tokenMiser={tokenMiser}
-        />
-        <p className="incident-explorer__savings-empty">
-          No reducer decision was recorded.
-        </p>
+        <div className="incident-explorer__savings-hero">
+          <p className="incident-explorer__savings-empty">
+            No reducer decision was recorded.
+          </p>
+          <TokenMiserContextTimeline
+            compactions={props.compactions}
+            usageLines={props.usageLines}
+          />
+        </div>
+        <SavingsDetailStack height={layout.detailsHeight} onMeasure={measure}>
+          <TokenMiserCodeModeStats
+            onToggle={toggleSection}
+            open={layout.openSections.includes("code-mode")}
+            tokenMiser={tokenMiser}
+          />
+        </SavingsDetailStack>
+        <SavingsSplitGrip measurement={measurement} onResize={resizeDetails} />
         <TokenMiserResultList entries={props.gates} tokenMiser={tokenMiser} />
       </div>
     );
@@ -1185,10 +1466,13 @@ function TokenMiserSavingsLens(props: {
         savings.savingsMicros,
       )
     : undefined;
+  const split = savings ? buildSavingsSplit(savings) : undefined;
+  const summarizedCount = tokenMiser.interceptionCount
+    - (tokenMiser.passThroughCount ?? 0);
   return (
     <div className="incident-explorer__savings">
       <div className="incident-explorer__savings-hero">
-        <div>
+        <div className="incident-explorer__savings-headline">
           {savings ? (
             <>
               <p className="incident-explorer__eyebrow">
@@ -1207,7 +1491,110 @@ function TokenMiserSavingsLens(props: {
                   <span>{sameTrajectoryCostChange.sentence}</span>
                 ) : null}
               </p>
-              {props.threadCostMicros > 0 ? (
+              <dl className="incident-explorer__savings-equation">
+                <div
+                  className="incident-explorer__savings-term"
+                  title={`${formatCompactTokens(tokenMiser.baselineParentTokens)} uncached`
+                    + (cachedBaselineTokens > 0
+                      ? ` + ${formatCompactTokens(cachedBaselineTokens)} cached`
+                      : "")
+                    + ` at ${savings.parentModel ?? "the parent model"} rates`}
+                >
+                  <dt>Without the gate</dt>
+                  <dd>
+                    {formatMicrosCurrency(
+                      savings.withoutGateCostMicros,
+                      savings.currency,
+                    )}
+                  </dd>
+                </div>
+                <span aria-hidden="true" className="incident-explorer__savings-operator">
+                  −
+                </span>
+                <div
+                  className="incident-explorer__savings-term"
+                  title={`${formatCompactTokens(props.gateTokens)} charged by `
+                    + `${savings.gateModel ?? "the helper"}`}
+                >
+                  <dt>Gate compute</dt>
+                  <dd>
+                    {formatMicrosCurrency(savings.gateCostMicros, savings.currency)}
+                  </dd>
+                </div>
+                <span aria-hidden="true" className="incident-explorer__savings-operator">
+                  −
+                </span>
+                <div
+                  className="incident-explorer__savings-term"
+                  title={`${formatCompactTokens(revealedTokens)} uncached`
+                    + (cachedRevealedTokens > 0
+                      ? ` + ${formatCompactTokens(cachedRevealedTokens)} cached`
+                      : "")
+                    + (tokenMiser.passThroughCount
+                      ? " · summaries, retrievals, and deliberate pass-throughs"
+                      : " · summaries and retrievals")}
+                >
+                  <dt>Revealed to parent</dt>
+                  <dd>
+                    {formatMicrosCurrency(
+                      savings.revealedCostMicros,
+                      savings.currency,
+                    )}
+                  </dd>
+                </div>
+                <span aria-hidden="true" className="incident-explorer__savings-operator">
+                  =
+                </span>
+                <div
+                  className="incident-explorer__savings-term"
+                  data-result="true"
+                >
+                  <dt>{savings.savingsMicros >= 0 ? "Saved" : "Overhead"}</dt>
+                  <dd>
+                    {formatMicrosCurrency(
+                      Math.abs(savings.savingsMicros),
+                      savings.currency,
+                    )}
+                  </dd>
+                </div>
+              </dl>
+              {split ? (
+                <>
+                  <span
+                    aria-hidden="true"
+                    className="incident-explorer__savings-split"
+                  >
+                    <i data-part="avoided" style={{ width: `${split.avoided}%` }} />
+                    <i data-part="gate" style={{ width: `${split.gate}%` }} />
+                    <i data-part="revealed" style={{ width: `${split.revealed}%` }} />
+                  </span>
+                  <p className="incident-explorer__savings-split-caption">
+                    <span>
+                      <b>{Math.round(split.avoided)}%</b> avoided
+                      {" · "}<b>{Math.round(split.gate)}%</b> gate
+                      {" · "}<b>{Math.round(split.revealed)}%</b> revealed
+                    </span>
+                    {props.threadCostMicros > 0 ? (
+                      <span>
+                        observed{" "}
+                        <b>
+                          {formatMicrosCurrency(
+                            props.threadCostMicros,
+                            savings.currency,
+                          )}
+                        </b>
+                        {" · unfiltered "}
+                        <b>
+                          {formatMicrosCurrency(
+                            props.threadCostMicros + savings.savingsMicros,
+                            savings.currency,
+                          )}
+                        </b>
+                      </span>
+                    ) : null}
+                  </p>
+                </>
+              ) : props.threadCostMicros > 0 ? (
                 <p className="incident-explorer__savings-compare">
                   Observed thread cost{" "}
                   <b>
@@ -1226,7 +1613,9 @@ function TokenMiserSavingsLens(props: {
             </>
           ) : (
             <>
-              <p className="incident-explorer__eyebrow">Kept out of the parent's context</p>
+              <p className="incident-explorer__eyebrow">
+                Kept out of the parent's context
+              </p>
               <p className="incident-explorer__savings-figure">
                 <strong>
                   {formatCompactTokens(props.comparison.avoidedParentTokens)}
@@ -1237,117 +1626,154 @@ function TokenMiserSavingsLens(props: {
                   {cachedReplayCount === 1 ? "replay" : "replays"}
                 </span>
               </p>
+              <dl className="incident-explorer__savings-tokens">
+                <div>
+                  <dt>Without the gate</dt>
+                  <dd>{formatCompactTokens(tokenMiser.baselineParentTokens)}</dd>
+                </div>
+                <div>
+                  <dt>Actual parent context</dt>
+                  <dd>{formatCompactTokens(revealedTokens)}</dd>
+                </div>
+                <div>
+                  <dt>Gate compute</dt>
+                  <dd>
+                    {props.gateTokens > 0
+                      ? formatCompactTokens(props.gateTokens)
+                      : "—"}
+                    <span>
+                      {props.gateCostMicros > 0
+                        ? formatMicrosCurrency(
+                            props.gateCostMicros,
+                            props.currency ?? "USD",
+                          )
+                        : "awaiting the pricing ledger"}
+                    </span>
+                  </dd>
+                </div>
+              </dl>
               <p className="incident-explorer__savings-compare">
                 {TOKEN_MISER_PENDING_PRICING_CAPTION}
               </p>
             </>
           )}
         </div>
-        {savings ? (
-          <dl className="incident-explorer__savings-terms" data-terms="3">
-            <div>
-              <dt>1 · Without the gate</dt>
-              <dd>
-                {formatMicrosCurrency(savings.withoutGateCostMicros, savings.currency)}
-                <span>
-                  {partialPricingPrefix}
-                  {formatCompactTokens(tokenMiser.baselineParentTokens)} uncached
-                  {cachedBaselineTokens > 0
-                    ? ` + ${formatCompactTokens(cachedBaselineTokens)} cached`
-                    : ""}
-                  {" · gated tool output at "}
-                  {savings.parentModel ?? "the parent model"} rates
-                </span>
-              </dd>
-            </div>
-            <div>
-              <dt>2 · Gate compute</dt>
-              <dd>
-                {formatMicrosCurrency(savings.gateCostMicros, savings.currency)}
-                <span>
-                  {formatCompactTokens(props.gateTokens)} total ·{" "}
-                  {savings.gateModel ?? "helper"}
-                </span>
-              </dd>
-            </div>
-            <div>
-              <dt>3 · Revealed to parent</dt>
-              <dd>
-                {formatMicrosCurrency(savings.revealedCostMicros, savings.currency)}
-                <span>
-                  {partialPricingPrefix}
-                  {formatCompactTokens(revealedTokens)} uncached
-                  {cachedRevealedTokens > 0
-                    ? ` + ${formatCompactTokens(cachedRevealedTokens)} cached`
-                    : ""}
-                  {tokenMiser.passThroughCount
-                    ? " · summaries, retrievals, and deliberate pass-throughs"
-                    : " · summaries and retrievals"}
-                </span>
-              </dd>
-            </div>
-          </dl>
-        ) : (
-          <dl className="incident-explorer__savings-terms">
-            <div>
-              <dt>Without the gate</dt>
-              <dd>{formatCompactTokens(tokenMiser.baselineParentTokens)}</dd>
-            </div>
-            <div>
-              <dt>Actual parent context</dt>
-              <dd>{formatCompactTokens(revealedTokens)}</dd>
-            </div>
-            <div>
-              <dt>Gate compute</dt>
-              <dd>
-                {props.gateTokens > 0
-                  ? formatCompactTokens(props.gateTokens)
-                  : "—"}
-                {props.gateCostMicros > 0 ? (
-                  <span>
-                    {formatMicrosCurrency(props.gateCostMicros, props.currency ?? "USD")}
-                  </span>
-                ) : (
-                  <span>awaiting the pricing ledger</span>
-                )}
-              </dd>
-            </div>
-          </dl>
-        )}
+        <TokenMiserContextTimeline
+          compactions={props.compactions}
+          usageLines={props.usageLines}
+        />
       </div>
 
-      <p className="incident-explorer__savings-caption">
-        {tokenMiser.passThroughCount
-          ? `${(tokenMiser.interceptionCount - tokenMiser.passThroughCount).toLocaleString()} summarized · ${tokenMiser.passThroughCount.toLocaleString()} passed through`
-          : `${tokenMiser.interceptionCount.toLocaleString()} gated ${tokenMiser.interceptionCount === 1 ? "call" : "calls"}`} ·{" "}
-        {tokenMiser.passThroughCount
-          ? hasCompleteDispositionBreakdown
-            ? `${formatCompactTokens(summarizedReplacementTokens)} summary tokens · ${formatCompactTokens(passedThroughReplacementTokens)} pass-through tokens`
-            : `${formatCompactTokens(tokenMiser.replacementTokens)} revealed before retrieval`
-          : `${formatCompactTokens(tokenMiser.replacementTokens)} of summaries`} ·{" "}
-        {tokenMiser.retrievedTokens > 0
-          ? `${formatCompactTokens(tokenMiser.retrievedTokens)} read back later`
-          : "nothing read back later"}
-      </p>
-      <p className="incident-explorer__savings-caption">
-        {tokenMiser.interceptionCount.toLocaleString()} decisions
-        {" · "}{(tokenMiser.helperDecisionCount ?? 0).toLocaleString()} Luna evaluations
-        {" · "}{(tokenMiser.policyPassThroughCount ?? 0).toLocaleString()} policy pass-throughs
-        {" · "}{(tokenMiser.helperPassThroughCount ?? 0).toLocaleString()} helper pass-throughs
-      </p>
-      <TokenMiserContextTimeline
-        compactions={props.compactions}
-        usageLines={props.usageLines}
-      />
-      <TokenMiserCompactionStats
-        compactions={props.compactions}
-        contextWindow={props.contextWindow}
-        currency={props.currency}
-      />
+      <SavingsDetailStack height={layout.detailsHeight} onMeasure={measure}>
+        <SavingsDetailSection
+          facts={[
+            { label: "decisions", value: tokenMiser.interceptionCount.toLocaleString() },
+            { label: "summarized", value: summarizedCount.toLocaleString() },
+            ...(tokenMiser.passThroughCount
+              ? [{
+                  label: "passed through",
+                  value: tokenMiser.passThroughCount.toLocaleString(),
+                }]
+              : []),
+            {
+              label: "kept out of parent",
+              value: formatCompactTokens(props.comparison.avoidedParentTokens),
+            },
+            {
+              label: "read back",
+              value: formatCompactTokens(tokenMiser.retrievedTokens),
+              zero: tokenMiser.retrievedTokens === 0,
+            },
+          ]}
+          label="Decisions"
+          onToggle={toggleSection}
+          open={layout.openSections.includes("decisions")}
+          sectionKey="decisions"
+        >
+          <SavingsFigureGrid
+            figures={[
+              {
+                detail: tokenMiser.passThroughCount
+                  ? hasCompleteDispositionBreakdown
+                    ? `${formatCompactTokens(summarizedReplacementTokens)} of summaries`
+                    : `${formatCompactTokens(tokenMiser.replacementTokens)} revealed before retrieval`
+                  : `${formatCompactTokens(tokenMiser.replacementTokens)} of summaries`,
+                label: "Summarized",
+                value: summarizedCount.toLocaleString(),
+              },
+              {
+                detail: [
+                  ...((tokenMiser.policyPassThroughCount ?? 0)
+                    + (tokenMiser.helperPassThroughCount ?? 0) > 0
+                    ? [`${(tokenMiser.policyPassThroughCount ?? 0).toLocaleString()} policy`
+                      + ` · ${(tokenMiser.helperPassThroughCount ?? 0).toLocaleString()} helper`]
+                    : []),
+                  ...(hasCompleteDispositionBreakdown && tokenMiser.passThroughCount
+                    ? [`${formatCompactTokens(passedThroughReplacementTokens)} tokens`]
+                    : []),
+                ].join(" · ") || undefined,
+                label: "Passed through",
+                value: (tokenMiser.passThroughCount ?? 0).toLocaleString(),
+                zero: (tokenMiser.passThroughCount ?? 0) === 0,
+              },
+              {
+                label: "Luna evaluations",
+                value: (tokenMiser.helperDecisionCount ?? 0).toLocaleString(),
+                zero: (tokenMiser.helperDecisionCount ?? 0) === 0,
+              },
+              {
+                detail: `${partialPricingPrefix}`
+                  + `${formatCompactTokens(tokenMiser.baselineParentTokens)} uncached`
+                  + (cachedBaselineTokens > 0
+                    ? ` · ${formatCompactTokens(cachedBaselineTokens)} cached`
+                    : ""),
+                label: "Kept out of parent",
+                value: formatCompactTokens(props.comparison.avoidedParentTokens),
+              },
+              {
+                detail: `${partialPricingPrefix}`
+                  + `${formatCompactTokens(revealedTokens)} uncached`
+                  + (cachedRevealedTokens > 0
+                    ? ` · ${formatCompactTokens(cachedRevealedTokens)} cached`
+                    : ""),
+                label: "Revealed to parent",
+                value: formatCompactTokens(revealedTokens),
+              },
+              {
+                detail: tokenMiser.retrievedTokens > 0
+                  ? undefined
+                  : "nothing read back later",
+                label: "Read back later",
+                value: formatCompactTokens(tokenMiser.retrievedTokens),
+                zero: tokenMiser.retrievedTokens === 0,
+              },
+              ...(savings?.parentModel
+                ? [{ label: "Parent rates", value: savings.parentModel }]
+                : []),
+              ...(savings?.gateModel
+                ? [{ label: "Gate model", value: savings.gateModel }]
+                : []),
+            ]}
+          />
+        </SavingsDetailSection>
 
-      <TokenMiserCodeModeStats
-        tokenMiser={tokenMiser}
-      />
+        <TokenMiserCompactionStats
+          compactions={props.compactions}
+          contextWindow={props.contextWindow}
+          currency={props.currency}
+          onToggle={toggleSection}
+          open={layout.openSections.includes("boundaries")}
+        />
+
+        <TokenMiserCodeModeStats
+          onToggle={toggleSection}
+          open={layout.openSections.includes("code-mode")}
+          tokenMiser={tokenMiser}
+        />
+      </SavingsDetailStack>
+
+      <SavingsSplitGrip measurement={measurement} onResize={resizeDetails} />
+
       <TokenMiserResultList entries={props.gates} tokenMiser={tokenMiser} />
     </div>
   );
@@ -1564,6 +1990,8 @@ function TokenMiserCompactionStats(props: {
   compactions: readonly ThreadCompactionRecord[];
   contextWindow?: TokenMiserContextWindowSummary;
   currency?: string;
+  onToggle: (key: SavingsSectionKey, open: boolean) => void;
+  open: boolean;
 }) {
   const coldReplayTokens = props.compactions.reduce(
     (total, entry) => total + (entry.coldUncachedTokens ?? 0),
@@ -1573,42 +2001,94 @@ function TokenMiserCompactionStats(props: {
     (total, entry) => total + (entry.coldCostMicros ?? 0),
     0,
   );
+  const currency = props.currency ?? "USD";
+  const contextWindow = props.contextWindow;
+  const nearLimit = contextWindow !== undefined
+    && contextWindow.peakModelContextWindow > 0
+    && contextWindow.peakTokens / contextWindow.peakModelContextWindow >= 0.85;
   return (
-    <section className="incident-explorer__gates" aria-label="Context boundaries">
-      <div className="incident-explorer__gates-head">
-        <p className="incident-explorer__eyebrow">Context boundaries</p>
-      </div>
-      <p className="incident-explorer__savings-caption">
-        {props.compactions.length.toLocaleString()} parent compactions
-        {" · "}{formatCompactTokens(coldReplayTokens)} compaction-attributed cold replay tokens
-        {" · "}{coldReplayCostMicros > 0
-          ? formatMicrosCurrency(coldReplayCostMicros, props.currency ?? "USD")
-          : "no attributed cold-replay cost"}
+    <SavingsDetailSection
+      facts={[
+        {
+          label: props.compactions.length === 1 ? "compaction" : "compactions",
+          value: props.compactions.length.toLocaleString(),
+          zero: props.compactions.length === 0,
+        },
+        ...(contextWindow
+          ? [
+              {
+                label: "peak of window",
+                value: formatContextWindowShare(
+                  contextWindow.peakTokens,
+                  contextWindow.peakModelContextWindow,
+                ),
+              },
+              {
+                label: "final",
+                value: formatCompactTokens(contextWindow.finalTokens),
+              },
+            ]
+          : []),
+        {
+          label: "cold replay",
+          value: formatMicrosCurrency(coldReplayCostMicros, currency),
+          zero: coldReplayCostMicros === 0,
+        },
+      ]}
+      label="Context boundaries"
+      onToggle={props.onToggle}
+      open={props.open}
+      sectionKey="boundaries"
+    >
+      <SavingsFigureGrid
+        figures={[
+          {
+            label: "Parent compactions",
+            value: props.compactions.length.toLocaleString(),
+            zero: props.compactions.length === 0,
+          },
+          {
+            detail: formatMicrosCurrency(coldReplayCostMicros, currency),
+            label: "Cold replay tokens",
+            value: formatCompactTokens(coldReplayTokens),
+            zero: coldReplayTokens === 0,
+          },
+          ...(contextWindow
+            ? [
+                {
+                  detail: formatContextWindowPoint(
+                    contextWindow.peakTokens,
+                    contextWindow.peakModelContextWindow,
+                  ),
+                  label: "Peak context",
+                  value: formatContextWindowShare(
+                    contextWindow.peakTokens,
+                    contextWindow.peakModelContextWindow,
+                  ),
+                },
+                {
+                  detail: formatContextWindowPoint(
+                    contextWindow.finalTokens,
+                    contextWindow.finalModelContextWindow,
+                  ),
+                  label: "Final context",
+                  value: formatContextWindowShare(
+                    contextWindow.finalTokens,
+                    contextWindow.finalModelContextWindow,
+                  ),
+                },
+              ]
+            : []),
+        ]}
+      />
+      <p className="incident-explorer__savings-note">
+        {contextWindow
+          ? "Token Miser replay savings stop at each recorded compaction boundary."
+          : "Token Miser replay savings stop at each recorded compaction boundary."
+            + " Peak and final context were not observed by this PwrAgent version."}
+        {nearLimit ? " Warning: this thread approached the context limit." : ""}
       </p>
-      <p className="incident-explorer__savings-caption">
-        Token Miser replay savings stop at each recorded compaction boundary.
-      </p>
-      {props.contextWindow ? (
-        <p className="incident-explorer__savings-caption">
-          Peak context {formatContextWindowPoint(
-            props.contextWindow.peakTokens,
-            props.contextWindow.peakModelContextWindow,
-          )}
-          {" · "}final context {formatContextWindowPoint(
-            props.contextWindow.finalTokens,
-            props.contextWindow.finalModelContextWindow,
-          )}
-          {props.contextWindow.peakTokens
-            / props.contextWindow.peakModelContextWindow >= 0.85
-            ? " · warning: this thread approached the context limit"
-            : ""}
-        </p>
-      ) : (
-        <p className="incident-explorer__savings-caption">
-          Peak and final context were not observed by this PwrAgent version.
-        </p>
-      )}
-    </section>
+    </SavingsDetailSection>
   );
 }
 
@@ -1650,6 +2130,18 @@ function buildContextWindowSummary(
   };
 }
 
+/**
+ * Just the share, for a folded row that has no space for the fraction.
+ *
+ * Whole percent rather than the one decimal `formatContextWindowPoint` keeps:
+ * this is the scannable landmark, and the exact figure sits beside it the
+ * moment the row is unfolded.
+ */
+function formatContextWindowShare(tokens: number, window: number): string {
+  if (window <= 0) return "—";
+  return `${Math.round(tokens / window * 100)}%`;
+}
+
 function formatContextWindowPoint(tokens: number, window: number): string {
   return `${formatCompactTokens(tokens)} / ${formatCompactTokens(window)} (${(
     tokens / window * 100
@@ -1657,41 +2149,100 @@ function formatContextWindowPoint(tokens: number, window: number): string {
 }
 
 function TokenMiserCodeModeStats(props: {
+  onToggle: (key: SavingsSectionKey, open: boolean) => void;
+  open: boolean;
   tokenMiser: NonNullable<ThreadToolAccounting["tokenMiser"]>;
 }) {
   const codeMode = props.tokenMiser.codeMode;
   if (!codeMode || codeMode.callCount === 0) return null;
   const commandCells = codeMode.commandCellCount ?? 0;
   const nestedCommands = codeMode.nestedCommandInvocationCount ?? 0;
+  const dispatchClusters = codeMode.dispatchClusterCount ?? 0;
+  const multiInvocation = codeMode.multiInvocationClusterCount ?? 0;
+  /* Gated and direct decompose callCount, which is why both belong on this
+     row. The reducer's own totals live on Decisions and are not repeated. */
+  const gatedCount = codeMode.summarizedCount + codeMode.passThroughCount;
   return (
-    <section className="incident-explorer__gates" aria-label="Code Mode behavior">
-      <div className="incident-explorer__gates-head">
-        <p className="incident-explorer__eyebrow">Code Mode behavior</p>
-      </div>
-      <p className="incident-explorer__savings-caption">
-        {codeMode.callCount.toLocaleString()} Code Mode calls
-        {" · "}{commandCells.toLocaleString()} command-bearing cells
-        {" · "}{nestedCommands.toLocaleString()} nested command invocations
-        {" · "}{commandCells > 0
-          ? (nestedCommands / commandCells).toFixed(2)
-          : "0.00"} per command cell
-        {" · "}{(codeMode.dispatchClusterCount ?? 0).toLocaleString()} dispatch clusters
-        {" · "}{(codeMode.multiInvocationClusterCount ?? 0).toLocaleString()} multi-invocation
-        {(codeMode.multiInvocationClusterCount ?? 0) > 0
-          ? ` (largest ${(codeMode.largestDispatchCluster ?? 0).toLocaleString()})`
-          : ""}
-      </p>
-      <p className="incident-explorer__savings-caption">
-        {(codeMode.directCommandCellCount ?? 0).toLocaleString()} direct command cells
-        {" · "}{props.tokenMiser.interceptionCount.toLocaleString()} reducer decisions
-        {" · "}{codeMode.summarizedCount.toLocaleString()} summarized
-        {" · "}{codeMode.passThroughCount.toLocaleString()} explicit pass-through
-        {" · "}{(codeMode.patchCellCount ?? 0).toLocaleString()} patch cells
-        {" · "}{(codeMode.otherCellCount ?? 0).toLocaleString()} other cells
-        {" · "}{codeMode.retrievalCount.toLocaleString()} retrieval cells
-        {" · "}{(codeMode.pollingCellCount ?? 0).toLocaleString()} polling cells
-      </p>
-    </section>
+    <SavingsDetailSection
+      facts={[
+        {
+          label: codeMode.callCount === 1 ? "call" : "calls",
+          value: codeMode.callCount.toLocaleString(),
+        },
+        {
+          label: "gated",
+          value: gatedCount.toLocaleString(),
+          zero: gatedCount === 0,
+        },
+        {
+          label: "direct",
+          value: codeMode.directCount.toLocaleString(),
+          zero: codeMode.directCount === 0,
+        },
+        {
+          label: "command cells",
+          value: commandCells.toLocaleString(),
+          zero: commandCells === 0,
+        },
+        {
+          label: "dispatch clusters",
+          value: dispatchClusters.toLocaleString(),
+          zero: dispatchClusters === 0,
+        },
+      ]}
+      label="Code Mode"
+      onToggle={props.onToggle}
+      open={props.open}
+      sectionKey="code-mode"
+    >
+      <SavingsFigureGrid
+        figures={[
+          {
+            detail: `${nestedCommands.toLocaleString()} nested · `
+              + `${commandCells > 0
+                ? (nestedCommands / commandCells).toFixed(2)
+                : "0.00"} per cell`,
+            label: "Command-bearing cells",
+            value: commandCells.toLocaleString(),
+            zero: commandCells === 0,
+          },
+          {
+            detail: `${multiInvocation.toLocaleString()} multi-invocation`
+              + (multiInvocation > 0
+                ? ` · largest ${(codeMode.largestDispatchCluster ?? 0).toLocaleString()}`
+                : ""),
+            label: "Dispatch clusters",
+            value: dispatchClusters.toLocaleString(),
+            zero: dispatchClusters === 0,
+          },
+          {
+            label: "Direct command cells",
+            value: (codeMode.directCommandCellCount ?? 0).toLocaleString(),
+            zero: (codeMode.directCommandCellCount ?? 0) === 0,
+          },
+          {
+            label: "Patch cells",
+            value: (codeMode.patchCellCount ?? 0).toLocaleString(),
+            zero: (codeMode.patchCellCount ?? 0) === 0,
+          },
+          {
+            label: "Other cells",
+            value: (codeMode.otherCellCount ?? 0).toLocaleString(),
+            zero: (codeMode.otherCellCount ?? 0) === 0,
+          },
+          {
+            label: "Retrieval cells",
+            value: codeMode.retrievalCount.toLocaleString(),
+            zero: codeMode.retrievalCount === 0,
+          },
+          {
+            label: "Polling cells",
+            value: (codeMode.pollingCellCount ?? 0).toLocaleString(),
+            zero: (codeMode.pollingCellCount ?? 0) === 0,
+          },
+        ]}
+      />
+    </SavingsDetailSection>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -1123,6 +1123,19 @@ function SavingsConfidence(props: { savings: ThreadTokenMiserSavings }) {
   );
 }
 
+type SavingsSplit = {
+  avoided: number;
+  gate: number;
+  revealed: number;
+  /**
+   * The caption's whole percents. The last term absorbs the rounding instead
+   * of being rounded itself: three shares of one whole, each rounded on its
+   * own, read as "51% · 3% · 47%" often enough to invite the reader to notice
+   * that the decomposition under the bar does not close.
+   */
+  rounded: { avoided: number; gate: number; revealed: number };
+};
+
 /**
  * The three terms as shares of the unfiltered cost.
  *
@@ -1132,20 +1145,39 @@ function SavingsConfidence(props: { savings: ThreadTokenMiserSavings }) {
  */
 function buildSavingsSplit(
   savings: ThreadTokenMiserSavings,
-): { avoided: number; gate: number; revealed: number } | undefined {
+): SavingsSplit | undefined {
   const whole = savings.withoutGateCostMicros;
   if (whole <= 0 || savings.savingsMicros <= 0) return undefined;
+  const avoided = savings.savingsMicros / whole * 100;
+  const gate = savings.gateCostMicros / whole * 100;
+  const roundedAvoided = Math.round(avoided);
+  const roundedGate = Math.round(gate);
   return {
-    avoided: savings.savingsMicros / whole * 100,
-    gate: savings.gateCostMicros / whole * 100,
+    avoided,
+    gate,
     revealed: savings.revealedCostMicros / whole * 100,
+    rounded: {
+      avoided: roundedAvoided,
+      gate: roundedGate,
+      revealed: Math.max(0, 100 - roundedAvoided - roundedGate),
+    },
   };
 }
 
 type SavingsDetailMeasurement = {
+  /**
+   * The height the two panes share: the detail stack plus the results list,
+   * measured rather than derived. Deliberately not the lens container, which
+   * also holds the hero, the grip, and the gaps between them — sizing the
+   * clamp against that lets a dragged height be stored hundreds of pixels
+   * past anything the window can honour.
+   */
   availableHeight: number;
   detailsHeight: number;
 };
+
+/** The results list, whose floor the grip must never cross. */
+const SAVINGS_RESULTS_SELECTOR = ".incident-explorer__gates";
 
 const EMPTY_SAVINGS_MEASUREMENT: SavingsDetailMeasurement = {
   availableHeight: 0,
@@ -1162,7 +1194,15 @@ const EMPTY_SAVINGS_MEASUREMENT: SavingsDetailMeasurement = {
 function useSavingsLayout() {
   const [layout, setLayout] = useState(readStoredSavingsLayout);
   const [measurement, setMeasurement] = useState(EMPTY_SAVINGS_MEASUREMENT);
+  /* Mount reads; only a change writes. Persisting on mount would create the
+     key for every operator who merely opened the lens, and leave the stored
+     state unable to say whether anyone ever moved the split. */
+  const persisted = useRef(false);
   useEffect(() => {
+    if (!persisted.current) {
+      persisted.current = true;
+      return;
+    }
     writeStoredSavingsLayout(layout);
   }, [layout]);
   const toggleSection = useCallback(
@@ -1214,11 +1254,26 @@ function SavingsDetailStack(props: {
   useLayoutEffect(() => {
     const node = stackRef.current;
     if (!node) return;
-    onMeasure({
-      availableHeight: node.parentElement?.getBoundingClientRect().height ?? 0,
-      detailsHeight: node.getBoundingClientRect().height,
-    });
-  });
+    const list = node.parentElement?.querySelector(SAVINGS_RESULTS_SELECTOR);
+    const measureNow = () => {
+      const stackHeight = node.getBoundingClientRect().height;
+      const listHeight = list?.getBoundingClientRect().height ?? 0;
+      onMeasure({
+        availableHeight: stackHeight + listHeight,
+        detailsHeight: stackHeight,
+      });
+    };
+    measureNow();
+    /* Observed rather than re-measured on every render. A render-time
+       measurement forces two layout flushes per poll and still misses the one
+       change that matters most — the operator resizing the window, which moves
+       the list without re-rendering the lens at all. */
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(measureNow);
+    observer.observe(node);
+    if (list) observer.observe(list);
+    return () => observer.disconnect();
+  }, [onMeasure]);
   return (
     <div
       className="incident-explorer__savings-details"
@@ -1255,7 +1310,9 @@ function SavingsSplitGrip(props: {
   measurement: SavingsDetailMeasurement;
   onResize: (height: number, available: number) => void;
 }) {
-  const dragRef = useRef<{ startHeight: number; startY: number }>(undefined);
+  const dragRef = useRef<
+    { pointerId: number; startHeight: number; startY: number }
+  >(undefined);
   const measurement = props.measurement;
   const onResize = props.onResize;
   return (
@@ -1277,18 +1334,31 @@ function SavingsSplitGrip(props: {
           measurement.availableHeight,
         );
       }}
+      /* Capture can end without a pointerup — a gesture the OS takes over, a
+         window that loses focus mid-drag. Clearing only on pointerup leaves
+         the drag armed, and every later hover across the handle then resizes
+         the split with no button held. */
+      onLostPointerCapture={() => {
+        dragRef.current = undefined;
+      }}
       onPointerDown={(event) => {
         if (event.button !== 0) return;
+        /* preventDefault stops the drag from selecting the text either side
+           of the grip, and takes the default focus action with it. Focus has
+           to be restored by hand, or the keyboard resize this separator
+           advertises is reachable only by tabbing to it. */
         event.preventDefault();
+        event.currentTarget.focus();
         event.currentTarget.setPointerCapture(event.pointerId);
         dragRef.current = {
+          pointerId: event.pointerId,
           startHeight: measurement.detailsHeight,
           startY: event.clientY,
         };
       }}
       onPointerMove={(event) => {
         const drag = dragRef.current;
-        if (!drag) return;
+        if (!drag || drag.pointerId !== event.pointerId) return;
         onResize(
           drag.startHeight + (event.clientY - drag.startY),
           measurement.availableHeight,
@@ -1364,6 +1434,42 @@ function SavingsDetailSection(props: {
   );
 }
 
+/**
+ * One term of the savings equation.
+ *
+ * The basis — the token counts, the cached split, the model whose rates were
+ * applied — was visible text under each term before this layout compacted the
+ * equation into a single line. `title` restores it for a mouse, and nothing
+ * else: it is not focusable, several screen readers ignore it, and this window
+ * is not covered by the a11y gate. So the same string also renders as text
+ * that is clipped rather than absent, and the accessible reading of the
+ * equation stays what it was.
+ */
+function SavingsTerm(props: {
+  basis?: string;
+  label: string;
+  result?: boolean;
+  value: string;
+}) {
+  return (
+    <div
+      className="incident-explorer__savings-term"
+      data-result={props.result === true ? "true" : undefined}
+      title={props.basis}
+    >
+      <dt>{props.label}</dt>
+      <dd>
+        {props.value}
+        {props.basis ? (
+          <span className="incident-explorer__savings-basis">
+            {" · "}{props.basis}
+          </span>
+        ) : null}
+      </dd>
+    </div>
+  );
+}
+
 function SavingsFigureGrid(props: { figures: SavingsFigure[] }) {
   return (
     <dl className="incident-explorer__savings-figures">
@@ -1417,6 +1523,10 @@ function TokenMiserSavingsLens(props: {
             usageLines={props.usageLines}
           />
         </div>
+        {/* Code Mode is the stack's only child here, and it always renders on
+            this branch: the window hands the lens `activeTokenMiser`, which
+            exists only when the thread gated or made a Code Mode call, and a
+            missing comparison means it did not gate. */}
         <SavingsDetailStack height={layout.detailsHeight} onMeasure={measure}>
           <TokenMiserCodeModeStats
             onToggle={toggleSection}
@@ -1492,71 +1602,60 @@ function TokenMiserSavingsLens(props: {
                 ) : null}
               </p>
               <dl className="incident-explorer__savings-equation">
-                <div
-                  className="incident-explorer__savings-term"
-                  title={`${formatCompactTokens(tokenMiser.baselineParentTokens)} uncached`
+                <SavingsTerm
+                  basis={`${partialPricingPrefix}`
+                    + `${formatCompactTokens(tokenMiser.baselineParentTokens)} uncached`
                     + (cachedBaselineTokens > 0
                       ? ` + ${formatCompactTokens(cachedBaselineTokens)} cached`
                       : "")
                     + ` at ${savings.parentModel ?? "the parent model"} rates`}
-                >
-                  <dt>Without the gate</dt>
-                  <dd>
-                    {formatMicrosCurrency(
-                      savings.withoutGateCostMicros,
-                      savings.currency,
-                    )}
-                  </dd>
-                </div>
+                  label="Without the gate"
+                  value={formatMicrosCurrency(
+                    savings.withoutGateCostMicros,
+                    savings.currency,
+                  )}
+                />
                 <span aria-hidden="true" className="incident-explorer__savings-operator">
                   −
                 </span>
-                <div
-                  className="incident-explorer__savings-term"
-                  title={`${formatCompactTokens(props.gateTokens)} charged by `
+                <SavingsTerm
+                  basis={`${formatCompactTokens(props.gateTokens)} charged by `
                     + `${savings.gateModel ?? "the helper"}`}
-                >
-                  <dt>Gate compute</dt>
-                  <dd>
-                    {formatMicrosCurrency(savings.gateCostMicros, savings.currency)}
-                  </dd>
-                </div>
+                  label="Gate compute"
+                  value={formatMicrosCurrency(
+                    savings.gateCostMicros,
+                    savings.currency,
+                  )}
+                />
                 <span aria-hidden="true" className="incident-explorer__savings-operator">
                   −
                 </span>
-                <div
-                  className="incident-explorer__savings-term"
-                  title={`${formatCompactTokens(revealedTokens)} uncached`
+                <SavingsTerm
+                  basis={`${partialPricingPrefix}`
+                    + `${formatCompactTokens(revealedTokens)} uncached`
                     + (cachedRevealedTokens > 0
                       ? ` + ${formatCompactTokens(cachedRevealedTokens)} cached`
                       : "")
                     + (tokenMiser.passThroughCount
                       ? " · summaries, retrievals, and deliberate pass-throughs"
                       : " · summaries and retrievals")}
-                >
-                  <dt>Revealed to parent</dt>
-                  <dd>
-                    {formatMicrosCurrency(
-                      savings.revealedCostMicros,
-                      savings.currency,
-                    )}
-                  </dd>
-                </div>
+                  label="Revealed to parent"
+                  value={formatMicrosCurrency(
+                    savings.revealedCostMicros,
+                    savings.currency,
+                  )}
+                />
                 <span aria-hidden="true" className="incident-explorer__savings-operator">
                   =
                 </span>
-                <div
-                  className="incident-explorer__savings-term"
-                  data-result="true"
-                >
-                  <dt>{savings.savingsMicros >= 0 ? "Saved" : "Overhead"}</dt>
-                  <dd>
-                    {formatMicrosCurrency(
-                      Math.abs(savings.savingsMicros),
-                      savings.currency,
-                    )}
-                  </dd>
-                </div>
+                <SavingsTerm
+                  label={savings.savingsMicros >= 0 ? "Saved" : "Overhead"}
+                  result
+                  value={formatMicrosCurrency(
+                    Math.abs(savings.savingsMicros),
+                    savings.currency,
+                  )}
+                />
               </dl>
               {split ? (
                 <>
@@ -1570,9 +1669,9 @@ function TokenMiserSavingsLens(props: {
                   </span>
                   <p className="incident-explorer__savings-split-caption">
                     <span>
-                      <b>{Math.round(split.avoided)}%</b> avoided
-                      {" · "}<b>{Math.round(split.gate)}%</b> gate
-                      {" · "}<b>{Math.round(split.revealed)}%</b> revealed
+                      <b>{split.rounded.avoided}%</b> avoided
+                      {" · "}<b>{split.rounded.gate}%</b> gate
+                      {" · "}<b>{split.rounded.revealed}%</b> revealed
                     </span>
                     {props.threadCostMicros > 0 ? (
                       <span>
@@ -2082,10 +2181,10 @@ function TokenMiserCompactionStats(props: {
         ]}
       />
       <p className="incident-explorer__savings-note">
+        Token Miser replay savings stop at each recorded compaction boundary.
         {contextWindow
-          ? "Token Miser replay savings stop at each recorded compaction boundary."
-          : "Token Miser replay savings stop at each recorded compaction boundary."
-            + " Peak and final context were not observed by this PwrAgent version."}
+          ? ""
+          : " Peak and final context were not observed by this PwrAgent version."}
         {nearLimit ? " Warning: this thread approached the context limit." : ""}
       </p>
     </SavingsDetailSection>
@@ -2160,7 +2259,8 @@ function TokenMiserCodeModeStats(props: {
   const dispatchClusters = codeMode.dispatchClusterCount ?? 0;
   const multiInvocation = codeMode.multiInvocationClusterCount ?? 0;
   /* Gated and direct decompose callCount, which is why both belong on this
-     row. The reducer's own totals live on Decisions and are not repeated. */
+     row. Gated's own halves are one unfold away below, and the reducer's
+     thread-wide totals live on Decisions and are not repeated here. */
   const gatedCount = codeMode.summarizedCount + codeMode.passThroughCount;
   return (
     <SavingsDetailSection
@@ -2197,6 +2297,16 @@ function TokenMiserCodeModeStats(props: {
     >
       <SavingsFigureGrid
         figures={[
+          {
+            label: "Summarized",
+            value: codeMode.summarizedCount.toLocaleString(),
+            zero: codeMode.summarizedCount === 0,
+          },
+          {
+            label: "Explicit pass-through",
+            value: codeMode.passThroughCount.toLocaleString(),
+            zero: codeMode.passThroughCount === 0,
+          },
           {
             detail: `${nestedCommands.toLocaleString()} nested · `
               + `${commandCells > 0

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -634,6 +634,67 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     });
   });
 
+  /* jsdom implements no pointer capture at all, so the grip's own calls have
+     to be stubbed for a drag to reach the handlers. Everything the assertions
+     read — the captured start height, the delta, and when the drag ends — is
+     still the component's. */
+  function stubPointerCapture(node: HTMLElement): void {
+    let captured = false;
+    Object.assign(node, {
+      hasPointerCapture: () => captured,
+      releasePointerCapture: () => {
+        captured = false;
+      },
+      setPointerCapture: () => {
+        captured = true;
+      },
+    });
+  }
+
+  it("resizes the detail stack while the pointer is down", async () => {
+    installApi({ readThread: async () => buildSavingsResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const grip = await screen.findByRole("separator", {
+      name: "Resize the Token Miser detail rows",
+    });
+    stubPointerCapture(grip);
+    const stack = document.querySelector(".incident-explorer__savings-details");
+    expect(stack).not.toHaveAttribute("style");
+
+    fireEvent.pointerDown(grip, { button: 0, clientY: 400, pointerId: 1 });
+    fireEvent.pointerMove(grip, { clientY: 520, pointerId: 1 });
+
+    // jsdom reports no geometry, so the clamp hands back its floor whatever
+    // the drag asked for. What this pins is that the drag ran and committed a
+    // height, which is the half the keyboard test cannot reach.
+    await waitFor(() => {
+      expect(stack).toHaveStyle({ height: `${SAVINGS_DETAILS_MIN_HEIGHT}px` });
+    });
+  });
+
+  /* A gesture the OS takes over ends in lostpointercapture, never pointerup.
+     Clearing the drag only on pointerup left it armed, and every later hover
+     across the handle then resized the split with no button held. */
+  it("stops resizing when a drag is cancelled instead of released", async () => {
+    installApi({ readThread: async () => buildSavingsResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const grip = await screen.findByRole("separator", {
+      name: "Resize the Token Miser detail rows",
+    });
+    stubPointerCapture(grip);
+    fireEvent.pointerDown(grip, { button: 0, clientY: 400, pointerId: 1 });
+    fireEvent.lostPointerCapture(grip, { pointerId: 1 });
+    fireEvent.pointerMove(grip, { clientY: 900, pointerId: 1 });
+
+    const stack = document.querySelector(".incident-explorer__savings-details");
+    expect(stack).not.toHaveAttribute("style");
+    expect(readStoredSavingsLayout().detailsHeight).toBeUndefined();
+  });
+
   it("shows the priced savings equation and how much of it was observed", async () => {
     const response = buildResponse();
     response.pricing = {
@@ -702,14 +763,25 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     const splitCaption = screen
       .getByText("avoided · gate · revealed")
       .closest("p");
-    expect(splitCaption).toHaveTextContent("51% avoided · 7% gate · 41% revealed");
+    // 51.5, 7.4 and 41.2 percent. The last term absorbs the rounding, so the
+    // three printed shares close on 100 instead of the 99 that rounding each
+    // of them on its own produces.
+    expect(splitCaption).toHaveTextContent("51% avoided · 7% gate · 42% revealed");
     expect(splitCaption).toHaveTextContent("observed $0.36 · unfiltered $0.71");
     expect(
       screen.getByText(/Directly observed · 47 payload replays across 4 gates, each counted at a request boundary/),
     ).toBeInTheDocument();
 
-    // The token basis of each term moved onto the decisions row rather than
-    // paying for two lines of sub-caption under every term.
+    // The basis stays readable to a screen reader even though the compact
+    // equation only paints it into a `title`. `toHaveTextContent` descends,
+    // which is the point: it sees what the accessibility tree sees.
+    expect(screen.getByText("Without the gate").closest("div"))
+      .toHaveTextContent("40k uncached + 1,850k cached at gpt-5.6-terra rates");
+    expect(screen.getByText("Gate compute").closest("div"))
+      .toHaveTextContent("0 charged by gpt-5.6-luna");
+
+    // The token basis of each term also lands on the decisions row rather than
+    // paying for two lines of visible sub-caption under every term.
     openSavingsSection("Decisions");
     const decisions = savingsSection("Decisions");
     expect(decisions.getByText(/40k uncached · 1,850k cached/))
@@ -767,6 +839,11 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     await screen.findByText("Estimated same-trajectory overhead");
     expect(screen.getByText("33.3% more than estimated unfiltered cost"))
       .toBeInTheDocument();
+    /* With negative savings the parts sum past the whole, and a bar
+       overflowing its own track reads as a rendering fault. The overspend
+       states itself in words above instead. */
+    expect(screen.queryByText("avoided · gate · revealed")).not.toBeInTheDocument();
+    expect(document.querySelector(".incident-explorer__savings-split")).toBeNull();
   });
 
   // Reconstructed replays are inferred from later tool calls and cannot see

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -12,12 +12,31 @@ import type {
   ThreadToolInvocationRecord,
 } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readStoredSavingsLayout,
+  SAVINGS_DETAILS_MIN_HEIGHT,
+} from "../token-miser-savings-layout";
 import { ToolOutputIncidentExplorerWindow } from "../ToolOutputIncidentExplorerWindow";
 
 afterEach(() => {
   Reflect.deleteProperty(window, "pwragent");
+  window.localStorage.clear();
   window.location.hash = "";
 });
+
+/**
+ * The Savings lens folds its reference sections by default, so a test that
+ * asserts on one has to open it first. Each section is a named region, which
+ * keeps these lookups off the results list below — its rows are buttons whose
+ * text also begins "Code Mode".
+ */
+function savingsSection(label: string) {
+  return within(screen.getByRole("region", { name: label }));
+}
+
+function openSavingsSection(label: string) {
+  fireEvent.click(savingsSection(label).getByRole("button"));
+}
 
 describe("ToolOutputIncidentExplorerWindow", () => {
   it("uses standard thread identity chrome without exposing the raw thread id", async () => {
@@ -189,8 +208,11 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
     render(<ToolOutputIncidentExplorerWindow />);
 
-    expect(await screen.findByText(/2 Code Mode calls/)).toBeInTheDocument();
-    expect(screen.getByText(/2 direct command cells · 0 reducer decisions/))
+    await screen.findByRole("region", { name: "Code Mode" });
+    expect(savingsSection("Code Mode").getByRole("button"))
+      .toHaveTextContent(/2 calls.*2 direct/);
+    openSavingsSection("Code Mode");
+    expect(savingsSection("Code Mode").getByText("Direct command cells"))
       .toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^All\s*2$/ })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^Direct\s*2$/ })).toBeInTheDocument();
@@ -257,22 +279,37 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
     render(<ToolOutputIncidentExplorerWindow />);
 
-    expect(await screen.findByText(
-      /143 Code Mode calls · 121 command-bearing cells · 122 nested command invocations · 1\.01 per command cell/,
-    )).toBeInTheDocument();
-    expect(screen.getByText(
-      /90 direct command cells · 31 reducer decisions/,
-    )).toBeInTheDocument();
-    expect(screen.getByText(
-      /31 decisions · 26 Luna evaluations · 5 policy pass-throughs · 2 helper pass-throughs/,
-    )).toBeInTheDocument();
+    // Folded, each section leads with its own headline counts. Code Mode
+    // calls, command cells and reducer decisions are three different numbers
+    // and must never be collapsed into one.
+    await screen.findByRole("region", { name: "Code Mode" });
+    expect(savingsSection("Code Mode").getByRole("button")).toHaveTextContent(
+      /143 calls.*121 command cells.*121 dispatch clusters/,
+    );
+    expect(savingsSection("Decisions").getByRole("button"))
+      .toHaveTextContent(/31 decisions/);
+
+    openSavingsSection("Code Mode");
+    const codeMode = savingsSection("Code Mode");
+    expect(codeMode.getByText(/122 nested · 1\.01 per cell/)).toBeInTheDocument();
+    expect(codeMode.getByText(/1 multi-invocation · largest 2/)).toBeInTheDocument();
+    expect(codeMode.getByText("Direct command cells").nextSibling)
+      .toHaveTextContent("90");
+    // Nested invocations divided by decisions rather than by command cells.
     expect(screen.queryByText(/3\.94 per/)).not.toBeInTheDocument();
-    expect(screen.getByText(
-      /1 parent compactions · 50k compaction-attributed cold replay tokens · \$0\.25/,
-    )).toBeInTheDocument();
-    expect(screen.getByText(
-      /Peak context 244k \/ 258k \(94\.4%\) · final context 131k \/ 258k \(50\.9%\)/,
-    )).toBeInTheDocument();
+
+    openSavingsSection("Decisions");
+    const decisions = savingsSection("Decisions");
+    expect(decisions.getByText("Luna evaluations").nextSibling)
+      .toHaveTextContent("26");
+    expect(decisions.getByText(/5 policy · 2 helper/)).toBeInTheDocument();
+
+    openSavingsSection("Context boundaries");
+    const boundaries = savingsSection("Context boundaries");
+    expect(boundaries.getByText("Cold replay tokens").nextSibling)
+      .toHaveTextContent(/50k\$0\.25/);
+    expect(boundaries.getByText(/244k \/ 258k \(94\.4%\)/)).toBeInTheDocument();
+    expect(boundaries.getByText(/131k \/ 258k \(50\.9%\)/)).toBeInTheDocument();
   });
 
   it("warns on a near-limit thread even when no compaction occurred", async () => {
@@ -299,11 +336,15 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     window.location.hash = "#tool-output-incidents/codex/thread-1/Near%20limit";
     render(<ToolOutputIncidentExplorerWindow />);
 
-    expect(await screen.findByText(
-      /0 parent compactions · 0 compaction-attributed cold replay tokens/,
-    )).toBeInTheDocument();
-    expect(screen.getByText(
-      /Peak context 240k \/ 258k \(92\.9%\) · final context 239k \/ 258k \(92\.5%\) · warning: this thread approached the context limit/,
+    await screen.findByRole("region", { name: "Context boundaries" });
+    openSavingsSection("Context boundaries");
+    const boundaries = savingsSection("Context boundaries");
+    expect(boundaries.getByText("Parent compactions").nextSibling)
+      .toHaveTextContent("0");
+    expect(boundaries.getByText(/240k \/ 258k \(92\.9%\)/)).toBeInTheDocument();
+    expect(boundaries.getByText(/239k \/ 258k \(92\.5%\)/)).toBeInTheDocument();
+    expect(boundaries.getByText(
+      /Warning: this thread approached the context limit/,
     )).toBeInTheDocument();
   });
 
@@ -437,7 +478,7 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(screen.queryByRole("button", { name: /win-1/ })).not.toBeInTheDocument();
   });
 
-  it("separates summary and pass-through tokens in the savings caption", async () => {
+  it("separates summary and pass-through tokens on the decisions row", async () => {
     const response = buildResponse();
     response.toolAccounting!.tokenMiser = {
       interceptionCount: 2,
@@ -480,9 +521,117 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     window.location.hash = "#tool-output-incidents/codex/thread-1/Adaptive%20proof";
     render(<ToolOutputIncidentExplorerWindow />);
 
-    expect(await screen.findByText(
-      /1 summarized · 1 passed through · 392 summary tokens · 2.7k pass-through tokens · nothing read back later/,
-    )).toBeInTheDocument();
+    await screen.findByRole("region", { name: "Decisions" });
+    expect(savingsSection("Decisions").getByRole("button")).toHaveTextContent(
+      /1 summarized.*1 passed through/,
+    );
+    openSavingsSection("Decisions");
+    const decisions = savingsSection("Decisions");
+    expect(decisions.getByText("392 of summaries")).toBeInTheDocument();
+    expect(decisions.getByText("2.7k tokens")).toBeInTheDocument();
+    expect(decisions.getByText("nothing read back later")).toBeInTheDocument();
+  });
+
+  /* The lens shipped with every band above the results list fixed-height and
+     fully expanded. At the 1000x700 window it runs in, they needed more than
+     the window, and the list — the only part an operator can explore — was
+     left rendering a single row. These three cover the fix: the reference
+     rows cost nothing until asked for, the operator's choice survives, and
+     the grip can never hand the list less than its floor. */
+  function buildSavingsResponse() {
+    const response = buildResponse();
+    response.toolAccounting!.tokenMiser = {
+      interceptionCount: 23,
+      passThroughCount: 5,
+      policyPassThroughCount: 0,
+      helperPassThroughCount: 5,
+      helperDecisionCount: 23,
+      originalCharacters: 100_000,
+      baselineParentTokens: 25_000,
+      replacementTokens: 3_000,
+      retrievedTokens: 0,
+      estimatedParentTokensSaved: 22_000,
+      interceptions: [],
+      codeMode: {
+        callCount: 37,
+        commandCellCount: 0,
+        directCommandCellCount: 0,
+        dispatchClusterCount: 0,
+        multiInvocationClusterCount: 0,
+        largestDispatchCluster: 0,
+        nestedCommandInvocationCount: 0,
+        patchCellCount: 0,
+        otherCellCount: 37,
+        pollingCellCount: 0,
+        directCount: 14,
+        summarizedCount: 18,
+        passThroughCount: 5,
+        retrievalCount: 0,
+        capturedNestedInvocationCount: 0,
+        observations: [],
+      },
+    };
+    return response;
+  }
+
+  it("folds every reference section so the results list is not squeezed", async () => {
+    installApi({ readThread: async () => buildSavingsResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    await screen.findByRole("region", { name: "Decisions" });
+    for (const label of ["Decisions", "Context boundaries", "Code Mode"]) {
+      expect(savingsSection(label).getByRole("button"))
+        .toHaveAttribute("aria-expanded", "false");
+    }
+    // Folded rows still carry their headline numbers, so nothing has to be
+    // opened to read the screen.
+    expect(savingsSection("Decisions").getByRole("button"))
+      .toHaveTextContent(/23 decisions.*18 summarized.*5 passed through/);
+    expect(savingsSection("Code Mode").getByRole("button"))
+      .toHaveTextContent(/37 calls.*23 gated.*14 direct/);
+    // No section body is mounted until one is asked for.
+    expect(screen.queryByText("Luna evaluations")).not.toBeInTheDocument();
+    expect(screen.queryByText("Retrieval cells")).not.toBeInTheDocument();
+  });
+
+  it("remembers which sections the operator unfolded", async () => {
+    installApi({ readThread: async () => buildSavingsResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    const first = render(<ToolOutputIncidentExplorerWindow />);
+
+    await screen.findByRole("region", { name: "Code Mode" });
+    openSavingsSection("Code Mode");
+    expect(savingsSection("Code Mode").getByText("Retrieval cells"))
+      .toBeInTheDocument();
+    first.unmount();
+
+    render(<ToolOutputIncidentExplorerWindow />);
+    await screen.findByRole("region", { name: "Code Mode" });
+    expect(savingsSection("Code Mode").getByRole("button"))
+      .toHaveAttribute("aria-expanded", "true");
+    expect(savingsSection("Decisions").getByRole("button"))
+      .toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("clamps the grip so the results list keeps its floor", async () => {
+    installApi({ readThread: async () => buildSavingsResponse() });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+
+    const grip = await screen.findByRole("separator", {
+      name: "Resize the Token Miser detail rows",
+    });
+    fireEvent.keyDown(grip, { key: "ArrowDown" });
+
+    /* jsdom lays nothing out, so every measured height is zero and the drag
+       asks for more than the window has. The stored value is the clamp's
+       floor rather than the requested one, which is the property that keeps
+       the list alive on a genuinely short window too. */
+    await waitFor(() => {
+      expect(readStoredSavingsLayout().detailsHeight)
+        .toBe(SAVINGS_DETAILS_MIN_HEIGHT);
+    });
   });
 
   it("shows the priced savings equation and how much of it was observed", async () => {
@@ -535,27 +684,41 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     await screen.findByRole("tab", { name: /Savings/, selected: true });
     expect(screen.getByText("Estimated same-trajectory savings"))
       .toBeInTheDocument();
-    expect(screen.getByText("$0.35")).toBeInTheDocument();
     expect(screen.getByText("49.3% less than estimated unfiltered cost"))
       .toBeInTheDocument();
-    expect(screen.getByText(/Observed thread cost/)).toHaveTextContent(
-      "Observed thread cost $0.36 · estimated same-trajectory cost without filtering $0.71",
-    );
-    expect(screen.getByText("1 · Without the gate")).toBeInTheDocument();
+    // The terms are laid out as the subtraction they are, so the headline and
+    // the result of the equation are the same figure printed twice.
+    expect(screen.getAllByText("$0.35")).toHaveLength(2);
+    expect(screen.getByText("Without the gate")).toBeInTheDocument();
     expect(screen.getByText("$0.68")).toBeInTheDocument();
-    expect(
-      screen.getByText(/40k uncached \+ 1,850k cached · gated tool output/),
-    ).toBeInTheDocument();
-    expect(screen.getByText("2 · Gate compute")).toBeInTheDocument();
+    expect(screen.getByText("Gate compute")).toBeInTheDocument();
     expect(screen.getByText("$0.05")).toBeInTheDocument();
-    expect(screen.getByText("3 · Revealed to parent")).toBeInTheDocument();
+    expect(screen.getByText("Revealed to parent")).toBeInTheDocument();
     expect(screen.getByText("$0.28")).toBeInTheDocument();
-    expect(
-      screen.getByText(/1.4k uncached \+ 50k cached · summaries and retrievals/),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+    // 350k saved, 50k gate and 280k revealed out of the 680k unfiltered.
+    // The split caption is matched on its own text nodes, because every figure
+    // in it sits inside a <b> that getByText does not descend into.
+    const splitCaption = screen
+      .getByText("avoided · gate · revealed")
+      .closest("p");
+    expect(splitCaption).toHaveTextContent("51% avoided · 7% gate · 41% revealed");
+    expect(splitCaption).toHaveTextContent("observed $0.36 · unfiltered $0.71");
     expect(
       screen.getByText(/Directly observed · 47 payload replays across 4 gates, each counted at a request boundary/),
     ).toBeInTheDocument();
+
+    // The token basis of each term moved onto the decisions row rather than
+    // paying for two lines of sub-caption under every term.
+    openSavingsSection("Decisions");
+    const decisions = savingsSection("Decisions");
+    expect(decisions.getByText(/40k uncached · 1,850k cached/))
+      .toBeInTheDocument();
+    expect(decisions.getByText(/1.4k uncached · 50k cached/)).toBeInTheDocument();
+    expect(decisions.getByText("Parent rates").nextSibling)
+      .toHaveTextContent("gpt-5.6-terra");
+    expect(decisions.getByText("Gate model").nextSibling)
+      .toHaveTextContent("gpt-5.6-luna");
   });
 
   it("shows same-trajectory overhead as a percentage of unfiltered cost", async () => {
@@ -638,7 +801,11 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(
       screen.getByText(/Partly reconstructed · 5 of 8 payload replays inferred from later tool calls · 1 gate is not priced yet/),
     ).toBeInTheDocument();
-    expect(screen.getAllByText(/All gates ·/)).toHaveLength(2);
+    // Token counts cover every gate while the dollars cover only the priced
+    // ones, so the two token figures say so.
+    openSavingsSection("Decisions");
+    expect(savingsSection("Decisions").getAllByText(/All gates ·/))
+      .toHaveLength(2);
   });
 
   it("shows Token Miser savings beside gross tool-output exposure", async () => {
@@ -695,10 +862,13 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(
       screen.getByText(/34.6k more across 6 replays/),
     ).toBeInTheDocument();
-    expect(
-      screen.getByText(/2 gated calls · 700 of summaries · 1.3k read back later/),
-    ).toBeInTheDocument();
     expect(screen.getByText("awaiting the pricing ledger")).toBeInTheDocument();
+    expect(savingsSection("Decisions").getByRole("button")).toHaveTextContent(
+      /2 decisions.*2 summarized.*1.3k read back/,
+    );
+    openSavingsSection("Decisions");
+    expect(savingsSection("Decisions").getByText("700 of summaries"))
+      .toBeInTheDocument();
 
     // The per-call gate box belongs to the incidents lens, beside the raw
     // output it replaced.

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/token-miser-savings-layout.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/token-miser-savings-layout.test.ts
@@ -1,0 +1,119 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clampDetailsHeight,
+  DEFAULT_SAVINGS_LAYOUT,
+  readStoredSavingsLayout,
+  SAVINGS_DETAILS_MIN_HEIGHT,
+  SAVINGS_RESULTS_MIN_HEIGHT,
+  writeStoredSavingsLayout,
+} from "../token-miser-savings-layout";
+
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(
+  path.resolve(testDir, "../../../styles/app.css"),
+  "utf8",
+);
+
+function extractRuleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("Savings lens layout preferences", () => {
+  it("starts with every reference section folded", () => {
+    expect(readStoredSavingsLayout()).toEqual(DEFAULT_SAVINGS_LAYOUT);
+    expect(DEFAULT_SAVINGS_LAYOUT.openSections).toEqual([]);
+    expect(DEFAULT_SAVINGS_LAYOUT.detailsHeight).toBeUndefined();
+  });
+
+  it("round-trips a stored split", () => {
+    writeStoredSavingsLayout({
+      detailsHeight: 220,
+      openSections: ["code-mode"],
+    });
+    expect(readStoredSavingsLayout()).toEqual({
+      detailsHeight: 220,
+      openSections: ["code-mode"],
+    });
+  });
+
+  /* A renamed section would otherwise keep unfolding a row that no longer
+     exists, and the operator would have no way to fold it again. */
+  it("drops section keys it does not recognize", () => {
+    window.localStorage.setItem(
+      "pwragent.toolOutput.savingsLayout",
+      JSON.stringify({ openSections: ["decisions", "gates", 7] }),
+    );
+    expect(readStoredSavingsLayout().openSections).toEqual(["decisions"]);
+  });
+
+  it("ignores a stored height that is not a usable number", () => {
+    for (const detailsHeight of [Number.NaN, Infinity, "220", null]) {
+      window.localStorage.setItem(
+        "pwragent.toolOutput.savingsLayout",
+        JSON.stringify({ detailsHeight, openSections: [] }),
+      );
+      expect(readStoredSavingsLayout().detailsHeight).toBeUndefined();
+    }
+  });
+
+  it("survives a corrupt entry rather than failing the lens", () => {
+    window.localStorage.setItem("pwragent.toolOutput.savingsLayout", "{oops");
+    expect(readStoredSavingsLayout()).toEqual(DEFAULT_SAVINGS_LAYOUT);
+  });
+});
+
+describe("clampDetailsHeight", () => {
+  it("leaves the results list its floor", () => {
+    expect(clampDetailsHeight(600, 700)).toBe(700 - SAVINGS_RESULTS_MIN_HEIGHT);
+  });
+
+  it("keeps a height that already clears the floor", () => {
+    expect(clampDetailsHeight(200, 700)).toBe(200);
+  });
+
+  it("never drags the stack away to nothing", () => {
+    expect(clampDetailsHeight(-40, 700)).toBe(SAVINGS_DETAILS_MIN_HEIGHT);
+  });
+
+  /* A window too short for both still has to produce a number. The stack wins
+     the arithmetic here and loses it in flexbox, where `flex-shrink` hands the
+     space back to the list. */
+  it("falls back to the stack minimum in a window shorter than the floor", () => {
+    expect(clampDetailsHeight(400, 120)).toBe(SAVINGS_DETAILS_MIN_HEIGHT);
+  });
+});
+
+/**
+ * The floor only works if the stylesheet agrees with the module the grip
+ * clamps against. Two numbers that must match, in two files, is exactly the
+ * pair that drifts silently — a smaller CSS value reopens the one-row bug and
+ * every test above still passes.
+ */
+describe("results-list floor", () => {
+  it("matches SAVINGS_RESULTS_MIN_HEIGHT in app.css", () => {
+    const declared = extractRuleBody(".incident-explorer__gates")
+      .match(/min-height:\s*(\d+)px;/)?.[1];
+    expect(Number(declared)).toBe(SAVINGS_RESULTS_MIN_HEIGHT);
+  });
+
+  it("lets the reference stack shrink so that floor can be honoured", () => {
+    const stack = extractRuleBody(".incident-explorer__savings-details");
+    expect(stack).toMatch(/flex:\s*0 1 auto;/);
+    expect(stack).toMatch(/min-height:\s*0;/);
+    expect(stack).toMatch(/overflow-y:\s*auto;/);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-layout.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/token-miser-savings-layout.ts
@@ -1,0 +1,98 @@
+/**
+ * Per-machine view state for the Explorer's Savings lens.
+ *
+ * Which reference sections are unfolded, and how tall the operator dragged the
+ * detail stack, are viewing preferences rather than thread facts. Two windows
+ * on the same thread may legitimately want different splits, and a peer
+ * instance has no business learning how this machine's operator reads the
+ * screen. localStorage, never SQLite, never federated — the rule drafts follow.
+ */
+export type SavingsSectionKey = "decisions" | "boundaries" | "code-mode";
+
+export type SavingsLayoutPreferences = {
+  /**
+   * Operator-chosen height of the detail stack, in CSS pixels. Absent until
+   * the grip is dragged, so an untouched lens keeps sizing itself to content.
+   */
+  detailsHeight?: number;
+  openSections: SavingsSectionKey[];
+};
+
+/**
+ * Everything folded.
+ *
+ * The lens answers one question — what did gating buy, and where. The
+ * reference sections matter on the day you are checking a compaction or
+ * debugging a dispatch cluster, and charging every visit for them is what
+ * squeezed the results list down to a single row.
+ */
+export const DEFAULT_SAVINGS_LAYOUT: SavingsLayoutPreferences = {
+  openSections: [],
+};
+
+/** Three result rows. Below this the list reads as broken, not as short. */
+export const SAVINGS_RESULTS_MIN_HEIGHT = 160;
+
+/** One folded row. The detail stack never drags away to nothing. */
+export const SAVINGS_DETAILS_MIN_HEIGHT = 34;
+
+const SECTION_KEYS: readonly SavingsSectionKey[] = [
+  "decisions",
+  "boundaries",
+  "code-mode",
+];
+
+const STORAGE_KEY = "pwragent.toolOutput.savingsLayout";
+
+export function readStoredSavingsLayout(): SavingsLayoutPreferences {
+  if (typeof window === "undefined") return DEFAULT_SAVINGS_LAYOUT;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_SAVINGS_LAYOUT;
+    const parsed = JSON.parse(raw) as Partial<SavingsLayoutPreferences>;
+    const height = parsed.detailsHeight;
+    return {
+      detailsHeight:
+        typeof height === "number" && Number.isFinite(height)
+          ? Math.max(SAVINGS_DETAILS_MIN_HEIGHT, Math.round(height))
+          : undefined,
+      // An unknown key is dropped rather than carried: a renamed section would
+      // otherwise keep unfolding a row that no longer exists.
+      openSections: Array.isArray(parsed.openSections)
+        ? SECTION_KEYS.filter((key) => parsed.openSections?.includes(key))
+        : [],
+    };
+  } catch {
+    return DEFAULT_SAVINGS_LAYOUT;
+  }
+}
+
+export function writeStoredSavingsLayout(value: SavingsLayoutPreferences): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+  } catch {
+    // A full or blocked store costs the operator their split, nothing more.
+  }
+}
+
+/**
+ * Keep the results list above its floor.
+ *
+ * The grip sets the detail stack's preferred height; the stack still shrinks
+ * below it when the window is short, because the list's floor wins. Clamping
+ * on drag stops the stored value from drifting far past anything the current
+ * window could honour.
+ */
+export function clampDetailsHeight(
+  height: number,
+  availableHeight: number,
+): number {
+  const ceiling = Math.max(
+    SAVINGS_DETAILS_MIN_HEIGHT,
+    availableHeight - SAVINGS_RESULTS_MIN_HEIGHT,
+  );
+  return Math.round(
+    Math.min(Math.max(height, SAVINGS_DETAILS_MIN_HEIGHT), ceiling),
+  );
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -17956,19 +17956,34 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 13px;
 }
 
+/* Headline left, verification chart right — the same two-column split the
+   Incidents lens uses for its own summary. The chart used to be a full-width
+   band between the hero and the results, which cost 120px of a 700px window
+   to draw, most often, a single 24px bar. */
 .incident-explorer__savings-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 12px 28px;
+  align-items: start;
+}
+
+/* The chart renders nothing on a thread with no measured turns, and a reserved
+   300px of empty column is worse than the full-width headline it displaces. */
+.incident-explorer__savings-hero:has(.incident-explorer__context-turns) {
+  grid-template-columns: minmax(0, 1fr) 300px;
+}
+
+.incident-explorer__savings-headline {
   display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 16px 32px;
+  flex-direction: column;
+  min-width: 0;
 }
 
 .incident-explorer__savings-figure {
   display: flex;
   align-items: baseline;
-  gap: 8px;
-  margin: 6px 0 0;
+  gap: 10px;
+  margin: 4px 0 0;
 }
 
 .incident-explorer__savings-figure strong {
@@ -17978,6 +17993,7 @@ a.transcript-message__messaging-origin:focus-visible {
   font-weight: 600;
   letter-spacing: -0.02em;
   font-variant-numeric: tabular-nums;
+  line-height: 1;
 }
 
 .incident-explorer__savings-figure span {
@@ -17985,42 +18001,133 @@ a.transcript-message__messaging-origin:focus-visible {
   font-size: 12.5px;
 }
 
-.incident-explorer__savings-terms {
+/* Savings is term 1 minus terms 2 and 3, so the terms are laid out as that
+   subtraction and end in the headline figure. Three equal tiles with the total
+   sixty pixels above them made the reader do the arithmetic to believe it. */
+.incident-explorer__savings-equation {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1px;
-  margin: 0;
-  min-width: min(560px, 62vw);
-  background: var(--border-subtle);
+  grid-template-columns: auto 14px auto 14px auto 18px auto;
+  align-items: end;
+  column-gap: 10px;
+  margin: 12px 0 0;
 }
 
-.incident-explorer__savings-terms div {
-  padding: 6px 10px;
-  background: var(--bg-panel);
+.incident-explorer__savings-operator {
+  padding-bottom: 4px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  text-align: center;
 }
 
-.incident-explorer__savings-terms dt {
+.incident-explorer__savings-term {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.incident-explorer__savings-term dt {
   color: var(--text-muted);
   font-size: 10px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.incident-explorer__savings-terms dd {
-  display: flex;
-  flex-direction: column;
-  margin: 2px 0 0;
+.incident-explorer__savings-term dd {
+  margin: 0;
   color: var(--text-primary);
   font-family: var(--font-mono);
-  font-size: 14px;
+  font-size: 17px;
   font-weight: 600;
   font-variant-numeric: tabular-nums;
 }
 
-.incident-explorer__savings-terms dd span {
+.incident-explorer__savings-term[data-result="true"] dt,
+.incident-explorer__savings-term[data-result="true"] dd {
+  color: var(--accent);
+}
+
+/* Token terms for a thread whose gates are not priced yet. Deliberately not
+   the equation above: the dollar terms subtract, these three do not. */
+.incident-explorer__savings-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 28px;
+  margin: 12px 0 0;
+}
+
+.incident-explorer__savings-tokens div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.incident-explorer__savings-tokens dt {
+  color: var(--text-muted);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.incident-explorer__savings-tokens dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.incident-explorer__savings-tokens dd span {
+  display: block;
   color: var(--text-muted);
   font-size: 10.5px;
   font-weight: 400;
+}
+
+/* How much of the unfiltered cost went away, as one bar. */
+.incident-explorer__savings-split {
+  display: flex;
+  height: 8px;
+  margin: 10px 0 0;
+  overflow: hidden;
+  border-radius: 2px;
+  background: var(--bg-panel-elevated);
+}
+
+.incident-explorer__savings-split i {
+  display: block;
+  height: 100%;
+}
+
+.incident-explorer__savings-split i[data-part="avoided"] {
+  background: var(--accent);
+}
+
+.incident-explorer__savings-split i[data-part="gate"] {
+  background: var(--status-warning);
+}
+
+.incident-explorer__savings-split i[data-part="revealed"] {
+  background: color-mix(in srgb, var(--text-secondary) 42%, transparent);
+}
+
+.incident-explorer__savings-split-caption {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 4px 16px;
+  margin: 5px 0 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.incident-explorer__savings-split-caption b {
+  color: var(--text-secondary);
+  font-weight: 500;
 }
 
 .incident-explorer__savings-compare {
@@ -18037,36 +18144,29 @@ a.transcript-message__messaging-origin:focus-visible {
 }
 
 /* Confidence marker. Semantic, not accent: this reports how much of the figure
-   was measured versus inferred, which is a different axis from emphasis. */
+   was measured versus inferred, which is a different axis from emphasis. It is
+   a line rather than a filled chip because it was the only bordered element in
+   a hero of unboxed figures, and it cost 38px to say one sentence. */
 .incident-explorer__confidence {
   display: inline-flex;
-  align-items: center;
+  align-items: baseline;
   gap: 7px;
-  margin: 10px 0 0;
-  padding: 5px 10px;
-  border: 1px solid var(--success-border);
-  border-radius: 4px;
-  background: var(--success-soft);
+  margin: 8px 0 0;
   color: var(--success-text);
   font-size: 11.5px;
 }
 
 .incident-explorer__confidence[data-kind="reconstructed"] {
-  border-color: color-mix(in srgb, var(--status-warning) 34%, transparent);
-  background: color-mix(in srgb, var(--status-warning) 12%, transparent);
   color: var(--status-warning);
 }
 
 .incident-explorer__confidence span {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   border-radius: 50%;
   background: currentColor;
   flex: none;
-}
-
-.incident-explorer__savings-terms[data-terms="3"] dd {
-  font-size: 17px;
+  transform: translateY(-1px);
 }
 
 .incident-explorer__savings-caption {
@@ -18080,12 +18180,17 @@ a.transcript-message__messaging-origin:focus-visible {
 /* Savings-lens verification chart. The axis comes from parent pricing turns,
    not tool calls, so a no-tool compaction still owns a column. Peak context is
    the quiet backdrop, final context is the solid signal, and compaction stays
-   a discrete event mark rather than becoming a third volume series. */
+   a discrete event mark rather than becoming a third volume series.
+
+   It sits in the hero's right column, so it carries a divider rather than the
+   full-width rules a standalone band needed. */
 .incident-explorer__context-turns {
-  flex: none;
-  padding: 9px 0 10px;
-  border-top: 1px solid var(--border-subtle);
-  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 100%;
+  padding-left: 20px;
+  border-left: 1px solid var(--border-subtle);
 }
 
 .incident-explorer__context-turns-head {
@@ -18094,7 +18199,6 @@ a.transcript-message__messaging-origin:focus-visible {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  margin-bottom: 6px;
 }
 
 .incident-explorer__context-turns-legend {
@@ -18136,8 +18240,7 @@ a.transcript-message__messaging-origin:focus-visible {
   display: flex;
   align-items: stretch;
   gap: 1px;
-  height: 72px;
-  margin-bottom: 7px;
+  height: 56px;
   overflow: hidden;
   border-bottom: 1px solid var(--border-subtle);
 }
@@ -18200,12 +18303,186 @@ a.transcript-message__messaging-origin:focus-visible {
   transform: rotate(45deg);
 }
 
+/* Reference rows, above the results list.
+
+   `flex-shrink` is the fix for what this lens shipped as: every band above the
+   list was `flex: none`, the list was the only thing that could yield, and it
+   yielded all of it — a header over one clipped row. The operator's dragged
+   height is a preference, not a floor, so this stack shrinks and scrolls
+   before the list gives up its three rows. */
+.incident-explorer__savings-details {
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__savings-section {
+  flex: none;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.incident-explorer__savings-section-row {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 150px) minmax(0, 1fr);
+  align-items: baseline;
+  gap: 12px;
+  width: 100%;
+  padding: 8px 4px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.incident-explorer__savings-section-row:hover {
+  background: var(--bg-panel-hover);
+}
+
+.incident-explorer__savings-chevron {
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid var(--text-muted);
+  transform: translateY(1px);
+  transition: transform 120ms ease;
+}
+
+.incident-explorer__savings-section[data-open="true"] .incident-explorer__savings-chevron {
+  transform: translate(1px, 2px) rotate(90deg);
+}
+
+.incident-explorer__savings-section-label {
+  color: var(--text-primary);
+  font-size: 12.5px;
+  font-weight: 600;
+}
+
+/* The numbers that used to be dot-joined runs of monospace at one weight.
+   Value bright, label muted, so a row has landmarks to land on. */
+.incident-explorer__savings-facts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 18px;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.incident-explorer__savings-facts b {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+/* Dimmed, never hidden: a zero here is an answer, and a row that dropped it
+   would read as a measurement this version failed to take. */
+.incident-explorer__savings-facts span[data-zero="true"] b {
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.incident-explorer__savings-figures {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px 18px;
+  margin: 0;
+  padding: 4px 4px 12px 30px;
+}
+
+.incident-explorer__savings-figures div {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.incident-explorer__savings-figures dt {
+  color: var(--text-muted);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.incident-explorer__savings-figures dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13.5px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+.incident-explorer__savings-figures div[data-zero="true"] dd {
+  color: var(--text-muted);
+}
+
+.incident-explorer__savings-figures dd span {
+  display: block;
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 400;
+}
+
+.incident-explorer__savings-note {
+  margin: 0;
+  padding: 0 4px 12px 30px;
+  color: var(--text-muted);
+  font-size: 11.5px;
+}
+
+/* The grip. The lens shipped with a plain rule here, so an operator who wanted
+   more of the list had nothing to pull. */
+.incident-explorer__savings-grip {
+  position: relative;
+  flex: none;
+  height: 11px;
+  margin: -3px 0;
+  cursor: row-resize;
+}
+
+.incident-explorer__savings-grip span {
+  position: absolute;
+  top: 4px;
+  left: 50%;
+  width: 36px;
+  height: 3px;
+  margin-left: -18px;
+  border-radius: 999px;
+  background: var(--border-strong);
+}
+
+.incident-explorer__savings-grip:hover span,
+.incident-explorer__savings-grip:focus-visible span {
+  background: var(--accent);
+}
+
+.incident-explorer__savings-grip:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .incident-explorer__savings-chevron {
+    transition: none;
+  }
+}
+
+/* The results list. `min-height` is its floor: the only explorable part of
+   this lens must never be squeezed below three rows by the reference bands
+   above it, however many of those the operator has unfolded. */
 .incident-explorer__gates {
   display: flex;
-  flex: 1;
+  flex: 1 1 0;
   flex-direction: column;
   gap: 10px;
-  min-height: 0;
+  min-height: 160px;
+  padding-top: 4px;
 }
 
 .incident-explorer__gates-head {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -18043,6 +18043,23 @@ a.transcript-message__messaging-origin:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
+/* The term's token basis, named for a screen reader without painting it. The
+   compact equation moved that text into `title`, which is a pointer-only
+   affordance. Scoped to this lens for the same reason `.star-map-card__state`
+   is scoped to the map: a repo-wide visually-hidden primitive deserves its own
+   decision. */
+.incident-explorer__savings-basis {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
 .incident-explorer__savings-term[data-result="true"] dt,
 .incident-explorer__savings-term[data-result="true"] dd {
   color: var(--accent);
@@ -18444,6 +18461,9 @@ a.transcript-message__messaging-origin:focus-visible {
   height: 11px;
   margin: -3px 0;
   cursor: row-resize;
+  /* The drag owns the vertical axis. Without this a touch or precision-pointer
+     gesture scrolls instead, and the scroll cancels the pointer capture. */
+  touch-action: none;
 }
 
 .incident-explorer__savings-grip span {


### PR DESCRIPTION
## Summary

- The Savings lens rendered its results list as a header over one clipped row at the 1000×700 window the Tool Output window runs in. Every band above the list was `flex: none` or a fixed plot height, and the list was the only `flex: 1` child, so it absorbed the entire shortfall. This is the fix, from a UX design review of the shipped screen.
- **The chart moves into the hero's right column.** `Context by turn` arrived in #1926 as a full-width band with its own rules and a 72px plot, spending ~120px of the window to draw, most often, a single 24px bar. The hero becomes the same two-column grid the Incidents lens already uses for its own summary, so the chart costs no vertical budget. The column collapses on a thread with no measured turns rather than reserving 300px of nothing.
- **The three savings terms are laid out as the subtraction they are** and end in the headline figure, with a bar showing how much of the unfiltered cost went away. Three equal tiles with the total sixty pixels above them in a different type size made the reader do the arithmetic to believe the headline.
- **Decisions, Context boundaries and Code Mode fold into single rows** that carry their headline numbers closed, replacing eight lines of dot-joined monospace at one weight, size and colour. Each count now appears exactly once — `18 summarized` was previously printed in the caption, in the Code Mode line, and in the filter row. Zeros stay visible but dimmed, since a zero here is an answer, not a missing measurement.
- **A row-resize grip sits above the results**, which keep a floor of three rows. The detail stack shrinks and scrolls before the list gives any of that up, so the split holds on a short window too. Open sections and the dragged height are per-machine renderer state in `localStorage`, never SQLite and never federated.

## Verification

- Full workspace suite green: **9,782 passed, 6 skipped, 663 files**. `typecheck`, `lint:eslint` (0 errors), `lint:colors` and `lint:boundaries` all clean.
- 14 new tests. Behavioural: sections fold by default so no body is mounted until asked for, open state survives a remount, and the grip clamps a drag so the list keeps its floor. Pure: `clampDetailsHeight` and the stored-preferences reader, including unknown section keys and corrupt entries.
- One contract test ties `min-height` on `.incident-explorer__gates` in `app.css` to `SAVINGS_RESULTS_MIN_HEIGHT`, and asserts the detail stack can still shrink. Two numbers in two files is exactly the pair that drifts silently: a smaller CSS value reopens the one-row bug while every other test stays green.
- Layout measured in headless Chromium against markup rendered by the real component, at 1000×700, in both themes:

  | State | Results section | Fully visible rows |
  |---|---|---|
  | Before | ~55px | 1 |
  | Folded | 271px | 4 |
  | All three sections open | 160px (the floor) | 2 |

  With all three open the detail stack scrolls and the list holds at its floor, which is the behaviour the old layout had no way to produce. No horizontal overflow in any variant.

## Notes

- Design review and the three layout options it chose between are in the PwrAgent Claude Design project: [Token Miser Savings UX Review](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Token+Miser+Savings+UX+Review.dc.html). This PR implements option A.
- The per-term token basis (`157k uncached + 2,559k cached · gated tool output at … rates`) moved from sub-captions under each term into the Decisions row, and stays reachable as a `title` on each term. That is what buys back the hero's height.
- The hero uses `:has()` to collapse the chart column. Chromium-only is fine here, but worth a look if anything ever renders this markup outside Electron.
- Seven existing tests asserted the old prose captions and the `1 · Without the gate` term labels. They were rewritten against the new structure rather than deleted — same facts, new home.
- The as-built record page for Tool Cost in the design project should get a pointer to this review once this lands. Not done here.
