### PR TITLE
fix(desktop): make the MCPs pane say what it knows

### DIFF
--- a/apps/desktop/src/renderer/src/components/McpInventoryLine.tsx
+++ b/apps/desktop/src/renderer/src/components/McpInventoryLine.tsx
@@ -12,6 +12,11 @@ export function McpInventoryLine(props: {
   label: string;
   previewLimit: number;
   values: string[];
+  /**
+   * Extra class, appended to the base line class rather than replacing it —
+   * the base carries the shared two-column line grid, and a caller that
+   * swapped it out silently lost that layout.
+   */
   className?: string;
 }) {
   const [expanded, setExpanded] = useState(false);
@@ -22,7 +27,13 @@ export function McpInventoryLine(props: {
   const hiddenCount = props.values.length - visibleValues.length;
 
   return (
-    <div className={props.className ?? "mcp-inventory-panel__line"}>
+    <div
+      className={
+        props.className
+          ? `mcp-inventory-panel__line ${props.className}`
+          : "mcp-inventory-panel__line"
+      }
+    >
       <span className="mcp-inventory-panel__line-label">
         {props.label}
         <span className="mcp-inventory-panel__line-count">

--- a/apps/desktop/src/renderer/src/components/McpInventoryLine.tsx
+++ b/apps/desktop/src/renderer/src/components/McpInventoryLine.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+/**
+ * The expandable "Tools · 28 — a, b, c … Show 20 more" line.
+ *
+ * Lifted out of `McpInventoryPanel` so the Settings → Plugins → MCPs pane can
+ * render the same payload the same way. Both surfaces receive the identical
+ * `CodexMcpServerSummary.tools` array; the Settings pane used to reduce it to
+ * a count and drop the names on the floor.
+ */
+export function McpInventoryLine(props: {
+  label: string;
+  previewLimit: number;
+  values: string[];
+  className?: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasOverflow = props.values.length > props.previewLimit;
+  const visibleValues = expanded || !hasOverflow
+    ? props.values
+    : props.values.slice(0, props.previewLimit);
+  const hiddenCount = props.values.length - visibleValues.length;
+
+  return (
+    <div className={props.className ?? "mcp-inventory-panel__line"}>
+      <span className="mcp-inventory-panel__line-label">
+        {props.label}
+        <span className="mcp-inventory-panel__line-count">
+          {` · ${props.values.length}`}
+        </span>
+      </span>
+      <div className="mcp-inventory-panel__line-value">
+        <span className="mcp-inventory-panel__line-items">
+          {visibleValues.length > 0 ? visibleValues.join(", ") : "None"}
+        </span>
+        {hasOverflow ? (
+          <button
+            type="button"
+            className="mcp-inventory-panel__line-toggle"
+            aria-expanded={expanded}
+            aria-label={
+              expanded
+                ? `Show fewer ${props.label}`
+                : `Show ${hiddenCount} more ${props.label}`
+            }
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded ? "Show less" : `Show ${hiddenCount} more`}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -72,10 +72,8 @@ function readStartupStatus(
 
 function matchesMcpFilter(
   server: CodexMcpServerSummary,
-  filter: string,
+  needle: string,
 ): boolean {
-  const needle = filter.trim().toLowerCase();
-  if (!needle) return true;
   return (
     server.name.toLowerCase().includes(needle)
     || server.tools.some((tool) => tool.toLowerCase().includes(needle))
@@ -104,7 +102,6 @@ export function PluginsSettings(props: {
   const [removeCandidate, setRemoveCandidate] =
     useState<CodexMcpServerSummary>();
   const [notice, setNotice] = useState<ActionNotice>();
-  const filterId = useId();
   const selectedProfile = props.snapshot.models.codex.profiles.profiles.find(
     (profile) => profile.selected,
   );
@@ -121,17 +118,26 @@ export function PluginsSettings(props: {
     && normalizeCodexHome(activeCodexHome)
       !== normalizeCodexHome(selectedCodexHome),
   );
+  // A CODEX_HOME outside `<profile root>/<name>` matches no discovered
+  // profile. Calling that "System default" would assert the store is
+  // `~/.codex` when it demonstrably is not, so it is named for what it is.
+  const activeProfileLabel = activeProfile?.displayName
+    ?? (activeCodexHome ? "Custom CODEX_HOME" : "Loading...");
   // The System-default profile *is* `~/.codex`, so PwrAgent and a bare `codex`
-  // share one store and there is no separation to warn about. Every named
-  // profile resolves to `<codex home>/profiles/<name>` and is fully isolated.
-  const usesNamedProfile = Boolean(activeProfile?.name);
+  // share one store and there is no separation to warn about. Every other
+  // home — a named profile or a custom CODEX_HOME — is fully isolated from it,
+  // and an unrecognized home is exactly where the note matters most.
+  const usesIsolatedCodexHome = Boolean(
+    activeCodexHome && activeProfile?.name !== "",
+  );
   const managedCodex = props.snapshot.runtime.tokenMiser?.managedCodex;
 
   const health = useMemo(() => countMcpServerHealth(servers), [servers]);
-  const visibleServers = useMemo(
-    () => servers.filter((server) => matchesMcpFilter(server, filter)),
-    [filter, servers],
-  );
+  const visibleServers = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return servers;
+    return servers.filter((server) => matchesMcpFilter(server, needle));
+  }, [filter, servers]);
 
   const setPendingAction = useCallback((action?: PendingAction) => {
     pendingActionRef.current = action;
@@ -203,6 +209,18 @@ export function PluginsSettings(props: {
       });
       setActiveCodexHome(response.codexHome);
       setServers(response.servers);
+      // A name that vanished (removed here, or edited out of `config.toml`)
+      // would otherwise sit in the expanded set forever and silently re-open
+      // the drawer if that name ever came back.
+      setExpandedServers((current) => {
+        if (current.size === 0) return current;
+        const live = new Set(response.servers.map((server) => server.name));
+        const next = new Set<string>();
+        for (const name of current) {
+          if (live.has(name)) next.add(name);
+        }
+        return next.size === current.size ? current : next;
+      });
       return true;
     } catch (error) {
       setNotice({
@@ -326,12 +344,22 @@ export function PluginsSettings(props: {
         });
       }
       const waiter = startupWaiterRef.current;
-      if (!waiter || !name || !status || name !== waiter.name || !isGlobalStatus) {
+      // `starting` is the normal precursor to a terminal status and must leave
+      // the waiter armed. Disarming on it would clear the fallback timer
+      // without resolving, and `finishLogin` would await a promise that can
+      // never settle — wedging the pane with its pending action forever.
+      if (
+        !waiter
+        || !name
+        || !status
+        || status === "starting"
+        || name !== waiter.name
+        || !isGlobalStatus
+      ) {
         return;
       }
       window.clearTimeout(waiter.timer);
       startupWaiterRef.current = undefined;
-      if (status === "starting") return;
       waiter.resolve({
         status,
         ...(typeof params.error === "string" ? { error: params.error } : {}),
@@ -525,13 +553,13 @@ export function PluginsSettings(props: {
             : `${health.total} ${health.total === 1 ? "server" : "servers"} · ${health.tools} tools`
         }
         chipKind={
-          health.needsSignIn > 0 ? "warn" : health.failed > 0 ? "err" : "default"
+          health.failed > 0 ? "err" : health.needsSignIn > 0 ? "warn" : "default"
         }
       >
         <div className="settings-mcp-scope">
           <span className="settings-mcp-scope__key">Profile</span>
           <span className="settings-mcp-scope__value">
-            <strong>{activeProfile?.displayName ?? "System default"}</strong>
+            <strong>{activeProfileLabel}</strong>
             <code>
               {activeCodexHome ? shortenCodexHome(activeCodexHome) : "Loading..."}
             </code>
@@ -554,7 +582,7 @@ export function PluginsSettings(props: {
               </span>
             ) : null}
           </span>
-          {usesNamedProfile ? (
+          {usesIsolatedCodexHome ? (
             <p className="settings-mcp-scope__note">
               These servers and their sign-ins live in <strong>this profile only</strong>.
               PwrAgent's own terminals use it too; a <code>codex</code> you run outside
@@ -593,7 +621,6 @@ export function PluginsSettings(props: {
             <div className="settings-mcp-toolbar">
               <input
                 className="settings-mcp-filter"
-                id={filterId}
                 aria-label="Filter MCP servers and tools"
                 placeholder="Filter servers and tools..."
                 type="search"
@@ -601,9 +628,16 @@ export function PluginsSettings(props: {
                 onChange={(event) => setFilter(event.target.value)}
               />
               <div className="settings-mcp-toolbar__counts">
-                <span className="settings-pathrow__chip settings-pathrow__chip--ok">
-                  {health.ready} ready
-                </span>
+                {health.ready > 0 ? (
+                  <span className="settings-pathrow__chip settings-pathrow__chip--ok">
+                    {health.ready} ready
+                  </span>
+                ) : null}
+                {health.starting > 0 ? (
+                  <span className="settings-pathrow__chip">
+                    {health.starting} starting
+                  </span>
+                ) : null}
                 {health.needsSignIn > 0 ? (
                   <span className="settings-pathrow__chip settings-pathrow__chip--warn">
                     {health.needsSignIn} need sign-in
@@ -629,7 +663,6 @@ export function PluginsSettings(props: {
                     busy={pendingAction?.name === server.name}
                     disabled={actionsDisabled}
                     expanded={expandedServers.has(server.name)}
-                    filter={filter}
                     server={server}
                     onSignIn={() => void signIn(server)}
                     onRemove={() => setRemoveCandidate(server)}
@@ -665,7 +698,6 @@ export function PluginsSettings(props: {
             <div className="settings-confirm-dialog__actions">
               <button
                 className="button button--secondary"
-                disabled={actionsDisabled}
                 type="button"
                 onClick={() => setRemoveCandidate(undefined)}
               >
@@ -691,7 +723,6 @@ function McpServerRow(props: {
   busy: boolean;
   disabled: boolean;
   expanded: boolean;
-  filter: string;
   server: CodexMcpServerSummary;
   onRemove: () => void;
   onSignIn: () => void;
@@ -714,7 +745,7 @@ function McpServerRow(props: {
     <article className="settings-mcp-row" data-health={health}>
       <div className="settings-mcp-row__main">
         <button
-          aria-controls={drawerId}
+          aria-controls={props.expanded ? drawerId : undefined}
           aria-expanded={props.expanded}
           className="settings-mcp-row__toggle"
           type="button"

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -1,15 +1,25 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import type {
-  CodexMcpAuthStatus,
   CodexMcpServerSummary,
   DesktopSettingsSnapshot,
 } from "@pwragent/shared";
+import { describeMcpAuthStatus } from "@pwragent/shared";
+import { McpInventoryLine } from "../../components/McpInventoryLine";
+import {
+  ChipContextMenu,
+  type ChipContextMenuPosition,
+} from "../chrome/ChipContextMenu";
 import type { DesktopApi } from "../../lib/desktop-api";
 import {
   SettingsPanelHead,
   SettingsSection,
   SettingsSectionStack,
 } from "./SettingsLayout";
+import {
+  countMcpServerHealth,
+  describeMcpServerTools,
+  readMcpServerHealth,
+} from "./mcp-server-health";
 
 type ActionNotice = {
   kind: "error" | "info" | "success" | "working";
@@ -28,6 +38,7 @@ type StartupResult = {
 
 const LOGIN_STARTUP_WAIT_MS = 5_000;
 const OAUTH_LOGIN_WAIT_MS = 120_000;
+const TOOL_PREVIEW_LIMIT = 12;
 
 function normalizeCodexHome(value: string): string {
   return value
@@ -37,6 +48,40 @@ function normalizeCodexHome(value: string): string {
     .replace(/^([A-Z]):/, (_, drive: string) => `${drive.toLowerCase()}:`);
 }
 
+/**
+ * `~/.codex/profiles/work` is the form operators recognise. Only the
+ * conventional `.codex` root is abbreviated; a `CODEX_HOME` pointed somewhere
+ * else is shown in full rather than given a misleading `~`.
+ */
+function shortenCodexHome(value: string): string {
+  const normalized = value.replaceAll("\\", "/").replace(/\/$/, "");
+  const match = /^.*?(\/\.codex(?:\/.*)?)$/.exec(normalized);
+  return match ? `~${match[1]}` : normalized;
+}
+
+function readStartupStatus(
+  value: unknown,
+): NonNullable<CodexMcpServerSummary["startupStatus"]> | undefined {
+  return value === "starting"
+    || value === "ready"
+    || value === "failed"
+    || value === "cancelled"
+    ? value
+    : undefined;
+}
+
+function matchesMcpFilter(
+  server: CodexMcpServerSummary,
+  filter: string,
+): boolean {
+  const needle = filter.trim().toLowerCase();
+  if (!needle) return true;
+  return (
+    server.name.toLowerCase().includes(needle)
+    || server.tools.some((tool) => tool.toLowerCase().includes(needle))
+  );
+}
+
 export function PluginsSettings(props: {
   desktopApi?: DesktopApi;
   snapshot: DesktopSettingsSnapshot;
@@ -44,6 +89,10 @@ export function PluginsSettings(props: {
   const [servers, setServers] = useState<CodexMcpServerSummary[]>([]);
   const [activeCodexHome, setActiveCodexHome] = useState<string>();
   const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState("");
+  const [expandedServers, setExpandedServers] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
   const [pendingAction, setPendingActionState] = useState<PendingAction>();
   const pendingActionRef = useRef<PendingAction | undefined>(undefined);
   const startupWaiterRef = useRef<{
@@ -55,6 +104,7 @@ export function PluginsSettings(props: {
   const [removeCandidate, setRemoveCandidate] =
     useState<CodexMcpServerSummary>();
   const [notice, setNotice] = useState<ActionNotice>();
+  const filterId = useId();
   const selectedProfile = props.snapshot.models.codex.profiles.profiles.find(
     (profile) => profile.selected,
   );
@@ -70,6 +120,17 @@ export function PluginsSettings(props: {
     activeCodexHome
     && normalizeCodexHome(activeCodexHome)
       !== normalizeCodexHome(selectedCodexHome),
+  );
+  // The System-default profile *is* `~/.codex`, so PwrAgent and a bare `codex`
+  // share one store and there is no separation to warn about. Every named
+  // profile resolves to `<codex home>/profiles/<name>` and is fully isolated.
+  const usesNamedProfile = Boolean(activeProfile?.name);
+  const managedCodex = props.snapshot.runtime.tokenMiser?.managedCodex;
+
+  const health = useMemo(() => countMcpServerHealth(servers), [servers]);
+  const visibleServers = useMemo(
+    () => servers.filter((server) => matchesMcpFilter(server, filter)),
+    [filter, servers],
   );
 
   const setPendingAction = useCallback((action?: PendingAction) => {
@@ -89,7 +150,7 @@ export function PluginsSettings(props: {
     setPendingAction(undefined);
     setNotice({
       kind: "info",
-      text: message ?? "Stopped waiting for login. You can try again.",
+      text: message ?? "Stopped waiting for sign-in. You can try again.",
     });
   }, [clearOAuthWaitTimer, setPendingAction]);
 
@@ -100,7 +161,7 @@ export function PluginsSettings(props: {
         pendingActionRef.current?.kind === "login"
         && pendingActionRef.current.name === name
       ) {
-        cancelLoginWait(`${name} login timed out. You can try again.`);
+        cancelLoginWait(`${name} sign-in timed out. You can try again.`);
       }
     }, OAUTH_LOGIN_WAIT_MS);
   }, [cancelLoginWait, clearOAuthWaitTimer]);
@@ -185,7 +246,7 @@ export function PluginsSettings(props: {
     setPendingAction({ kind: "reload", name });
     setNotice({
       kind: "working",
-      text: `${name} login completed. Reloading its MCP connection...`,
+      text: `${name} sign-in completed. Reloading its MCP connection...`,
     });
     const startup = waitForGlobalStartup(name);
     try {
@@ -197,18 +258,18 @@ export function PluginsSettings(props: {
         setNotice({
           kind: "error",
           text: startupResult.error
-            ? `${name} login completed, but startup failed: ${startupResult.error}`
-            : `${name} login completed, but its MCP connection failed to start.`,
+            ? `${name} signed in, but startup failed: ${startupResult.error}`
+            : `${name} signed in, but its MCP connection failed to start.`,
         });
       } else if (startupResult?.status === "cancelled") {
         setNotice({
           kind: "error",
-          text: `${name} login completed, but its MCP connection startup was cancelled.`,
+          text: `${name} signed in, but its MCP connection startup was cancelled.`,
         });
       } else {
         setNotice({
           kind: "success",
-          text: `${name} login completed and its row was refreshed.`,
+          text: `${name} signed in and its row was refreshed.`,
         });
       }
     } catch (error) {
@@ -238,22 +299,41 @@ export function PluginsSettings(props: {
         : typeof params.serverName === "string"
           ? params.serverName
           : undefined;
+      const status = readStartupStatus(params.status);
+      const isGlobalStatus = typeof params.threadId !== "string" && Boolean(status);
+      // Keep every row's health current, not just the one an action is
+      // waiting on. Without this the pane only ever learns a startup status
+      // while a sign-in is in flight, so a server that died on launch is
+      // indistinguishable from one that publishes no tools.
+      if (name && status && isGlobalStatus) {
+        const error = typeof params.error === "string" ? params.error : undefined;
+        setServers((current) => {
+          let changed = false;
+          const next = current.map((server) => {
+            if (server.name !== name) return server;
+            if (server.startupStatus === status && server.startupError === error) {
+              return server;
+            }
+            changed = true;
+            const { startupError: _dropped, ...rest } = server;
+            return {
+              ...rest,
+              startupStatus: status,
+              ...(error ? { startupError: error } : {}),
+            };
+          });
+          return changed ? next : current;
+        });
+      }
       const waiter = startupWaiterRef.current;
-      if (
-        !waiter
-        || !name
-        || name !== waiter.name
-        || typeof params.threadId === "string"
-        || (params.status !== "ready"
-          && params.status !== "failed"
-          && params.status !== "cancelled")
-      ) {
+      if (!waiter || !name || !status || name !== waiter.name || !isGlobalStatus) {
         return;
       }
       window.clearTimeout(waiter.timer);
       startupWaiterRef.current = undefined;
+      if (status === "starting") return;
       waiter.resolve({
-        status: params.status,
+        status,
         ...(typeof params.error === "string" ? { error: params.error } : {}),
       });
       return;
@@ -281,7 +361,7 @@ export function PluginsSettings(props: {
       kind: "error",
       text: typeof params.error === "string"
         ? params.error
-        : `${name} login did not complete.`,
+        : `${name} sign-in did not complete.`,
     });
   }), [
     clearOAuthWaitTimer,
@@ -319,7 +399,7 @@ export function PluginsSettings(props: {
     }
   };
 
-  const relogin = async (server: CodexMcpServerSummary) => {
+  const signIn = async (server: CodexMcpServerSummary) => {
     if (
       !props.desktopApi?.startCodexMcpServerLogin
       || pendingActionRef.current
@@ -329,7 +409,7 @@ export function PluginsSettings(props: {
     setPendingAction({ kind: "login", name: server.name });
     setNotice({
       kind: "working",
-      text: `Waiting for ${server.name} login to complete...`,
+      text: `Waiting for ${server.name} sign-in to complete...`,
     });
     scheduleLoginTimeout(server.name);
     try {
@@ -389,21 +469,43 @@ export function PluginsSettings(props: {
       setPendingAction(undefined);
     }
   };
+
+  const toggleServer = (name: string) => {
+    setExpandedServers((current) => {
+      const next = new Set(current);
+      if (!next.delete(name)) next.add(name);
+      return next;
+    });
+  };
+
   const actionsDisabled = Boolean(pendingAction)
     || profileChanged
     || !activeCodexHome;
+  // `Reload config` also goes dim while a load is in flight or the pane is
+  // scoped to a stale profile. A dim button with no stated reason reads as a
+  // defect, so the reason travels with it.
+  const reloadDisabledReason = profileChanged
+    ? "Restart PwrAgent before managing MCP servers for the newly selected Codex profile."
+    : !activeCodexHome
+      ? "The active Codex profile is still loading."
+      : pendingAction
+        ? `Waiting for ${pendingAction.name}.`
+        : undefined;
 
   return (
     <SettingsSectionStack paneId="plugins" aria-label="Plugin settings">
       <SettingsPanelHead
         eyebrow="Plugins"
-        title="Plugin connections"
-        help="Inspect and repair the MCP servers configured for this PwrAgent profile's selected Codex profile."
+        title="Codex MCP servers"
+        help="MCP servers give Codex threads extra tools. They are configured per Codex profile — PwrAgent inspects and repairs the profile it is running."
         action={
           <button
             className="button button--secondary"
             disabled={loading || actionsDisabled}
-            title="Re-read installed MCP configuration and expose it to loaded Codex threads on their next turn."
+            title={
+              reloadDisabledReason
+              ?? "Re-read installed MCP configuration and expose it to loaded Codex threads on their next turn."
+            }
             type="button"
             onClick={() => void reloadConfig()}
           >
@@ -416,17 +518,54 @@ export function PluginsSettings(props: {
         eyebrow="Plugins"
         title="MCP servers"
         sectionId="mcp-servers"
-        description="Relogin replaces expired OAuth credentials. Remove deletes only this server's configuration from the selected Codex profile."
-        chip={`${servers.length} configured`}
+        description="Sign-in replaces expired OAuth credentials. Remove deletes only this server's configuration from the selected Codex profile."
+        chip={
+          loading
+            ? "Loading..."
+            : `${health.total} ${health.total === 1 ? "server" : "servers"} · ${health.tools} tools`
+        }
+        chipKind={
+          health.needsSignIn > 0 ? "warn" : health.failed > 0 ? "err" : "default"
+        }
       >
-        <div className="settings-plugin-profile">
-          <span>Active Codex profile</span>
-          <strong>{activeProfile?.displayName ?? "Default"}</strong>
-          <code>{activeCodexHome ?? "Loading..."}</code>
+        <div className="settings-mcp-scope">
+          <span className="settings-mcp-scope__key">Profile</span>
+          <span className="settings-mcp-scope__value">
+            <strong>{activeProfile?.displayName ?? "System default"}</strong>
+            <code>
+              {activeCodexHome ? shortenCodexHome(activeCodexHome) : "Loading..."}
+            </code>
+          </span>
+          <span className="settings-mcp-scope__key">Codex</span>
+          <span className="settings-mcp-scope__value">
+            <strong>
+              {managedCodex?.state === "unavailable"
+                ? "System Codex"
+                : "PwrAgent managed"}
+            </strong>
+            {managedCodex?.version ? <code>{managedCodex.version}</code> : null}
+            {managedCodex?.state === "ready" ? (
+              <span className="settings-pathrow__chip settings-pathrow__chip--ok">
+                Token Miser ready
+              </span>
+            ) : managedCodex?.state === "pending-switch" ? (
+              <span className="settings-pathrow__chip">
+                Token Miser pending restart
+              </span>
+            ) : null}
+          </span>
+          {usesNamedProfile ? (
+            <p className="settings-mcp-scope__note">
+              These servers and their sign-ins live in <strong>this profile only</strong>.
+              PwrAgent's own terminals use it too; a <code>codex</code> you run outside
+              PwrAgent falls back to <code>~/.codex</code> and has its own separate
+              sign-ins.
+            </p>
+          ) : null}
         </div>
         {profileChanged ? (
           <p className="settings-plugin-notice settings-plugin-notice--error" role="alert">
-            Codex profile selection changed to {selectedProfile?.displayName ?? "Default"}.
+            Codex profile selection changed to {selectedProfile?.displayName ?? "System default"}.
             Restart PwrAgent before managing MCP servers for that profile.
           </p>
         ) : null}
@@ -442,7 +581,7 @@ export function PluginsSettings(props: {
                 type="button"
                 onClick={() => cancelLoginWait()}
               >
-                Cancel login
+                Cancel sign-in
               </button>
             ) : null}
           </div>
@@ -450,18 +589,60 @@ export function PluginsSettings(props: {
         {loading ? (
           <p className="settings-empty">Loading MCP servers...</p>
         ) : servers.length ? (
-          <div className="settings-mcp-list">
-            {servers.map((server) => (
-              <McpServerRow
-                key={server.name}
-                busy={pendingAction?.name === server.name}
-                disabled={actionsDisabled}
-                server={server}
-                onRelogin={() => void relogin(server)}
-                onRemove={() => setRemoveCandidate(server)}
+          <>
+            <div className="settings-mcp-toolbar">
+              <input
+                className="settings-mcp-filter"
+                id={filterId}
+                aria-label="Filter MCP servers and tools"
+                placeholder="Filter servers and tools..."
+                type="search"
+                value={filter}
+                onChange={(event) => setFilter(event.target.value)}
               />
-            ))}
-          </div>
+              <div className="settings-mcp-toolbar__counts">
+                <span className="settings-pathrow__chip settings-pathrow__chip--ok">
+                  {health.ready} ready
+                </span>
+                {health.needsSignIn > 0 ? (
+                  <span className="settings-pathrow__chip settings-pathrow__chip--warn">
+                    {health.needsSignIn} need sign-in
+                  </span>
+                ) : null}
+                {health.failed > 0 ? (
+                  <span className="settings-pathrow__chip settings-pathrow__chip--err">
+                    {health.failed} failed
+                  </span>
+                ) : null}
+                {health.unknown > 0 ? (
+                  <span className="settings-pathrow__chip">
+                    {health.unknown} not reported
+                  </span>
+                ) : null}
+              </div>
+            </div>
+            {visibleServers.length ? (
+              <div className="settings-mcp-list">
+                {visibleServers.map((server) => (
+                  <McpServerRow
+                    key={server.name}
+                    busy={pendingAction?.name === server.name}
+                    disabled={actionsDisabled}
+                    expanded={expandedServers.has(server.name)}
+                    filter={filter}
+                    server={server}
+                    onSignIn={() => void signIn(server)}
+                    onRemove={() => setRemoveCandidate(server)}
+                    onToggle={() => toggleServer(server.name)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="settings-empty">
+                No MCP server or tool matches “{filter.trim()}”.
+              </p>
+            )}
+          </>
         ) : (
           <p className="settings-empty">No MCP servers are configured.</p>
         )}
@@ -509,68 +690,123 @@ export function PluginsSettings(props: {
 function McpServerRow(props: {
   busy: boolean;
   disabled: boolean;
+  expanded: boolean;
+  filter: string;
   server: CodexMcpServerSummary;
-  onRelogin: () => void;
   onRemove: () => void;
+  onSignIn: () => void;
+  onToggle: () => void;
 }) {
   const server = props.server;
-  const canRelogin = server.authStatus === "oAuth"
-    || server.authStatus === "notLoggedIn";
+  const drawerId = useId();
+  const [menuPosition, setMenuPosition] = useState<ChipContextMenuPosition>();
+  const menuInvokerRef = useRef<HTMLButtonElement | null>(null);
+  const health = readMcpServerHealth(server);
+  const auth = describeMcpAuthStatus(server.authStatus);
+  const canSignIn = auth.canSignIn;
+  const openMenu = (event: { currentTarget: HTMLButtonElement }) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    menuInvokerRef.current = event.currentTarget;
+    setMenuPosition({ x: rect.left, y: rect.bottom + 4, anchorTop: rect.top });
+  };
+
   return (
-    <article className="settings-mcp-row">
-      <div className="settings-mcp-row__body">
-        <strong>{server.name}</strong>
-        <span>{server.tools.length} tools</span>
-        {server.startupError ? (
-          <p className="settings-mcp-row__error">{server.startupError}</p>
-        ) : null}
-      </div>
-      <div className="settings-mcp-row__chips">
-        <span className="settings-pathrow__chip">
-          {formatAuthStatus(server.authStatus)}
-        </span>
-        {server.startupStatus ? (
+    <article className="settings-mcp-row" data-health={health}>
+      <div className="settings-mcp-row__main">
+        <button
+          aria-controls={drawerId}
+          aria-expanded={props.expanded}
+          className="settings-mcp-row__toggle"
+          type="button"
+          onClick={props.onToggle}
+        >
+          <span
+            aria-hidden="true"
+            className="settings-mcp-row__health"
+          />
+          <span aria-hidden="true" className="settings-mcp-row__chevron" />
+          <span className="settings-mcp-row__name">{server.name}</span>
+          <span className="settings-mcp-row__meta">
+            {describeMcpServerTools(server, health)}
+          </span>
+        </button>
+        <div className="settings-mcp-row__chips">
           <span
             className={`settings-pathrow__chip${
-              server.startupStatus === "failed"
-                ? " settings-pathrow__chip--err"
-                : server.startupStatus === "ready"
-                  ? " settings-pathrow__chip--ok"
+              auth.tone === "ok"
+                ? " settings-pathrow__chip--ok"
+                : auth.tone === "warn"
+                  ? " settings-pathrow__chip--warn"
                   : ""
             }`}
+            title={auth.description}
           >
-            {server.startupStatus}
+            {auth.label}
           </span>
-        ) : null}
-      </div>
-      <div className="settings-mcp-row__actions">
-        {canRelogin ? (
+        </div>
+        <div className="settings-mcp-row__actions">
+          {health === "needsSignIn" ? (
+            <button
+              className="button button--secondary"
+              disabled={props.disabled}
+              type="button"
+              onClick={props.onSignIn}
+            >
+              {props.busy ? "Waiting..." : "Sign in"}
+            </button>
+          ) : null}
           <button
-            className="button button--secondary"
+            aria-haspopup="menu"
+            aria-label={`More actions for ${server.name}`}
+            className="button button--ghost settings-mcp-row__more"
             disabled={props.disabled}
+            title={`More actions for ${server.name}`}
             type="button"
-            onClick={props.onRelogin}
+            onClick={openMenu}
           >
-            {props.busy ? "Waiting..." : "Relogin"}
+            <span aria-hidden="true">···</span>
           </button>
-        ) : null}
-        <button
-          className="button button--ghost settings-mcp-row__remove"
-          disabled={props.disabled}
-          type="button"
-          onClick={props.onRemove}
-        >
-          Remove
-        </button>
+        </div>
       </div>
+      {server.startupError ? (
+        <p className="settings-mcp-row__error">{server.startupError}</p>
+      ) : health === "needsSignIn" ? (
+        <p className="settings-mcp-row__error">
+          Sign in to load this server's tools.
+        </p>
+      ) : null}
+      {props.expanded ? (
+        <div className="settings-mcp-row__drawer" id={drawerId}>
+          <McpInventoryLine
+            className="settings-mcp-row__tools"
+            label="Tools"
+            previewLimit={TOOL_PREVIEW_LIMIT}
+            values={server.tools}
+          />
+        </div>
+      ) : null}
+      {menuPosition && menuInvokerRef.current ? (
+        <ChipContextMenu
+          items={[
+            ...(canSignIn
+              ? [{
+                  label: health === "needsSignIn"
+                    ? `Sign in to ${server.name}`
+                    : `Sign in to ${server.name} again`,
+                  action: props.onSignIn,
+                }]
+              : []),
+            {
+              label: `Remove ${server.name}`,
+              action: props.onRemove,
+              separated: canSignIn,
+            },
+          ]}
+          position={menuPosition}
+          returnFocusTo={menuInvokerRef.current}
+          onClose={() => setMenuPosition(undefined)}
+        />
+      ) : null}
     </article>
   );
-}
-
-function formatAuthStatus(status: CodexMcpAuthStatus): string {
-  if (status === "oAuth") return "OAuth";
-  if (status === "bearerToken") return "Bearer token";
-  if (status === "notLoggedIn") return "Login required";
-  if (status === "unknown") return "Authentication unknown";
-  return "No login";
 }

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
@@ -325,4 +325,55 @@ describe("PluginsSettings", () => {
     const counts = screen.getByText("1 failed");
     expect(within(counts).queryByText("0")).not.toBeInTheDocument();
   });
+
+  it("finishes a sign-in whose server reports starting before it reports ready", async () => {
+    let emit: ((event: { notification: { method: string; params: Record<string, unknown> } }) => void) | undefined;
+    const desktopApi = {
+      ...createDesktopApi([
+        server({ name: "datadog", authStatus: "notLoggedIn" }),
+      ]),
+      startCodexMcpServerLogin: vi.fn().mockResolvedValue({ ok: true }),
+      onAgentEvent: vi.fn((listener: typeof emit) => {
+        emit = listener;
+        return () => {};
+      }),
+    } as unknown as DesktopApi;
+
+    render(<PluginsSettings desktopApi={desktopApi} snapshot={createSnapshot()} />);
+
+    fireEvent.click(await screen.findByRole("button", { name: "Sign in" }));
+    await waitFor(() => {
+      expect(desktopApi.startCodexMcpServerLogin).toHaveBeenCalled();
+    });
+
+    emit?.({
+      notification: {
+        method: "mcpServer/oauthLogin/completed",
+        params: { serverName: "datadog", success: true },
+      },
+    });
+
+    // A reload reports `starting` before it reports `ready`. Treating that as
+    // a terminal answer disarmed the waiter without resolving it, so the
+    // promise the pane awaits never settled and every control on the row
+    // stayed disabled for the life of the window.
+    emit?.({
+      notification: {
+        method: "mcpServer/startupStatus/updated",
+        params: { name: "datadog", status: "starting" },
+      },
+    });
+    emit?.({
+      notification: {
+        method: "mcpServer/startupStatus/updated",
+        params: { name: "datadog", status: "ready" },
+      },
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "More actions for datadog" }),
+      ).toBeEnabled();
+    });
+  });
 });

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
@@ -1,0 +1,328 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type {
+  CodexMcpServerSummary,
+  DesktopSettingsSnapshot,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { PluginsSettings } from "../PluginsSettings";
+
+afterEach(() => {
+  cleanup();
+});
+
+const CODEX_HOME = "/Users/operator/.codex/profiles/work";
+const DEFAULT_CODEX_HOME = "/Users/operator/.codex";
+
+/**
+ * The pane reads three things off the snapshot. Building the whole
+ * `DesktopSettingsSnapshot` here would be ~200 lines of unrelated defaults, so
+ * this narrows to what it actually consumes; the cast is what keeps that
+ * honest rather than a partial type that would hide a new read.
+ */
+function createSnapshot(options: {
+  codexHome?: string;
+  managedCodexVersion?: string;
+  profileName?: string;
+} = {}): DesktopSettingsSnapshot {
+  const profileName = options.profileName ?? "work";
+  const codexHome = options.codexHome ?? CODEX_HOME;
+  return {
+    runtime: {
+      messaging: { disabled: false },
+      tokenMiser: {
+        managedCodex: {
+          state: "ready",
+          version: options.managedCodexVersion ?? "pwragent-v0.149.0",
+        },
+        interceptionCount: 0,
+        originalCharacters: 0,
+        baselineParentTokens: 0,
+        replacementTokens: 0,
+        retrievedTokens: 0,
+        estimatedParentTokensSaved: 0,
+      },
+    },
+    models: {
+      codex: {
+        profiles: {
+          profileRoot: `${DEFAULT_CODEX_HOME}/profiles`,
+          effectiveCodexHome: codexHome,
+          profiles: [
+            {
+              name: "",
+              displayName: "System default",
+              codexHome: DEFAULT_CODEX_HOME,
+              source: "default",
+              exists: true,
+              selected: profileName === "",
+              hasAuthFile: true,
+              hasConfigFile: true,
+            },
+            {
+              name: "work",
+              displayName: "work",
+              codexHome: CODEX_HOME,
+              source: "directory",
+              exists: true,
+              selected: profileName === "work",
+              hasAuthFile: true,
+              hasConfigFile: true,
+            },
+          ],
+        },
+      },
+    },
+  } as unknown as DesktopSettingsSnapshot;
+}
+
+function server(
+  overrides: Partial<CodexMcpServerSummary> & { name: string },
+): CodexMcpServerSummary {
+  return {
+    authStatus: "unsupported",
+    tools: [],
+    ...overrides,
+  };
+}
+
+function createDesktopApi(
+  servers: CodexMcpServerSummary[],
+  codexHome = CODEX_HOME,
+): DesktopApi {
+  return {
+    listCodexMcpServers: vi.fn().mockResolvedValue({
+      codexHome,
+      detail: "toolsAndAuthOnly",
+      servers,
+    }),
+    reloadCodexMcpServers: vi.fn().mockResolvedValue({ codexHome, queued: true }),
+    removeCodexMcpServer: vi.fn(),
+    startCodexMcpServerLogin: vi.fn(),
+    onAgentEvent: vi.fn().mockReturnValue(() => {}),
+  } as unknown as DesktopApi;
+}
+
+describe("PluginsSettings", () => {
+  it("shows each server's tools instead of only counting them", async () => {
+    const tools = Array.from({ length: 28 }, (_, index) => `tool_${index + 1}`);
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "datadog", authStatus: "oAuth", tools }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    const toggle = await screen.findByRole("button", { name: /^datadog/ });
+    // Collapsed, the row still only claims a count — the defect was that this
+    // was the *only* thing the pane ever said about 206 tools.
+    expect(screen.queryByText(/tool_1,/)).not.toBeInTheDocument();
+
+    fireEvent.click(toggle);
+
+    expect(screen.getByText(/tool_1, tool_2/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show 16 more Tools" }),
+    ).toBeInTheDocument();
+  });
+
+  it("tells a server that publishes nothing apart from one that never started", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "awsdocs", startupStatus: "ready" }),
+          server({ name: "atlassian", authStatus: "notLoggedIn" }),
+          server({
+            name: "broken",
+            startupStatus: "failed",
+            startupError: "spawn ENOENT",
+          }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    expect(
+      await screen.findByText("ready — no tools published"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("no tools — sign-in required")).toBeInTheDocument();
+    expect(screen.getByText("no tools — failed to start")).toBeInTheDocument();
+    expect(screen.getByText("spawn ENOENT")).toBeInTheDocument();
+  });
+
+  it("names the sign-in state rather than the mechanism", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "datadog", authStatus: "oAuth", tools: ["a"] }),
+          server({ name: "codex_apps", authStatus: "bearerToken", tools: ["b"] }),
+          server({ name: "awsdocs", startupStatus: "ready" }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    expect(await screen.findByText("Signed in")).toBeInTheDocument();
+    expect(screen.getByText("Signed in · token")).toBeInTheDocument();
+    expect(screen.getByText("No sign-in needed")).toBeInTheDocument();
+    expect(screen.queryByText("OAuth")).not.toBeInTheDocument();
+    expect(screen.queryByText("No login")).not.toBeInTheDocument();
+  });
+
+  it("counts health, not configuration", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "a", authStatus: "oAuth", tools: ["t1", "t2"] }),
+          server({ name: "b", authStatus: "notLoggedIn" }),
+          server({
+            name: "c",
+            startupStatus: "failed",
+            startupError: "boom",
+          }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    expect(await screen.findByText("3 servers · 2 tools")).toBeInTheDocument();
+    expect(screen.getByText("1 ready")).toBeInTheDocument();
+    expect(screen.getByText("1 need sign-in")).toBeInTheDocument();
+    expect(screen.getByText("1 failed")).toBeInTheDocument();
+    expect(screen.queryByText("3 configured")).not.toBeInTheDocument();
+  });
+
+  it("offers Sign in only where the operator has something to do", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "signed-in", authStatus: "oAuth", tools: ["t"] }),
+          server({ name: "needs-login", authStatus: "notLoggedIn" }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    await screen.findByRole("button", { name: /^needs-login/ });
+    expect(screen.getAllByRole("button", { name: "Sign in" })).toHaveLength(1);
+  });
+
+  it("keeps Remove out of the collapsed row", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "datadog", authStatus: "oAuth", tools: ["t"] }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    await screen.findByRole("button", { name: /^datadog/ });
+    // It used to render on all twelve rows at full prominence — the most
+    // destructive verb on the pane was also its most available one.
+    expect(screen.queryByRole("button", { name: /^Remove/ })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "More actions for datadog" }),
+    ).toBeInTheDocument();
+  });
+
+  it("filters by server name and by tool name", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "datadog", authStatus: "oAuth", tools: ["aggregate_spans"] }),
+          server({ name: "context7", tools: ["resolve-library-id"] }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    const filter = await screen.findByLabelText("Filter MCP servers and tools");
+
+    fireEvent.change(filter, { target: { value: "context" } });
+    expect(screen.queryByRole("button", { name: /^datadog/ })).not.toBeInTheDocument();
+
+    fireEvent.change(filter, { target: { value: "aggregate_spans" } });
+    expect(screen.getByRole("button", { name: /^datadog/ })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^context7/ })).not.toBeInTheDocument();
+  });
+
+  it("names the Codex profile and build the list came from", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([server({ name: "a", tools: ["t"] })])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    expect(await screen.findByText("~/.codex/profiles/work")).toBeInTheDocument();
+    expect(screen.getByText("PwrAgent managed")).toBeInTheDocument();
+    expect(screen.getByText("pwragent-v0.149.0")).toBeInTheDocument();
+    expect(
+      screen.getByText(/have its own separate sign-ins|separate\s+sign-ins/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not warn about a split that does not exist on System default", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi(
+          [server({ name: "a", tools: ["t"] })],
+          DEFAULT_CODEX_HOME,
+        )}
+        snapshot={createSnapshot({
+          codexHome: DEFAULT_CODEX_HOME,
+          profileName: "",
+        })}
+      />,
+    );
+
+    // System default *is* `~/.codex`, so PwrAgent and a bare `codex` share one
+    // store. Warning about separate sign-ins there would be false.
+    expect(await screen.findByText("System default")).toBeInTheDocument();
+    expect(screen.queryByText(/separate\s+sign-ins/)).not.toBeInTheDocument();
+  });
+
+  it("keeps row health current from startup notifications after mount", async () => {
+    let emit: ((event: { notification: { method: string; params: Record<string, unknown> } }) => void) | undefined;
+    const desktopApi = {
+      ...createDesktopApi([server({ name: "flaky" })]),
+      onAgentEvent: vi.fn((listener: typeof emit) => {
+        emit = listener;
+        return () => {};
+      }),
+    } as unknown as DesktopApi;
+
+    render(<PluginsSettings desktopApi={desktopApi} snapshot={createSnapshot()} />);
+
+    expect(
+      await screen.findByText("no tools reported — not started yet"),
+    ).toBeInTheDocument();
+
+    // The pane used to consume these only while a sign-in was in flight, so a
+    // server that died on launch stayed indistinguishable from a quiet one.
+    emit?.({
+      notification: {
+        method: "mcpServer/startupStatus/updated",
+        params: { name: "flaky", status: "failed", error: "connect ECONNREFUSED" },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("no tools — failed to start")).toBeInTheDocument();
+    });
+    expect(screen.getByText("connect ECONNREFUSED")).toBeInTheDocument();
+    const counts = screen.getByText("1 failed");
+    expect(within(counts).queryByText("0")).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/mcp-server-health.test.ts
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/mcp-server-health.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import type { CodexMcpServerSummary } from "@pwragent/shared";
+import {
+  countMcpServerHealth,
+  describeMcpServerTools,
+  readMcpServerHealth,
+} from "../mcp-server-health";
+
+function server(
+  overrides: Partial<CodexMcpServerSummary> & { name: string },
+): CodexMcpServerSummary {
+  return { authStatus: "unsupported", tools: [], ...overrides };
+}
+
+describe("readMcpServerHealth", () => {
+  it("treats a missing startup report as unknown, not ready", () => {
+    // `startupStatus` arrives on a notification the pane may never have been
+    // mounted to receive. Calling that "ready" is what made a dead server and
+    // a healthy one identical.
+    expect(readMcpServerHealth(server({ name: "quiet" }))).toBe("unknown");
+  });
+
+  it("accepts published tools as proof the server answered", () => {
+    expect(readMcpServerHealth(server({ name: "a", tools: ["t"] }))).toBe("ready");
+  });
+
+  it("puts sign-in ahead of a failed start", () => {
+    expect(
+      readMcpServerHealth(
+        server({ name: "a", authStatus: "notLoggedIn", startupStatus: "failed" }),
+      ),
+    ).toBe("needsSignIn");
+  });
+
+  it("reports a cancelled start as failed", () => {
+    expect(
+      readMcpServerHealth(server({ name: "a", startupStatus: "cancelled" })),
+    ).toBe("failed");
+  });
+
+  it("does not call a server mid-start ready on the strength of its tools", () => {
+    expect(
+      readMcpServerHealth(
+        server({ name: "a", startupStatus: "starting", tools: ["t"] }),
+      ),
+    ).toBe("unknown");
+  });
+});
+
+describe("describeMcpServerTools", () => {
+  it("separates the two ways a server can have no tools", () => {
+    const quiet = server({ name: "awsdocs", startupStatus: "ready" });
+    const broken = server({ name: "atlassian", authStatus: "notLoggedIn" });
+    expect(describeMcpServerTools(quiet, readMcpServerHealth(quiet)))
+      .toBe("ready — no tools published");
+    expect(describeMcpServerTools(broken, readMcpServerHealth(broken)))
+      .toBe("no tools — sign-in required");
+  });
+
+  it("counts in singular and plural", () => {
+    const one = server({ name: "a", tools: ["t"] });
+    const many = server({ name: "b", tools: ["t", "u"] });
+    expect(describeMcpServerTools(one, "ready")).toBe("1 tool");
+    expect(describeMcpServerTools(many, "ready")).toBe("2 tools");
+  });
+});
+
+describe("countMcpServerHealth", () => {
+  it("counts health and tools rather than configuration", () => {
+    expect(
+      countMcpServerHealth([
+        server({ name: "a", authStatus: "oAuth", tools: ["t1", "t2"] }),
+        server({ name: "b", authStatus: "notLoggedIn" }),
+        server({ name: "c", startupStatus: "failed" }),
+        server({ name: "d" }),
+      ]),
+    ).toEqual({
+      total: 4,
+      tools: 2,
+      ready: 1,
+      needsSignIn: 1,
+      failed: 1,
+      unknown: 1,
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/mcp-server-health.test.ts
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/mcp-server-health.test.ts
@@ -39,11 +39,13 @@ describe("readMcpServerHealth", () => {
   });
 
   it("does not call a server mid-start ready on the strength of its tools", () => {
+    // Nor `unknown`: folding mid-start into that bucket made the pane say
+    // "not started yet" about a server that was starting right then.
     expect(
       readMcpServerHealth(
         server({ name: "a", startupStatus: "starting", tools: ["t"] }),
       ),
-    ).toBe("unknown");
+    ).toBe("starting");
   });
 });
 
@@ -55,6 +57,12 @@ describe("describeMcpServerTools", () => {
       .toBe("ready — no tools published");
     expect(describeMcpServerTools(broken, readMcpServerHealth(broken)))
       .toBe("no tools — sign-in required");
+  });
+
+  it("says a starting server is starting rather than idle", () => {
+    const starting = server({ name: "a", startupStatus: "starting" });
+    expect(describeMcpServerTools(starting, readMcpServerHealth(starting)))
+      .toBe("starting…");
   });
 
   it("counts in singular and plural", () => {
@@ -78,6 +86,7 @@ describe("countMcpServerHealth", () => {
       total: 4,
       tools: 2,
       ready: 1,
+      starting: 0,
       needsSignIn: 1,
       failed: 1,
       unknown: 1,

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -6173,12 +6173,21 @@ describe("SettingsScreen", () => {
       .closest<HTMLElement>(".settings-mcp-row");
     expect(datadogRow).not.toBeNull();
     expect(atlassianRow).not.toBeNull();
-    fireEvent.click(within(datadogRow!).getByRole("button", { name: "Relogin" }));
+
+    // Both servers hold OAuth credentials, so neither row carries a bare
+    // "Sign in" button — that is promoted only for `notLoggedIn`. Signing in
+    // again, and removing, live in the row's overflow menu so the destructive
+    // verb is not the pane's most available control.
+    fireEvent.click(
+      within(datadogRow!).getByRole("button", { name: "More actions for datadog" }),
+    );
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Sign in to datadog again" }),
+    );
     expect(
-      within(atlassianRow!).getByRole("button", { name: "Relogin" }),
-    ).toBeDisabled();
-    expect(
-      within(atlassianRow!).getByRole("button", { name: "Remove" }),
+      within(atlassianRow!).getByRole("button", {
+        name: "More actions for atlassian",
+      }),
     ).toBeDisabled();
     await waitFor(() => {
       expect(startCodexMcpServerLogin).toHaveBeenCalledWith({
@@ -6202,7 +6211,9 @@ describe("SettingsScreen", () => {
       });
     });
     expect(
-      within(atlassianRow!).getByRole("button", { name: "Relogin" }),
+      within(atlassianRow!).getByRole("button", {
+        name: "More actions for atlassian",
+      }),
     ).toBeDisabled();
     await act(async () => {
       agentEventListener?.({
@@ -6214,11 +6225,14 @@ describe("SettingsScreen", () => {
       });
     });
     expect(await screen.findByText(
-      "datadog login completed and its row was refreshed.",
+      "datadog signed in and its row was refreshed.",
     )).toBeInTheDocument();
     expect(reloadCodexMcpServers).toHaveBeenCalledWith({ codexHome });
 
-    fireEvent.click(within(datadogRow!).getByRole("button", { name: "Remove" }));
+    fireEvent.click(
+      within(datadogRow!).getByRole("button", { name: "More actions for datadog" }),
+    );
+    fireEvent.click(screen.getByRole("menuitem", { name: "Remove datadog" }));
     fireEvent.click(screen.getByRole("button", { name: "Remove server" }));
     await waitFor(() => {
       expect(removeCodexMcpServer).toHaveBeenCalledWith({
@@ -6231,16 +6245,21 @@ describe("SettingsScreen", () => {
     });
 
     fireEvent.click(
-      within(atlassianRow!).getByRole("button", { name: "Relogin" }),
+      within(atlassianRow!).getByRole("button", {
+        name: "More actions for atlassian",
+      }),
     );
-    expect(await screen.findByRole("button", { name: "Cancel login" }))
+    fireEvent.click(
+      screen.getByRole("menuitem", { name: "Sign in to atlassian again" }),
+    );
+    expect(await screen.findByRole("button", { name: "Cancel sign-in" }))
       .toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Cancel login" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel sign-in" }));
     expect(await screen.findByText(
-      "Stopped waiting for login. You can try again.",
+      "Stopped waiting for sign-in. You can try again.",
     )).toBeInTheDocument();
     expect(
-      within(datadogRow!).getByRole("button", { name: "Relogin" }),
+      within(datadogRow!).getByRole("button", { name: "More actions for datadog" }),
     ).toBeEnabled();
   });
 
@@ -6291,9 +6310,12 @@ describe("SettingsScreen", () => {
       "Codex profile selection changed to work. Restart PwrAgent before managing MCP servers for that profile.",
     )).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Reload config" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Relogin" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled();
-    expect(screen.getByText("/home/example/.codex")).toBeInTheDocument();
+    // Every mutation is behind the row overflow now, so disabling that button
+    // is what closes off Sign in and Remove together.
+    expect(
+      screen.getByRole("button", { name: "More actions for atlassian" }),
+    ).toBeDisabled();
+    expect(screen.getByText("~/.codex")).toBeInTheDocument();
   });
 
   it("shows when messaging is disabled by a runtime override", () => {

--- a/apps/desktop/src/renderer/src/features/settings/mcp-server-health.ts
+++ b/apps/desktop/src/renderer/src/features/settings/mcp-server-health.ts
@@ -1,0 +1,76 @@
+import type { CodexMcpServerSummary } from "@pwragent/shared";
+
+/**
+ * What the pane can honestly say about one MCP server.
+ *
+ * Sign-in state and startup state are separate axes and the pane must not let
+ * one impersonate the other: `authStatus` reports a *stored credential*, not a
+ * live probe, so an expired refresh token still reads as `oAuth` until a start
+ * attempt fails. `startupStatus` is the proof.
+ *
+ * `unknown` exists because `startupStatus` is populated from
+ * `mcpServer/startupStatus/updated` notifications, and a pane opened after
+ * startup has simply never seen one. Reporting that as "ready" would make a
+ * dead server and a healthy one identical — which is the defect this replaces.
+ */
+export type McpServerHealth = "ready" | "needsSignIn" | "failed" | "unknown";
+
+export function readMcpServerHealth(
+  server: CodexMcpServerSummary,
+): McpServerHealth {
+  // Sign-in outranks a failed start: when a server needs credentials the
+  // failure is explained, and signing in is the action either way.
+  if (server.authStatus === "notLoggedIn") return "needsSignIn";
+  if (server.startupStatus === "failed" || server.startupStatus === "cancelled") {
+    return "failed";
+  }
+  if (server.startupStatus === "ready") return "ready";
+  if (server.startupStatus === "starting") return "unknown";
+  // No startup report at all. Published tools are the only proof left that the
+  // server answered; without them the pane does not know.
+  return server.tools.length > 0 ? "ready" : "unknown";
+}
+
+export type McpServerHealthCounts = {
+  total: number;
+  tools: number;
+  ready: number;
+  needsSignIn: number;
+  failed: number;
+  unknown: number;
+};
+
+export function countMcpServerHealth(
+  servers: readonly CodexMcpServerSummary[],
+): McpServerHealthCounts {
+  const counts: McpServerHealthCounts = {
+    total: servers.length,
+    tools: 0,
+    ready: 0,
+    needsSignIn: 0,
+    failed: 0,
+    unknown: 0,
+  };
+  for (const server of servers) {
+    counts.tools += server.tools.length;
+    counts[readMcpServerHealth(server)] += 1;
+  }
+  return counts;
+}
+
+/**
+ * The line that replaces a bare "0 tools" — the count alone made a server that
+ * failed to start and one that simply publishes nothing look the same.
+ */
+export function describeMcpServerTools(
+  server: CodexMcpServerSummary,
+  health: McpServerHealth,
+): string {
+  if (server.tools.length > 0) {
+    return `${server.tools.length} ${server.tools.length === 1 ? "tool" : "tools"}`;
+  }
+  if (health === "needsSignIn") return "no tools — sign-in required";
+  if (health === "failed") return "no tools — failed to start";
+  if (health === "ready") return "ready — no tools published";
+  return "no tools reported — not started yet";
+}

--- a/apps/desktop/src/renderer/src/features/settings/mcp-server-health.ts
+++ b/apps/desktop/src/renderer/src/features/settings/mcp-server-health.ts
@@ -13,7 +13,12 @@ import type { CodexMcpServerSummary } from "@pwragent/shared";
  * startup has simply never seen one. Reporting that as "ready" would make a
  * dead server and a healthy one identical — which is the defect this replaces.
  */
-export type McpServerHealth = "ready" | "needsSignIn" | "failed" | "unknown";
+export type McpServerHealth =
+  | "ready"
+  | "starting"
+  | "needsSignIn"
+  | "failed"
+  | "unknown";
 
 export function readMcpServerHealth(
   server: CodexMcpServerSummary,
@@ -25,7 +30,9 @@ export function readMcpServerHealth(
     return "failed";
   }
   if (server.startupStatus === "ready") return "ready";
-  if (server.startupStatus === "starting") return "unknown";
+  // Mid-start is its own state. Folding it into `unknown` made the pane say
+  // "not started yet" about a server that is starting right now.
+  if (server.startupStatus === "starting") return "starting";
   // No startup report at all. Published tools are the only proof left that the
   // server answered; without them the pane does not know.
   return server.tools.length > 0 ? "ready" : "unknown";
@@ -35,6 +42,7 @@ export type McpServerHealthCounts = {
   total: number;
   tools: number;
   ready: number;
+  starting: number;
   needsSignIn: number;
   failed: number;
   unknown: number;
@@ -47,6 +55,7 @@ export function countMcpServerHealth(
     total: servers.length,
     tools: 0,
     ready: 0,
+    starting: 0,
     needsSignIn: 0,
     failed: 0,
     unknown: 0,
@@ -69,6 +78,7 @@ export function describeMcpServerTools(
   if (server.tools.length > 0) {
     return `${server.tools.length} ${server.tools.length === 1 ? "tool" : "tools"}`;
   }
+  if (health === "starting") return "starting…";
   if (health === "needsSignIn") return "no tools — sign-in required";
   if (health === "failed") return "no tools — failed to start";
   if (health === "ready") return "ready — no tools published";

--- a/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/McpInventoryPanel.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type {
-  CodexMcpAuthStatus,
   CodexMcpInventoryDetail,
   CodexMcpServerSummary,
   NavigationThreadSummary,
 } from "@pwragent/shared";
+import { describeMcpAuthStatus } from "@pwragent/shared";
+import { McpInventoryLine } from "../../components/McpInventoryLine";
 import { CheckIcon, CloseIcon } from "../../icons";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
@@ -241,25 +242,28 @@ function McpServerRow(props: {
     <li className="mcp-inventory-panel__server">
       <div className="mcp-inventory-panel__server-header">
         <span className="mcp-inventory-panel__server-name">{props.server.name}</span>
-        <span className="mcp-inventory-panel__auth">
-          {formatAuthStatus(props.server.authStatus)}
+        <span
+          className="mcp-inventory-panel__auth"
+          title={describeMcpAuthStatus(props.server.authStatus).description}
+        >
+          {describeMcpAuthStatus(props.server.authStatus).label}
         </span>
       </div>
-      <InventoryLine
+      <McpInventoryLine
         label="Tools"
         previewLimit={TOOL_PREVIEW_LIMIT}
         values={props.server.tools}
       />
       {props.detail === "full" ? (
         <>
-          <InventoryLine
+          <McpInventoryLine
             label="Resources"
             previewLimit={CATALOG_PREVIEW_LIMIT}
             values={(props.server.resources ?? []).map((resource) =>
               `${resource.title ?? resource.name} (${resource.uri})`
             )}
           />
-          <InventoryLine
+          <McpInventoryLine
             label="Templates"
             previewLimit={CATALOG_PREVIEW_LIMIT}
             values={(props.server.resourceTemplates ?? []).map((template) =>
@@ -270,63 +274,4 @@ function McpServerRow(props: {
       ) : null}
     </li>
   );
-}
-
-function InventoryLine(props: {
-  label: string;
-  previewLimit: number;
-  values: string[];
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const hasOverflow = props.values.length > props.previewLimit;
-  const visibleValues = expanded || !hasOverflow
-    ? props.values
-    : props.values.slice(0, props.previewLimit);
-  const hiddenCount = props.values.length - visibleValues.length;
-
-  return (
-    <div className="mcp-inventory-panel__line">
-      <span className="mcp-inventory-panel__line-label">
-        {props.label}
-        <span className="mcp-inventory-panel__line-count">
-          {` · ${props.values.length}`}
-        </span>
-      </span>
-      <div className="mcp-inventory-panel__line-value">
-        <span className="mcp-inventory-panel__line-items">
-          {visibleValues.length > 0 ? visibleValues.join(", ") : "None"}
-        </span>
-        {hasOverflow ? (
-          <button
-            type="button"
-            className="mcp-inventory-panel__line-toggle"
-            aria-expanded={expanded}
-            aria-label={
-              expanded
-                ? `Show fewer ${props.label}`
-                : `Show ${hiddenCount} more ${props.label}`
-            }
-            onClick={() => setExpanded((current) => !current)}
-          >
-            {expanded ? "Show less" : `Show ${hiddenCount} more`}
-          </button>
-        ) : null}
-      </div>
-    </div>
-  );
-}
-
-function formatAuthStatus(status: CodexMcpAuthStatus): string {
-  switch (status) {
-    case "unknown":
-      return "Authentication unknown";
-    case "notLoggedIn":
-      return "Sign-in required";
-    case "bearerToken":
-      return "Bearer token";
-    case "oAuth":
-      return "OAuth";
-    case "unsupported":
-      return "No authentication";
-  }
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/mcp-inventory-panel.test.tsx
@@ -55,7 +55,9 @@ describe("McpInventoryPanel", () => {
     expect(screen.getByText("Reading MCP inventory…")).toBeInTheDocument();
     expect(await screen.findByText("atlassian-rovo")).toBeInTheDocument();
     expect(screen.getByText("fetch, search")).toBeInTheDocument();
-    expect(screen.getByText("OAuth")).toBeInTheDocument();
+    // Shared vocabulary (`formatMcpAuthStatus`): the chip names the state the
+    // operator is in, not the protocol that produced it.
+    expect(screen.getByText("Signed in")).toBeInTheDocument();
     expect(listThreadMcpServers).toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-1",
@@ -87,7 +89,7 @@ describe("McpInventoryPanel", () => {
     );
 
     expect(await screen.findByText("offline-local-server")).toBeInTheDocument();
-    expect(screen.getByText("Authentication unknown")).toBeInTheDocument();
+    expect(screen.getByText("Sign-in state unknown")).toBeInTheDocument();
   });
 
   it("holds confirmed reload feedback and explains the next-turn boundary", async () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -11143,6 +11143,12 @@ textarea,
   background: var(--status-ok);
 }
 
+/* Mid-start is neither healthy nor broken. `--info-text` is the in-progress
+   dot color the transcript and messaging surfaces already use. */
+.settings-mcp-row[data-health="starting"] .settings-mcp-row__health {
+  background: var(--info-text);
+}
+
 .settings-mcp-row[data-health="needsSignIn"] .settings-mcp-row__health {
   background: var(--status-warning);
 }
@@ -11222,8 +11228,7 @@ textarea,
 }
 
 .settings-mcp-row__tools {
-  display: grid;
-  gap: 4px;
+  align-items: baseline;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -10961,27 +10961,70 @@ textarea,
   flex: 0 0 auto;
 }
 
-.settings-plugin-profile {
+/* Which Codex profile these MCP servers belong to is the sentence that
+   explains every surprise on this pane, so it gets a banner rather than the
+   11px grey footnote it used to be. */
+.settings-mcp-scope {
   display: grid;
-  grid-template-columns: auto auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: baseline;
-  gap: 8px;
+  gap: 4px 12px;
   margin-bottom: 12px;
-  color: var(--text-muted);
-  font-size: 11px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-row-active);
 }
 
-.settings-plugin-profile strong {
-  color: var(--text-secondary);
+.settings-mcp-scope__key {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.settings-mcp-scope__value {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+
+.settings-mcp-scope__value strong {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
   font-size: 12px;
 }
 
-.settings-plugin-profile code {
+.settings-mcp-scope__value code {
   overflow: hidden;
   color: var(--text-muted);
   font-family: var(--font-mono);
+  font-size: 11px;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.settings-mcp-scope__note {
+  grid-column: 1 / -1;
+  margin: 4px 0 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.settings-mcp-scope__note strong {
+  color: var(--text-primary);
+}
+
+.settings-mcp-scope__note code {
+  color: var(--accent-bright);
+  font-family: var(--font-mono);
+  font-size: 11px;
 }
 
 .settings-plugin-notice {
@@ -11022,62 +11065,171 @@ textarea,
   gap: 8px;
 }
 
-.settings-mcp-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+.settings-mcp-toolbar {
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.settings-mcp-filter {
+  flex: 1 1 220px;
+  min-width: 0;
+  padding: 7px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  background: var(--bg-input);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 12px;
+}
+
+.settings-mcp-filter::placeholder {
+  color: var(--text-muted);
+}
+
+.settings-mcp-toolbar__counts {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 4px;
+}
+
+.settings-mcp-row {
+  padding: 8px 12px;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
   background: var(--bg-panel-elevated);
 }
 
-.settings-mcp-row__body {
+.settings-mcp-row[data-health="failed"] {
+  border-color: var(--danger-border);
+}
+
+.settings-mcp-row__main {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* The row is a disclosure: the whole name/count run opens the tool drawer,
+   so the count stops being the only thing the pane says about a server. */
+.settings-mcp-row__toggle {
+  display: flex;
+  flex: 1;
+  align-items: baseline;
+  gap: 9px;
   min-width: 0;
+  padding: 4px 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
 }
 
-.settings-mcp-row__body strong,
-.settings-mcp-row__body > span {
-  display: block;
+.settings-mcp-row__health {
+  flex: 0 0 auto;
+  align-self: center;
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--text-subtle);
 }
 
-.settings-mcp-row__body strong {
+.settings-mcp-row[data-health="ready"] .settings-mcp-row__health {
+  background: var(--status-ok);
+}
+
+.settings-mcp-row[data-health="needsSignIn"] .settings-mcp-row__health {
+  background: var(--status-warning);
+}
+
+.settings-mcp-row[data-health="failed"] .settings-mcp-row__health {
+  background: var(--status-error);
+}
+
+/* Standard inline disclosure chevron (see .transcript-activity__chevron): an
+   unfilled border "V", right when collapsed, down when expanded. The filled
+   caret is the sidebar navigation-tree vocabulary and does not belong here. */
+.settings-mcp-row__chevron {
+  display: inline-block;
+  flex: 0 0 auto;
+  align-self: center;
+  width: 7px;
+  height: 7px;
+  border-right: 1.5px solid var(--text-muted);
+  border-bottom: 1.5px solid var(--text-muted);
+  transform: rotate(-45deg);
+  transition: transform 120ms ease;
+}
+
+.settings-mcp-row__toggle[aria-expanded="true"] .settings-mcp-row__chevron {
+  transform: rotate(45deg);
+}
+
+.settings-mcp-row__name {
   overflow: hidden;
   color: var(--text-primary);
   font-family: var(--font-mono);
   font-size: 13px;
+  font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.settings-mcp-row__body > span {
-  margin-top: 3px;
+.settings-mcp-row__meta {
   color: var(--text-muted);
-  font-size: 11px;
+  font-size: 11.5px;
+  white-space: nowrap;
 }
 
 .settings-mcp-row__error {
-  margin: 6px 0 0;
+  margin: 4px 0 0 26px;
   color: var(--danger-text);
   font-size: 11px;
   line-height: 1.35;
   overflow-wrap: anywhere;
 }
 
+.settings-mcp-row[data-health="needsSignIn"] .settings-mcp-row__error {
+  color: var(--text-muted);
+}
+
 .settings-mcp-row__chips,
 .settings-mcp-row__actions {
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   gap: 6px;
 }
 
-.settings-mcp-row__remove {
-  color: var(--danger-text);
+/* Remove lives behind this menu rather than on every row: it was the most
+   consistently available control on the pane, and it is the destructive one. */
+.settings-mcp-row__more {
+  min-width: 28px;
+  padding: 0 6px;
+  color: var(--text-muted);
+  line-height: 1;
 }
 
-.settings-mcp-row__remove:hover:not([disabled]) {
-  background: var(--danger-soft);
+.settings-mcp-row__drawer {
+  margin: 8px 0 2px 26px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.settings-mcp-row__tools {
+  display: grid;
+  gap: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-mcp-row__chevron {
+    transition: none;
+  }
 }
 
 .settings-archive-empty,

--- a/packages/shared/src/__tests__/mcp-auth-status.test.ts
+++ b/packages/shared/src/__tests__/mcp-auth-status.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import type { CodexMcpAuthStatus } from "../contracts/agent";
+import { describeMcpAuthStatus, formatMcpAuthStatus } from "../mcp-auth-status";
+
+const ALL_STATUSES: CodexMcpAuthStatus[] = [
+  "unknown",
+  "unsupported",
+  "notLoggedIn",
+  "bearerToken",
+  "oAuth",
+];
+
+describe("formatMcpAuthStatus", () => {
+  // Both MCP surfaces used to carry their own copy of this switch and had
+  // already drifted ("No login" vs "No authentication"). Asserting the full
+  // enum here means a sixth protocol value cannot ship as a silent blank.
+  it("labels every protocol value", () => {
+    for (const status of ALL_STATUSES) {
+      expect(formatMcpAuthStatus(status)).toMatch(/\S/);
+      expect(describeMcpAuthStatus(status).description).toMatch(/\S/);
+    }
+  });
+
+  it("names the operator's state rather than the mechanism", () => {
+    expect(formatMcpAuthStatus("oAuth")).toBe("Signed in");
+    expect(formatMcpAuthStatus("bearerToken")).toBe("Signed in · token");
+  });
+
+  it("does not describe a server that needs no auth as signed out", () => {
+    expect(formatMcpAuthStatus("unsupported")).toBe("No sign-in needed");
+  });
+
+  it("warns only where the operator has something to do", () => {
+    expect(describeMcpAuthStatus("notLoggedIn").tone).toBe("warn");
+    for (const status of ALL_STATUSES.filter((value) => value !== "notLoggedIn")) {
+      expect(describeMcpAuthStatus(status).tone).not.toBe("warn");
+    }
+  });
+
+  it("offers sign-in exactly where the pane can start one", () => {
+    const canSignIn = ALL_STATUSES.filter(
+      (status) => describeMcpAuthStatus(status).canSignIn,
+    );
+    expect(canSignIn).toEqual(["notLoggedIn", "oAuth"]);
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -33,6 +33,7 @@ export * from "./contracts/thread-tools";
 export * from "./contracts/thread-search";
 export * from "./messaging-contact-labels";
 export * from "./messaging-id-validation";
+export * from "./mcp-auth-status";
 export * from "./profile-names";
 export * from "./directory-pins";
 export * from "./directory-navigation";

--- a/packages/shared/src/mcp-auth-status.ts
+++ b/packages/shared/src/mcp-auth-status.ts
@@ -1,0 +1,77 @@
+import type { CodexMcpAuthStatus } from "./contracts/agent";
+
+/**
+ * One wording for the Codex MCP sign-in enum, shared by every surface that
+ * renders it: the Settings → Plugins → MCPs pane and the thread rail's MCP
+ * inventory panel.
+ *
+ * Two rules the previous per-surface copies broke:
+ *
+ * - Each label names the **state the operator is in**, never the protocol
+ *   mechanism. `oAuth` used to render as "OAuth", which answers a question
+ *   nobody asked; it means Codex holds OAuth credentials, so it reads
+ *   "Signed in".
+ * - `unsupported` means the server authenticates nobody. It used to render as
+ *   "No login", which scans as *not logged in* — the opposite of the truth,
+ *   and the majority state on a typical profile.
+ */
+export type McpAuthStatusPresentation = {
+  /** Chip text. */
+  label: string;
+  /** Longer sentence for a title/tooltip. */
+  description: string;
+  /**
+   * Chip tone. `notLoggedIn` is the only state that needs the operator, so it
+   * is the only one that earns a warning; the rest are healthy or neutral. A
+   * failed *startup* is a separate axis and owns the danger tone.
+   */
+  tone: "ok" | "warn" | "neutral";
+  /** Whether this state can start an interactive sign-in. */
+  canSignIn: boolean;
+};
+
+const PRESENTATIONS: Record<CodexMcpAuthStatus, McpAuthStatusPresentation> = {
+  oAuth: {
+    label: "Signed in",
+    description:
+      "Signed in with OAuth. PwrAgent proves the credential when the server next starts.",
+    tone: "ok",
+    canSignIn: true,
+  },
+  bearerToken: {
+    label: "Signed in · token",
+    description:
+      "A bearer token is configured for this server. It is a working credential, just not an interactive one.",
+    tone: "ok",
+    canSignIn: false,
+  },
+  notLoggedIn: {
+    label: "Sign-in required",
+    description: "This server needs an interactive sign-in before it can publish tools.",
+    tone: "warn",
+    canSignIn: true,
+  },
+  unsupported: {
+    label: "No sign-in needed",
+    description: "This server does not authenticate. Nothing to sign in to.",
+    tone: "neutral",
+    canSignIn: false,
+  },
+  unknown: {
+    label: "Sign-in state unknown",
+    description:
+      "The running Codex build did not report a sign-in state for this server.",
+    tone: "neutral",
+    canSignIn: false,
+  },
+};
+
+export function describeMcpAuthStatus(
+  status: CodexMcpAuthStatus,
+): McpAuthStatusPresentation {
+  return PRESENTATIONS[status];
+}
+
+export function formatMcpAuthStatus(status: CodexMcpAuthStatus): string {
+  return describeMcpAuthStatus(status).label;
+}


### PR DESCRIPTION
## Summary

Settings → Plugins → MCPs counted 206 tools and showed none of them, and printed the OAuth *mechanism* where the operator was looking for a *state*. Steps 1–7 of the design review below.

- **Show the tools.** `McpServerRow` rendered `{tools.length} tools` as dead text while the thread rail rendered the identical `CodexMcpServerSummary.tools` payload expandably. `InventoryLine` moves to a shared `McpInventoryLine`; the row becomes a disclosure. No contract or protocol change — the array was already fetched.
- **One vocabulary**, exported from `@pwragent/shared`. Two `formatAuthStatus` copies had already drifted ("No login" here, "No authentication" in the rail). Each label now names the state the operator is in: `oAuth` reads **Signed in**, and `unsupported` reads **No sign-in needed** rather than "No login" — which scanned as the opposite of its meaning on seven of the twelve rows in the report.
- **Separate the credential from its proof.** `authStatus` reports a stored credential, never a live probe, so the health dot comes from `startupStatus` and the chip from `authStatus`. The pane now consumes `mcpServer/startupStatus/updated` from mount rather than only while a sign-in is in flight — without that, a server that died on launch and one that simply publishes nothing were both "0 tools".
- **Header counts health, not configuration:** `12 servers · 206 tools` with ready / need-sign-in / failed, replacing `12 configured`.
- **Name the scope.** Which Codex profile owns these servers is the sentence that explains every surprise on this pane, and it was an 11px grey footnote. It becomes a banner carrying the profile, its `CODEX_HOME`, the managed Codex build from `runtime.tokenMiser.managedCodex`, and — only for a named profile — that a `codex` run outside PwrAgent falls back to `~/.codex` with its own sign-ins. Suppressed on System default, which *is* `~/.codex` and has no split to warn about.
- **Rebuild the row, demote Remove.** Name and actions sat at opposite edges with ~900px of nothing between at 1440px. Remove — the pane's most destructive verb — was on every row unconditionally and moves into an overflow menu; Sign in is promoted only where `notLoggedIn`. Adds a filter over server and tool names.

## Notes

- The chevron uses the shared **unfilled** inline-disclosure language, not the sidebar's filled caret. `chevron-contract.test.ts` caught the first attempt.
- Two `settings-screen` tests drove the old row verbs and now drive the overflow menu; the behaviours they protect (sign-in → reload → notice, remove, cancel, disabled-while-pending) are unchanged.
- Design review: Claude Design → **PwrAgent** → *Settings Plugins MCPs UX Review*. The review also proposes a second, read-only list for the System-default profile's MCP servers. **That is not in this PR** — every fact on the current list comes from the one running app-server bound to one `CODEX_HOME`, and the repo's Codex data boundary rules out reading `~/.codex/config.toml` to fake it, so it needs a boundary-safe names-only source first.
- Tool *descriptions* remain out of scope but are one contract change away, not one protocol change away: `readMcpServerStatusPage` receives `tools` as an object keyed by tool name and discards the values via `Object.keys(tools).sort(...)`.

## Verification

- `pnpm test` — 672 files, 9,889 passed, 6 skipped
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:codex-storage`, `pnpm lint:colors`
- Headless render probe of the new row: status dots resolve to `--status-ok` / `--status-warning` / `--status-error`, the chevron rotates -45°→45°, the disclosure toggle claims 728 of 920px (the dead middle is gone), and the pane does not overflow horizontally.

New coverage: `mcp-auth-status.test.ts` (all five protocol values, so a sixth cannot ship as a silent blank), `mcp-server-health.test.ts`, `PluginsSettings.test.tsx` (10 cases, one per defect above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)