### PR TITLE
fix(desktop): unclip sidebar chip text and even out chrome rhythm

### DIFF
--- a/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
+++ b/apps/desktop/e2e/visual-regression.spec.ts-snapshots/todo-thread-shell-darwin.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:230c01396a1f445f493d9fab9e426af7956ff138ac7658c4b6bb35aafd18a22b
-size 124714
+oid sha256:32a0468207a0a38049181bf9344c0cdfcfe0c09d7cddfeae3ea40ff29cb3ba2a
+size 119060

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3219,6 +3219,10 @@ textarea,
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  /* `overflow: hidden` makes this line box a clip box, so the pill's
+     `line-height: 1` would shave the glyphs. `normal` is the font's own
+     ink box — see `.runtime-identity__text`. */
+  line-height: normal;
 }
 
 .runtime-identity {
@@ -3227,14 +3231,21 @@ textarea,
   min-width: 0;
   align-items: center;
   gap: 6px;
+  /* 6px above and below, so the boundary between two adjacent chrome rows
+     is 12px — the same 12px `.sidebar__section` pays below the last row.
+     Every gap in the chrome stack is this one number; do not tune one edge
+     in isolation. See the uniform-rhythm note on `.sidebar__section`. */
   padding: 6px 0;
-  /* Pull out to the lane inset so the pills and their divider line up with
-     the thread/directory cards below instead of sitting at the wider rail
+  /* Pull out to the lane inset so the pills line up with the
+     thread/directory cards below instead of sitting at the wider rail
      inset. This is an auto-width flex row, so the negative margin simply
      shrinks it onto the lane edges (cf. `.lens-switch`, which needs an
      explicit width). See `--sidebar-masthead-pull` on `.sidebar`. */
   margin-inline: var(--sidebar-masthead-pull);
-  border-bottom: 1px solid var(--border-subtle);
+  /* No bottom rule. Each row is already a line of bordered pills, so a
+     full-width divider under them drew a second frame around content that
+     was framed — and the two rules cut a 3-item chrome stack into three
+     boxes that read as unrelated. Separation here is the 12px of air. */
   -webkit-app-region: no-drag;
 }
 
@@ -3300,6 +3311,16 @@ textarea,
   overflow: hidden;
   text-overflow: clip;
   white-space: nowrap;
+  /* `overflow: hidden` (needed for the truncation above) makes this line box
+     a CLIP box, not just a spacing one — so the pill's `line-height: 1`
+     shaved the glyphs instead of merely crowding them. At 10.5px the mono
+     stack asks for 13px of ink, ascent 10 + descent 3, inside a 10.5px box:
+     2px off the ascenders and 0.5px off the descenders, so `/`, `y`, `g`,
+     and `p` lost their tails. `normal` is that ink box exactly, derived from
+     the font rather than guessed, so it stays right if the stack ever
+     changes — and it centers the text in the pill, which a hand-picked
+     ratio does not. Same remedy as `.review-chip__label`. */
+  line-height: normal;
 }
 
 .thread-header__title,
@@ -3309,13 +3330,24 @@ textarea,
 }
 
 /* Only ever worn together with `--fill`, so this padding is the gap between
-   the runtime-identity divider and the lens switch. 16px read as a hole: the
-   row above it is 6px of padding around a single line of text, so the strip
-   was floating away from the chrome it belongs to. 10px keeps the lens switch
-   legible as its own band without the drift. */
+   the last runtime-identity row and the lens switch — and it is the third
+   and last gap in the sidebar's chrome stack, so it has to agree with the
+   other two rather than be tuned on its own.
+
+   The stack now pays one number, 12px, at every internal boundary: two
+   adjacent `.runtime-identity` rows each contribute 6px, and this 6px plus
+   the last row's 6px closes the stack. Before, the gaps were 13px and 17px —
+   the strip visibly drifted further from the chrome above it at each step.
+   Change one of these and change all three.
+
+   The gap ABOVE the first row is not this number and is not platform-neutral.
+   On macOS and Linux it is the masthead band's own trailing air (~11.5px for
+   a 17px wordmark centered in the 40px band), which is why
+   `.sidebar__masthead + .runtime-identity` drops its top padding. On Windows
+   the masthead is `display: none`, that adjacency still matches, and the
+   first pill lands flush at 0. Do not quote a single number for that edge. */
 .sidebar__section {
-  padding: 10px 0 0;
-  border-bottom: 1px solid var(--border-subtle);
+  padding: 6px 0 0;
 }
 
 .sidebar__section--fill {


### PR DESCRIPTION
The identity pills at the top of the rail were shaving their own glyphs, and the gaps in the chrome stack were three different numbers.

## Before / after

Contrived fixture data, 4x, rendered against the real `app.css`. Watch the `p` in `profile:` and the `/` in the directory chip.

### Before
![sidebar chrome before](https://github.com/user-attachments/assets/04ccf820-2479-4381-861c-2822e569888a)

### After
![sidebar chrome after](https://github.com/user-attachments/assets/7b04532f-ce74-4312-9ba4-b193d82cebd9)

## Clipped ascenders and descenders

`.runtime-identity__text` carries `overflow: hidden` so it can truncate, which makes its line box a **clipping** box rather than just a spacing one — and the pill set `line-height: 1`. At 10.5px the mono stack (IBM Plex Mono is not bundled, so this resolves to SF Mono) asks for **13px** of ink, ascent 10 + descent 3, inside a **10.5px** box. That shaved 2.0px off the ascenders and 0.5px off the descenders: `/`, `y`, `g`, and `p` all lost their tails, which reads as a rendering fault rather than a style.

The fix goes on the element whose overflow does the clipping, and lets the **font** size the box: `line-height: normal` measures 13.0px — the ink box exactly — so nothing clips, and the text *centers* in the pill (ink at 4.5px in a 20px interior). This is the remedy the codebase already uses at `.review-chip__label`, whose comment describes the same defect. `.federation-remote-badge__text`, the title-bar form of the same marker, gets it too so the two cannot drift.

No chip dimension changes: height, padding, radius, and truncation are all untouched.

## Uneven vertical rhythm, and two rules that framed framed content

The two internal boundaries paid **13px** and **17px** — each gap looser than the one above, so the lens switch read as drifting away from the chrome it belongs to instead of closing it. `.sidebar__section` drops `10px` → `6px`, making every internal boundary **12px**: 6px from the row above plus 6px from the row below, the rule the rail already followed everywhere else.

Both `.runtime-identity` bottom rules are gone. Each row is already a line of bordered pills, so a full-width divider drew a second frame around content that was framed, and the two of them cut one chrome cluster into three boxes that read as unrelated.

Also drops an unreachable `border-bottom` on `.sidebar__section` — the class is only ever used with `--fill`, which sets `border-bottom: 0`.

## Verification

Measured in headless Chromium against the shipped `app.css` at a 300px rail, macOS, dark — element rects, not estimates.

| | Before | After |
|---|---|---|
| Ink box vs line box | 13px in 10.5px | 13px in 13.0px |
| Clipped | 2.0px top, 0.5px bottom | none |
| Ink position in pill | 3.75px (high) | 4.5px (centered) |
| Gap: chip row → profile | 13px | 12px |
| Gap: profile → lens switch | 17px | 12px |
| Pill height | 22px | 22px |

`pnpm test` on `sidebar.test.tsx` + `theme-contract.test.tsx` — 225 passed. `pnpm lint:colors` and `pnpm typecheck` clean.

## Visual baseline

`todo-thread-shell-darwin.webp` is regenerated — the rail's chrome moves, so the old baseline was stale by 6666 pixels on CI. The new reference was generated **in the PwrSuiteLab Tart guest** per CONTRIBUTING, not promoted from the CI artifact, so the lab remains the authoritative golden environment. The focused spec passes on the guest against it (`2 passed`).

`pending-approval.webp` is unaffected — its locator excludes the sidebar.

Design review with annotated before/after and the ink-box detail: https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Sidebar+Identity+Chrome+UX+Review.dc.html

## Known, not changed here

On Windows `.sidebar__masthead` is `display: none`, but `.sidebar__masthead + .runtime-identity` still matches it, so the first pill lands flush at **0px** with no top air (measured; macOS puts it at 40px). That is pre-existing, and a Windows layout change wants verification on a Windows VM, so it is recorded in the rhythm comment rather than silently "fixed" here.

The same clip-box pattern also remains at `.settings-pathrow__chip` and `.star-map-load-card__metrics dt`.

The branch chip's mid-elision is deliberate — it keeps the prefix and the distinguishing tail, and the full value is in the tooltip and one click from the clipboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
