### PR TITLE
docs(tests): route macOS E2E through PwrSuiteLab

### DIFF
--- a/.agents/skills/macos-vm-e2e-lab/SKILL.md
+++ b/.agents/skills/macos-vm-e2e-lab/SKILL.md
@@ -2,10 +2,10 @@
 name: macos-vm-e2e-lab
 description: >-
   Route PwrAgent macOS Tart, self-hosted runner, headed E2E, and visual-golden
-  work to PwrSuiteLab when a checkout is available. Use when a user mentions
-  Tart, a local macOS VM, self-hosted macOS runners, E2E windows stealing
-  focus, or PwrAgent visual goldens. Do not use for Windows VM probes or
-  Windows E2E.
+  work through an existing PwrSuiteLab checkout and its managed controllers.
+  Use when a user mentions Tart, a local macOS VM, self-hosted macOS runners,
+  E2E windows stealing focus, or PwrAgent visual goldens. Do not use for
+  Windows VM probes or Windows E2E.
 ---
 
 # PwrAgent macOS VM E2E lab
@@ -15,32 +15,70 @@ PwrSuiteLab does. Do not provision a product-local Tart lab from this
 repository. Do not clone a Cirrus image or register a GitHub Actions runner
 from these files.
 
-## Prefer PwrSuiteLab
+Keep the boundary explicit: product tests and CI contracts belong in
+PwrAgent; private lab inventory, configuration, transport, diagnosis, and
+recovery belong only in PwrSuiteLab. Never copy private access values,
+addresses, usernames, fingerprints, keys, configuration contents, host
+inventory, or lab construction details into PwrAgent.
 
-1. Resolve an existing PwrSuiteLab checkout from linked directories,
-   Federation, MCP, or an explicit operator pointer. Do not assume a
-   pathname. Do not clone, install, or provision PwrSuiteLab as part of a
-   product task.
-2. Use the attached primary checkout. Do not select a disposable worktree.
-3. Confirm the ignored config with an exact filesystem test. Headed E2E
-   uses `local-config/macos-tart.sh`. Runner work uses
-   `local-config/macos-runner.sh`. `rg --files`, `git ls-files`, and other
-   worktrees do not prove that a config is absent. Do not read, print, or
-   copy the config. If the exact default is absent, ask the operator for
-   an existing config path only.
-4. Read the matching skill in that checkout and follow it:
+## Resolve the lab checkout
+
+1. Discover an existing PwrSuiteLab checkout from the current thread's
+   attached or linked directories, known local project checkouts, or
+   PwrAgent/Federation project metadata. An explicit operator pointer is also
+   valid. Do not assume or hardcode a machine-specific pathname. Do not clone,
+   install, or provision PwrSuiteLab as a fallback.
+2. Use PwrSuiteLab's primary checkout for controllers. Do not select or operate
+   from one of its disposable worktrees.
+3. Read that checkout's `AGENTS.md`, then read the current `macos-tart`
+   runbook and any applicable skill it identifies before running or diagnosing
+   anything. The lab checkout is authoritative; do not reconstruct its
+   procedure from this skill.
+4. Confirm the required ignored config in the primary checkout with an exact
+   filesystem existence test. Headed E2E uses
+   `local-config/macos-tart.sh`; runner work uses
+   `local-config/macos-runner.sh`. `rg --files`, `git ls-files`, and checks in
+   other worktrees do not prove that a config is absent. Never read, print,
+   copy, summarize, or expose the ignored config. If the exact default is
+   absent, ask the operator only for an existing config path.
+5. Follow the matching current PwrSuiteLab instructions:
 
    | Work | Skill in the PwrSuiteLab checkout |
    |---|---|
-   | Headed E2E and visual goldens | `macos-tart/README.md` and `macos-tart/run-e2e.sh` |
+   | Headed E2E and visual goldens | The current `macos-tart` runbook/skill and `macos-tart/run-e2e.sh` |
    | Runner start, stop, pause, resume | `.agents/skills/operate-macos-gha-runner/SKILL.md` |
    | Runner inspection | `.agents/skills/inspect-macos-gha-runner/SKILL.md` |
    | Runner or E2E VM rebuild | `.agents/skills/rebuild-macos-lab-vm/SKILL.md` |
    | VNC, SSH, registration, recovery | `.agents/skills/manage-macos-gha-runner/SKILL.md` |
    | Windows probes or Windows E2E | `.agents/skills/use-windows-vm-lab/SKILL.md` |
 
-If no checkout is discoverable, ask the operator for the lab pointer and
-stop. Do not invent a fallback lab.
+If a usable primary checkout is not discoverable, ask the operator where the
+existing checkout is or to attach it, then stop. If the requested work would
+require private construction or access details, ask the operator to handle or
+provide the supported PwrSuiteLab path, then stop. Do not invent a fallback
+lab.
+
+## Use the managed controller
+
+Normal headed E2E and visual-golden generation use PwrSuiteLab's
+`macos-tart/run-e2e.sh` controller. The controller owns starting the pet guest
+when needed and applying the lab's configured strict transport. Use the
+PwrAgent invocation documented in
+[CONTRIBUTING.md](../../../CONTRIBUTING.md), subject to the current PwrSuiteLab
+runbook and its approval gates.
+
+For E2E lock, status, execution, or recovery, never run or recommend:
+
+- bare `tart` commands, including `tart ip`;
+- raw `ssh`;
+- manual host-key acceptance or the global known-hosts file;
+- password-prompting authentication;
+- disabling strict host-key checking; or
+- asking the operator to run any of those shortcuts.
+
+Lab diagnosis and recovery must remain in PwrSuiteLab and use its current
+skills/controllers with their approval gates. Do not bypass the controller to
+inspect or repair the guest.
 
 ## PwrAgent product facts
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,19 +69,14 @@
 - Run desktop E2E from the repository root with `pnpm test:desktop-e2e`.
 - The package command `pnpm --filter @pwragent/desktop test:e2e` is also safe.
 - Both commands build `apps/desktop/out/` before Playwright starts.
-- Before headed desktop E2E, ask the operator whether an off-desktop lab is available.
-- If a lab is available, ask for its repository or skill.
 - For PwrSuiteLab macOS Tart, runner, or headed E2E work, follow
-  `.agents/skills/macos-vm-e2e-lab/SKILL.md`. It routes to PwrSuiteLab.
-  Do not provision a product-local Tart lab from this repository.
+  `.agents/skills/macos-vm-e2e-lab/SKILL.md`. It discovers an existing
+  PwrSuiteLab checkout and routes all lab access through that checkout's
+  current instructions and controllers. Do not provision a product-local
+  Tart lab or improvise direct Tart or SSH access from this repository.
 - For PwrSuiteLab Windows probes or headed E2E, read
   `.agents/skills/use-windows-vm-lab/SKILL.md` in the attached lab checkout.
   Do not use the macOS VM skill for Windows work.
-- Use the attached primary PwrSuiteLab checkout for its controllers. Check an
-  expected ignored config with an exact filesystem test. `rg --files`,
-  `git ls-files`, and other worktrees do not prove that config is absent.
-- Do not read or print lab configuration. If the exact default is absent, ask
-  the operator for an existing config path only.
 - Review the current ownership and readiness constraints before you change:
   - Windows Git or Bash process launch and shutdown.
   - Vitest process isolation.


### PR DESCRIPTION
## Summary

- route macOS headed E2E and visual-golden work through an existing primary PwrSuiteLab checkout
- require current lab instructions, exact ignored-config existence checks, and managed controllers
- prohibit raw Tart/SSH access and keep private lab implementation out of PwrAgent

## Validation

- Skill Creator quick_validate.py
- git diff --check
- private-detail scan
- root CLAUDE.md symlink check