### PR TITLE
fix(desktop): roll up live PR automation prompts

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -3057,6 +3057,84 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it("preserves PR automation provenance on a live user message", async () => {
+    let agentEventHandler:
+      | ((event: {
+          backend: "codex" | "acp:grok";
+          notification: {
+            method: string;
+            params: Record<string, unknown>;
+          };
+        }) => void)
+      | undefined;
+    const desktopApi: DesktopApi = {
+      onAgentEvent: (callback) => {
+        agentEventHandler = callback as typeof agentEventHandler;
+        return () => undefined;
+      },
+      readThread: async () => readThreadResponse({
+        entries: [],
+        hasPreviousPage: false,
+      }),
+    };
+
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+    await waitForThreadHydration(result);
+
+    act(() => {
+      agentEventHandler?.({
+        backend: "codex",
+        notification: {
+          method: "item/started",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-2",
+            item: {
+              id: "user-message-2",
+              type: "userMessage",
+              content: [{ type: "text", text: "Repair the failing PR." }],
+              origin: {
+                kind: "pwragent",
+                prAutomation: {
+                  kind: "auto-fix",
+                  prKey: "pwrdrvr/PwrAgent#1948",
+                  prNumber: 1948,
+                  prTitle: "Fix disappearing launch message",
+                  failedCheckUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/1",
+                  headSha: "c6f1ab8df5304858c8b83cefbe1c7e8822a9571b",
+                  eventKinds: ["ci-failure", "merge-conflict"],
+                },
+              },
+            },
+          },
+        },
+      });
+    });
+
+    expect(result.current.entries).toHaveLength(1);
+    expect(result.current.entries[0]).toMatchObject({
+      type: "message",
+      role: "user",
+      origin: {
+        kind: "pwragent",
+        prAutomation: {
+          kind: "auto-fix",
+          prKey: "pwrdrvr/PwrAgent#1948",
+          prNumber: 1948,
+          prTitle: "Fix disappearing launch message",
+          failedCheckUrl: "https://github.com/pwrdrvr/PwrAgent/actions/runs/1",
+          headSha: "c6f1ab8df5304858c8b83cefbe1c7e8822a9571b",
+          eventKinds: ["ci-failure", "merge-conflict"],
+        },
+      },
+    });
+  });
+
   it("does not duplicate a final reported by both item and turn completion", async () => {
     let agentEventHandler:
       | ((event: {

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4068,12 +4068,17 @@ function threadMessageOriginFromUnknown(
     record.kind === "sub-agent"
       ? threadMessageSubAgentOriginFromUnknown(record.subAgent)
       : undefined;
+  const prAutomation =
+    record.kind === "pwragent"
+      ? threadMessagePrAutomationOriginFromUnknown(record.prAutomation)
+      : undefined;
   const source = record.sourceThread;
   if (!source || typeof source !== "object" || Array.isArray(source)) {
     return {
       kind: record.kind,
       ...(messaging ? { messaging } : {}),
       ...(subAgent ? { subAgent } : {}),
+      ...(prAutomation ? { prAutomation } : {}),
     };
   }
   const sourceRecord = source as Record<string, unknown>;
@@ -4084,6 +4089,7 @@ function threadMessageOriginFromUnknown(
     return {
       kind: record.kind,
       ...(messaging ? { messaging } : {}),
+      ...(prAutomation ? { prAutomation } : {}),
     };
   }
   return {
@@ -4106,6 +4112,46 @@ function threadMessageOriginFromUnknown(
     },
     ...(messaging ? { messaging } : {}),
     ...(subAgent ? { subAgent } : {}),
+    ...(prAutomation ? { prAutomation } : {}),
+  };
+}
+
+function threadMessagePrAutomationOriginFromUnknown(
+  value: unknown,
+): AppServerThreadMessageOrigin["prAutomation"] | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    (record.kind !== "auto-fix" && record.kind !== "watch")
+    || typeof record.prKey !== "string"
+    || typeof record.prNumber !== "number"
+    || typeof record.headSha !== "string"
+  ) {
+    return undefined;
+  }
+  const eventKinds = Array.isArray(record.eventKinds)
+    ? record.eventKinds.filter(
+        (eventKind): eventKind is "ci-failure" | "merge-conflict" =>
+          eventKind === "ci-failure" || eventKind === "merge-conflict",
+      )
+    : undefined;
+  return {
+    kind: record.kind,
+    prKey: record.prKey,
+    prNumber: record.prNumber,
+    ...(typeof record.prTitle === "string"
+      ? { prTitle: record.prTitle }
+      : {}),
+    ...(typeof record.failedCheckUrl === "string"
+      ? { failedCheckUrl: record.failedCheckUrl }
+      : {}),
+    headSha: record.headSha,
+    ...(eventKinds ? { eventKinds } : {}),
+    ...(record.outcome === "success" || record.outcome === "failure"
+      ? { outcome: record.outcome }
+      : {}),
   };
 }
 


### PR DESCRIPTION
## Summary

- I preserved `prAutomation` provenance when the renderer materializes a live PwrAgent user message.
- I added a regression test covering the active-turn event path that previously rendered the full auto-fix prompt until completion hydration.

## Verification

- I ran the full workspace test suite: 667 files passed, 9,826 tests passed, and 6 tests were skipped.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint` (0 errors, 44 pre-existing warnings).
- I ran `pnpm lint:boundaries` (no violations).
- I ran `git diff --check`.

## Notes

- This changes only renderer-side presentation. It does not change the prompt or message exposed to the agent, PR automation dispatch, or persisted transcript data.
