### PR TITLE
feat(desktop): name the Grok build channel and let operators update it

### DIFF
--- a/apps/desktop/src/main/__tests__/grok-build-channel.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-build-channel.test.ts
@@ -1,0 +1,69 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  isPwrAgentSuppliedGrokCommand,
+  managedGrokTagForCommand,
+} from "../acp/grok-build-channel";
+
+const managedRoot = path.join("/tmp", "pwragent-root", "agents", "grok");
+const resourcesPath = path.join("/Applications", "PwrAgent.app", "Contents", "Resources");
+const options = { managedRoot, resourcesPath };
+
+describe("managedGrokTagForCommand", () => {
+  it("recovers the release tag from a managed install path", () => {
+    expect(managedGrokTagForCommand(
+      path.join(managedRoot, "versions", "pwragent-v1.0.4-pwragent.2", "grok"),
+      options,
+    )).toBe("pwragent-v1.0.4-pwragent.2");
+  });
+
+  it("has no tag for the version directory itself or anything outside it", () => {
+    expect(managedGrokTagForCommand(
+      path.join(managedRoot, "versions", "pwragent-v1.0.4-pwragent.2"),
+      options,
+    )).toBeUndefined();
+    expect(managedGrokTagForCommand(
+      path.join(managedRoot, "managed-release.json"),
+      options,
+    )).toBeUndefined();
+    expect(managedGrokTagForCommand("/Users/me/.grok/bin/grok", options))
+      .toBeUndefined();
+    expect(managedGrokTagForCommand(undefined, options)).toBeUndefined();
+  });
+});
+
+describe("isPwrAgentSuppliedGrokCommand", () => {
+  it("claims managed downloads and the packaged bundle copy", () => {
+    expect(isPwrAgentSuppliedGrokCommand(
+      path.join(managedRoot, "versions", "pwragent-v1.0.4-pwragent.2", "grok"),
+      options,
+    )).toBe(true);
+    expect(isPwrAgentSuppliedGrokCommand(
+      path.join(resourcesPath, "agents", "grok", "grok"),
+      options,
+    )).toBe(true);
+  });
+
+  it("claims a superseded managed version, not only the newest", () => {
+    // The whole point: provenance is a property of the binary. An operator
+    // pinned to an older tag is still on the PwrAgent channel, and must not
+    // collect an xAI update notice because the channel moved on without them.
+    expect(isPwrAgentSuppliedGrokCommand(
+      path.join(managedRoot, "versions", "pwragent-v1.0.0-pwragent.1", "grok"),
+      options,
+    )).toBe(true);
+  });
+
+  it("leaves vendor installs alone", () => {
+    expect(isPwrAgentSuppliedGrokCommand("/Users/me/.grok/bin/grok", options))
+      .toBe(false);
+    expect(isPwrAgentSuppliedGrokCommand("/opt/homebrew/bin/grok", options))
+      .toBe(false);
+    // A sibling directory whose name merely starts with the managed root's.
+    expect(isPwrAgentSuppliedGrokCommand(
+      `${managedRoot}-backup/versions/pwragent-v1.0.4-pwragent.2/grok`,
+      options,
+    )).toBe(false);
+    expect(isPwrAgentSuppliedGrokCommand(undefined, options)).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/grok-cli-update.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-cli-update.test.ts
@@ -1,11 +1,14 @@
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
   checkGrokCliUpdate,
   GROK_UPDATE_FAILURE_TTL_MS,
   GROK_UPDATE_SUCCESS_TTL_MS,
   grokUpdateChecksDisabled,
+  isPwrAgentOwnedGrokRuntime,
   shouldCheckGrokCliUpdate,
 } from "../acp/grok-cli-update";
+import { resolvePwragentRoot } from "../profile";
 
 describe("checkGrokCliUpdate", () => {
   it("normalizes the official JSON status and preserves same-version acknowledgement", async () => {
@@ -200,5 +203,54 @@ describe("grokUpdateChecksDisabled", () => {
     expect(grokUpdateChecksDisabled({ isPackaged: false })).toBe(false);
 
     vi.unstubAllEnvs();
+  });
+});
+
+describe("isPwrAgentOwnedGrokRuntime", () => {
+  const managedCommand = (tag: string) => path.join(
+    resolvePwragentRoot(),
+    "agents",
+    "grok",
+    "versions",
+    tag,
+    "grok",
+  );
+
+  it("trusts the discovery stamp", () => {
+    expect(isPwrAgentOwnedGrokRuntime({
+      launchDescriptor: {
+        command: "/Users/me/.grok/bin/grok",
+        args: [],
+        env: { GROK_INSTALLER: "pwragent" },
+      },
+    } as never)).toBe(true);
+  });
+
+  it("claims a managed build the stamp missed", () => {
+    // Discovery stamps by comparing against the command this run's release
+    // check resolved, so a pinned older version, or any version present while
+    // a check failed, arrives unstamped. It is still ours, and running the
+    // vendor updater against it is what produced an xAI version number next to
+    // a `-pwragent` build in the update toast.
+    expect(isPwrAgentOwnedGrokRuntime({
+      activeCommand: managedCommand("pwragent-v1.0.0-pwragent.1"),
+      launchDescriptor: {
+        command: managedCommand("pwragent-v1.0.0-pwragent.1"),
+        args: [],
+        env: {},
+      },
+    } as never)).toBe(true);
+  });
+
+  it("leaves an unstamped vendor install on the vendor channel", () => {
+    expect(isPwrAgentOwnedGrokRuntime({
+      activeCommand: "/Users/me/.grok/bin/grok",
+      launchDescriptor: {
+        command: "/Users/me/.grok/bin/grok",
+        args: [],
+        env: {},
+      },
+    } as never)).toBe(false);
+    expect(isPwrAgentOwnedGrokRuntime({} as never)).toBe(false);
   });
 });

--- a/apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts
@@ -319,6 +319,65 @@ describe("ensureManagedGrokRuntime", () => {
     );
   });
 
+  it("re-checks when the fresh cache was installed for the other track", async () => {
+    // The managed root is machine-wide. A profile on Prerelease rewrites the
+    // record a profile on Latest reads next, and the fresh `checkedAt` alone
+    // would hand Latest the build it exists to avoid.
+    const rootDir = await temporaryRoot();
+    const cachedTag = "pwragent-v2.1.0-pwragent.1";
+    await writeManagedCache(rootDir, {
+      asset: "pwragent-grok-2.1.0-pwragent.1-linux-x86_64.tar.gz",
+      channel: "prerelease",
+      tag: cachedTag,
+    });
+    const archiveName = "pwragent-grok-2.0.0-pwragent.1-linux-x86_64.tar.gz";
+    const archive = Buffer.from("promoted archive bytes");
+    const digest = createHash("sha256").update(archive).digest("hex");
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === MANAGED_GROK_RELEASES_URL) {
+        return Response.json([
+          release("pwragent-v2.1.0-pwragent.1", [
+            asset("SHA256SUMS"),
+            asset("pwragent-grok-2.1.0-pwragent.1-linux-x86_64.tar.gz"),
+          ], { prerelease: true }),
+          release("pwragent-v2.0.0-pwragent.1", [
+            asset("SHA256SUMS"),
+            asset(archiveName, digest, archive.length),
+          ]),
+        ]);
+      }
+      if (url.endsWith("/SHA256SUMS")) {
+        return new Response(`${digest}  ${archiveName}\n`);
+      }
+      if (url.endsWith(`/${archiveName}`)) {
+        return new Response(archive);
+      }
+      return new Response("missing", { status: 404 });
+    });
+
+    const runtime = await ensureManagedGrokRuntime({
+      arch: "x64",
+      channel: "latest",
+      // A TTL check against a record written moments ago: the short-circuit
+      // this test exists to defeat.
+      checkMode: "ttl",
+      extractArchive: async (_archivePath, targetDir) => {
+        await writeFakeBundle(targetDir);
+      },
+      fetch: fetchMock as typeof globalThis.fetch,
+      now: () => 200,
+      platform: "linux",
+      probeVersion: async () => "grok 2.0.0-test",
+      rootDir,
+    });
+
+    expect(runtime?.metadata.tag).toBe("pwragent-v2.0.0-pwragent.1");
+    expect(runtime?.metadata.channel).toBe("latest");
+    // Both tracks are recorded, so the pane can name each one.
+    expect(runtime?.metadata.prereleaseTag).toBe("pwragent-v2.1.0-pwragent.1");
+  });
+
   it("keeps the cached build on Latest when only the feed answers", async () => {
     // The feed cannot say which builds are promoted, so the Latest track has
     // no usable answer this cycle. Installing the newest tag anyway would put
@@ -640,6 +699,7 @@ async function writeManagedCache(
   rootDir: string,
   options: {
     asset: string;
+    channel?: string;
     commandContents?: string;
     tag: string;
   },
@@ -655,6 +715,7 @@ async function writeManagedCache(
     path.join(rootDir, "managed-release.json"),
     `${JSON.stringify({
       asset: options.asset,
+      ...(options.channel ? { channel: options.channel } : {}),
       checkedAt: 100,
       installedAt: 100,
       repository: "pwrdrvr/grok-build",

--- a/apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/grok-managed-runtime.test.ts
@@ -20,6 +20,7 @@ import {
   MANAGED_GROK_RELEASES_URL,
   selectManagedGrokRelease,
   selectManagedGrokReleaseFromFeed,
+  selectManagedGrokReleaseSlots,
   setManagedGrokSignatureRejectionReporter,
 } from "../acp/grok-managed-runtime";
 
@@ -34,14 +35,14 @@ afterEach(async () => {
 });
 
 describe("managed Grok release selection", () => {
-  it("selects the newest complete PwrAgent prerelease for the platform", () => {
+  it("selects the newest complete PwrAgent build for the platform", () => {
     const selected = selectManagedGrokRelease([
       release("pwragent-v2.0.0-pwragent.2", []),
       release("pwragent-v2.0.0-pwragent.1", [
         asset("SHA256SUMS"),
         asset("pwragent-grok-2.0.0-pwragent.1-macos-universal.tar.gz"),
       ]),
-    ], "macos-universal");
+    ], "macos-universal", "latest");
 
     expect(selected).toMatchObject({
       tag: "pwragent-v2.0.0-pwragent.1",
@@ -49,6 +50,77 @@ describe("managed Grok release selection", () => {
         name: "pwragent-grok-2.0.0-pwragent.1-macos-universal.tar.gz",
       },
     });
+  });
+
+  it("keeps a build published for testing off the Latest track", () => {
+    const releases = [
+      release("pwragent-v2.1.0-pwragent.1", [
+        asset("SHA256SUMS"),
+        asset("pwragent-grok-2.1.0-pwragent.1-macos-universal.tar.gz"),
+      ], { prerelease: true }),
+      release("pwragent-v2.0.0-pwragent.1", [
+        asset("SHA256SUMS"),
+        asset("pwragent-grok-2.0.0-pwragent.1-macos-universal.tar.gz"),
+      ]),
+    ];
+
+    expect(selectManagedGrokReleaseSlots(releases, "macos-universal")).toMatchObject({
+      latest: { tag: "pwragent-v2.0.0-pwragent.1" },
+      prerelease: { tag: "pwragent-v2.1.0-pwragent.1" },
+    });
+  });
+
+  it("gives both tracks the same build once the newest one is promoted", () => {
+    // The state the control exists for: nothing is under test right now, so
+    // the tracks agree — and Prerelease has to stay selectable anyway, or an
+    // operator cannot be on it when the next test build lands.
+    const releases = [
+      release("pwragent-v2.1.0-pwragent.2", [
+        asset("SHA256SUMS"),
+        asset("pwragent-grok-2.1.0-pwragent.2-macos-universal.tar.gz"),
+      ]),
+      release("pwragent-v2.1.0-pwragent.1", [
+        asset("SHA256SUMS"),
+        asset("pwragent-grok-2.1.0-pwragent.1-macos-universal.tar.gz"),
+      ], { prerelease: true }),
+    ];
+
+    const slots = selectManagedGrokReleaseSlots(releases, "macos-universal");
+    expect(slots.latest?.tag).toBe("pwragent-v2.1.0-pwragent.2");
+    expect(slots.prerelease?.tag).toBe("pwragent-v2.1.0-pwragent.2");
+  });
+
+  it("orders by precedence, not by the order GitHub returned", () => {
+    // A promotion is published against a release that already existed, so the
+    // newest entry in the response is not the newest build.
+    const releases = [
+      release("pwragent-v2.0.0-pwragent.1", [
+        asset("SHA256SUMS"),
+        asset("pwragent-grok-2.0.0-pwragent.1-linux-x86_64.tar.gz"),
+      ]),
+      release("pwragent-v2.10.0-pwragent.1", [
+        asset("SHA256SUMS"),
+        asset("pwragent-grok-2.10.0-pwragent.1-linux-x86_64.tar.gz"),
+      ]),
+    ];
+
+    expect(
+      selectManagedGrokRelease(releases, "linux-x86_64", "latest")?.tag,
+    ).toBe("pwragent-v2.10.0-pwragent.1");
+  });
+
+  it("refuses to serve the Latest track from the unlabeled Atom feed", () => {
+    // The feed carries tags, not release records, so it cannot tell a promoted
+    // build from one published for testing. Answering the Latest track from it
+    // would hand over exactly the build the operator opted out of.
+    const feed =
+      '<link href="https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v1.0.4-pwragent.2"/>';
+    expect(
+      selectManagedGrokReleaseFromFeed(feed, "linux-x86_64", "latest"),
+    ).toBeUndefined();
+    expect(
+      selectManagedGrokReleaseFromFeed(feed, "linux-x86_64", "prerelease"),
+    ).toMatchObject({ tag: "pwragent-v1.0.4-pwragent.2" });
   });
 
   it("maps every currently published desktop target", () => {
@@ -64,6 +136,7 @@ describe("managed Grok release selection", () => {
     const selected = selectManagedGrokReleaseFromFeed(
       '<link href="https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v1.0.4-pwragent.2"/>',
       "windows-x86_64",
+      "prerelease",
     );
 
     expect(selected).toMatchObject({
@@ -92,10 +165,11 @@ describe("managed Grok release selection", () => {
         asset("SHA256SUMS"),
         asset("pwragent-grok-1.0.4-pwragent.1-linux-x86_64.tar.gz"),
       ]),
-    ], "linux-x86_64")).toBeUndefined();
+    ], "linux-x86_64", "prerelease")).toBeUndefined();
     expect(selectManagedGrokReleaseFromFeed(
       '<link href="https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v1.0.4-pwragent.1"/>',
       "linux-x86_64",
+      "prerelease",
     )).toBeUndefined();
   });
 });
@@ -199,7 +273,7 @@ describe("ensureManagedGrokRuntime", () => {
     expect(runtime?.metadata.tag).toBe(tag);
   });
 
-  it("uses the public release feed when the unauthenticated API is limited", async () => {
+  it("uses the public release feed on Prerelease when the API is limited", async () => {
     const rootDir = await temporaryRoot();
     const tag = "pwragent-v2.1.0-pwragent.1";
     const archiveName = "pwragent-grok-2.1.0-pwragent.1-linux-x86_64.tar.gz";
@@ -226,6 +300,7 @@ describe("ensureManagedGrokRuntime", () => {
 
     const runtime = await ensureManagedGrokRuntime({
       arch: "x64",
+      channel: "prerelease",
       checkMode: "force",
       extractArchive: async (_archivePath, targetDir) => {
         await writeFakeBundle(targetDir);
@@ -237,9 +312,50 @@ describe("ensureManagedGrokRuntime", () => {
     });
 
     expect(runtime?.metadata.tag).toBe(tag);
+    expect(runtime?.metadata.channel).toBe("prerelease");
     expect(fetchMock).toHaveBeenCalledWith(
       MANAGED_GROK_RELEASES_FEED_URL,
       expect.any(Object),
+    );
+  });
+
+  it("keeps the cached build on Latest when only the feed answers", async () => {
+    // The feed cannot say which builds are promoted, so the Latest track has
+    // no usable answer this cycle. Installing the newest tag anyway would put
+    // an untested build on the track that exists to avoid them.
+    const rootDir = await temporaryRoot();
+    const cachedTag = "pwragent-v1.0.4-pwragent.2";
+    await writeManagedCache(rootDir, {
+      asset: "pwragent-grok-1.0.4-pwragent.2-linux-x86_64.tar.gz",
+      tag: cachedTag,
+    });
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url === MANAGED_GROK_RELEASES_URL) {
+        return new Response("limited", { status: 403 });
+      }
+      if (url === MANAGED_GROK_RELEASES_FEED_URL) {
+        return new Response(
+          '<link href="https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v2.1.0-pwragent.1"/>',
+        );
+      }
+      return new Response("missing", { status: 404 });
+    });
+
+    const runtime = await ensureManagedGrokRuntime({
+      arch: "x64",
+      channel: "latest",
+      checkMode: "force",
+      fetch: fetchMock as typeof globalThis.fetch,
+      platform: "linux",
+      probeVersion: async () => "grok 1.0.4-pwragent.2",
+      rootDir,
+    });
+
+    expect(runtime?.metadata.tag).toBe(cachedTag);
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      expect.stringContaining("pwragent-v2.1.0-pwragent.1"),
+      expect.anything(),
     );
   });
 
@@ -476,11 +592,15 @@ describe("ensureManagedGrokRuntime", () => {
   });
 });
 
-function release(tag: string, assets: ReturnType<typeof asset>[]) {
+function release(
+  tag: string,
+  assets: ReturnType<typeof asset>[],
+  options: { prerelease?: boolean } = {},
+) {
   return {
     assets,
     draft: false,
-    prerelease: true,
+    prerelease: options.prerelease === true,
     published_at: "2026-08-15T00:00:00Z",
     tag_name: tag,
   };

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1353,9 +1353,13 @@ describe("settings ipc", () => {
     const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
     // The pin has to be a real configured override, because that is the cause
     // `pinnedBehind` reports. A bare tag mismatch is not enough.
+    // The path has to be escaped, not interpolated raw. A Windows path is
+    // `C:\Users\...`, and the config parser rejects `\U` as an unknown escape,
+    // drops the key, and leaves the override unset. The parser reads basic
+    // strings only, so a literal string is not an option here.
     fs.writeFileSync(
       path.join(tempRoot, "config.toml"),
-      `[acp_agents.grok]\ncli_path = "${pinnedCommand}"\n`,
+      `[acp_agents.grok]\ncli_path = ${JSON.stringify(pinnedCommand)}\n`,
     );
     const service = new DesktopSettingsService({
       configPath: path.join(tempRoot, "config.toml"),

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1530,6 +1530,108 @@ describe("settings ipc", () => {
     }
   });
 
+  it("reports the track the operator picked and what each track resolved to", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const managedRoot = path.join(tempRoot, "agents", "grok");
+    fs.mkdirSync(managedRoot, { recursive: true });
+    // The state the Prerelease track exists for: a build is published for
+    // testing and the promoted one is a version behind it.
+    fs.writeFileSync(
+      path.join(managedRoot, "managed-release.json"),
+      JSON.stringify({
+        asset: "pwragent-grok-1.0.5-pwragent.1-macos-universal.tar.gz",
+        channel: "prerelease",
+        checkedAt: 5_000,
+        installedAt: 4_000,
+        latestTag: "pwragent-v1.0.4-pwragent.2",
+        prereleaseTag: "pwragent-v1.0.5-pwragent.1",
+        repository: "pwrdrvr/grok-build",
+        schemaVersion: 1,
+        sha256: "a".repeat(64),
+        tag: "pwragent-v1.0.5-pwragent.1",
+      }),
+    );
+    fs.writeFileSync(
+      path.join(tempRoot, "config.toml"),
+      "[acp_agents.grok]\nmanaged_build_channel = \"prerelease\"\n",
+    );
+    const activeCommand = path.join(
+      managedRoot,
+      "versions",
+      "pwragent-v1.0.5-pwragent.1",
+      "grok",
+    );
+
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState("bootstrap");
+    try {
+      new AcpAgentStore(getAppStateDb()).upsertInstalledAgent({
+        backendId: "acp:grok",
+        registryId: "grok",
+        name: "Grok",
+        version: "1.0.5-pwragent.1",
+        distributionKind: "local",
+        distributionSource: "grok agent stdio",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-grok-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        activeCommand,
+        instances: [
+          { command: activeCommand, version: "1.0.5-pwragent.1", source: "fallback" },
+        ],
+        launchDescriptor: {
+          backendId: "acp:grok",
+          registryId: "grok",
+          distributionKind: "local",
+          command: activeCommand,
+          args: ["agent", "stdio"],
+          env: { NO_COLOR: "1" },
+        },
+      });
+      registerSettingsIpcHandlers(service);
+
+      const response = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: false },
+      )) as { entries?: AcpAgentSettingsEntry[] } | undefined;
+      const grok = response?.entries?.find(
+        (entry) => entry.registryId === "grok",
+      );
+
+      expect(grok?.managedBuild).toMatchObject({
+        channel: "prerelease",
+        latestTag: "pwragent-v1.0.4-pwragent.2",
+        prereleaseTag: "pwragent-v1.0.5-pwragent.1",
+        installedTag: "pwragent-v1.0.5-pwragent.1",
+        activeTag: "pwragent-v1.0.5-pwragent.1",
+      });
+      // Following a build published for testing is not being held back by a
+      // pin. Nothing here needs a person.
+      expect(grok?.managedBuild?.pinnedBehind).toBeUndefined();
+    } finally {
+      disposeAppState();
+    }
+  });
+
   it("persists legacy Kimi diagnostics without probing or retaining models", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),
@@ -1632,6 +1734,7 @@ describe("settings ipc", () => {
         expect.objectContaining({
           enabledRegistryIds: ["gemini", "grok", "kimi", "qwen"],
           managedGrok: {
+            channel: "latest",
             enabled: true,
             checkMode: "once-per-process",
             requirePlatformSignature: false,

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1351,6 +1351,12 @@ describe("settings ipc", () => {
     const { AcpAgentStore } = await import("../acp/acp-agent-store");
     const { registerSettingsIpcHandlers } = await import("../ipc/settings");
     const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    // The pin has to be a real configured override, because that is the cause
+    // `pinnedBehind` reports. A bare tag mismatch is not enough.
+    fs.writeFileSync(
+      path.join(tempRoot, "config.toml"),
+      `[acp_agents.grok]\ncli_path = "${pinnedCommand}"\n`,
+    );
     const service = new DesktopSettingsService({
       configPath: path.join(tempRoot, "config.toml"),
       env: {},
@@ -1413,6 +1419,108 @@ describe("settings ipc", () => {
         { command: "/Users/me/.grok/bin/grok" },
       ]);
       expect(grok?.instances?.[1]?.pwrAgentBuild).toBeUndefined();
+    } finally {
+      disposeAppState();
+    }
+  });
+
+  it("does not report a pin, or a channel, that the config does not have", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const managedRoot = path.join(tempRoot, "agents", "grok");
+    fs.mkdirSync(managedRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(managedRoot, "managed-release.json"),
+      JSON.stringify({
+        asset: "pwragent-grok-1.0.5-pwragent.1-macos-universal.tar.gz",
+        checkedAt: 5_000,
+        installedAt: 4_000,
+        repository: "pwrdrvr/grok-build",
+        schemaVersion: 1,
+        sha256: "a".repeat(64),
+        tag: "pwragent-v1.0.5-pwragent.1",
+      }),
+    );
+    const olderCommand = path.join(
+      managedRoot,
+      "versions",
+      "pwragent-v1.0.4-pwragent.2",
+      "grok",
+    );
+    // The managed root is machine-wide, so a sibling instance can install a
+    // newer tag while this record still names the older one. That is a tag
+    // mismatch with no override behind it, and the durable notice it would
+    // feed tells the operator to clear a manual path that does not exist.
+    fs.writeFileSync(
+      path.join(tempRoot, "config.toml"),
+      "[acp_agents.grok]\nmanaged_builds = false\n",
+    );
+
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState("bootstrap");
+    try {
+      new AcpAgentStore(getAppStateDb()).upsertInstalledAgent({
+        backendId: "acp:grok",
+        registryId: "grok",
+        name: "Grok",
+        version: "1.0.4-pwragent.2",
+        distributionKind: "local",
+        distributionSource: "grok agent stdio",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-grok-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        activeCommand: olderCommand,
+        instances: [
+          { command: olderCommand, version: "1.0.4-pwragent.2", source: "fallback" },
+        ],
+        launchDescriptor: {
+          backendId: "acp:grok",
+          registryId: "grok",
+          distributionKind: "local",
+          command: olderCommand,
+          args: ["agent", "stdio"],
+          env: { NO_COLOR: "1" },
+        },
+      });
+      registerSettingsIpcHandlers(service);
+
+      const response = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: false },
+      )) as { entries?: AcpAgentSettingsEntry[] } | undefined;
+      const grok = response?.entries?.find(
+        (entry) => entry.registryId === "grok",
+      );
+
+      // Managed builds are off, so the pane must not report a channel at all
+      // — no installed tag, no "Check for updates" for a channel the operator
+      // disabled.
+      expect(grok?.managedBuild).toBeUndefined();
+      // Provenance survives the channel being off: the binary is still ours,
+      // so the vendor updater still must not claim it.
+      expect(grok).toMatchObject({ pwrAgentManagedRuntime: true });
+      expect(grok?.instances?.[0]).toMatchObject({
+        pwrAgentBuild: true,
+        pwrAgentBuildTag: "pwragent-v1.0.4-pwragent.2",
+      });
     } finally {
       disposeAppState();
     }

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AcpAgentSettingsEntry } from "@pwragent/shared";
 import { DesktopSettingsService } from "../settings/desktop-settings-service";
 import { MemoryDesktopSecretStore } from "../settings/desktop-secret-store";
 
@@ -1310,6 +1311,108 @@ describe("settings ipc", () => {
       );
       expect(grok).toMatchObject({ pwrAgentManagedRuntime: true });
       expect(grok?.update).toBeUndefined();
+    } finally {
+      disposeAppState();
+    }
+  });
+
+  it("reports the managed Grok channel and the pin holding it back", async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    const managedRoot = path.join(tempRoot, "agents", "grok");
+    fs.mkdirSync(managedRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(managedRoot, "managed-release.json"),
+      JSON.stringify({
+        asset: "pwragent-grok-1.0.5-pwragent.1-macos-universal.tar.gz",
+        checkedAt: 5_000,
+        installedAt: 4_000,
+        repository: "pwrdrvr/grok-build",
+        schemaVersion: 1,
+        sha256: "a".repeat(64),
+        tag: "pwragent-v1.0.5-pwragent.1",
+      }),
+    );
+    // The operator pinned an older managed version with a manual path, so the
+    // newest verified build is installed and never runs.
+    const pinnedCommand = path.join(
+      managedRoot,
+      "versions",
+      "pwragent-v1.0.4-pwragent.2",
+      "grok",
+    );
+
+    const { initializeAppState, disposeAppState, getAppStateDb } = await import(
+      "../state/app-state"
+    );
+    const { AcpAgentStore } = await import("../acp/acp-agent-store");
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState("bootstrap");
+    try {
+      new AcpAgentStore(getAppStateDb()).upsertInstalledAgent({
+        backendId: "acp:grok",
+        registryId: "grok",
+        name: "Grok",
+        version: "1.0.4-pwragent.2",
+        distributionKind: "local",
+        distributionSource: "grok agent stdio",
+        installStatus: "installed",
+        authStatus: "not-required",
+        verificationStatus: "not-applicable",
+        allowlistRuleId: "local-grok-cli",
+        installedAt: 1234,
+        updatedAt: 1234,
+        activeCommand: pinnedCommand,
+        instances: [
+          { command: pinnedCommand, version: "1.0.4-pwragent.2", source: "override" },
+          { command: "/Users/me/.grok/bin/grok", version: "1.0.5", source: "path" },
+        ],
+        launchDescriptor: {
+          backendId: "acp:grok",
+          registryId: "grok",
+          distributionKind: "local",
+          command: pinnedCommand,
+          args: ["agent", "stdio"],
+          // Deliberately unstamped: discovery only stamps the command the
+          // current release check resolved, which a pinned older version is
+          // not. Provenance still has to come out right.
+          env: { NO_COLOR: "1" },
+        },
+      });
+      registerSettingsIpcHandlers(service);
+
+      const response = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: false },
+      )) as { entries?: AcpAgentSettingsEntry[] } | undefined;
+      const grok = response?.entries?.find(
+        (entry) => entry.registryId === "grok",
+      );
+
+      expect(grok).toMatchObject({ pwrAgentManagedRuntime: true });
+      expect(grok?.managedBuild).toMatchObject({
+        repository: "pwrdrvr/grok-build",
+        installedTag: "pwragent-v1.0.5-pwragent.1",
+        activeTag: "pwragent-v1.0.4-pwragent.2",
+        checkedAt: 5_000,
+        pinnedBehind: true,
+      });
+      expect(grok?.instances).toMatchObject([
+        { pwrAgentBuild: true, pwrAgentBuildTag: "pwragent-v1.0.4-pwragent.2" },
+        { command: "/Users/me/.grok/bin/grok" },
+      ]);
+      expect(grok?.instances?.[1]?.pwrAgentBuild).toBeUndefined();
     } finally {
       disposeAppState();
     }

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1756,6 +1756,51 @@ describe("settings ipc", () => {
     // setup doesn't flake the suite.
   }, 20_000);
 
+  it("passes the configured managed Grok track to local discovery", async () => {
+    // The whole feature is this value reaching `ensureManagedGrokRuntime`.
+    // Every other test on this path would pass with the chain unwired,
+    // because an unwired chain produces the default.
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), "pwragent-settings-ipc-"),
+    );
+    tempRoots.push(tempRoot);
+    vi.stubEnv("PWRAGENT_HOME", tempRoot);
+    fs.writeFileSync(
+      path.join(tempRoot, "config.toml"),
+      "[acp_agents.grok]\nmanaged_build_channel = \"prerelease\"\n",
+    );
+    const { initializeAppState, disposeAppState } = await import(
+      "../state/app-state"
+    );
+    const { registerSettingsIpcHandlers } = await import("../ipc/settings");
+    const { ACP_AGENTS_LIST_CHANNEL } = await import("../../shared/ipc");
+    const service = new DesktopSettingsService({
+      configPath: path.join(tempRoot, "config.toml"),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+      now: () => 20,
+    });
+
+    initializeAppState();
+    try {
+      registerSettingsIpcHandlers(service);
+      await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+        {},
+        { refresh: true, discoveryIntent: "settings-user-action" },
+      );
+
+      expect(
+        localAcpDiscoveryMock.discoverLocalAcpAgentRecords,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          managedGrok: expect.objectContaining({ channel: "prerelease" }),
+        }),
+      );
+    } finally {
+      disposeAppState();
+    }
+  }, 20_000);
+
   it("skips local discovery and runtime probes for disabled ACP agents", async () => {
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), "pwragent-settings-ipc-"),

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -26,6 +26,7 @@ import type {
   AcpAgentPreference,
   AcpBackendId,
   AcpRejectedAgentInstance,
+  DesktopUpdateChannel,
 } from "@pwragent/shared";
 import { resolveActiveAcpInstance } from "./acp-instance-resolver.js";
 import { acpAgentCapabilitiesForRegistryId } from "./acp-agent-capabilities.js";
@@ -105,6 +106,7 @@ export type DiscoverAcpAgentInstancesOptions = {
    * Grok itself and the managed-build preference are both enabled.
    */
   managedGrok?: {
+    channel?: DesktopUpdateChannel;
     checkMode?: ManagedGrokCheckMode;
     enabled: boolean;
     requirePlatformSignature?: boolean;
@@ -623,6 +625,9 @@ async function resolveManagedGrokCommand(
     );
   }
   return (await ensureManagedGrokRuntime({
+    ...(options.managedGrok.channel
+      ? { channel: options.managedGrok.channel }
+      : {}),
     checkMode,
     requirePlatformSignature:
       options.managedGrok.requirePlatformSignature === true,

--- a/apps/desktop/src/main/acp/acp-instance-discovery.ts
+++ b/apps/desktop/src/main/acp/acp-instance-discovery.ts
@@ -34,6 +34,7 @@ import {
   ensureManagedGrokRuntime,
   type ManagedGrokCheckMode,
 } from "./grok-managed-runtime.js";
+import { isPwrAgentSuppliedGrokCommand } from "./grok-build-channel.js";
 import { normalizeAcpLaunchDescriptor } from "./acp-launch-descriptor.js";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
 import type {
@@ -275,10 +276,16 @@ export async function discoverLocalAcpAgentRecords(
       args: group.args,
       env: {
         ...group.env,
+        // Equality covers the command this run's check just resolved (and the
+        // injected commands discovery tests supply); the path check covers
+        // every other PwrAgent build the machine holds — an older managed
+        // version an operator pinned, or one left active while a release check
+        // failed. Both are ours, so neither may reach the vendor updater.
         ...(group.strategyId === "grok"
           && (
             active.command === managedGrokCommand
             || active.command === bundledGrokCommand
+            || isPwrAgentSuppliedGrokCommand(active.command)
           )
           ? { GROK_INSTALLER: "pwragent" }
           : {}),

--- a/apps/desktop/src/main/acp/grok-build-channel.ts
+++ b/apps/desktop/src/main/acp/grok-build-channel.ts
@@ -1,0 +1,83 @@
+import path from "node:path";
+import { resolvePwragentRoot } from "../profile.js";
+import { BUNDLED_GROK_RELATIVE_PATH } from "./acp-bundled-agent.js";
+
+/** `agents/grok` under the PwrAgent root — the machine-wide managed root. */
+export const MANAGED_GROK_ROOT_SEGMENTS = ["agents", "grok"] as const;
+
+export type GrokBuildChannelOptions = {
+  /** Overrides `<pwragent root>/agents/grok`. Tests and alternate roots. */
+  managedRoot?: string;
+  /** Overrides `process.resourcesPath` for the packaged bundle copy. */
+  resourcesPath?: string;
+};
+
+export function managedGrokRoot(options?: GrokBuildChannelOptions): string {
+  return options?.managedRoot
+    ?? path.join(resolvePwragentRoot(), ...MANAGED_GROK_ROOT_SEGMENTS);
+}
+
+/**
+ * The release tag a Grok command was installed under, or `undefined` when the
+ * command is not a managed install. `installRelease` lays every download out as
+ * `<managed root>/versions/<tag>/<executable>`, so the tag is recoverable from
+ * the path alone — which is what lets an *older* managed version still be
+ * recognized as one after the channel has moved on.
+ */
+export function managedGrokTagForCommand(
+  command: string | undefined,
+  options?: GrokBuildChannelOptions,
+): string | undefined {
+  if (!command) {
+    return undefined;
+  }
+  const relative = path.relative(
+    path.resolve(managedGrokRoot(options), "versions"),
+    path.resolve(command),
+  );
+  if (
+    relative === ""
+    || relative.startsWith("..")
+    || path.isAbsolute(relative)
+  ) {
+    return undefined;
+  }
+  const [tag, ...rest] = relative.split(path.sep);
+  // `versions/<tag>` alone is the directory, not an executable inside it.
+  return tag && rest.length > 0 ? tag : undefined;
+}
+
+/**
+ * Whether this command is a Grok build PwrAgent supplied — a managed download
+ * under `versions/`, or the copy inside the packaged app.
+ *
+ * Deliberately decided from the path rather than from equality with whatever
+ * command the current release check resolved. Provenance is a property of the
+ * binary; "is it the newest one" is a separate question. Conflating the two is
+ * how a pinned older managed build — or any build present while a check failed
+ * — used to change channel and collect an xAI update notice.
+ */
+export function isPwrAgentSuppliedGrokCommand(
+  command: string | undefined,
+  options?: GrokBuildChannelOptions,
+): boolean {
+  if (!command) {
+    return false;
+  }
+  if (managedGrokTagForCommand(command, options) !== undefined) {
+    return true;
+  }
+  const resourcesPath = options?.resourcesPath ?? process.resourcesPath;
+  if (!resourcesPath) {
+    return false;
+  }
+  const relative = path.relative(
+    path.resolve(resourcesPath, ...BUNDLED_GROK_RELATIVE_PATH),
+    path.resolve(command),
+  );
+  return (
+    relative !== ""
+    && !relative.startsWith("..")
+    && !path.isAbsolute(relative)
+  );
+}

--- a/apps/desktop/src/main/acp/grok-cli-update.ts
+++ b/apps/desktop/src/main/acp/grok-cli-update.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import type { AcpAgentUpdateStatus } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env.js";
+import { isPwrAgentSuppliedGrokCommand } from "./grok-build-channel.js";
 import type { AcpInstalledAgentRecord } from "./acp-registry-types.js";
 
 const execFile = promisify(execFileCallback);
@@ -27,16 +28,30 @@ export type GrokCliUpdateProbe = (
 
 /**
  * Whether this record's active runtime is a PwrAgent-supplied Grok build
- * (managed download or app bundle). Discovery stamps `GROK_INSTALLER=pwragent`
- * on the launch descriptor when the resolved active command is one of those,
- * and that stamp is the single marker every update-status path keys on: the
- * vendor updater follows a different channel, so its result must never run
- * against, decorate, or survive on a PwrAgent-owned runtime.
+ * (managed download or app bundle). The vendor updater follows a different
+ * channel, so its result must never run against, decorate, or survive on a
+ * PwrAgent-owned runtime.
+ *
+ * Two sources, and the second is load-bearing. Discovery stamps
+ * `GROK_INSTALLER=pwragent` on the launch descriptor, which also reaches the
+ * spawned process; but that stamp used to be the *only* marker, and discovery
+ * sets it by comparing the active command against the command this run's
+ * release check resolved. Any moment where those disagree — a manual path
+ * pinning an older managed version, a failed check with nothing cached, the
+ * managed toggle off while an override still points into `versions/` — silently
+ * moved a PwrAgent build onto the vendor channel, and the operator was shown an
+ * xAI version against a `-pwragent` build. Provenance does not depend on which
+ * release is newest, so read it from the path too.
  */
 export function isPwrAgentOwnedGrokRuntime(
-  record: Pick<AcpInstalledAgentRecord, "launchDescriptor">,
+  record: Pick<AcpInstalledAgentRecord, "launchDescriptor" | "activeCommand">,
 ): boolean {
-  return record.launchDescriptor?.env?.GROK_INSTALLER === "pwragent";
+  if (record.launchDescriptor?.env?.GROK_INSTALLER === "pwragent") {
+    return true;
+  }
+  return isPwrAgentSuppliedGrokCommand(
+    record.activeCommand ?? record.launchDescriptor?.command,
+  );
 }
 
 /**

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -1,3 +1,8 @@
+import type { DesktopUpdateChannel } from "@pwragent/shared";
+import {
+  isDesktopUpdateChannel,
+  MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
+} from "@pwragent/shared";
 import { createHash } from "node:crypto";
 import {
   createReadStream,
@@ -145,8 +150,14 @@ type ManagedGrokRelease = {
 
 type ManagedGrokMetadata = {
   asset: string;
+  /** Track the check that installed this bundle was following. */
+  channel?: DesktopUpdateChannel;
   checkedAt: number;
   installedAt: number;
+  /** Newest promoted tag the last check saw, whichever track it served. */
+  latestTag?: string;
+  /** Newest tag overall the last check saw, promoted or not. */
+  prereleaseTag?: string;
   repository: string;
   schemaVersion: number;
   sha256: string;
@@ -161,6 +172,7 @@ export type ManagedGrokRuntime = {
 type ManagedGrokRuntimeOptions = {
   applicationCommand?: string;
   arch?: NodeJS.Architecture;
+  channel?: DesktopUpdateChannel;
   checkMode?: ManagedGrokCheckMode;
   extractArchive?: (archivePath: string, targetDir: string) => Promise<void>;
   fetch?: typeof globalThis.fetch;
@@ -203,6 +215,9 @@ export type ManagedGrokInstallSummary = {
   tag: string;
   checkedAt: number;
   installedAt: number;
+  channel?: DesktopUpdateChannel;
+  latestTag?: string;
+  prereleaseTag?: string;
 };
 
 /**
@@ -225,6 +240,11 @@ export async function readManagedGrokInstallSummary(options?: {
         tag: metadata.tag,
         checkedAt: metadata.checkedAt,
         installedAt: metadata.installedAt,
+        ...(metadata.channel ? { channel: metadata.channel } : {}),
+        ...(metadata.latestTag ? { latestTag: metadata.latestTag } : {}),
+        ...(metadata.prereleaseTag
+          ? { prereleaseTag: metadata.prereleaseTag }
+          : {}),
       }
     : undefined;
 }
@@ -261,7 +281,16 @@ async function readManagedGrokMetadata(
   ) {
     return undefined;
   }
-  return metadata as ManagedGrokMetadata;
+  // The track fields arrived after the first shipped format, so a bundle
+  // installed by an older build carries none of them. They are reporting
+  // detail, never a reason to reject an otherwise valid install: drop a field
+  // that does not parse and keep the record.
+  return {
+    ...(metadata as ManagedGrokMetadata),
+    channel: readMetadataChannel(metadata.channel),
+    latestTag: readMetadataTag(metadata.latestTag),
+    prereleaseTag: readMetadataTag(metadata.prereleaseTag),
+  };
 }
 
 export async function ensureManagedGrokRuntime(
@@ -289,6 +318,7 @@ async function ensureManagedGrokRuntimeInner(
   const now = options.now?.() ?? Date.now();
   const cached = await readCachedRuntime(rootDir, options);
   const checkMode = options.checkMode ?? "ttl";
+  const channel = options.channel ?? MANAGED_GROK_BUILD_CHANNEL_DEFAULT;
   if (
     (checkMode === "once-per-process" && processChecks.has(rootDir))
     || (
@@ -304,12 +334,22 @@ async function ensureManagedGrokRuntimeInner(
 
   processChecks.add(rootDir);
   try {
-    const release = await fetchLatestCompatibleRelease(options);
+    const slots = await fetchCompatibleReleaseSlots(options, channel);
+    const release = slots[channel];
     if (!release) {
-      throw new Error("No compatible complete PwrAgent Grok release was found");
+      throw new Error(
+        `No compatible complete PwrAgent Grok release was found on the ${channel} track`,
+      );
     }
+    // What each track resolved to, recorded on every check so the settings
+    // pane can name both versions without a second network round trip.
+    const observed = {
+      channel,
+      ...(slots.latest ? { latestTag: slots.latest.tag } : {}),
+      ...(slots.prerelease ? { prereleaseTag: slots.prerelease.tag } : {}),
+    };
     if (cached?.metadata.tag === release.tag) {
-      const metadata = { ...cached.metadata, checkedAt: now };
+      const metadata = { ...cached.metadata, ...observed, checkedAt: now };
       await writeMetadata(rootDir, metadata);
       return await activateRuntime(
         rootDir,
@@ -317,7 +357,13 @@ async function ensureManagedGrokRuntimeInner(
         options,
       );
     }
-    const runtime = await installRelease(rootDir, release, now, options);
+    const runtime = await installRelease(
+      rootDir,
+      release,
+      now,
+      options,
+      observed,
+    );
     managedGrokLog.info("managed_grok_runtime_installed", {
       asset: runtime.metadata.asset,
       command: runtime.command,
@@ -331,6 +377,7 @@ async function ensureManagedGrokRuntimeInner(
       reportSignatureRejection(error, "download", true);
     }
     managedGrokLog.warn("managed_grok_runtime_update_failed", {
+      channel,
       error: error instanceof Error ? error.message : String(error),
       usingCachedTag: cached?.metadata.tag,
     });
@@ -340,15 +387,16 @@ async function ensureManagedGrokRuntimeInner(
   }
 }
 
-async function fetchLatestCompatibleRelease(
+async function fetchCompatibleReleaseSlots(
   options: ManagedGrokRuntimeOptions,
-): Promise<ManagedGrokRelease | undefined> {
+  channel: DesktopUpdateChannel,
+): Promise<ManagedGrokReleaseSlots> {
   const assetPlatform = managedGrokAssetPlatform(
     options.platform ?? process.platform,
     options.arch ?? process.arch,
   );
   if (!assetPlatform) {
-    return undefined;
+    return {};
   }
   const fetchImpl = options.fetch ?? globalThis.fetch;
   const response = await fetchImpl(MANAGED_GROK_RELEASES_URL, {
@@ -364,7 +412,7 @@ async function fetchLatestCompatibleRelease(
     if (!Array.isArray(releases)) {
       throw new Error("GitHub release check returned an invalid response");
     }
-    return selectManagedGrokRelease(releases, assetPlatform);
+    return selectManagedGrokReleaseSlots(releases, assetPlatform);
   }
   if (response.status !== 403 && response.status !== 429) {
     throw new Error(`GitHub release check failed with HTTP ${response.status}`);
@@ -382,23 +430,47 @@ async function fetchLatestCompatibleRelease(
       `GitHub release feed failed with HTTP ${feedResponse.status} after API HTTP ${response.status}`,
     );
   }
-  return selectManagedGrokReleaseFromFeed(
+  const fromFeed = selectManagedGrokReleaseFromFeed(
     await feedResponse.text(),
     assetPlatform,
+    channel,
   );
+  // The feed answers one track. Reporting the other track's slot from it
+  // would be a guess, and the pane would print that guess as a version.
+  return fromFeed ? { [channel]: fromFeed } : {};
 }
 
-export function selectManagedGrokRelease(
+/**
+ * The newest complete release on each track.
+ *
+ * `latest` holds the newest release GitHub reports as promoted; `prerelease`
+ * holds the newest release overall. When the newest release is a promoted one
+ * both slots hold it, which is the point: the tracks agree until a build is
+ * published for testing, and the control stays meaningful in between.
+ */
+export type ManagedGrokReleaseSlots = {
+  latest?: ManagedGrokRelease;
+  prerelease?: ManagedGrokRelease;
+};
+
+export function selectManagedGrokReleaseSlots(
   releases: GithubRelease[],
   assetPlatform: string,
-): ManagedGrokRelease | undefined {
+): ManagedGrokReleaseSlots {
+  const candidates: Array<{
+    prerelease: boolean;
+    release: ManagedGrokRelease;
+    version: ParsedSemver;
+  }> = [];
   for (const release of releases) {
     const tag = typeof release.tag_name === "string"
       ? release.tag_name.trim()
       : "";
+    const version = parseManagedGrokSemver(tag);
     if (
       release.draft === true
       || !isManagedGrokTagEligible(tag)
+      || version === undefined
       || !Array.isArray(release.assets)
     ) {
       continue;
@@ -416,48 +488,79 @@ export function selectManagedGrokRelease(
     if (!checksum || !archive) {
       continue;
     }
-    return {
-      archive,
-      checksum,
-      ...(typeof release.published_at === "string"
-        ? { publishedAt: release.published_at }
-        : {}),
-      tag,
-    };
+    candidates.push({
+      prerelease: release.prerelease === true,
+      release: {
+        archive,
+        checksum,
+        ...(typeof release.published_at === "string"
+          ? { publishedAt: release.published_at }
+          : {}),
+        tag,
+      },
+      version,
+    });
   }
-  return undefined;
+  // Precedence, not publish order. A promotion lands on a release published
+  // weeks ago, and a repair to an older line is published last; either one
+  // makes the newest entry in the response the wrong answer.
+  candidates.sort((left, right) => compareParsedSemver(right.version, left.version));
+  const latest = candidates.find((candidate) => !candidate.prerelease)?.release;
+  const newest = candidates[0]?.release;
+  return {
+    ...(latest ? { latest } : {}),
+    ...(newest ? { prerelease: newest } : {}),
+  };
+}
+
+export function selectManagedGrokRelease(
+  releases: GithubRelease[],
+  assetPlatform: string,
+  channel: DesktopUpdateChannel,
+): ManagedGrokRelease | undefined {
+  return selectManagedGrokReleaseSlots(releases, assetPlatform)[channel];
 }
 
 export function selectManagedGrokReleaseFromFeed(
   feed: string,
   assetPlatform: string,
+  channel: DesktopUpdateChannel,
 ): ManagedGrokRelease | undefined {
+  if (channel === "latest") {
+    // The Atom feed carries tags, not release records: it cannot tell a
+    // promoted release from one published for testing, and it lists tags that
+    // have no release at all. Serving it to the Latest track would hand an
+    // operator exactly the build they opted out of, so the track goes without
+    // an update this cycle and keeps the cached runtime.
+    return undefined;
+  }
   const linkPattern = new RegExp(
     `https://github\\.com/${MANAGED_GROK_REPOSITORY}/releases/tag/`
       + "(pwragent-v[0-9A-Za-z][0-9A-Za-z.+-]*)",
     "gu",
   );
-  for (const match of feed.matchAll(linkPattern)) {
-    const tag = match[1];
-    if (!isManagedGrokTagEligible(tag)) {
-      continue;
-    }
-    const assetName = managedGrokArchiveName(tag, assetPlatform);
-    const releaseBase =
-      `https://github.com/${MANAGED_GROK_REPOSITORY}/releases/download/${tag}`;
-    return {
-      archive: {
-        name: assetName,
-        url: `${releaseBase}/${assetName}`,
-      },
-      checksum: {
-        name: "SHA256SUMS",
-        url: `${releaseBase}/SHA256SUMS`,
-      },
-      tag,
-    };
+  const tags = [...feed.matchAll(linkPattern)]
+    .map((match) => match[1])
+    .filter((tag) => isManagedGrokTagEligible(tag))
+    .sort((left, right) => compareManagedGrokTags(right, left));
+  const tag = tags[0];
+  if (tag === undefined) {
+    return undefined;
   }
-  return undefined;
+  const assetName = managedGrokArchiveName(tag, assetPlatform);
+  const releaseBase =
+    `https://github.com/${MANAGED_GROK_REPOSITORY}/releases/download/${tag}`;
+  return {
+    archive: {
+      name: assetName,
+      url: `${releaseBase}/${assetName}`,
+    },
+    checksum: {
+      name: "SHA256SUMS",
+      url: `${releaseBase}/SHA256SUMS`,
+    },
+    tag,
+  };
 }
 
 export function isManagedGrokTagEligible(tag: string): boolean {
@@ -471,6 +574,27 @@ export function isManagedGrokTagEligible(tag: string): boolean {
     && minimum
     && compareParsedSemver(candidate, minimum) >= 0,
   );
+}
+
+function readMetadataChannel(value: unknown): DesktopUpdateChannel | undefined {
+  return typeof value === "string" && isDesktopUpdateChannel(value)
+    ? value
+    : undefined;
+}
+
+function readMetadataTag(value: unknown): string | undefined {
+  return typeof value === "string" && isManagedGrokTag(value)
+    ? value
+    : undefined;
+}
+
+/** Precedence order for two tags both known to parse. */
+function compareManagedGrokTags(left: string, right: string): number {
+  const leftVersion = parseManagedGrokSemver(left);
+  const rightVersion = parseManagedGrokSemver(right);
+  return leftVersion && rightVersion
+    ? compareParsedSemver(leftVersion, rightVersion)
+    : 0;
 }
 
 function isManagedGrokTag(tag: string): boolean {
@@ -580,6 +704,10 @@ async function installRelease(
   release: ManagedGrokRelease,
   now: number,
   options: ManagedGrokRuntimeOptions,
+  observed: Pick<
+    ManagedGrokMetadata,
+    "channel" | "latestTag" | "prereleaseTag"
+  >,
 ): Promise<ManagedGrokRuntime> {
   await mkdir(rootDir, { recursive: true });
   const stagingRoot = await mkdtemp(path.join(rootDir, ".install-"));
@@ -625,6 +753,7 @@ async function installRelease(
       validationOptions,
     );
     const metadata: ManagedGrokMetadata = {
+      ...observed,
       asset: release.archive.name,
       checkedAt: now,
       installedAt: now,

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -1,7 +1,7 @@
 import type { DesktopUpdateChannel } from "@pwragent/shared";
 import {
-  isDesktopUpdateChannel,
   MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
+  parseDesktopUpdateChannel,
 } from "@pwragent/shared";
 import { createHash } from "node:crypto";
 import {
@@ -287,7 +287,7 @@ async function readManagedGrokMetadata(
   // that does not parse and keep the record.
   return {
     ...(metadata as ManagedGrokMetadata),
-    channel: readMetadataChannel(metadata.channel),
+    channel: parseDesktopUpdateChannel(metadata.channel),
     latestTag: readMetadataTag(metadata.latestTag),
     prereleaseTag: readMetadataTag(metadata.prereleaseTag),
   };
@@ -319,12 +319,24 @@ async function ensureManagedGrokRuntimeInner(
   const cached = await readCachedRuntime(rootDir, options);
   const checkMode = options.checkMode ?? "ttl";
   const channel = options.channel ?? MANAGED_GROK_BUILD_CHANNEL_DEFAULT;
+  // A cache installed for the other track is not this track's answer. The
+  // managed root is machine-wide, so a profile following Prerelease rewrites
+  // the record a profile following Latest reads next; without this the fresh
+  // `checkedAt` alone would hand Latest the build it exists to avoid. A record
+  // written before tracks existed names no channel and is left alone, so an
+  // offline machine does not re-check on every launch forever.
+  const cachedOtherTrack =
+    cached?.metadata.channel !== undefined
+    && cached.metadata.channel !== channel;
   if (
-    (checkMode === "once-per-process" && processChecks.has(rootDir))
-    || (
-      checkMode === "ttl"
-      && cached
-      && now - cached.metadata.checkedAt < MANAGED_GROK_CHECK_TTL_MS
+    !cachedOtherTrack
+    && (
+      (checkMode === "once-per-process" && processChecks.has(rootDir))
+      || (
+        checkMode === "ttl"
+        && cached
+        && now - cached.metadata.checkedAt < MANAGED_GROK_CHECK_TTL_MS
+      )
     )
   ) {
     return cached
@@ -342,11 +354,17 @@ async function ensureManagedGrokRuntimeInner(
       );
     }
     // What each track resolved to, recorded on every check so the settings
-    // pane can name both versions without a second network round trip.
+    // pane can name both versions without a second network round trip. A check
+    // that answered from the Atom feed saw one track only; carry the other
+    // track's last known tag rather than blanking a version this machine
+    // already learned, whichever branch below writes the record.
+    const latestTag = slots.latest?.tag ?? cached?.metadata.latestTag;
+    const prereleaseTag =
+      slots.prerelease?.tag ?? cached?.metadata.prereleaseTag;
     const observed = {
       channel,
-      ...(slots.latest ? { latestTag: slots.latest.tag } : {}),
-      ...(slots.prerelease ? { prereleaseTag: slots.prerelease.tag } : {}),
+      ...(latestTag ? { latestTag } : {}),
+      ...(prereleaseTag ? { prereleaseTag } : {}),
     };
     if (cached?.metadata.tag === release.tag) {
       const metadata = { ...cached.metadata, ...observed, checkedAt: now };
@@ -504,7 +522,9 @@ export function selectManagedGrokReleaseSlots(
   // Precedence, not publish order. A promotion lands on a release published
   // weeks ago, and a repair to an older line is published last; either one
   // makes the newest entry in the response the wrong answer.
-  candidates.sort((left, right) => compareParsedSemver(right.version, left.version));
+  candidates.sort(
+    (left, right) => compareParsedSemver(right.version, left.version),
+  );
   const latest = candidates.find((candidate) => !candidate.prerelease)?.release;
   const newest = candidates[0]?.release;
   return {
@@ -539,11 +559,17 @@ export function selectManagedGrokReleaseFromFeed(
       + "(pwragent-v[0-9A-Za-z][0-9A-Za-z.+-]*)",
     "gu",
   );
-  const tags = [...feed.matchAll(linkPattern)]
-    .map((match) => match[1])
-    .filter((tag) => isManagedGrokTagEligible(tag))
-    .sort((left, right) => compareManagedGrokTags(right, left));
-  const tag = tags[0];
+  const candidates: Array<{ tag: string; version: ParsedSemver }> = [];
+  for (const match of feed.matchAll(linkPattern)) {
+    const version = parseManagedGrokSemver(match[1]);
+    if (isManagedGrokTagEligible(match[1]) && version !== undefined) {
+      candidates.push({ tag: match[1], version });
+    }
+  }
+  candidates.sort(
+    (left, right) => compareParsedSemver(right.version, left.version),
+  );
+  const tag = candidates[0]?.tag;
   if (tag === undefined) {
     return undefined;
   }
@@ -576,25 +602,13 @@ export function isManagedGrokTagEligible(tag: string): boolean {
   );
 }
 
-function readMetadataChannel(value: unknown): DesktopUpdateChannel | undefined {
-  return typeof value === "string" && isDesktopUpdateChannel(value)
-    ? value
-    : undefined;
-}
-
 function readMetadataTag(value: unknown): string | undefined {
-  return typeof value === "string" && isManagedGrokTag(value)
+  // The same bar the record's own tag is held to. A tag below the first signed
+  // release can never be installed, so reporting one as a track's version
+  // would offer the operator a build that selecting the track cannot produce.
+  return typeof value === "string" && isManagedGrokTagEligible(value)
     ? value
     : undefined;
-}
-
-/** Precedence order for two tags both known to parse. */
-function compareManagedGrokTags(left: string, right: string): number {
-  const leftVersion = parseManagedGrokSemver(left);
-  const rightVersion = parseManagedGrokSemver(right);
-  return leftVersion && rightVersion
-    ? compareParsedSemver(leftVersion, rightVersion)
-    : 0;
 }
 
 function isManagedGrokTag(tag: string): boolean {

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -198,6 +198,55 @@ const processChecks = new Set<string>();
 const activeChecks = new Map<string, Promise<ManagedGrokRuntime | undefined>>();
 const markedRuntimeCommands = new Map<string, string>();
 
+/** What the last managed release check decided, as recorded on disk. */
+export type ManagedGrokInstallSummary = {
+  tag: string;
+  checkedAt: number;
+  installedAt: number;
+};
+
+/**
+ * Read `managed-release.json` and nothing else.
+ *
+ * Deliberately weaker than `readCachedRuntime`: it does not validate the
+ * bundle, probe a version, or verify a signature, so it must never be used to
+ * choose a runtime. It answers one reporting question — which tag the last
+ * check installed, and when — for a settings pane that would otherwise have to
+ * start a download to say anything at all.
+ */
+export async function readManagedGrokInstallSummary(options?: {
+  rootDir?: string;
+}): Promise<ManagedGrokInstallSummary | undefined> {
+  const rootDir = options?.rootDir ?? path.join(
+    resolvePwragentRoot(),
+    "agents",
+    "grok",
+  );
+  try {
+    const metadata = JSON.parse(
+      await readFile(path.join(rootDir, "managed-release.json"), "utf8"),
+    ) as Partial<ManagedGrokMetadata>;
+    if (
+      metadata.schemaVersion !== MANAGED_GROK_METADATA_VERSION
+      || metadata.repository !== MANAGED_GROK_REPOSITORY
+      || typeof metadata.tag !== "string"
+      || !isManagedGrokTagEligible(metadata.tag)
+      || typeof metadata.checkedAt !== "number"
+      || typeof metadata.installedAt !== "number"
+    ) {
+      return undefined;
+    }
+    return {
+      tag: metadata.tag,
+      checkedAt: metadata.checkedAt,
+      installedAt: metadata.installedAt,
+    };
+  } catch {
+    // No install yet, or unreadable metadata. Both mean "nothing to report".
+    return undefined;
+  }
+}
+
 export async function ensureManagedGrokRuntime(
   options: ManagedGrokRuntimeOptions = {},
 ): Promise<ManagedGrokRuntime | undefined> {

--- a/apps/desktop/src/main/acp/grok-managed-runtime.ts
+++ b/apps/desktop/src/main/acp/grok-managed-runtime.ts
@@ -23,7 +23,7 @@ import { pipeline } from "node:stream/promises";
 import { execFile as execFileCallback } from "node:child_process";
 import { promisify } from "node:util";
 import type { ManagedGrokSignatureRejectedEvent } from "../../shared/managed-grok-signature.js";
-import { resolvePwragentRoot } from "../profile.js";
+import { managedGrokRoot } from "./grok-build-channel.js";
 import { getMainLogger } from "../log.js";
 import { verifyMatchingPlatformSignature } from "../managed-runtime-signature.js";
 
@@ -217,44 +217,57 @@ export type ManagedGrokInstallSummary = {
 export async function readManagedGrokInstallSummary(options?: {
   rootDir?: string;
 }): Promise<ManagedGrokInstallSummary | undefined> {
-  const rootDir = options?.rootDir ?? path.join(
-    resolvePwragentRoot(),
-    "agents",
-    "grok",
+  const metadata = await readManagedGrokMetadata(
+    options?.rootDir ?? managedGrokRoot(),
   );
+  return metadata
+    ? {
+        tag: metadata.tag,
+        checkedAt: metadata.checkedAt,
+        installedAt: metadata.installedAt,
+      }
+    : undefined;
+}
+
+/**
+ * Parse and validate `managed-release.json`. One validator for one on-disk
+ * format: both the runtime path and the reporting path read this file, and a
+ * second copy of these checks would let the pane name a tag the runtime path
+ * rejects. Platform-asset agreement is deliberately NOT checked here — that
+ * asks whether the cache is usable on this machine, which is the runtime
+ * path's question, not "what did the last check install".
+ */
+async function readManagedGrokMetadata(
+  rootDir: string,
+): Promise<ManagedGrokMetadata | undefined> {
+  let metadata: Partial<ManagedGrokMetadata>;
   try {
-    const metadata = JSON.parse(
+    metadata = JSON.parse(
       await readFile(path.join(rootDir, "managed-release.json"), "utf8"),
     ) as Partial<ManagedGrokMetadata>;
-    if (
-      metadata.schemaVersion !== MANAGED_GROK_METADATA_VERSION
-      || metadata.repository !== MANAGED_GROK_REPOSITORY
-      || typeof metadata.tag !== "string"
-      || !isManagedGrokTagEligible(metadata.tag)
-      || typeof metadata.checkedAt !== "number"
-      || typeof metadata.installedAt !== "number"
-    ) {
-      return undefined;
-    }
-    return {
-      tag: metadata.tag,
-      checkedAt: metadata.checkedAt,
-      installedAt: metadata.installedAt,
-    };
   } catch {
     // No install yet, or unreadable metadata. Both mean "nothing to report".
     return undefined;
   }
+  if (
+    metadata.schemaVersion !== MANAGED_GROK_METADATA_VERSION
+    || metadata.repository !== MANAGED_GROK_REPOSITORY
+    || typeof metadata.tag !== "string"
+    || !isManagedGrokTagEligible(metadata.tag)
+    || typeof metadata.asset !== "string"
+    || typeof metadata.sha256 !== "string"
+    || typeof metadata.checkedAt !== "number"
+    || typeof metadata.installedAt !== "number"
+  ) {
+    return undefined;
+  }
+  return metadata as ManagedGrokMetadata;
 }
 
 export async function ensureManagedGrokRuntime(
   options: ManagedGrokRuntimeOptions = {},
 ): Promise<ManagedGrokRuntime | undefined> {
-  const rootDir = options.rootDir ?? path.join(
-    resolvePwragentRoot(),
-    "agents",
-    "grok",
-  );
+  const rootDir = options.rootDir ?? managedGrokRoot();
   const existing = activeChecks.get(rootDir);
   if (existing) {
     return await existing;
@@ -824,19 +837,8 @@ async function readCachedRuntime(
   options: ManagedGrokRuntimeOptions,
 ): Promise<ManagedGrokRuntime | undefined> {
   try {
-    const metadata = JSON.parse(
-      await readFile(path.join(rootDir, "managed-release.json"), "utf8"),
-    ) as Partial<ManagedGrokMetadata>;
-    if (
-      metadata.schemaVersion !== MANAGED_GROK_METADATA_VERSION
-      || metadata.repository !== MANAGED_GROK_REPOSITORY
-      || typeof metadata.tag !== "string"
-      || !isManagedGrokTagEligible(metadata.tag)
-      || typeof metadata.asset !== "string"
-      || typeof metadata.sha256 !== "string"
-      || typeof metadata.checkedAt !== "number"
-      || typeof metadata.installedAt !== "number"
-    ) {
+    const metadata = await readManagedGrokMetadata(rootDir);
+    if (!metadata) {
       return undefined;
     }
     const assetPlatform = managedGrokAssetPlatform(
@@ -854,7 +856,7 @@ async function readCachedRuntime(
       ...bundleValidationOptions(options),
       tag: metadata.tag,
     });
-    return { command, metadata: metadata as ManagedGrokMetadata };
+    return { command, metadata };
   } catch (error) {
     // Every other failure here is ordinary (no install yet, a partially
     // written directory, unreadable metadata) and resolves by reinstalling.

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -58,6 +58,7 @@ import {
 import {
   acpProviderCommandOverrideFromSnapshot,
   acpProviderEnabledFromSnapshot,
+  managedGrokBuildChannelFromSnapshot,
   managedGrokBuildsEnabledFromSnapshot,
   providerProjectionForRegistryId,
 } from "../settings/config-store/provider-runtime-config";
@@ -205,6 +206,7 @@ export function createLocalAcpAgentDiscovery(params: {
     const records = await discoverLocalAcpAgentRecords({
       enabledRegistryIds,
       managedGrok: {
+        channel: managedGrokBuildChannelFromSnapshot(providers),
         enabled:
           managedGrokBuildsEnabledFromSnapshot(
             providers,

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type {
   AcpAgentPreference,
   AcpAgentSettingsEntry,
+  AcpManagedBuildStatus,
   AcknowledgeAcpAgentUpdateRequest,
   AcknowledgeAcpAgentUpdateResponse,
   CheckDesktopCodexAuthProfileStatusRequest,
@@ -87,6 +88,7 @@ import {
   managedGrokBuildsEnabledFromSnapshot,
   providerProjectionForRegistryId,
 } from "../settings/config-store/provider-runtime-config";
+import type { ConfigDomainMap } from "../settings/config-store/config-domains";
 import {
   getDesktopBackendRegistry,
 } from "../app-server/backend-registry";
@@ -120,6 +122,14 @@ import { discoverAcpRuntimeCapabilities } from "../acp/acp-runtime-discovery";
 import { shouldReprobeAcpCapabilities } from "../acp/acp-capability-freshness";
 import { describeDistributionSource } from "../acp/acp-install-provenance";
 import { isPwrAgentOwnedGrokRuntime } from "../acp/grok-cli-update";
+import {
+  MANAGED_GROK_REPOSITORY,
+  readManagedGrokInstallSummary,
+} from "../acp/grok-managed-runtime";
+import {
+  isPwrAgentSuppliedGrokCommand,
+  managedGrokTagForCommand,
+} from "../acp/grok-build-channel";
 import { selectAcpDistributionForCurrentPlatform } from "../acp/acp-platform-distribution";
 import { AcpRegistryService } from "../acp/acp-registry-service";
 import type {
@@ -442,10 +452,92 @@ async function listAcpAgentSettingsImpl(
     })
     .map(({ entry }) => entry);
 
+  await decorateManagedGrokBuild(
+    orderedEntries,
+    settingsService.readProvidersConfig(),
+  );
+
   return {
     fetchedAt: snapshot?.fetchedAt ?? Date.now(),
     entries: orderedEntries,
     ...(error ? { error } : {}),
+  };
+}
+
+/**
+ * Label each Grok executable with the channel that publishes it, and attach
+ * the managed channel's own state.
+ *
+ * Two products answer to the word "Grok" on this pane: xAI's CLI, which the
+ * operator updates from x.ai/build, and the `-pwragent` builds PwrAgent
+ * downloads, verifies and installs itself. They carry different version
+ * strings and different release pages, so a surface that cannot tell them
+ * apart ends up describing one in the other's terms.
+ *
+ * Everything reported here was already written to disk by the last release
+ * check, so this adds no network call and starts no download — the pane can
+ * name the installed tag and say when it was checked without one.
+ */
+async function decorateManagedGrokBuild(
+  entries: AcpAgentSettingsEntry[],
+  providers: ConfigDomainMap["providers"],
+): Promise<void> {
+  const index = entries.findIndex((entry) => entry.registryId === "grok");
+  if (index === -1) {
+    return;
+  }
+  const entry = entries[index];
+  // Provenance is labeled whether or not the channel is enabled: the copy
+  // inside the app bundle is a PwrAgent build even with managed downloads off,
+  // and so is a managed version an operator pinned before turning them off.
+  const instances = entry.instances?.map((instance) => {
+    const tag = managedGrokTagForCommand(instance.command);
+    if (tag === undefined && !isPwrAgentSuppliedGrokCommand(instance.command)) {
+      return instance;
+    }
+    return {
+      ...instance,
+      pwrAgentBuild: true,
+      ...(tag !== undefined ? { pwrAgentBuildTag: tag } : {}),
+    };
+  });
+
+  if (
+    !managedGrokBuildsEnabledFromSnapshot(
+      providers,
+      process.env,
+      app?.isPackaged === true,
+    )
+  ) {
+    if (instances) {
+      entries[index] = { ...entry, instances };
+    }
+    return;
+  }
+
+  const summary = await readManagedGrokInstallSummary();
+  const activeTag = managedGrokTagForCommand(entry.activeCommand);
+  const managedBuild: AcpManagedBuildStatus = {
+    repository: MANAGED_GROK_REPOSITORY,
+    ...(summary
+      ? {
+          installedTag: summary.tag,
+          checkedAt: summary.checkedAt,
+          installedAt: summary.installedAt,
+        }
+      : {}),
+    ...(activeTag !== undefined ? { activeTag } : {}),
+    // Only a managed build can be *behind* this channel. A vendor install is
+    // on a different channel entirely, and calling it "behind" a `-pwragent`
+    // tag is exactly the cross-channel comparison this work exists to remove.
+    ...(summary && activeTag !== undefined && activeTag !== summary.tag
+      ? { pinnedBehind: true }
+      : {}),
+  };
+  entries[index] = {
+    ...entry,
+    ...(instances ? { instances } : {}),
+    managedBuild,
   };
 }
 

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -517,6 +517,13 @@ async function decorateManagedGrokBuild(
 
   const summary = await readManagedGrokInstallSummary();
   const activeTag = managedGrokTagForCommand(entry.activeCommand);
+  // `pinnedBehind` is what the pane and the durable notice cite as the *cause*
+  // ("a manual path pins X"), so verify that cause rather than inferring it
+  // from a tag mismatch. The managed root is machine-wide: a sibling instance
+  // or profile can install a newer tag while this instance's durable record
+  // still names the older one, and a mismatch alone would then accuse an
+  // override that does not exist.
+  const pinnedBy = acpProviderCommandOverrideFromSnapshot(providers, "grok");
   const managedBuild: AcpManagedBuildStatus = {
     repository: MANAGED_GROK_REPOSITORY,
     ...(summary
@@ -530,7 +537,11 @@ async function decorateManagedGrokBuild(
     // Only a managed build can be *behind* this channel. A vendor install is
     // on a different channel entirely, and calling it "behind" a `-pwragent`
     // tag is exactly the cross-channel comparison this work exists to remove.
-    ...(summary && activeTag !== undefined && activeTag !== summary.tag
+    ...(summary
+      && activeTag !== undefined
+      && activeTag !== summary.tag
+      && pinnedBy !== undefined
+      && pinnedBy === entry.activeCommand
       ? { pinnedBehind: true }
       : {}),
   };

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -85,6 +85,7 @@ import {
 import {
   acpProviderCommandOverrideFromSnapshot,
   acpProviderEnabledFromSnapshot,
+  managedGrokBuildChannelFromSnapshot,
   managedGrokBuildsEnabledFromSnapshot,
   providerProjectionForRegistryId,
 } from "../settings/config-store/provider-runtime-config";
@@ -526,11 +527,19 @@ async function decorateManagedGrokBuild(
   const pinnedBy = acpProviderCommandOverrideFromSnapshot(providers, "grok");
   const managedBuild: AcpManagedBuildStatus = {
     repository: MANAGED_GROK_REPOSITORY,
+    channel: managedGrokBuildChannelFromSnapshot(providers),
     ...(summary
       ? {
           installedTag: summary.tag,
           checkedAt: summary.checkedAt,
           installedAt: summary.installedAt,
+          // Both tracks as the last check resolved them. A check that fell
+          // back to the Atom feed knows one track only, so a missing tag here
+          // means "not observed", never "no such release".
+          ...(summary.latestTag ? { latestTag: summary.latestTag } : {}),
+          ...(summary.prereleaseTag
+            ? { prereleaseTag: summary.prereleaseTag }
+            : {}),
         }
       : {}),
     ...(activeTag !== undefined ? { activeTag } : {}),
@@ -626,6 +635,7 @@ async function listInstalledAndLocalAcpAgents(
       discovered = (await discoverLocalAcpAgentRecords({
         enabledRegistryIds: discoveryRegistryIds,
         managedGrok: {
+          channel: managedGrokBuildChannelFromSnapshot(providers),
           enabled:
             managedGrokBuildsEnabledFromSnapshot(
               providers,

--- a/apps/desktop/src/main/settings/config-store/config-domains.ts
+++ b/apps/desktop/src/main/settings/config-store/config-domains.ts
@@ -5,6 +5,7 @@ import type {
   DesktopOnboardingCompletedSource,
   DesktopSpendAlertPolicy,
   DesktopSettingsSecretName,
+  DesktopUpdateChannel,
   DesktopTextSize,
   DesktopToolOutputAlertPolicy,
   PrAutoDispatchBudgetConfig,
@@ -71,6 +72,7 @@ export type ProviderProjection = Readonly<{
     enabled: boolean;
     commandOverride?: string;
     managedBuilds?: boolean;
+    managedBuildChannel?: DesktopUpdateChannel;
   }>;
   lastKnownGood?: Readonly<{
     /** Configuration dependency fingerprint this observation verified. Older
@@ -179,6 +181,10 @@ export function normalizeConfigDomains(params: {
           provider === "grok"
             ? config.acpAgents?.grok?.managedBuilds
             : undefined,
+        managedBuildChannel:
+          provider === "grok"
+            ? config.acpAgents?.grok?.managedBuildChannel
+            : undefined,
         provider,
       });
       const previous = params.previousProviders?.[provider];
@@ -201,6 +207,13 @@ export function normalizeConfigDomains(params: {
           ...(provider === "grok"
             && config.acpAgents?.grok?.managedBuilds !== undefined
             ? { managedBuilds: config.acpAgents.grok.managedBuilds }
+            : {}),
+          ...(provider === "grok"
+            && config.acpAgents?.grok?.managedBuildChannel !== undefined
+            ? {
+                managedBuildChannel:
+                  config.acpAgents.grok.managedBuildChannel,
+              }
             : {}),
         },
         ...(lastKnownGood
@@ -274,6 +287,7 @@ export function providerDependencyFingerprint(params: {
   commandOverride?: string;
   enabled: boolean;
   managedBuilds?: boolean;
+  managedBuildChannel?: DesktopUpdateChannel;
   provider: ProviderId;
 }): string {
   return createHash("sha256")
@@ -282,6 +296,7 @@ export function providerDependencyFingerprint(params: {
       commandOverride: params.commandOverride ?? "",
       enabled: params.enabled,
       managedBuilds: params.managedBuilds ?? null,
+      managedBuildChannel: params.managedBuildChannel ?? null,
       platform: process.platform,
       provider: params.provider,
       schemaVersion: CONFIG_STORE_DURABLE_SCHEMA_VERSION,

--- a/apps/desktop/src/main/settings/config-store/provider-runtime-config.ts
+++ b/apps/desktop/src/main/settings/config-store/provider-runtime-config.ts
@@ -1,3 +1,5 @@
+import type { DesktopUpdateChannel } from "@pwragent/shared";
+import { MANAGED_GROK_BUILD_CHANNEL_DEFAULT } from "@pwragent/shared";
 import type {
   ConfigDomainMap,
   ProviderProjection,
@@ -43,6 +45,24 @@ export function acpProviderCommandOverrideFromSnapshot(
   }
   return providerProjectionForRegistryId(providers, registryId)
     ?.configured.commandOverride;
+}
+
+/**
+ * Which grok-build track the managed runtime follows for this profile.
+ *
+ * Latest is the default and the safe answer: it serves only releases the
+ * operator promoted out of testing. Prerelease stays selectable even when both
+ * tracks resolve to the same tag, because that is the state an operator sits
+ * in between publishing a build and promoting it.
+ */
+export function managedGrokBuildChannelFromSnapshot(
+  providers: ConfigDomainMap["providers"],
+): DesktopUpdateChannel {
+  return (
+    providerProjectionForRegistryId(providers, "grok")
+      ?.configured.managedBuildChannel
+    ?? MANAGED_GROK_BUILD_CHANNEL_DEFAULT
+  );
 }
 
 export function managedGrokBuildsEnabledFromSnapshot(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -50,9 +50,8 @@ import {
   isDesktopIntegratedTerminalWindowsShell,
   isDesktopOnboardingCompletedSource,
   isDesktopWorktreeStorageLocation,
-  isDesktopUpdateChannel,
   isDesktopUpdateTrain,
-  MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
+  parseDesktopUpdateChannel,
   sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
@@ -398,20 +397,6 @@ export function managedGrokBuildsEnabledFor(
   defaultEnabled = true,
 ): boolean {
   return config.acpAgents?.grok?.managedBuilds ?? defaultEnabled;
-}
-
-/**
- * Which grok-build track the managed runtime follows. Latest is the default:
- * an operator who never opens the control must not be handed a build that was
- * published for testing.
- */
-export function managedGrokBuildChannelFor(
-  config: DesktopSettingsConfig,
-): DesktopUpdateChannel {
-  return (
-    config.acpAgents?.grok?.managedBuildChannel
-    ?? MANAGED_GROK_BUILD_CHANNEL_DEFAULT
-  );
 }
 
 /**
@@ -2383,9 +2368,7 @@ function readToolUpdateMode(
 function readUpdateChannel(
   value: TomlScalar | undefined,
 ): DesktopUpdateChannel | undefined {
-  return typeof value === "string" && isDesktopUpdateChannel(value)
-    ? value
-    : undefined;
+  return parseDesktopUpdateChannel(value);
 }
 
 function readUpdateTrain(

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -52,6 +52,7 @@ import {
   isDesktopWorktreeStorageLocation,
   isDesktopUpdateChannel,
   isDesktopUpdateTrain,
+  MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
   sanitizeMessagingContactHandle,
   sanitizeMessagingContactLabel,
 } from "@pwragent/shared";
@@ -272,6 +273,7 @@ export type DesktopSettingsConfig = {
       cliPath?: string;
       enabled?: boolean;
       managedBuilds?: boolean;
+      managedBuildChannel?: DesktopUpdateChannel;
     };
     kimi?: {
       cliPath?: string;
@@ -396,6 +398,20 @@ export function managedGrokBuildsEnabledFor(
   defaultEnabled = true,
 ): boolean {
   return config.acpAgents?.grok?.managedBuilds ?? defaultEnabled;
+}
+
+/**
+ * Which grok-build track the managed runtime follows. Latest is the default:
+ * an operator who never opens the control must not be handed a build that was
+ * published for testing.
+ */
+export function managedGrokBuildChannelFor(
+  config: DesktopSettingsConfig,
+): DesktopUpdateChannel {
+  return (
+    config.acpAgents?.grok?.managedBuildChannel
+    ?? MANAGED_GROK_BUILD_CHANNEL_DEFAULT
+  );
 }
 
 /**
@@ -1517,6 +1533,12 @@ export function desktopSettingsPatchToEdits(
       patch.acpAgents.grok.managedBuilds,
     );
   }
+  if (patch.acpAgents?.grok?.managedBuildChannel !== undefined) {
+    set(
+      ["acp_agents", "grok", "managed_build_channel"],
+      patch.acpAgents.grok.managedBuildChannel,
+    );
+  }
   if (patch.acpAgents?.kimi?.cliPath !== undefined) {
     set(["acp_agents", "kimi", "cli_path"], patch.acpAgents.kimi.cliPath);
   }
@@ -1974,6 +1996,9 @@ function normalizeDesktopConfig(
         cliPath: readString(acpAgentsGrok?.cli_path),
         enabled: readBoolean(acpAgentsGrok?.enabled),
         managedBuilds: readBoolean(acpAgentsGrok?.managed_builds),
+        managedBuildChannel: readUpdateChannel(
+          acpAgentsGrok?.managed_build_channel,
+        ),
       },
       kimi: {
         cliPath: readString(acpAgentsKimi?.cli_path),

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -62,6 +62,7 @@ import {
   DESKTOP_UPDATE_TRAIN_DEFAULT,
   inferDesktopUpdateSelection,
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
+  MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
   MAX_PR_AUTO_DISPATCH_BUDGET_CAPACITY,
   MAX_PR_AUTO_DISPATCH_BUDGET_REFILL_PER_MINUTE,
   MAX_REPEATED_LARGE_OUTPUT_CALLS,
@@ -314,6 +315,7 @@ function providerConfigSection(provider: ProviderProjection): {
   cliPath?: string;
   enabled?: boolean;
   managedBuilds?: boolean;
+  managedBuildChannel?: DesktopUpdateChannel;
 } {
   return {
     enabled: provider.configured.enabled,
@@ -322,6 +324,9 @@ function providerConfigSection(provider: ProviderProjection): {
       : {}),
     ...(provider.configured.managedBuilds !== undefined
       ? { managedBuilds: provider.configured.managedBuilds }
+      : {}),
+    ...(provider.configured.managedBuildChannel !== undefined
+      ? { managedBuildChannel: provider.configured.managedBuildChannel }
       : {}),
   };
 }
@@ -1362,6 +1367,9 @@ export class DesktopSettingsService {
             config.acpAgents?.grok?.managedBuilds
             ?? this.options.defaultManagedGrokBuilds
             ?? true,
+          managedBuildChannel:
+            config.acpAgents?.grok?.managedBuildChannel
+            ?? MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
         },
         kimi: {
           cliPath: this.resolveString(

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -129,7 +129,10 @@ import {
 import type { CodexMissingThreadsSignal } from "./features/notifications/codex-missing-threads-notice";
 import { buildPrAutoDispatchBudgetNotice } from "./features/notifications/pr-auto-dispatch-budget-notice";
 import { MessagingErrorNotices } from "./features/notifications/MessagingErrorNotices";
-import { GrokCliUpdateNotice } from "./features/notifications/GrokCliUpdateNotice";
+import {
+  GROK_UPDATE_NOTICE_ID_PREFIXES,
+  GrokCliUpdateNotice,
+} from "./features/notifications/GrokCliUpdateNotice";
 import { buildGithubPrSamlEnforcementNotice } from "./features/notifications/github-pr-saml-notice";
 import { buildManagedGrokSignatureRejectedNotice } from "./features/notifications/managed-grok-signature-notice";
 import { buildGithubPrAuthenticationNotice } from "./features/notifications/github-pr-authentication-notice";
@@ -635,10 +638,12 @@ function DesktopAppShell(props: {
   const syncGrokCliUpdateNotice = useCallback((
     notice: AppNoticeToastNotice | undefined,
   ): void => {
-    dispatchAppNotice({
-      type: "dismiss-prefix",
-      prefix: "acp-update:acp:grok:",
-    });
+    // Sweep every id family this producer can emit, not just the vendor one:
+    // both its notices are durable, so one left standing after its condition
+    // cleared would sit on screen until the window reloaded.
+    for (const prefix of GROK_UPDATE_NOTICE_ID_PREFIXES) {
+      dispatchAppNotice({ type: "dismiss-prefix", prefix });
+    }
     if (notice) {
       showAppNotice(notice);
     }

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -5,7 +5,19 @@ import {
   managedGrokReleaseUrl,
   XAI_GROK_UPDATE_URL,
 } from "../../lib/grok-build-channel";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+/**
+ * Every durable notice id this producer can emit, as prefixes. The host sweeps
+ * these before showing the current notice, so a notice whose condition has
+ * cleared leaves the screen. A new id family that is not listed here would
+ * never be swept and would outlive the state it describes.
+ */
+export const GROK_UPDATE_NOTICE_ID_PREFIXES = [
+  "acp-update:acp:grok:",
+  "managed-grok-build:",
+] as const;
 
 export function GrokCliUpdateNotice(props: {
   desktopApi?: DesktopApi;
@@ -36,6 +48,23 @@ export function GrokCliUpdateNotice(props: {
       }
     });
   }, [desktopApi, refresh]);
+
+  // The vendor-update event above never fires on a machine running a PwrAgent
+  // build — `refreshGrokUpdateStatusInBackground` returns before emitting it
+  // for exactly those runtimes — so the managed-build notice would otherwise
+  // evaluate only at mount, and could neither appear when a pin arises nor
+  // clear when the operator fixes one. The settings pane raises this event
+  // after every discovery refresh, which is what "Use newest build", "Check
+  // for updates" and the build toggle all run.
+  useEffect(() => {
+    const onRefreshed = () => {
+      void refresh().catch(() => undefined);
+    };
+    window.addEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, onRefreshed);
+    return () => {
+      window.removeEventListener(BACKEND_SUMMARIES_REFRESH_EVENT, onRefreshed);
+    };
+  }, [refresh]);
 
   const snoozedUntil = entry?.update?.snoozedUntil;
   useEffect(() => {
@@ -70,13 +99,24 @@ export function GrokCliUpdateNotice(props: {
     window.open(url, "_blank", "noopener,noreferrer");
   }, []);
 
+  // The managed channel has no persisted acknowledgement of its own — the
+  // vendor notice's `dismissedAt`/`snoozedUntil` live on `AcpAgentUpdateStatus`,
+  // which describes the other channel. Without this, closing the toast would
+  // only drop it from the host's in-memory list and the next refresh would
+  // upsert the identical id straight back. Held per tag, so a newer verified
+  // build asks again; held in memory, so an unresolved pin asks again at the
+  // next launch.
+  const [dismissedManagedTag, setDismissedManagedTag] = useState<string>();
+
   // The two channels are mutually exclusive by construction: the managed
   // notice needs a PwrAgent build to be active, and the vendor notice refuses
   // to render for one. Ordering here only decides which wins if that ever
   // stops being true, and the channel PwrAgent owns should win.
   const notice = useMemo(() => (
     buildManagedGrokBuildNotice({
+      dismissedTag: dismissedManagedTag,
       entry,
+      onDismiss: setDismissedManagedTag,
       onOpenReleasePage: openUpdatePage,
     })
     ?? buildXaiGrokCliUpdateNotice({
@@ -90,7 +130,7 @@ export function GrokCliUpdateNotice(props: {
         void acknowledge("snooze");
       },
     })
-  ), [acknowledge, clock, entry, openUpdatePage]);
+  ), [acknowledge, clock, dismissedManagedTag, entry, openUpdatePage]);
 
   useEffect(() => {
     onNoticeChanged(notice);
@@ -108,35 +148,42 @@ export function GrokCliUpdateNotice(props: {
  * has already done.
  */
 export function buildManagedGrokBuildNotice(params: {
+  /** Tag the operator has already closed this notice for, this session. */
+  dismissedTag?: string;
   entry?: AcpAgentSettingsEntry;
+  onDismiss: (tag: string) => void;
   onOpenReleasePage: (url: string) => void;
 }): AppNoticeToastNotice | undefined {
   const managed = params.entry?.managedBuild;
+  const installedTag = managed?.installedTag;
+  const activeTag = managed?.activeTag;
   if (
     params.entry?.registryId !== "grok"
     || params.entry.pwrAgentManagedRuntime !== true
     || managed?.pinnedBehind !== true
-    || !managed.installedTag
-    || !managed.activeTag
+    || !installedTag
+    || !activeTag
+    || installedTag === params.dismissedTag
   ) {
     return undefined;
   }
   return {
-    id: `managed-grok-build:${managed.installedTag}`,
+    id: `managed-grok-build:${installedTag}`,
     autoDismiss: false,
     title: "PwrAgent Grok build update not in use",
     message:
-      `${managed.installedTag} is verified and installed, but a manual path`
-      + ` pins ${managed.activeTag}, so new threads keep using the older build.`,
+      `${installedTag} is verified and installed, but a manual path`
+      + ` pins ${activeTag}, so new threads keep using the older build.`,
     detail:
       "Clear the manual path in Settings → AI Providers → Grok to follow the"
       + " newest build. Running threads keep the build they started on.",
+    onDismiss: () => params.onDismiss(installedTag),
     tone: "warning",
     actions: [
       {
         label: "Release notes",
         onClick: () => params.onOpenReleasePage(
-          managedGrokReleaseUrl(managed.repository, managed.installedTag ?? ""),
+          managedGrokReleaseUrl(managed.repository, installedTag),
         ),
         tone: "primary",
       },

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import {
+  managedGrokReleaseUrl,
+  XAI_GROK_UPDATE_URL,
+} from "../../lib/grok-build-channel";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
-
-export const GROK_BUILD_UPDATE_URL = "https://x.ai/build";
 
 export function GrokCliUpdateNotice(props: {
   desktopApi?: DesktopApi;
@@ -64,19 +66,31 @@ export function GrokCliUpdateNotice(props: {
     [desktopApi, entry?.update?.latestVersion, now],
   );
 
-  const notice = useMemo(() => buildGrokCliUpdateNotice({
-    entry,
-    now: clock,
-    onOpenUpdatePage: (url) => {
-      window.open(url, "_blank", "noopener,noreferrer");
-    },
-    onDismiss: () => {
-      void acknowledge("dismiss");
-    },
-    onSnooze: () => {
-      void acknowledge("snooze");
-    },
-  }), [acknowledge, clock, entry]);
+  const openUpdatePage = useCallback((url: string) => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, []);
+
+  // The two channels are mutually exclusive by construction: the managed
+  // notice needs a PwrAgent build to be active, and the vendor notice refuses
+  // to render for one. Ordering here only decides which wins if that ever
+  // stops being true, and the channel PwrAgent owns should win.
+  const notice = useMemo(() => (
+    buildManagedGrokBuildNotice({
+      entry,
+      onOpenReleasePage: openUpdatePage,
+    })
+    ?? buildXaiGrokCliUpdateNotice({
+      entry,
+      now: clock,
+      onOpenUpdatePage: openUpdatePage,
+      onDismiss: () => {
+        void acknowledge("dismiss");
+      },
+      onSnooze: () => {
+        void acknowledge("snooze");
+      },
+    })
+  ), [acknowledge, clock, entry, openUpdatePage]);
 
   useEffect(() => {
     onNoticeChanged(notice);
@@ -85,7 +99,59 @@ export function GrokCliUpdateNotice(props: {
   return null;
 }
 
-export function buildGrokCliUpdateNotice(params: {
+/**
+ * The PwrAgent-built Grok channel has exactly one state worth interrupting
+ * for: a newer verified build is installed and something is holding an older
+ * one in place for new threads. Every other state resolves itself — PwrAgent
+ * downloads and installs the newest build on its own — so a "an update is
+ * available" prompt on this channel would ask the operator to do work PwrAgent
+ * has already done.
+ */
+export function buildManagedGrokBuildNotice(params: {
+  entry?: AcpAgentSettingsEntry;
+  onOpenReleasePage: (url: string) => void;
+}): AppNoticeToastNotice | undefined {
+  const managed = params.entry?.managedBuild;
+  if (
+    params.entry?.registryId !== "grok"
+    || params.entry.pwrAgentManagedRuntime !== true
+    || managed?.pinnedBehind !== true
+    || !managed.installedTag
+    || !managed.activeTag
+  ) {
+    return undefined;
+  }
+  return {
+    id: `managed-grok-build:${managed.installedTag}`,
+    autoDismiss: false,
+    title: "PwrAgent Grok build update not in use",
+    message:
+      `${managed.installedTag} is verified and installed, but a manual path`
+      + ` pins ${managed.activeTag}, so new threads keep using the older build.`,
+    detail:
+      "Clear the manual path in Settings → AI Providers → Grok to follow the"
+      + " newest build. Running threads keep the build they started on.",
+    tone: "warning",
+    actions: [
+      {
+        label: "Release notes",
+        onClick: () => params.onOpenReleasePage(
+          managedGrokReleaseUrl(managed.repository, managed.installedTag ?? ""),
+        ),
+        tone: "primary",
+      },
+    ],
+  };
+}
+
+/**
+ * The vendor channel: an xAI install the operator updates themselves from
+ * x.ai/build. It must never render against a PwrAgent build — those carry
+ * `-pwragent` versions from a different publisher, and pairing one with an xAI
+ * version number in the same sentence is the confusion this split exists to
+ * end.
+ */
+export function buildXaiGrokCliUpdateNotice(params: {
   entry?: AcpAgentSettingsEntry;
   now: number;
   onOpenUpdatePage: (url: string) => void;
@@ -112,15 +178,19 @@ export function buildGrokCliUpdateNotice(params: {
   return {
     id: `acp-update:acp:grok:${update.latestVersion}`,
     autoDismiss: false,
-    title: "Grok update available",
-    message: `Grok ${update.latestVersion} is available; ${update.currentVersion} is installed.`,
-    detail: "Update Grok from x.ai/build, then restart active Grok sessions.",
+    title: "xAI Grok CLI update available",
+    message:
+      `xAI Grok ${update.latestVersion} is available;`
+      + ` your xAI install is ${update.currentVersion}.`,
+    detail:
+      "PwrAgent does not update this build. Update it from x.ai/build, then"
+      + " restart active Grok sessions.",
     onDismiss: params.onDismiss,
     tone: "warning",
     actions: [
       {
-        label: "Open update page",
-        onClick: () => params.onOpenUpdatePage(GROK_BUILD_UPDATE_URL),
+        label: "Open x.ai/build",
+        onClick: () => params.onOpenUpdatePage(XAI_GROK_UPDATE_URL),
         tone: "primary",
       },
       { label: "Tomorrow", onClick: params.onSnooze },

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import type { AcpAgentSettingsEntry } from "@pwragent/shared";
 import {
-  buildGrokCliUpdateNotice,
-  GROK_BUILD_UPDATE_URL,
+  buildManagedGrokBuildNotice,
+  buildXaiGrokCliUpdateNotice,
 } from "../GrokCliUpdateNotice";
+import { XAI_GROK_UPDATE_URL } from "../../../lib/grok-build-channel";
 
 function grokEntry(
   update: AcpAgentSettingsEntry["update"],
@@ -26,11 +27,11 @@ function grokEntry(
   };
 }
 
-describe("buildGrokCliUpdateNotice", () => {
+describe("buildXaiGrokCliUpdateNotice", () => {
   it("builds a version-keyed durable update notice", () => {
     const onOpenUpdatePage = vi.fn();
     const onDismiss = vi.fn();
-    const notice = buildGrokCliUpdateNotice({
+    const notice = buildXaiGrokCliUpdateNotice({
       entry: grokEntry({
         status: "available",
         checkedAt: 100,
@@ -46,12 +47,14 @@ describe("buildGrokCliUpdateNotice", () => {
     expect(notice).toMatchObject({
       id: "acp-update:acp:grok:1.0.0",
       autoDismiss: false,
-      message: "Grok 1.0.0 is available; 0.2.118 is installed.",
+      title: "xAI Grok CLI update available",
+      message: "xAI Grok 1.0.0 is available; your xAI install is 0.2.118.",
       detail:
-        "Update Grok from x.ai/build, then restart active Grok sessions.",
+        "PwrAgent does not update this build. Update it from x.ai/build, then"
+        + " restart active Grok sessions.",
     });
     notice?.actions?.[0]?.onClick();
-    expect(onOpenUpdatePage).toHaveBeenCalledWith(GROK_BUILD_UPDATE_URL);
+    expect(onOpenUpdatePage).toHaveBeenCalledWith(XAI_GROK_UPDATE_URL);
     notice?.onDismiss?.();
     expect(onDismiss).toHaveBeenCalledOnce();
   });
@@ -68,27 +71,27 @@ describe("buildGrokCliUpdateNotice", () => {
       currentVersion: "0.2.118",
       latestVersion: "1.0.0",
     };
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry({ ...available, dismissedAt: 150 }),
       now: 200,
       ...callbacks,
     })).toBeUndefined();
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry({ ...available, snoozedUntil: 300 }),
       now: 200,
       ...callbacks,
     })).toBeUndefined();
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry({ ...available, snoozedUntil: 199 }),
       now: 200,
       ...callbacks,
     })).toBeDefined();
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry({ ...available, status: "up-to-date" }),
       now: 200,
       ...callbacks,
     })).toBeUndefined();
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry({ ...available, status: "failed" }),
       now: 200,
       ...callbacks,
@@ -108,7 +111,7 @@ describe("buildGrokCliUpdateNotice", () => {
       latestVersion: "1.0.5",
     };
 
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry(available, {
         pwrAgentManagedRuntime: true,
         version: "1.0.4-pwragent.2",
@@ -118,15 +121,74 @@ describe("buildGrokCliUpdateNotice", () => {
     })).toBeUndefined();
     // A status left over from a vendor binary that is no longer the runtime:
     // the notice is durable, so a stale one would never clear itself.
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry(available, { version: "1.0.4-pwragent.2" }),
       now: 200,
       ...callbacks,
     })).toBeUndefined();
-    expect(buildGrokCliUpdateNotice({
+    expect(buildXaiGrokCliUpdateNotice({
       entry: grokEntry(available, { version: "1.0.3" }),
       now: 200,
       ...callbacks,
     })).toBeDefined();
+  });
+});
+
+describe("buildManagedGrokBuildNotice", () => {
+  const managed = {
+    repository: "pwrdrvr/grok-build",
+    installedTag: "pwragent-v1.0.5-pwragent.1",
+    activeTag: "pwragent-v1.0.4-pwragent.2",
+    checkedAt: 100,
+    installedAt: 100,
+    pinnedBehind: true,
+  };
+
+  it("names the PwrAgent channel and links its own release page", () => {
+    const onOpenReleasePage = vi.fn();
+    const notice = buildManagedGrokBuildNotice({
+      entry: grokEntry(undefined, {
+        managedBuild: managed,
+        pwrAgentManagedRuntime: true,
+        version: "1.0.4-pwragent.2",
+      }),
+      onOpenReleasePage,
+    });
+
+    expect(notice).toMatchObject({
+      id: "managed-grok-build:pwragent-v1.0.5-pwragent.1",
+      autoDismiss: false,
+      title: "PwrAgent Grok build update not in use",
+    });
+    expect(notice?.message).toContain("pwragent-v1.0.5-pwragent.1");
+    expect(notice?.message).toContain("pwragent-v1.0.4-pwragent.2");
+    // Never the vendor's download page: this build does not come from there.
+    expect(notice?.message).not.toContain("x.ai");
+    notice?.actions?.[0]?.onClick();
+    expect(onOpenReleasePage).toHaveBeenCalledWith(
+      "https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v1.0.5-pwragent.1",
+    );
+  });
+
+  it("stays silent when the channel can resolve itself", () => {
+    const onOpenReleasePage = vi.fn();
+    // Not pinned: PwrAgent installs the newest build itself, so there is
+    // nothing to ask the operator for.
+    expect(buildManagedGrokBuildNotice({
+      entry: grokEntry(undefined, {
+        managedBuild: { ...managed, pinnedBehind: false },
+        pwrAgentManagedRuntime: true,
+      }),
+      onOpenReleasePage,
+    })).toBeUndefined();
+    // A vendor install is on the other channel entirely.
+    expect(buildManagedGrokBuildNotice({
+      entry: grokEntry(undefined, { managedBuild: managed }),
+      onOpenReleasePage,
+    })).toBeUndefined();
+    expect(buildManagedGrokBuildNotice({
+      entry: grokEntry(undefined, { pwrAgentManagedRuntime: true }),
+      onOpenReleasePage,
+    })).toBeUndefined();
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -146,12 +146,14 @@ describe("buildManagedGrokBuildNotice", () => {
 
   it("names the PwrAgent channel and links its own release page", () => {
     const onOpenReleasePage = vi.fn();
+    const onDismiss = vi.fn();
     const notice = buildManagedGrokBuildNotice({
       entry: grokEntry(undefined, {
         managedBuild: managed,
         pwrAgentManagedRuntime: true,
         version: "1.0.4-pwragent.2",
       }),
+      onDismiss,
       onOpenReleasePage,
     });
 
@@ -168,10 +170,36 @@ describe("buildManagedGrokBuildNotice", () => {
     expect(onOpenReleasePage).toHaveBeenCalledWith(
       "https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v1.0.5-pwragent.1",
     );
+    // The managed channel has no persisted acknowledgement, so closing the
+    // toast has to be remembered by the producer or the next refresh upserts
+    // the identical id straight back.
+    notice?.onDismiss?.();
+    expect(onDismiss).toHaveBeenCalledWith("pwragent-v1.0.5-pwragent.1");
+  });
+
+  it("stays closed for a tag the operator already dismissed", () => {
+    const entry = grokEntry(undefined, {
+      managedBuild: managed,
+      pwrAgentManagedRuntime: true,
+    });
+    expect(buildManagedGrokBuildNotice({
+      dismissedTag: "pwragent-v1.0.5-pwragent.1",
+      entry,
+      onDismiss: vi.fn(),
+      onOpenReleasePage: vi.fn(),
+    })).toBeUndefined();
+    // A newer verified build is a new question, so it asks again.
+    expect(buildManagedGrokBuildNotice({
+      dismissedTag: "pwragent-v1.0.4-pwragent.2",
+      entry,
+      onDismiss: vi.fn(),
+      onOpenReleasePage: vi.fn(),
+    })).toBeDefined();
   });
 
   it("stays silent when the channel can resolve itself", () => {
     const onOpenReleasePage = vi.fn();
+    const onDismiss = vi.fn();
     // Not pinned: PwrAgent installs the newest build itself, so there is
     // nothing to ask the operator for.
     expect(buildManagedGrokBuildNotice({
@@ -179,15 +207,18 @@ describe("buildManagedGrokBuildNotice", () => {
         managedBuild: { ...managed, pinnedBehind: false },
         pwrAgentManagedRuntime: true,
       }),
+      onDismiss,
       onOpenReleasePage,
     })).toBeUndefined();
     // A vendor install is on the other channel entirely.
     expect(buildManagedGrokBuildNotice({
       entry: grokEntry(undefined, { managedBuild: managed }),
+      onDismiss,
       onOpenReleasePage,
     })).toBeUndefined();
     expect(buildManagedGrokBuildNotice({
       entry: grokEntry(undefined, { pwrAgentManagedRuntime: true }),
+      onDismiss,
       onOpenReleasePage,
     })).toBeUndefined();
   });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -137,6 +137,7 @@ describe("buildXaiGrokCliUpdateNotice", () => {
 describe("buildManagedGrokBuildNotice", () => {
   const managed = {
     repository: "pwrdrvr/grok-build",
+    channel: "latest" as const,
     installedTag: "pwragent-v1.0.5-pwragent.1",
     activeTag: "pwragent-v1.0.4-pwragent.2",
     checkedAt: 100,

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -436,11 +436,18 @@ function AcpAgentSection(props: {
               props.managedGrokBuilds && entry.managedBuild ? (
                 <ManagedBuildStatus
                   managedBuild={entry.managedBuild}
-                  busy={pathControlsDisabled}
+                  // Deliberately not `pathControlsDisabled`: that folds in
+                  // `envForced`, which says the CLI *path* comes from the
+                  // environment. A release check has nothing to do with which
+                  // path is in effect, so an env override must not disable it.
+                  busy={props.saving === true || pathUpdating}
                   refreshing={props.refreshing === true}
                   onCheckForUpdates={() => void refreshPathStatus()}
                   onUseNewestBuild={
-                    props.onCliPathChange
+                    // Clearing the config override cannot dislodge an
+                    // environment one, so the button is absent rather than
+                    // disabled when it could not do what it says.
+                    props.onCliPathChange && !envForced
                       ? () => {
                           void commitPath("");
                         }
@@ -483,6 +490,10 @@ function AcpAgentSection(props: {
                       instance.pwrAgentBuildTag !== undefined
                       && instance.pwrAgentBuildTag
                         === entry.managedBuild?.installedTag;
+                    // Explicit keys: this array is spliced between renders
+                    // (the channel chip appears once discovery labels the
+                    // instance), and SettingsPathRow's `tone-index` fallback
+                    // only holds for a stable array.
                     const chips: SettingsPathRowChip[] = [];
                     // Which product this binary is, before which version it
                     // is: "v1.0.5" next to "v1.0.4-pwragent.2" reads as one
@@ -492,18 +503,21 @@ function AcpAgentSection(props: {
                       chips.push(
                         instance.pwrAgentBuild
                           ? {
+                              key: "channel",
                               label: "PwrAgent build",
                               tone: newestManagedBuild ? "ok" : "muted",
                             }
-                          : { label: "xAI build", tone: "muted" },
+                          : { key: "channel", label: "xAI build", tone: "muted" },
                       );
                     }
                     chips.push(
                       {
+                        key: "source",
                         label: instance.source === "override" ? "override" : "path",
                         tone: "muted",
                       },
                       {
+                        key: "version",
                         label: instance.version
                           ? `v${instance.version}`
                           : "version unknown",
@@ -511,7 +525,11 @@ function AcpAgentSection(props: {
                       },
                     );
                     if (!active) {
-                      chips.push({ label: "available", tone: "muted" });
+                      chips.push({
+                        key: "availability",
+                        label: "available",
+                        tone: "muted",
+                      });
                     }
                     return (
                       <SettingsPathRow
@@ -670,20 +688,28 @@ function ManagedBuildStatus(props: {
   const { managedBuild } = props;
   const pinned = managedBuild.pinnedBehind === true;
   const checkedAt = managedBuild.checkedAt;
+  // Three states, because "installed" and "running" are different facts. An
+  // operator whose manual path points at a vendor install has the newest
+  // verified build on disk and is not running any of it; saying only
+  // "installed · newest verified build" would read as "this is what my threads
+  // use".
+  const inUse = managedBuild.activeTag !== undefined;
   return (
     <div className="acp-build">
       <p className="acp-build__line">
         {managedBuild.installedTag ? (
           <>
             <span
-              className={`status-dot${pinned ? " status-dot--warning" : " status-dot--ok"}`}
+              className={`status-dot${inUse && !pinned ? " status-dot--ok" : " status-dot--warning"}`}
               aria-hidden="true"
             />
             <span className="acp-build__tag">{managedBuild.installedTag}</span>
             <span className="acp-build__state">
               {pinned
                 ? `installed and verified · not in use, a manual path pins ${managedBuild.activeTag}`
-                : "installed · newest verified build"}
+                : inUse
+                  ? "installed · newest verified build"
+                  : "installed and verified · not in use, another Grok install is active"}
               {checkedAt !== undefined
                 ? ` · checked ${acpRelativeTime(checkedAt)}`
                 : ""}

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -59,6 +59,19 @@ function managedGrokBuildsSnapshot(
 }
 
 /**
+ * The track the config holds, not the one the last discovery reported.
+ *
+ * The two differ for as long as a switch takes to rescan — a forced release
+ * check that can download a build — and permanently if that rescan fails. The
+ * control has to follow the write it made, the way the sibling toggle does.
+ */
+function managedGrokBuildChannelSnapshot(
+  snapshot: DesktopSettingsSnapshot | undefined,
+): DesktopUpdateChannel | undefined {
+  return snapshot?.acpAgents.grok?.managedBuildChannel;
+}
+
+/**
  * Renders each discovered ACP agent (Gemini / Grok / Kimi / Qwen) as its own
  * `SettingsSection`, styled identically to the Codex section (SettingsField
  * rows + the shared SettingsPathRow install list). Returns a FRAGMENT — no
@@ -168,6 +181,9 @@ export function AcpAgentsSettings(props: {
             cliPathSnapshot={cliPathSnapshotFor(props.snapshot, entry.registryId)}
             enabled={acpAgentEnabledInSnapshot(props.snapshot, entry.registryId)}
             managedGrokBuilds={managedGrokBuildsSnapshot(props.snapshot)}
+            managedGrokBuildChannel={
+              managedGrokBuildChannelSnapshot(props.snapshot)
+            }
             saving={props.saving}
             refreshing={refreshing || loading || props.catalogRefreshing}
             onCliPathChange={
@@ -310,6 +326,8 @@ function AcpAgentSection(props: {
   cliPathSnapshot: DesktopSettingsValue<string> | undefined;
   enabled: boolean;
   managedGrokBuilds: boolean;
+  /** Track the config holds, which the control follows. */
+  managedGrokBuildChannel?: DesktopUpdateChannel;
   saving?: boolean;
   refreshing?: boolean;
   onCliPathChange?: (
@@ -506,7 +524,7 @@ function AcpAgentSection(props: {
             // Same wait as the toggle: the config write, then the rescan that
             // installs and activates the track's build.
             pendingLabel="Saving and rescanning…"
-            value={managedBuild.channel}
+            value={props.managedGrokBuildChannel ?? managedBuild.channel}
             onChange={(channel) => {
               return (
                 props.onManagedGrokBuildChannelChange?.(channel).then(

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -4,14 +4,24 @@ import type {
   AcpManagedBuildStatus,
   DesktopSettingsSnapshot,
   DesktopSettingsValue,
+  DesktopUpdateChannel,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { managedGrokReleaseUrl } from "../../lib/grok-build-channel";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
-import { SettingsField, SettingsSection, ToggleField } from "./SettingsLayout";
+import {
+  SegmentedField,
+  SettingsField,
+  SettingsSection,
+  ToggleField,
+} from "./SettingsLayout";
 import { SettingsCopyValue } from "./SettingsCopyValue";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
-import { acpRelativeTime, acpStatusLabel } from "./acp-agent-copy";
+import {
+  acpRelativeTime,
+  acpStatusLabel,
+  managedGrokBuildVersion,
+} from "./acp-agent-copy";
 import {
   acpAgentEnabledInSnapshot,
   displayOrderedAcpEntries,
@@ -70,6 +80,10 @@ export function AcpAgentsSettings(props: {
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
   /** Persist whether PwrAgent downloads and prefers its Grok fork build. */
   onManagedGrokBuildsChange?: (enabled: boolean) => Promise<boolean>;
+  /** Persist which grok-build track the managed runtime follows. */
+  onManagedGrokBuildChannelChange?: (
+    channel: DesktopUpdateChannel,
+  ) => Promise<boolean>;
 }) {
   const [entries, setEntries] = useState<AcpAgentSettingsEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -180,6 +194,9 @@ export function AcpAgentsSettings(props: {
             }
             onEnabledChange={props.onEnabledChange}
             onManagedGrokBuildsChange={props.onManagedGrokBuildsChange}
+            onManagedGrokBuildChannelChange={
+              props.onManagedGrokBuildChannelChange
+            }
             onRefresh={() => refresh(true, true)}
           />
         </Fragment>
@@ -301,9 +318,13 @@ function AcpAgentSection(props: {
   ) => Promise<AcpCliPathUpdateResult>;
   onEnabledChange?: (registryId: string, enabled: boolean) => Promise<void>;
   onManagedGrokBuildsChange?: (enabled: boolean) => Promise<boolean>;
+  onManagedGrokBuildChannelChange?: (
+    channel: DesktopUpdateChannel,
+  ) => Promise<boolean>;
   onRefresh: () => Promise<boolean>;
 }) {
   const { entry, enabled } = props;
+  const managedBuild = entry.managedBuild;
   const instances = entry.instances ?? [];
   const rejectedInstances = entry.rejectedInstances ?? [];
   const savedPath = props.cliPathSnapshot?.value ?? "";
@@ -464,6 +485,38 @@ function AcpAgentSection(props: {
                   return props.onRefresh();
                 }
               }) ?? Promise.resolve();
+            }}
+          />
+        ) : null}
+
+        {entry.registryId === "grok"
+          && managedBuild
+          && props.managedGrokBuilds
+          && props.onManagedGrokBuildChannelChange ? (
+          <SegmentedField
+            label="Build track"
+            sub="Latest installs promoted builds only. Prerelease installs the newest build whether or not it has been promoted — and stays selectable while both tracks name the same version, which is where a build sits between publication and promotion."
+            disabled={
+              props.saving || pathUpdating || props.refreshing || !enabled
+            }
+            options={MANAGED_BUILD_CHANNEL_OPTIONS.map((option) => ({
+              ...option,
+              meta: managedBuildTrackVersion(managedBuild, option.value),
+            }))}
+            // Same wait as the toggle: the config write, then the rescan that
+            // installs and activates the track's build.
+            pendingLabel="Saving and rescanning…"
+            value={managedBuild.channel}
+            onChange={(channel) => {
+              return (
+                props.onManagedGrokBuildChannelChange?.(channel).then(
+                  (saved) => {
+                    if (saved) {
+                      return props.onRefresh();
+                    }
+                  },
+                ) ?? Promise.resolve()
+              );
             }}
           />
         ) : null}
@@ -665,6 +718,32 @@ function AcpAgentSection(props: {
       </div>
     </SettingsSection>
   );
+}
+
+const MANAGED_BUILD_CHANNEL_OPTIONS: Array<{
+  label: string;
+  value: DesktopUpdateChannel;
+}> = [
+  { label: "Latest", value: "latest" },
+  { label: "Prerelease", value: "prerelease" },
+];
+
+/**
+ * The version a track resolves to, as of the last release check.
+ *
+ * "Unavailable" is not "there is no such build": a check that fell back to the
+ * public Atom feed can only speak for one track, and no check has run at all
+ * before the first install.
+ */
+function managedBuildTrackVersion(
+  managedBuild: AcpManagedBuildStatus,
+  channel: DesktopUpdateChannel,
+): string {
+  const tag =
+    channel === "latest"
+      ? managedBuild.latestTag
+      : managedBuild.prereleaseTag;
+  return tag ? managedGrokBuildVersion(tag) : "Unavailable";
 }
 
 /**

--- a/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/AcpAgentsSettings.tsx
@@ -1,15 +1,17 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import type {
   AcpAgentSettingsEntry,
+  AcpManagedBuildStatus,
   DesktopSettingsSnapshot,
   DesktopSettingsValue,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { managedGrokReleaseUrl } from "../../lib/grok-build-channel";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import { SettingsField, SettingsSection, ToggleField } from "./SettingsLayout";
 import { SettingsCopyValue } from "./SettingsCopyValue";
 import { SettingsPathRow, type SettingsPathRowChip } from "./SettingsPathRow";
-import { acpStatusLabel } from "./acp-agent-copy";
+import { acpRelativeTime, acpStatusLabel } from "./acp-agent-copy";
 import {
   acpAgentEnabledInSnapshot,
   displayOrderedAcpEntries,
@@ -335,6 +337,16 @@ function AcpAgentSection(props: {
             ? ` · v${activeOverrideInstance.version}`
             : ""}.`
           : undefined;
+  // A manual path that resolves to a PwrAgent-managed version directory turns
+  // an auto-updating channel into a permanent pin: newer verified builds keep
+  // downloading and never run. Nothing else on the pane says so, and clicking
+  // "Use" on a managed row is enough to end up here.
+  const pinnedManagedBuild =
+    entry.registryId === "grok"
+    && overrideActive
+    && entry.managedBuild?.pinnedBehind === true
+      ? entry.managedBuild
+      : undefined;
   const inactiveOverrideError =
     enabled
     && normalizedSavedPath !== ""
@@ -418,7 +430,25 @@ function AcpAgentSection(props: {
             // rescan chained below, so "Saving…" would name only the first
             // and shortest part of the wait.
             pendingLabel="Saving and rescanning…"
-            sub="Download verified releases from pwrdrvr/grok-build and prefer the newest one for new threads. Packaged macOS and Windows apps require platform signing; manual paths still win."
+            source={entry.managedBuild?.repository}
+            sub="PwrAgent downloads, verifies and installs Grok builds from pwrdrvr/grok-build. New threads use the newest verified build. Packaged macOS and Windows apps require platform signing; manual paths still win."
+            actions={
+              props.managedGrokBuilds && entry.managedBuild ? (
+                <ManagedBuildStatus
+                  managedBuild={entry.managedBuild}
+                  busy={pathControlsDisabled}
+                  refreshing={props.refreshing === true}
+                  onCheckForUpdates={() => void refreshPathStatus()}
+                  onUseNewestBuild={
+                    props.onCliPathChange
+                      ? () => {
+                          void commitPath("");
+                        }
+                      : undefined
+                  }
+                />
+              ) : null
+            }
             onChange={(next) => {
               // The refresh is awaited rather than floated, so the row stays
               // pending until the agent list actually reflects the change.
@@ -449,7 +479,26 @@ function AcpAgentSection(props: {
                   {instances.map((instance) => {
                     const active =
                       enabled && instance.command === entry.activeCommand;
-                    const chips: SettingsPathRowChip[] = [
+                    const newestManagedBuild =
+                      instance.pwrAgentBuildTag !== undefined
+                      && instance.pwrAgentBuildTag
+                        === entry.managedBuild?.installedTag;
+                    const chips: SettingsPathRowChip[] = [];
+                    // Which product this binary is, before which version it
+                    // is: "v1.0.5" next to "v1.0.4-pwragent.2" reads as one
+                    // release behind until you know they are different builds
+                    // from different publishers.
+                    if (entry.registryId === "grok") {
+                      chips.push(
+                        instance.pwrAgentBuild
+                          ? {
+                              label: "PwrAgent build",
+                              tone: newestManagedBuild ? "ok" : "muted",
+                            }
+                          : { label: "xAI build", tone: "muted" },
+                      );
+                    }
+                    chips.push(
                       {
                         label: instance.source === "override" ? "override" : "path",
                         tone: "muted",
@@ -460,7 +509,7 @@ function AcpAgentSection(props: {
                           : "version unknown",
                         tone: "muted",
                       },
-                    ];
+                    );
                     if (!active) {
                       chips.push({ label: "available", tone: "muted" });
                     }
@@ -525,13 +574,19 @@ function AcpAgentSection(props: {
             source={
               envForced
                 ? "env override"
-                : overrideActive
-                  ? "active override"
-                  : normalizedSavedPath
-                    ? "saved override"
-                    : undefined
+                : pinnedManagedBuild
+                  ? "pinning a PwrAgent build"
+                  : overrideActive
+                    ? "active override"
+                    : normalizedSavedPath
+                      ? "saved override"
+                      : undefined
             }
-            help={overrideHelp}
+            help={
+              pinnedManagedBuild
+                ? `This path pins one PwrAgent build. ${pinnedManagedBuild.installedTag} is already downloaded and verified but will never run. Clear it to follow the newest build again.`
+                : overrideHelp
+            }
             error={pathActionError ?? inactiveOverrideError}
             control={
               <div className="settings-secret">
@@ -571,7 +626,11 @@ function AcpAgentSection(props: {
 
         <SettingsField
           label="Re-probe"
-          sub="Re-run discovery for enabled agents (versions, installs, capabilities)."
+          sub={
+            entry.registryId === "grok" && entry.managedBuild
+              ? "Re-run discovery for enabled agents (versions, installs, capabilities). Release checks have their own control above."
+              : "Re-run discovery for enabled agents (versions, installs, capabilities)."
+          }
           control={
             <div className="settings-inline-actions">
               <button
@@ -587,6 +646,92 @@ function AcpAgentSection(props: {
         />
       </div>
     </SettingsSection>
+  );
+}
+
+/**
+ * The PwrAgent build channel, reported as a channel rather than as a switch.
+ *
+ * Four facts in the order an operator asks for them: which tag is installed,
+ * whether it is the one running, when PwrAgent last checked, and what to press.
+ * There is deliberately no "install" verb in the common case — on this channel
+ * PwrAgent has already downloaded, verified and installed the newest build, so
+ * asking the operator to install it would be asking for work already done. The
+ * one state that needs a person is a manual path pinning an older build, which
+ * never resolves on its own.
+ */
+function ManagedBuildStatus(props: {
+  busy: boolean;
+  managedBuild: AcpManagedBuildStatus;
+  refreshing: boolean;
+  onCheckForUpdates: () => void;
+  onUseNewestBuild?: () => void;
+}) {
+  const { managedBuild } = props;
+  const pinned = managedBuild.pinnedBehind === true;
+  const checkedAt = managedBuild.checkedAt;
+  return (
+    <div className="acp-build">
+      <p className="acp-build__line">
+        {managedBuild.installedTag ? (
+          <>
+            <span
+              className={`status-dot${pinned ? " status-dot--warning" : " status-dot--ok"}`}
+              aria-hidden="true"
+            />
+            <span className="acp-build__tag">{managedBuild.installedTag}</span>
+            <span className="acp-build__state">
+              {pinned
+                ? `installed and verified · not in use, a manual path pins ${managedBuild.activeTag}`
+                : "installed · newest verified build"}
+              {checkedAt !== undefined
+                ? ` · checked ${acpRelativeTime(checkedAt)}`
+                : ""}
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="status-dot" aria-hidden="true" />
+            <span className="acp-build__state">
+              No verified build downloaded yet.
+            </span>
+          </>
+        )}
+      </p>
+      <div className="settings-inline-actions">
+        {pinned && props.onUseNewestBuild ? (
+          <button
+            className="button button--primary"
+            disabled={props.busy}
+            type="button"
+            onClick={props.onUseNewestBuild}
+          >
+            Use newest build
+          </button>
+        ) : null}
+        <button
+          className="button button--secondary"
+          disabled={props.busy}
+          type="button"
+          onClick={props.onCheckForUpdates}
+        >
+          {props.refreshing ? "Checking…" : "Check for updates"}
+        </button>
+        {managedBuild.installedTag ? (
+          <a
+            className="button button--ghost"
+            href={managedGrokReleaseUrl(
+              managedBuild.repository,
+              managedBuild.installedTag,
+            )}
+            target="_blank"
+            rel="noreferrer"
+          >
+            Release notes
+          </a>
+        ) : null}
+      </div>
+    </div>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -9,6 +9,7 @@ import type {
   DesktopProviderThreadModelMigration,
   DesktopSettingsSecretName,
   DesktopSettingsSnapshot,
+  DesktopUpdateChannel,
 } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
@@ -121,6 +122,9 @@ export function ModelsSettings(props: {
   onAcpEnabledChange: (registryId: string, enabled: boolean) => Promise<void>;
   /** Persist the Grok managed-build preference. */
   onManagedGrokBuildsChange?: (enabled: boolean) => Promise<boolean>;
+  onManagedGrokBuildChannelChange?: (
+    channel: DesktopUpdateChannel,
+  ) => Promise<boolean>;
 }) {
   const [codexPath, setCodexPath] = useState(props.snapshot.models.codex.path.value);
   const [backends, setBackends] = useState<BackendSummary[]>(
@@ -478,6 +482,9 @@ export function ModelsSettings(props: {
           onCliPathChange={props.onAcpCliPathChange}
           onEnabledChange={props.onAcpEnabledChange}
           onManagedGrokBuildsChange={props.onManagedGrokBuildsChange}
+          onManagedGrokBuildChannelChange={
+            props.onManagedGrokBuildChannelChange
+          }
         />
       </SettingsSectionStack>
     );

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -1171,6 +1171,11 @@ function SettingsSectionBody(props: {
           acpAgents: { grok: { managedBuilds } },
         });
       }}
+      onManagedGrokBuildChannelChange={async (managedBuildChannel) => {
+        return await props.settings.writeConfig({
+          acpAgents: { grok: { managedBuildChannel } },
+        });
+      }}
     />
   );
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -6,6 +6,7 @@ import {
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
@@ -41,6 +42,7 @@ function geminiEntry(): AcpAgentSettingsEntry {
 function grokEntry(params?: {
   activeCommand?: string;
   instances?: AcpAgentSettingsEntry["instances"];
+  managedBuild?: AcpAgentSettingsEntry["managedBuild"];
 }): AcpAgentSettingsEntry {
   const activeCommand = params?.activeCommand ?? "/usr/bin/grok";
   return {
@@ -60,8 +62,11 @@ function grokEntry(params?: {
       { command: activeCommand, version: "1.0.0", source: "path" },
     ],
     activeCommand,
+    ...(params?.managedBuild ? { managedBuild: params.managedBuild } : {}),
   } satisfies AcpAgentSettingsEntry;
 }
+
+const MANAGED_VERSIONS = "/Users/me/.pwragent/agents/grok/versions";
 
 function acpSnapshot(
   registryId: "grok" | "qwen",
@@ -80,6 +85,146 @@ function acpSnapshot(
     },
   } as unknown as DesktopSettingsSnapshot;
 }
+
+describe("AcpAgentsSettings — Grok build channel", () => {
+  it("names the installed PwrAgent build and when it was checked", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            installedTag: "pwragent-v1.0.4-pwragent.2",
+            activeTag: "pwragent-v1.0.4-pwragent.2",
+            checkedAt: Date.now() - 2 * 60 * 60_000,
+            installedAt: Date.now() - 2 * 60 * 60_000,
+          },
+        }),
+      ],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "")}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(await screen.findByText("pwragent-v1.0.4-pwragent.2"))
+      .toBeInTheDocument();
+    expect(screen.getByText(/checked 2h ago/)).toBeInTheDocument();
+    // The channel is up to date, so there is nothing to install — PwrAgent
+    // already did. Only an explicit re-check is offered.
+    expect(
+      screen.getByRole("button", { name: "Check for updates" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Use newest build" }))
+      .not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Release notes" }))
+      .toHaveAttribute(
+        "href",
+        "https://github.com/pwrdrvr/grok-build/releases/tag/pwragent-v1.0.4-pwragent.2",
+      );
+  });
+
+  it("offers a one-click way out of a pinned older build", async () => {
+    const pinned = `${MANAGED_VERSIONS}/pwragent-v1.0.4-pwragent.2/grok`;
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          activeCommand: pinned,
+          instances: [
+            {
+              command: pinned,
+              version: "1.0.4-pwragent.2",
+              source: "override",
+              pwrAgentBuild: true,
+              pwrAgentBuildTag: "pwragent-v1.0.4-pwragent.2",
+            },
+          ],
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            installedTag: "pwragent-v1.0.5-pwragent.1",
+            activeTag: "pwragent-v1.0.4-pwragent.2",
+            checkedAt: Date.now(),
+            installedAt: Date.now(),
+            pinnedBehind: true,
+          },
+        }),
+      ],
+    }));
+    const onCliPathChange = vi.fn(async () => true);
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", pinned)}
+        onCliPathChange={onCliPathChange}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/a manual path pins pwragent-v1\.0\.4-pwragent\.2/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/This path pins one PwrAgent build/))
+      .toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Use newest build" }));
+    // Clearing the override is the whole fix: with managed builds on,
+    // discovery already ranks the newest managed build ahead of everything.
+    await waitFor(() => {
+      expect(onCliPathChange).toHaveBeenCalledWith("grok", "");
+    });
+  });
+
+  it("labels which product each detected Grok binary is", async () => {
+    const managed = `${MANAGED_VERSIONS}/pwragent-v1.0.4-pwragent.2/grok`;
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          activeCommand: managed,
+          instances: [
+            {
+              command: managed,
+              version: "1.0.4-pwragent.2",
+              source: "fallback",
+              pwrAgentBuild: true,
+              pwrAgentBuildTag: "pwragent-v1.0.4-pwragent.2",
+            },
+            { command: "/Users/me/.grok/bin/grok", version: "1.0.5", source: "path" },
+          ],
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            installedTag: "pwragent-v1.0.4-pwragent.2",
+            activeTag: "pwragent-v1.0.4-pwragent.2",
+            checkedAt: Date.now(),
+            installedAt: Date.now(),
+          },
+        }),
+      ],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "")}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+      />,
+    );
+
+    // Without these, "v1.0.5" next to "v1.0.4-pwragent.2" reads as one release
+    // behind rather than as a different product from a different publisher.
+    // Scoped to the install list: the row that configures the channel is also
+    // labelled "PwrAgent build".
+    const installs = await screen.findByLabelText("Grok installs");
+    expect(within(installs).getByText("PwrAgent build")).toBeInTheDocument();
+    expect(within(installs).getByText("xAI build")).toBeInTheDocument();
+  });
+});
 
 describe("AcpAgentsSettings", () => {
   it("lets Grok users opt out of managed PwrAgent builds", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -180,6 +180,41 @@ describe("AcpAgentsSettings — Grok build channel", () => {
     });
   });
 
+  it("does not imply the newest build is running when it is not", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          activeCommand: "/Users/me/.grok/bin/grok",
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            installedTag: "pwragent-v1.0.4-pwragent.2",
+            checkedAt: Date.now(),
+            installedAt: Date.now(),
+          },
+        }),
+      ],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "/Users/me/.grok/bin/grok")}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+      />,
+    );
+
+    // The newest verified build is on disk and none of it is running: an
+    // operator reads "newest verified build" as "this is what my threads use".
+    expect(
+      await screen.findByText(/not in use, another Grok install is active/),
+    ).toBeInTheDocument();
+    // The row's own sub-line legitimately contains "newest verified build";
+    // the status line must not.
+    expect(screen.queryByText(/installed · newest verified build/))
+      .not.toBeInTheDocument();
+  });
+
   it("labels which product each detected Grok binary is", async () => {
     const managed = `${MANAGED_VERSIONS}/pwragent-v1.0.4-pwragent.2/grok`;
     const listAcpAgents = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -1088,6 +1088,50 @@ describe("AcpAgentsSettings", () => {
     });
   });
 
+  it("follows the track the config holds, not the last discovery", async () => {
+    // A switch writes the config, then rescans. If the rescan fails — offline,
+    // or the forced release check throws — the control must still show the
+    // track that was written, not snap back and claim the write did not take.
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
+            latestTag: "pwragent-v1.0.4-pwragent.2",
+            prereleaseTag: "pwragent-v1.0.5-pwragent.1",
+            installedTag: "pwragent-v1.0.4-pwragent.2",
+            activeTag: "pwragent-v1.0.4-pwragent.2",
+            checkedAt: 1_000,
+            installedAt: 1_000,
+          },
+        }),
+      ],
+    }));
+    const snapshot = acpSnapshot("grok", "");
+    (
+      snapshot.acpAgents as unknown as {
+        grok: { managedBuildChannel?: string };
+      }
+    ).grok.managedBuildChannel = "prerelease";
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={snapshot}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+        onManagedGrokBuildChannelChange={vi.fn(async () => true)}
+      />,
+    );
+
+    const track = await screen.findByRole("radiogroup", { name: "Build track" });
+    expect(within(track).getByRole("radio", { name: /Prerelease/ }))
+      .toHaveAttribute("aria-checked", "true");
+    expect(within(track).getByRole("radio", { name: /Latest/ }))
+      .toHaveAttribute("aria-checked", "false");
+  });
+
   it("keeps Prerelease selectable when both tracks are the same build", async () => {
     // Between publishing a build and promoting it the tracks agree. The
     // control still has to be usable: this is exactly when an operator moves

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/acp-agents-settings.test.tsx
@@ -94,6 +94,7 @@ describe("AcpAgentsSettings — Grok build channel", () => {
         grokEntry({
           managedBuild: {
             repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
             installedTag: "pwragent-v1.0.4-pwragent.2",
             activeTag: "pwragent-v1.0.4-pwragent.2",
             checkedAt: Date.now() - 2 * 60 * 60_000,
@@ -146,6 +147,7 @@ describe("AcpAgentsSettings — Grok build channel", () => {
           ],
           managedBuild: {
             repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
             installedTag: "pwragent-v1.0.5-pwragent.1",
             activeTag: "pwragent-v1.0.4-pwragent.2",
             checkedAt: Date.now(),
@@ -188,6 +190,7 @@ describe("AcpAgentsSettings — Grok build channel", () => {
           activeCommand: "/Users/me/.grok/bin/grok",
           managedBuild: {
             repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
             installedTag: "pwragent-v1.0.4-pwragent.2",
             checkedAt: Date.now(),
             installedAt: Date.now(),
@@ -234,6 +237,7 @@ describe("AcpAgentsSettings — Grok build channel", () => {
           ],
           managedBuild: {
             repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
             installedTag: "pwragent-v1.0.4-pwragent.2",
             activeTag: "pwragent-v1.0.4-pwragent.2",
             checkedAt: Date.now(),
@@ -1038,6 +1042,87 @@ describe("AcpAgentsSettings", () => {
         "ACP registry controls are unavailable in this build.",
       ),
     ).not.toBeInTheDocument();
+  });
+
+  it("names both build tracks and writes the one the operator picks", async () => {
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
+            latestTag: "pwragent-v1.0.4-pwragent.2",
+            prereleaseTag: "pwragent-v1.0.5-pwragent.1",
+            installedTag: "pwragent-v1.0.4-pwragent.2",
+            activeTag: "pwragent-v1.0.4-pwragent.2",
+            checkedAt: 1_000,
+            installedAt: 1_000,
+          },
+        }),
+      ],
+    }));
+    const onManagedGrokBuildChannelChange = vi.fn(async () => true);
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "")}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+        onManagedGrokBuildChannelChange={onManagedGrokBuildChannelChange}
+      />,
+    );
+
+    const track = await screen.findByRole("radiogroup", { name: "Build track" });
+    // Each track names the version it resolves to, so the operator can see
+    // what switching would actually get them before they switch.
+    expect(within(track).getByText("1.0.4-pwragent.2")).toBeInTheDocument();
+    expect(within(track).getByText("1.0.5-pwragent.1")).toBeInTheDocument();
+    expect(within(track).getByRole("radio", { name: /Latest/ }))
+      .toHaveAttribute("aria-checked", "true");
+
+    fireEvent.click(within(track).getByRole("radio", { name: /Prerelease/ }));
+    await waitFor(() => {
+      expect(onManagedGrokBuildChannelChange)
+        .toHaveBeenCalledExactlyOnceWith("prerelease");
+    });
+  });
+
+  it("keeps Prerelease selectable when both tracks are the same build", async () => {
+    // Between publishing a build and promoting it the tracks agree. The
+    // control still has to be usable: this is exactly when an operator moves
+    // onto Prerelease to pick up the next test build.
+    const listAcpAgents = vi.fn(async () => ({
+      fetchedAt: 1_000,
+      entries: [
+        grokEntry({
+          managedBuild: {
+            repository: "pwrdrvr/grok-build",
+            channel: "latest" as const,
+            latestTag: "pwragent-v1.0.5-pwragent.1",
+            prereleaseTag: "pwragent-v1.0.5-pwragent.1",
+            installedTag: "pwragent-v1.0.5-pwragent.1",
+            activeTag: "pwragent-v1.0.5-pwragent.1",
+            checkedAt: 1_000,
+            installedAt: 1_000,
+          },
+        }),
+      ],
+    }));
+
+    render(
+      <AcpAgentsSettings
+        desktopApi={{ listAcpAgents } as DesktopApi}
+        snapshot={acpSnapshot("grok", "")}
+        onManagedGrokBuildsChange={vi.fn(async () => true)}
+        onManagedGrokBuildChannelChange={vi.fn(async () => true)}
+      />,
+    );
+
+    const track = await screen.findByRole("radiogroup", { name: "Build track" });
+    expect(within(track).getByRole("radio", { name: /Prerelease/ }))
+      .toBeEnabled();
+    expect(within(track).getAllByText("1.0.5-pwragent.1")).toHaveLength(2);
   });
 
   it("renders Gemini CLI last even though the catalog lists it first", async () => {

--- a/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
+++ b/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
@@ -42,3 +42,12 @@ export function acpRelativeTime(timestamp: number, now = Date.now()): string {
   if (deltaHours < 24) return `${deltaHours}h ago`;
   return `${Math.round(deltaHours / 24)}d ago`;
 }
+
+/**
+ * The version inside a grok-build tag: `pwragent-v1.0.12-pwragent.2` reads as
+ * `1.0.12-pwragent.2`. The repository prefix is the same on every tag, so in a
+ * control that shows two of them side by side it is noise.
+ */
+export function managedGrokBuildVersion(tag: string): string {
+  return tag.startsWith("pwragent-v") ? tag.slice("pwragent-v".length) : tag;
+}

--- a/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
+++ b/apps/desktop/src/renderer/src/features/settings/acp-agent-copy.ts
@@ -27,3 +27,18 @@ export function acpStatusLabel(entry: AcpAgentSettingsEntry): string {
   }
   return "Unavailable";
 }
+
+/**
+ * "2h ago" for a settings status line. Timestamps here report when PwrAgent
+ * last did something on the operator's behalf (a release check), and the exact
+ * clock time is never the question being asked.
+ */
+export function acpRelativeTime(timestamp: number, now = Date.now()): string {
+  const deltaSeconds = Math.max(0, Math.round((now - timestamp) / 1000));
+  if (deltaSeconds < 60) return "just now";
+  const deltaMinutes = Math.round(deltaSeconds / 60);
+  if (deltaMinutes < 60) return `${deltaMinutes}m ago`;
+  const deltaHours = Math.round(deltaMinutes / 60);
+  if (deltaHours < 24) return `${deltaHours}h ago`;
+  return `${Math.round(deltaHours / 24)}d ago`;
+}

--- a/apps/desktop/src/renderer/src/lib/grok-build-channel.ts
+++ b/apps/desktop/src/renderer/src/lib/grok-build-channel.ts
@@ -1,0 +1,16 @@
+/**
+ * Two products answer to "Grok" in this app, and each has its own release
+ * page. Shared by the settings pane and the update notices so neither can
+ * point an operator at the other channel's page.
+ */
+
+/** Where an operator updates a vendor Grok install. Never a PwrAgent build. */
+export const XAI_GROK_UPDATE_URL = "https://x.ai/build";
+
+/** The public release page for one PwrAgent-built Grok tag. */
+export function managedGrokReleaseUrl(
+  repository: string,
+  tag: string,
+): string {
+  return `https://github.com/${repository}/releases/tag/${encodeURIComponent(tag)}`;
+}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -3763,6 +3763,17 @@ textarea,
   padding: 0 12px;
 }
 
+/* An `<a class="button">` — an external link that reads as an action, e.g. a
+   release-notes or install-guide link. A native <button> centers its content
+   and carries no underline for free; an inline anchor does neither, so it
+   renders as underlined text in a box the min-height never reaches. */
+a.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
 .button:focus,
 .thread-row:focus,
 .transcript-activity__toggle:focus,
@@ -10396,6 +10407,51 @@ textarea,
   align-items: center;
   justify-content: flex-start;
   gap: 8px;
+}
+
+/* ------------------------------------------------------------------
+   ACP MANAGED BUILD STATUS (Settings -> AI Providers -> Grok)
+
+   The PwrAgent-build row reports a release channel, not a boolean:
+   which tag is installed, whether it is the one running, and when
+   PwrAgent last checked. One status line above the row's action
+   buttons, both inside the field's `actions` slot.
+   ------------------------------------------------------------------ */
+
+.acp-build {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+.acp-build__line {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  margin: 0;
+  min-width: 0;
+}
+
+/* The dot is a baseline-aligned marker in a text line, not a flex row
+   item of its own — nudge it onto the text's optical center. */
+.acp-build__line .status-dot {
+  align-self: center;
+}
+
+.acp-build__tag {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+
+.acp-build__state {
+  color: var(--text-secondary);
+  font-size: 11.5px;
+  line-height: 1.45;
 }
 
 .settings-provider-defaults__fast {

--- a/docs/bundled-grok-acp.md
+++ b/docs/bundled-grok-acp.md
@@ -65,6 +65,42 @@ cached, ordinary PATH and bundled discovery continue unchanged. Disabling Grok
 also disables release checks. Operators can turn off only the managed-build
 behavior without disabling Grok itself.
 
+## Build tracks: Latest and Prerelease
+
+The managed channel publishes on two tracks, selected in Settings → AI
+Providers → Grok → **Build track**, and stored as
+`[acp_agents.grok] managed_build_channel`:
+
+- **Latest** (default) installs only releases promoted out of testing — a
+  GitHub release whose Pre-release flag is clear.
+- **Prerelease** installs the newest release, promoted or not.
+
+Track selection follows semantic-version precedence, never the order GitHub
+returned the releases: a promotion is published against a release that already
+existed, and a repair to an older line can be published last. When the newest
+release is a promoted one, both tracks resolve to the same tag; Prerelease
+stays selectable in that state, because that is where a build sits between
+publication and promotion, and it is when an operator opts in to the next one.
+
+The publishing workflow is what makes the tracks mean anything: publish a build
+for testing, run it on the Prerelease track, then mark the release Latest once
+it holds up. Operators on Latest never see the untested build. GitHub does not
+allow a pre-release to also be the latest release, so promoting one clears its
+Pre-release flag.
+
+Switching the track forces a release check immediately rather than waiting out
+the 24-hour window, and installs that track's build even when it is a step back
+from what is running — a downgrade is the point of moving from Prerelease to
+Latest.
+
+Each check records what both tracks resolved to, so the pane can name each
+track's version without a second network round trip. One case cannot: when the
+unauthenticated GitHub API is rate-limited, PwrAgent falls back to the public
+Atom feed, which carries tags rather than release records and cannot say which
+of them are promoted. That fallback serves the Prerelease track only. The
+Latest track keeps its cached build for that cycle instead, and the pane shows
+its version as `Unavailable` — meaning "not observed", never "no such build".
+
 ## Two channels, never crossed
 
 An operator can be running either an xAI Grok CLI or a PwrAgent build. They are

--- a/docs/bundled-grok-acp.md
+++ b/docs/bundled-grok-acp.md
@@ -93,6 +93,13 @@ the 24-hour window, and installs that track's build even when it is a step back
 from what is running — a downgrade is the point of moving from Prerelease to
 Latest.
 
+The verified download is machine-wide, and it holds one build. A check that
+finds the cached build was installed for the other track ignores its TTL and
+re-checks, so a profile on Latest is never handed a build a profile on
+Prerelease installed. Two profiles on the same machine following different
+tracks therefore reinstall in turn rather than sharing, which costs a download
+each time the tracks disagree.
+
 Each check records what both tracks resolved to, so the pane can name each
 track's version without a second network round trip. One case cannot: when the
 unauthenticated GitHub API is rate-limited, PwrAgent falls back to the public

--- a/docs/bundled-grok-acp.md
+++ b/docs/bundled-grok-acp.md
@@ -58,11 +58,48 @@ Development runs enable managed builds by default and check once per Electron
 process, which makes a fresh `pnpm dev` pick up a newly published downstream
 build. Packaged apps keep the setting off by default, require the PwrDrvr Apple
 or Windows signing identity when it is turned on, and check at most once per 24
-hours. The provider's Refresh button forces a check.
+hours. **Check for updates** on the provider's PwrAgent build row forces one,
+as does the provider's Refresh button.
 Offline and failed checks retain the last verified managed build; if none is
 cached, ordinary PATH and bundled discovery continue unchanged. Disabling Grok
 also disables release checks. Operators can turn off only the managed-build
 behavior without disabling Grok itself.
+
+## Two channels, never crossed
+
+An operator can be running either an xAI Grok CLI or a PwrAgent build. They are
+different products from different publishers, with different version strings
+(`1.0.5` against `1.0.4-pwragent.2`), different release pages, and different
+updaters — so no surface may describe one in the other's terms:
+
+- Settings → AI Providers → Grok labels every detected binary with the channel
+  that publishes it, and the PwrAgent build row reports the installed tag, when
+  the last release check ran, and whether the newest verified build is the one
+  running.
+- The xAI update notice names that channel, cites only xAI versions, and links
+  x.ai/build. It never renders for a PwrAgent build.
+- The PwrAgent-build notice names that channel and links the release page for
+  its own tag under `pwrdrvr/grok-build`. It fires only when a manual path pins
+  an older managed version, because that is the one state PwrAgent cannot
+  resolve on its own — otherwise the newest verified build installs itself.
+
+Which channel a runtime belongs to is decided by **provenance**, not by whether
+it is the newest build: any command under `~/.pwragent/agents/grok/versions/`
+(or inside the packaged app) is a PwrAgent build, even after the channel has
+published a newer tag. `GROK_INSTALLER=pwragent` still reaches the spawned
+process, but it is no longer the only marker — discovery sets that stamp by
+comparing against the command the current release check resolved, and a pinned
+older version, or any build present while a check failed, would otherwise change
+channel and collect an xAI update notice.
+
+## Pinning a build with a manual path
+
+A manual path is an explicit pin and always wins. Pointing one at a version
+directory under `~/.pwragent/agents/grok/versions/` freezes that build: newer
+verified builds keep downloading and never run. The Manual path row says so
+whenever it is doing that, and **Use newest build** clears it. With managed
+builds on, discovery already ranks the newest managed build ahead of every PATH
+install, so no override is needed to prefer one.
 
 ## Updating the pin
 

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -1,5 +1,6 @@
 import type { AppServerBackendKind, ThreadExecutionMode } from "./normalized-app-server";
 import type { FederationTarget } from "./federation";
+import type { DesktopUpdateChannel } from "./settings";
 
 export type BackendSourceKind = "builtin" | "acp";
 
@@ -313,6 +314,15 @@ export type AcpAgentSettingsEntry = {
 export type AcpManagedBuildStatus = {
   /** GitHub repository the channel publishes from, e.g. `pwrdrvr/grok-build`. */
   repository: string;
+  /** Track this profile follows: promoted releases only, or the newest build
+   *  whether or not it has been promoted. */
+  channel: DesktopUpdateChannel;
+  /** Newest promoted tag the last check saw. Absent until a check has run, or
+   *  when the check fell back to a source that cannot report promotion. */
+  latestTag?: string;
+  /** Newest tag overall the last check saw. Equal to `latestTag` whenever the
+   *  newest build has been promoted — the state both tracks share. */
+  prereleaseTag?: string;
   /** Newest verified build installed on this machine by the last check. */
   installedTag?: string;
   /** Release tag of the active runtime, when that runtime is a managed build.

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -295,8 +295,38 @@ export type AcpAgentSettingsEntry = {
    *  bundle) rather than a vendor install. Those runtimes follow the verified
    *  PwrAgent release feed, so vendor update notices never apply to them. */
   pwrAgentManagedRuntime?: boolean;
+  /** State of the PwrAgent-managed build channel for this agent (Grok only
+   *  today). Present whenever the channel is enabled, whether or not the
+   *  active runtime happens to be one of its builds. */
+  managedBuild?: AcpManagedBuildStatus;
   enabled?: boolean;
   preference?: AcpAgentPreference;
+};
+
+/**
+ * The PwrAgent-managed build channel, as the settings pane needs to describe
+ * it. Distinct from `AcpAgentUpdateStatus`, which reports the *vendor*
+ * updater's answer about a vendor install: the two channels publish different
+ * artifacts under different version strings, and a surface must never describe
+ * one in the other's terms.
+ */
+export type AcpManagedBuildStatus = {
+  /** GitHub repository the channel publishes from, e.g. `pwrdrvr/grok-build`. */
+  repository: string;
+  /** Newest verified build installed on this machine by the last check. */
+  installedTag?: string;
+  /** Release tag of the active runtime, when that runtime is a managed build.
+   *  Absent when a vendor install or the app-bundled copy is active. */
+  activeTag?: string;
+  /** When the last release check ran. */
+  checkedAt?: number;
+  /** When `installedTag` was installed. */
+  installedAt?: number;
+  /** `installedTag` is installed and ready but something is holding an older
+   *  managed build in place for new threads — in practice a manual path
+   *  override pinning one version directory. The one managed-channel state
+   *  that never resolves on its own. */
+  pinnedBehind?: boolean;
 };
 
 export type AcpAgentUpdateStatus = {
@@ -326,6 +356,13 @@ export type AcpAgentInstance = {
   version?: string;
   /** How the path was found: user override, a `PATH` match, or a fallback path. */
   source: AcpAgentInstanceSource;
+  /** PwrAgent supplied this executable — a managed download or the copy inside
+   *  the app bundle. A vendor install leaves it unset. Independent of whether
+   *  this is the *newest* build: provenance does not change when the channel
+   *  publishes a newer tag. */
+  pwrAgentBuild?: boolean;
+  /** Release tag of a managed download, when the executable is one. */
+  pwrAgentBuildTag?: string;
 };
 
 /** An executable that was found but did not pass ACP discovery. A timed-out

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -1828,6 +1828,19 @@ export function isDesktopUpdateChannel(
   return DESKTOP_UPDATE_CHANNELS.includes(value as DesktopUpdateChannel);
 }
 
+/**
+ * Read a persisted update channel from an unvalidated source — a TOML scalar,
+ * a JSON field on disk. One parser for both, so a channel that stops being
+ * accepted stops being accepted everywhere at once.
+ */
+export function parseDesktopUpdateChannel(
+  value: unknown,
+): DesktopUpdateChannel | undefined {
+  return typeof value === "string" && isDesktopUpdateChannel(value)
+    ? value
+    : undefined;
+}
+
 export function isDesktopUpdateTrain(
   value: string,
 ): value is DesktopUpdateTrain {

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -58,6 +58,14 @@ export type DesktopUpdateChannel = (typeof DESKTOP_UPDATE_CHANNELS)[number];
 
 export const DESKTOP_UPDATE_CHANNEL_DEFAULT: DesktopUpdateChannel = "latest";
 
+/**
+ * The managed Grok build follows the same two tracks as the application, and
+ * defaults to Latest for the same reason: a build published for testing is
+ * something an operator opts into, never something they inherit.
+ */
+export const MANAGED_GROK_BUILD_CHANNEL_DEFAULT: DesktopUpdateChannel =
+  "latest";
+
 export const DESKTOP_UPDATE_TRAINS = ["stable", "beta"] as const;
 
 export type DesktopUpdateTrain = (typeof DESKTOP_UPDATE_TRAINS)[number];
@@ -1042,6 +1050,8 @@ export type DesktopSettingsSnapshot = {
       enabled: boolean;
       /** Download and prefer PwrAgent's verified Grok fork build. */
       managedBuilds?: boolean;
+      /** Which grok-build track the managed runtime follows. */
+      managedBuildChannel?: DesktopUpdateChannel;
     };
     kimi: {
       /**
@@ -1281,6 +1291,7 @@ export type DesktopSettingsConfigPatch = {
       cliPath?: string;
       enabled?: boolean;
       managedBuilds?: boolean;
+      managedBuildChannel?: DesktopUpdateChannel;
     };
     kimi?: {
       cliPath?: string;


### PR DESCRIPTION
Settings → AI Providers → Grok can be running a binary **PwrAgent itself** downloaded, checksummed, signature-checked and installed from `pwrdrvr/grok-build` — and it says nothing about it. No installed tag, no last-checked time, no "a newer build exists", no check button. The only control that actually forces a release check is labelled **Refresh** and described as re-running discovery.

Meanwhile the provider's one update notice is written for the *other* channel — an xAI install updated from x.ai/build — and titles itself "Grok update available" without ever saying which Grok.

## The crossed notice

`isPwrAgentOwnedGrokRuntime` decided channel ownership solely from `GROK_INSTALLER=pwragent`, and discovery stamps that only when the active command is string-equal to the command **that run's release check resolved**. Any moment those disagree, the same binary silently changed channel:

- a manual path pinning an older managed version,
- a failed check with nothing cached,
- the managed toggle off while an override still points into `versions/`.

The vendor updater then ran against a `-pwragent` build and its answer was shown to the operator — an xAI version number paired with a PwrAgent build version in one sentence.

Provenance does not depend on which release is newest, so it is now read from the path as well: anything under the managed `versions/` root, or inside the packaged app, is a PwrAgent build regardless of what the last check resolved.

## What changed on the screen

| | |
|---|---|
| **PwrAgent build row** | Reports the channel: installed tag, whether it is the one running, when the last check ran. `Check for updates` forces a release check on its own; `Use newest build` and `Release notes` appear when something is holding an older build in place. Every value comes from metadata the last check already wrote — no network call to render the row. |
| **Detected paths** | Each binary is chipped with the channel that publishes it. `v1.0.5` beside `v1.0.4-pwragent.2` reads as one release behind until you know they are different products from different publishers. |
| **Manual path** | Says when it is pinning a managed version and what that costs. Clicking `Use` on a managed row is enough to freeze a build forever, and nothing said so. |
| **Re-probe** | Stops being the secret updater; its sub-line points at the control that is. |

There is deliberately **no install verb in the common case**. On this channel PwrAgent has already downloaded, verified and installed the newest build, so asking the operator to install it would be asking for work already done.

## The notices

Split in two, each naming its channel in the title and citing only its own versions and release page:

- **xAI Grok CLI update available** — vendor versions, links x.ai/build. Never renders for a PwrAgent build.
- **PwrAgent Grok build update not in use** — `-pwragent` tags, links `github.com/pwrdrvr/grok-build/releases/tag/<tag>`. Fires only for the pinned-and-stale case, which is the one state this channel cannot resolve on its own.

## Also

`a.button` now gets the box behavior a native `<button>` has for free (centered content, no underline). Without it a link styled as a button renders as underlined text in a box its `min-height` never reaches — visible on the existing Kimi install-guide link too.

## Testing

- `pnpm test` — 670 files, 9878 passed.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:colors`.
- New coverage: path-provenance predicate, the unstamped-managed-build ownership case, the settings IPC decoration (installed tag / active tag / `pinnedBehind` / per-instance channel), both notices, and the three settings states.
- Both themes rendered off a headless harness against the real `app.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)