### PR TITLE
fix(desktop): keep retained work with its transcript turn

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -387,22 +387,9 @@ describe("codex environment runtime", () => {
 
   it("strips parent Electron runtime variables from detached actions", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-electron-"));
-    const shellPath = path.join(root, "test-shell.sh");
     const outputPath = path.join(root, "env.txt");
 
     try {
-      await writeFile(
-        shellPath,
-        [
-          "#!/bin/sh",
-          'if [ "$1" != "-lc" ]; then exit 64; fi',
-          'exec /bin/sh -c "$2"',
-          "",
-        ].join("\n"),
-        "utf8",
-      );
-      await chmod(shellPath, 0o755);
-
       const result = await startLocalCodexEnvironmentAction({
         actionId: "start-dev",
         runId: "test-run-3",
@@ -411,9 +398,10 @@ describe("codex environment runtime", () => {
           ELECTRON_RENDERER_URL: "http://127.0.0.1:5173",
           ELECTRON_RUN_AS_NODE: "1",
           PWRAGENT_TEST_HYDRATED_ENV: "hydrated",
-          // On Windows the `.sh` passthrough script isn't directly spawnable;
-          // use Git bash. Electron-var stripping is shell-independent.
-          SHELL: spawnableShell(shellPath),
+          // Electron-var stripping is shell-independent. Use a stable shell
+          // instead of executing a just-written fixture, which can race with
+          // file closure on Linux and fail spawn with ETXTBSY.
+          SHELL: spawnableShell("/bin/sh"),
           VITE_DEV_SERVER_URL: "http://127.0.0.1:5174",
         },
         runtime: {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -798,9 +798,10 @@ function normalizeNotificationDuration(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function buildCompletedLiveTurnMetadata(params: {
+function buildTerminalLiveTurnMetadata(params: {
   activeTurnStartedAt?: number;
   fallbackTurnId?: string;
+  status: Exclude<AppServerThreadTurnMetadata["status"], "in_progress" | undefined>;
   turn?: {
     id?: unknown;
     startedAt?: unknown;
@@ -819,7 +820,7 @@ function buildCompletedLiveTurnMetadata(params: {
       normalizeNotificationTimestamp(params.turn?.startedAt) ?? params.activeTurnStartedAt,
     completedAt: normalizeNotificationTimestamp(params.turn?.completedAt) ?? Date.now(),
     durationMs: normalizeNotificationDuration(params.turn?.durationMs),
-    status: "completed",
+    status: params.status,
   });
 }
 
@@ -2728,9 +2729,35 @@ export function ThreadView(props: ThreadViewProps) {
         // that turn's work instead of dropping it until a replay refresh
         // happens to re-fetch it. Protocol/usage entries are status/cost,
         // not edits, so they're still cleared.
+        const terminalTurnRecord =
+          typeof event.notification.params.turn === "object" &&
+          event.notification.params.turn !== null
+            ? event.notification.params.turn
+            : undefined;
+        const terminalTurn = buildTerminalLiveTurnMetadata({
+          activeTurnStartedAt: props.activeTurnStartedAt,
+          fallbackTurnId:
+            props.activeTurnId ??
+            (typeof event.notification.params.turnId === "string"
+              ? event.notification.params.turnId
+              : undefined),
+          status:
+            event.notification.method === "turn/failed"
+              ? "failed"
+              : "cancelled",
+          turn: terminalTurnRecord,
+        });
+        const liveTerminalTurn =
+          terminalTurn && props.activeTurnId && terminalTurn.id !== props.activeTurnId
+            ? { ...terminalTurn, id: props.activeTurnId }
+            : terminalTurn;
         const interruptedActivity = pendingActivityEntryRef.current;
         if (interruptedActivity && activityHasFileDiff(interruptedActivity)) {
-          deferLiveTranscriptEntry(interruptedActivity);
+          deferLiveTranscriptEntry(
+            liveTerminalTurn
+              ? { ...interruptedActivity, turn: liveTerminalTurn }
+              : interruptedActivity,
+          );
         }
         setPendingActivityEntry(undefined);
         setPendingProtocolActivityEntry(undefined);
@@ -2744,13 +2771,14 @@ export function ThreadView(props: ThreadViewProps) {
           event.notification.params.turn !== null
             ? event.notification.params.turn
             : undefined;
-        const turn = buildCompletedLiveTurnMetadata({
+        const turn = buildTerminalLiveTurnMetadata({
           activeTurnStartedAt: props.activeTurnStartedAt,
           fallbackTurnId:
             props.activeTurnId ??
             (typeof event.notification.params.turnId === "string"
               ? event.notification.params.turnId
               : undefined),
+          status: "completed",
           turn: completedTurnRecord,
         });
         const liveTurn =

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -6585,97 +6585,120 @@ describe("ThreadView", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("retains a failed turn's edits in the rail instead of dropping them", async () => {
-    let agentEventHandler: ((event: AgentEvent) => void) | undefined;
-    const liveDiff = [
-      "diff --git a/src/example.ts b/src/example.ts",
-      "--- a/src/example.ts",
-      "+++ b/src/example.ts",
-      "@@ -1,1 +1,2 @@",
-      " existing line",
-      "+added before the failure",
-    ].join("\n");
+  it.each(["failed", "cancelled"] as const)(
+    "retains a %s turn's edits with terminal turn metadata",
+    async (status) => {
+      let agentEventHandler: ((event: AgentEvent) => void) | undefined;
+      const onPublished = vi.fn();
+      const threadId = `thread-${status}`;
+      const liveDiff = [
+        "diff --git a/src/example.ts b/src/example.ts",
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1,1 +1,2 @@",
+        " existing line",
+        "+added before the failure",
+      ].join("\n");
 
-    function Harness() {
-      const [entries, setEntries] = useState<AppServerThreadEntry[]>([]);
-      return (
-        <ThreadView
-          activeTurnId="turn-1"
-          activeTurnStartedAt={1_000}
-          addOptimisticUserMessage={(_text) => "optimistic-1"}
-          backends={[]}
-          composerDisabled={false}
-          desktopApi={{
-            onAgentEvent: (callback) => {
-              agentEventHandler = callback as typeof agentEventHandler;
-              return () => undefined;
-            },
-          }}
-          loading={false}
-          loadingMore={false}
-          messageCount={entries.length}
-          selectedThread={{
-            id: "thread-fail",
-            title: "Failure lifecycle",
-            titleSource: "explicit",
-            source: "codex",
-            updatedAt: Date.now(),
-            linkedDirectories: [],
-            inbox: { inInbox: false },
-          }}
-          skills={[]}
-          transcriptEntries={entries}
-          clearPendingRequest={() => undefined}
-          onLiveTranscriptEntry={(entry) => {
-            setEntries((current) => [...current, entry]);
-          }}
-          onLoadOlder={async () => undefined}
-          removeOptimisticMessage={(_id) => undefined}
-        />
-      );
-    }
+      function Harness() {
+        const [entries, setEntries] = useState<AppServerThreadEntry[]>([]);
+        return (
+          <ThreadView
+            activeTurnId="turn-1"
+            activeTurnStartedAt={1_000}
+            addOptimisticUserMessage={(_text) => "optimistic-1"}
+            backends={[]}
+            composerDisabled={false}
+            desktopApi={{
+              onAgentEvent: (callback) => {
+                agentEventHandler = callback as typeof agentEventHandler;
+                return () => undefined;
+              },
+            }}
+            loading={false}
+            loadingMore={false}
+            messageCount={entries.length}
+            selectedThread={{
+              id: threadId,
+              title: "Terminal turn lifecycle",
+              titleSource: "explicit",
+              source: "codex",
+              updatedAt: Date.now(),
+              linkedDirectories: [],
+              inbox: { inInbox: false },
+            }}
+            skills={[]}
+            transcriptEntries={entries}
+            clearPendingRequest={() => undefined}
+            onLiveTranscriptEntry={(entry) => {
+              onPublished(entry);
+              setEntries((current) => [...current, entry]);
+            }}
+            onLoadOlder={async () => undefined}
+            removeOptimisticMessage={(_id) => undefined}
+          />
+        );
+      }
 
-    render(<Harness />);
+      render(<Harness />);
 
-    await act(async () => {
-      agentEventHandler?.(
-        buildRendererLiveDiffEvent({
-          additions: 1,
-          diff: liveDiff,
-          path: "src/example.ts",
-          removals: 0,
-          threadId: "thread-fail",
-          turnId: "turn-1",
+      await act(async () => {
+        agentEventHandler?.(
+          buildRendererLiveDiffEvent({
+            additions: 1,
+            diff: liveDiff,
+            path: "src/example.ts",
+            removals: 0,
+            threadId,
+            turnId: "turn-1",
+          }),
+        );
+      });
+      await act(async () => {
+        const notification: AppServerNotification = status === "failed"
+          ? {
+              method: "turn/failed",
+              params: {
+                threadId,
+                turnId: "turn-1",
+                turn: {
+                  id: "turn-1",
+                  status,
+                  error: { message: "boom" },
+                },
+              },
+            }
+          : {
+              method: "turn/cancelled",
+              params: {
+                threadId,
+                turnId: "turn-1",
+                turn: {
+                  id: "turn-1",
+                  status,
+                },
+              },
+            };
+        agentEventHandler?.({
+          backend: "codex",
+          notification,
+        });
+      });
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // A terminal turn's edit is deferred into the transcript with terminal
+      // metadata so paged-history projection can keep it beside that turn.
+      expect(onPublished).toHaveBeenCalledWith(
+        expect.objectContaining({
+          turn: expect.objectContaining({ id: "turn-1", status }),
         }),
       );
-    });
-    await act(async () => {
-      agentEventHandler?.({
-        backend: "codex",
-        notification: {
-          method: "turn/failed",
-          params: {
-            threadId: "thread-fail",
-            turnId: "turn-1",
-            turn: {
-              id: "turn-1",
-              status: "failed",
-              error: { message: "boom" },
-            },
-          },
-        },
-      });
-    });
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // The failed turn made a real edit before stopping; it is deferred
-    // into the transcript so the accumulated Edited Files groups keep it
-    // rather than dropping it until a replay refresh re-fetches it.
-    expect(
-      screen.getByRole("complementary", { name: /Edited 1 file/ }),
-    ).toBeInTheDocument();
-  });
+      expect(
+        screen.getByRole("complementary", { name: /Edited 1 file/ }),
+      ).toBeInTheDocument();
+    },
+  );
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts
@@ -208,6 +208,182 @@ describe("segmented transcript history", () => {
     expect(retainedHistoryIdReads).toBe(0);
   });
 
+  it("places a retained completed plan beside its owning historical turn", () => {
+    const index = createTranscriptHistoryIndex();
+    const olderTurn = {
+      id: "turn-older",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 2_000,
+    };
+    const retainedPlan: AppServerThreadEntry = {
+      type: "plan",
+      id: "retained-plan",
+      createdAt: 1_500,
+      steps: [{ status: "completed", step: "Keep the plan with its turn" }],
+      turn: olderTurn,
+    };
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([{
+        ...message("older-final"),
+        createdAt: 2_000,
+        turn: olderTurn,
+      }]),
+      tailEntries: [],
+    });
+    const tail: AppServerThreadEntry[] = [
+      {
+        ...message("newer-commentary"),
+        createdAt: 3_100,
+        turn: {
+          id: "turn-newer",
+          status: "in_progress",
+          startedAt: 3_000,
+        },
+      },
+      retainedPlan,
+    ];
+
+    const entries = combineTranscriptEntries(
+      history,
+      index,
+      tail,
+      undefined,
+      [retainedPlan],
+    );
+
+    expect(entries.map((entry) => entry.id)).toEqual([
+      "retained-plan",
+      "older-final",
+      "newer-commentary",
+    ]);
+  });
+
+  it.each(["failed", "cancelled"] as const)(
+    "places retained edits from a %s turn beside that historical turn",
+    (status) => {
+      const index = createTranscriptHistoryIndex();
+      const olderTurn = {
+        id: "turn-older",
+        status,
+        startedAt: 1_000,
+        completedAt: 2_000,
+      };
+      const retainedEdit: AppServerThreadEntry = {
+        type: "activity",
+        id: `retained-${status}-edit`,
+        createdAt: 1_500,
+        details: [],
+        status: "completed",
+        summary: "Edited 1 file",
+        turn: olderTurn,
+      };
+      const history = prependTranscriptHistoryPage({
+        history: undefined,
+        index,
+        page: response([{
+          ...message("older-terminal-message"),
+          createdAt: 2_000,
+          turn: olderTurn,
+        }]),
+        tailEntries: [],
+      });
+      const tail: AppServerThreadEntry[] = [
+        {
+          ...message("newer-commentary"),
+          createdAt: 3_100,
+          turn: {
+            id: "turn-newer",
+            status: "in_progress",
+            startedAt: 3_000,
+          },
+        },
+        retainedEdit,
+      ];
+
+      const entries = combineTranscriptEntries(
+        history,
+        index,
+        tail,
+        undefined,
+        [retainedEdit],
+      );
+
+      expect(entries.map((entry) => entry.id)).toEqual([
+        `retained-${status}-edit`,
+        "older-terminal-message",
+        "newer-commentary",
+      ]);
+    },
+  );
+
+  it("caches retained-entry placement across streamed tail updates", () => {
+    const index = createTranscriptHistoryIndex();
+    const olderTurn = {
+      id: "turn-older",
+      status: "completed" as const,
+    };
+    let owningTurnTimeReads = 0;
+    let unrelatedTurnTimeReads = 0;
+    const history = prependTranscriptHistoryPage({
+      history: undefined,
+      index,
+      page: response([
+        ...Array.from({ length: 100 }, (_value, entryIndex) => ({
+          ...message(`unrelated-${entryIndex}`),
+          get createdAt() {
+            unrelatedTurnTimeReads += 1;
+            return entryIndex;
+          },
+          turn: { id: `unrelated-turn-${entryIndex}`, status: "completed" as const },
+        })),
+        {
+          ...message("older-final"),
+          get createdAt() {
+            owningTurnTimeReads += 1;
+            return 2_000;
+          },
+          turn: olderTurn,
+        },
+      ]),
+      tailEntries: [],
+    });
+    const retainedEdit: AppServerThreadEntry = {
+      type: "activity",
+      id: "retained-edit",
+      createdAt: 1_500,
+      details: [],
+      status: "completed",
+      summary: "Edited 1 file",
+      turn: olderTurn,
+    };
+
+    expect(combineTranscriptEntries(
+      history,
+      index,
+      [message("streaming-message"), retainedEdit],
+      undefined,
+      [retainedEdit],
+    )).toHaveLength(103);
+    expect(owningTurnTimeReads).toBe(1);
+    expect(unrelatedTurnTimeReads).toBe(0);
+
+    owningTurnTimeReads = 0;
+    for (let updateIndex = 0; updateIndex < 100; updateIndex += 1) {
+      expect(combineTranscriptEntries(
+        history,
+        index,
+        [message("streaming-message", `update-${updateIndex}`), retainedEdit],
+        undefined,
+        [retainedEdit],
+      )).toHaveLength(103);
+    }
+    expect(owningTurnTimeReads).toBe(0);
+    expect(unrelatedTurnTimeReads).toBe(0);
+  });
+
   it("pins linear work for reverse numeric-index searches", () => {
     const index = createTranscriptHistoryIndex();
     let history: LoadedTranscriptHistory | undefined;

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -7655,6 +7655,89 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("keeps retained completed work beside its older turn while a newer turn streams", async () => {
+    const olderTurn = {
+      id: "turn-older",
+      status: "completed" as const,
+      startedAt: 1_000,
+      completedAt: 2_000,
+    };
+    const newerTurn = {
+      id: "turn-newer",
+      status: "in_progress" as const,
+      startedAt: 3_000,
+    };
+    const readThread = vi
+      .fn()
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [{
+          ...messageEntry({
+            id: "newer-commentary",
+            text: "I am working on the next turn.",
+            createdAt: 3_100,
+          }),
+          phase: "commentary" as const,
+          turn: newerTurn,
+        }],
+        hasPreviousPage: true,
+        previousCursor: "older-turn",
+        threadStatus: "active",
+      }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: [{
+          ...messageEntry({
+            id: "older-final",
+            text: "The older turn is complete.",
+            createdAt: 2_000,
+          }),
+          phase: "final" as const,
+          turn: olderTurn,
+        }],
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = {
+      onAgentEvent: () => () => undefined,
+      readThread,
+    };
+    const { result } = renderHook(() =>
+      useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      })
+    );
+
+    await waitForThreadHydration(result);
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "message:The older turn is complete.",
+      "message:I am working on the next turn.",
+    ]);
+
+    act(() => {
+      result.current.upsertLiveTranscriptEntry({
+        type: "activity",
+        id: "older-retained-work",
+        summary: "Edited 18 files, +764, -41",
+        createdAt: 1_500,
+        status: "completed",
+        details: [{
+          id: "older-retained-work-detail",
+          kind: "write",
+          label: "Update old-turn.ts",
+        }],
+        turn: olderTurn,
+      });
+    });
+
+    expect(transcriptLabels(result.current.entries)).toEqual([
+      "activity:Edited 18 files, +764, -41",
+      "message:The older turn is complete.",
+      "message:I am working on the next turn.",
+    ]);
+  });
+
   it("preserves session-owned live activity across thread switches and hydration", async () => {
     let now = 20_000;
     vi.spyOn(Date, "now").mockImplementation(() => now++);

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -30,10 +30,16 @@ export type LoadedTranscriptHistory = {
   pagination: AppServerReadThreadResponse["replay"]["pagination"];
 };
 
+type TranscriptHistoryTurnPage = {
+  entryIndexes: number[];
+  page: TranscriptHistoryPage;
+};
+
 export type TranscriptHistoryIndex = {
   entryIds: Set<string>;
   messageIds: Set<string>;
   review: TranscriptReviewHistoryIndex;
+  turnPages: Map<string, TranscriptHistoryTurnPage[]>;
 };
 
 export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
@@ -41,6 +47,7 @@ export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
     entryIds: new Set(),
     messageIds: new Set(),
     review: createTranscriptReviewHistoryIndex(),
+    turnPages: new Map(),
   };
 }
 
@@ -119,6 +126,21 @@ export function prependTranscriptHistoryPage(params: {
       // views remain bounded by their captured entry count, so attaching the
       // next page cannot make a previously returned view grow.
       oldestPage.olderPage = page;
+    }
+    const entryIndexesByTurn = new Map<string, number[]>();
+    entries.forEach((entry, entryIndex) => {
+      const turnId = entry.turn?.id;
+      if (!turnId) {
+        return;
+      }
+      const entryIndexes = entryIndexesByTurn.get(turnId) ?? [];
+      entryIndexes.push(entryIndex);
+      entryIndexesByTurn.set(turnId, entryIndexes);
+    });
+    for (const [turnId, entryIndexes] of entryIndexesByTurn) {
+      const turnPages = params.index.turnPages.get(turnId) ?? [];
+      turnPages.push({ entryIndexes, page });
+      params.index.turnPages.set(turnId, turnPages);
     }
     oldestPage = page;
     newestPage ??= page;
@@ -443,15 +465,153 @@ export function combineTranscriptEntries(
   for (const id of presentation?.excludedHistoryEntryIds ?? []) {
     excludedHistoryIds.add(id);
   }
+  const historyInsertions = placeMisorderedCompletedActivityInHistory(
+    tailEntries,
+    index,
+  );
+  const insertedEntries = new Set(
+    [...historyInsertions.values()].flatMap((insertionsByIndex) =>
+      [...insertionsByIndex.values()].flat()
+    )
+  );
+  const projectedTailEntries = insertedEntries.size > 0
+    ? tailEntries.filter((entry) => !insertedEntries.has(entry))
+    : tailEntries;
   return createSegmentedArray({
     excludedHistoryIds,
-    historyCount: history.entryCount,
+    historyCount: history.entryCount + insertedEntries.size,
     historyNewestPage: history.newestPage,
     historyPage: history.oldestPage,
     itemOverrides: presentation?.historyEntryOverrides,
-    pageItems: (page) => page.entries,
-    tail: tailEntries,
+    pageItems: (page) => entriesWithHistoryInsertions(
+      page,
+      historyInsertions.get(page),
+    ),
+    tail: projectedTailEntries,
   });
+}
+
+type HistoryEntryInsertions = Map<
+  TranscriptHistoryPage,
+  Map<number, AppServerThreadEntry[]>
+>;
+
+function isCompletedActivityEntry(
+  entry: AppServerThreadEntry,
+): boolean {
+  const status = entry.turn?.status;
+  return (
+    entry.type === "activity"
+    && Boolean(entry.turn)
+    && (
+      status === "completed"
+      || status === "failed"
+      || status === "cancelled"
+      || status === "interrupted"
+      || typeof entry.turn?.completedAt === "number"
+      || typeof entry.turn?.durationMs === "number"
+    )
+  );
+}
+
+function transcriptEntryTime(entry: AppServerThreadEntry): number | undefined {
+  return entry.createdAt ?? entry.turn?.completedAt ?? entry.turn?.startedAt;
+}
+
+function findHistoryInsertionPoint(
+  entry: AppServerThreadEntry,
+  turnPages: TranscriptHistoryTurnPage[],
+): { entryIndex: number; page: TranscriptHistoryPage } | undefined {
+  const entryTime = transcriptEntryTime(entry);
+  let lastTurnEntry:
+    | { entryIndex: number; page: TranscriptHistoryPage }
+    | undefined;
+
+  for (let pageIndex = turnPages.length - 1; pageIndex >= 0; pageIndex -= 1) {
+    const turnPage = turnPages[pageIndex]!;
+    for (const entryIndex of turnPage.entryIndexes) {
+      const historyEntry = turnPage.page.entries[entryIndex];
+      if (!historyEntry) {
+        continue;
+      }
+      const historyEntryTime = transcriptEntryTime(historyEntry);
+      if (
+        typeof entryTime === "number"
+        && typeof historyEntryTime === "number"
+        && historyEntryTime > entryTime
+      ) {
+        return { entryIndex, page: turnPage.page };
+      }
+      lastTurnEntry = { entryIndex, page: turnPage.page };
+    }
+  }
+
+  return lastTurnEntry
+    ? {
+        entryIndex: lastTurnEntry.entryIndex + 1,
+        page: lastTurnEntry.page,
+      }
+    : undefined;
+}
+
+function placeMisorderedCompletedActivityInHistory(
+  tailEntries: AppServerThreadEntry[],
+  index: TranscriptHistoryIndex,
+): HistoryEntryInsertions {
+  const insertions: HistoryEntryInsertions = new Map();
+  let greatestSeenTime: number | undefined;
+
+  for (const entry of tailEntries) {
+    const entryTime = transcriptEntryTime(entry);
+    const turnId = entry.turn?.id;
+    const turnPages = turnId ? index.turnPages.get(turnId) : undefined;
+    // A turn can legitimately span the history/tail boundary. Move only a
+    // completed activity that has already fallen behind a newer tail item.
+    // The owning-turn index then restores its position without walking pages
+    // from unrelated turns on each streamed update.
+    const belongsBeforeTail =
+      isCompletedActivityEntry(entry)
+      && typeof entryTime === "number"
+      && typeof greatestSeenTime === "number"
+      && entryTime < greatestSeenTime
+      && Boolean(turnPages?.length)
+      && !index.entryIds.has(entry.id);
+    if (belongsBeforeTail && turnPages) {
+      const insertionPoint = findHistoryInsertionPoint(entry, turnPages);
+      if (insertionPoint) {
+        const insertionsByIndex = insertions.get(insertionPoint.page) ?? new Map();
+        const entries = insertionsByIndex.get(insertionPoint.entryIndex) ?? [];
+        entries.push(entry);
+        insertionsByIndex.set(insertionPoint.entryIndex, entries);
+        insertions.set(insertionPoint.page, insertionsByIndex);
+        continue;
+      }
+    }
+
+    if (typeof entryTime === "number") {
+      greatestSeenTime = Math.max(greatestSeenTime ?? entryTime, entryTime);
+    }
+  }
+
+  return insertions;
+}
+
+function entriesWithHistoryInsertions(
+  page: TranscriptHistoryPage,
+  insertionsByIndex: Map<number, AppServerThreadEntry[]> | undefined,
+): AppServerThreadEntry[] {
+  if (!insertionsByIndex || insertionsByIndex.size === 0) {
+    return page.entries;
+  }
+
+  const entries: AppServerThreadEntry[] = [];
+  for (let entryIndex = 0; entryIndex <= page.entries.length; entryIndex += 1) {
+    entries.push(...(insertionsByIndex.get(entryIndex) ?? []));
+    if (entryIndex < page.entries.length) {
+      entries.push(page.entries[entryIndex]!);
+    }
+  }
+  return entries;
 }
 
 export function combineTranscriptMessages(

--- a/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
+++ b/apps/desktop/src/renderer/src/lib/segmented-transcript.ts
@@ -35,9 +35,22 @@ type TranscriptHistoryTurnPage = {
   page: TranscriptHistoryPage;
 };
 
+type TranscriptHistoryInsertionPoint = {
+  entryIndex: number;
+  page: TranscriptHistoryPage;
+};
+
+type CachedRetainedEntryPlacement = {
+  entryTime: number | undefined;
+  insertionPoint: TranscriptHistoryInsertionPoint;
+  turnId: string;
+  turnPageCount: number;
+};
+
 export type TranscriptHistoryIndex = {
   entryIds: Set<string>;
   messageIds: Set<string>;
+  retainedEntryPlacements: Map<string, CachedRetainedEntryPlacement>;
   review: TranscriptReviewHistoryIndex;
   turnPages: Map<string, TranscriptHistoryTurnPage[]>;
 };
@@ -46,6 +59,7 @@ export function createTranscriptHistoryIndex(): TranscriptHistoryIndex {
   return {
     entryIds: new Set(),
     messageIds: new Set(),
+    retainedEntryPlacements: new Map(),
     review: createTranscriptReviewHistoryIndex(),
     turnPages: new Map(),
   };
@@ -170,6 +184,7 @@ function historyOverlapIds<T extends { id: string }>(
 
 type SegmentedArraySource<T> = {
   excludedHistoryIds: ReadonlySet<string>;
+  excludedTailIds?: ReadonlySet<string>;
   historyCount: number;
   historyNewestPage: TranscriptHistoryPage | undefined;
   historyPage: TranscriptHistoryPage | undefined;
@@ -190,14 +205,21 @@ function* iterateSegmentedArray<T extends { id: string }>(
     }
     page = page.newerPage;
   }
-  yield* source.tail;
+  for (const item of source.tail) {
+    if (!source.excludedTailIds?.has(item.id)) {
+      yield item;
+    }
+  }
 }
 
 function* iterateSegmentedArrayReverse<T extends { id: string }>(
   source: SegmentedArraySource<T>,
 ): Generator<T> {
   for (let index = source.tail.length - 1; index >= 0; index -= 1) {
-    yield source.tail[index]!;
+    const item = source.tail[index]!;
+    if (!source.excludedTailIds?.has(item.id)) {
+      yield item;
+    }
   }
 
   let remainingHistoryItems =
@@ -322,7 +344,11 @@ function isArrayIndex(property: PropertyKey): property is string {
 function createSegmentedArray<T extends { id: string }>(
   source: SegmentedArraySource<T>,
 ): T[] {
-  const length = source.historyCount - source.excludedHistoryIds.size + source.tail.length;
+  const length =
+    source.historyCount
+    - source.excludedHistoryIds.size
+    + source.tail.length
+    - (source.excludedTailIds?.size ?? 0);
   const target = new Array<T>(length);
   let materialized: T[] | undefined;
   const materialize = (): T[] => {
@@ -457,6 +483,7 @@ export function combineTranscriptEntries(
     TranscriptReviewPresentation,
     "excludedHistoryEntryIds" | "historyEntryOverrides"
   >,
+  retainedEntries: readonly AppServerThreadEntry[] = [],
 ): AppServerThreadEntry[] {
   if (!history?.oldestPage || !index) {
     return tailEntries;
@@ -465,21 +492,19 @@ export function combineTranscriptEntries(
   for (const id of presentation?.excludedHistoryEntryIds ?? []) {
     excludedHistoryIds.add(id);
   }
-  const historyInsertions = placeMisorderedCompletedActivityInHistory(
-    tailEntries,
+  const historyInsertions = placeRetainedArtifactsInHistory(
+    retainedEntries,
     index,
   );
-  const insertedEntries = new Set(
+  const insertedEntryIds = new Set(
     [...historyInsertions.values()].flatMap((insertionsByIndex) =>
-      [...insertionsByIndex.values()].flat()
+      [...insertionsByIndex.values()].flat().map((entry) => entry.id)
     )
   );
-  const projectedTailEntries = insertedEntries.size > 0
-    ? tailEntries.filter((entry) => !insertedEntries.has(entry))
-    : tailEntries;
   return createSegmentedArray({
     excludedHistoryIds,
-    historyCount: history.entryCount + insertedEntries.size,
+    excludedTailIds: insertedEntryIds,
+    historyCount: history.entryCount + insertedEntryIds.size,
     historyNewestPage: history.newestPage,
     historyPage: history.oldestPage,
     itemOverrides: presentation?.historyEntryOverrides,
@@ -487,7 +512,7 @@ export function combineTranscriptEntries(
       page,
       historyInsertions.get(page),
     ),
-    tail: projectedTailEntries,
+    tail: tailEntries,
   });
 }
 
@@ -496,12 +521,12 @@ type HistoryEntryInsertions = Map<
   Map<number, AppServerThreadEntry[]>
 >;
 
-function isCompletedActivityEntry(
+function isTerminalRetainedArtifactEntry(
   entry: AppServerThreadEntry,
 ): boolean {
   const status = entry.turn?.status;
   return (
-    entry.type === "activity"
+    (entry.type === "activity" || entry.type === "plan")
     && Boolean(entry.turn)
     && (
       status === "completed"
@@ -521,7 +546,7 @@ function transcriptEntryTime(entry: AppServerThreadEntry): number | undefined {
 function findHistoryInsertionPoint(
   entry: AppServerThreadEntry,
   turnPages: TranscriptHistoryTurnPage[],
-): { entryIndex: number; page: TranscriptHistoryPage } | undefined {
+): TranscriptHistoryInsertionPoint | undefined {
   const entryTime = transcriptEntryTime(entry);
   let lastTurnEntry:
     | { entryIndex: number; page: TranscriptHistoryPage }
@@ -554,30 +579,59 @@ function findHistoryInsertionPoint(
     : undefined;
 }
 
-function placeMisorderedCompletedActivityInHistory(
-  tailEntries: AppServerThreadEntry[],
+function retainedEntryInsertionPoint(
+  entry: AppServerThreadEntry,
+  index: TranscriptHistoryIndex,
+  turnId: string,
+  turnPages: TranscriptHistoryTurnPage[],
+): TranscriptHistoryInsertionPoint | undefined {
+  const entryTime = transcriptEntryTime(entry);
+  const cached = index.retainedEntryPlacements.get(entry.id);
+  if (
+    cached
+    && cached.entryTime === entryTime
+    && cached.turnId === turnId
+    && cached.turnPageCount === turnPages.length
+  ) {
+    return cached.insertionPoint;
+  }
+
+  const insertionPoint = findHistoryInsertionPoint(entry, turnPages);
+  if (insertionPoint) {
+    index.retainedEntryPlacements.set(entry.id, {
+      entryTime,
+      insertionPoint,
+      turnId,
+      turnPageCount: turnPages.length,
+    });
+  }
+  return insertionPoint;
+}
+
+function placeRetainedArtifactsInHistory(
+  retainedEntries: readonly AppServerThreadEntry[],
   index: TranscriptHistoryIndex,
 ): HistoryEntryInsertions {
   const insertions: HistoryEntryInsertions = new Map();
-  let greatestSeenTime: number | undefined;
 
-  for (const entry of tailEntries) {
-    const entryTime = transcriptEntryTime(entry);
+  for (const entry of retainedEntries) {
     const turnId = entry.turn?.id;
     const turnPages = turnId ? index.turnPages.get(turnId) : undefined;
-    // A turn can legitimately span the history/tail boundary. Move only a
-    // completed activity that has already fallen behind a newer tail item.
-    // The owning-turn index then restores its position without walking pages
-    // from unrelated turns on each streamed update.
-    const belongsBeforeTail =
-      isCompletedActivityEntry(entry)
-      && typeof entryTime === "number"
-      && typeof greatestSeenTime === "number"
-      && entryTime < greatestSeenTime
+    // ThreadView supplies only the small set of live artifacts retained at a
+    // terminal turn boundary. The owning-turn index avoids any transcript
+    // history scan, and the cached insertion point avoids rescanning even
+    // that turn while a newer message streams character updates.
+    const belongsInHistory =
+      isTerminalRetainedArtifactEntry(entry)
       && Boolean(turnPages?.length)
       && !index.entryIds.has(entry.id);
-    if (belongsBeforeTail && turnPages) {
-      const insertionPoint = findHistoryInsertionPoint(entry, turnPages);
+    if (belongsInHistory && turnId && turnPages) {
+      const insertionPoint = retainedEntryInsertionPoint(
+        entry,
+        index,
+        turnId,
+        turnPages,
+      );
       if (insertionPoint) {
         const insertionsByIndex = insertions.get(insertionPoint.page) ?? new Map();
         const entries = insertionsByIndex.get(insertionPoint.entryIndex) ?? [];
@@ -586,10 +640,6 @@ function placeMisorderedCompletedActivityInHistory(
         insertions.set(insertionPoint.page, insertionsByIndex);
         continue;
       }
-    }
-
-    if (typeof entryTime === "number") {
-      greatestSeenTime = Math.max(greatestSeenTime ?? entryTime, entryTime);
     }
   }
 

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -7474,11 +7474,13 @@ export function useThreadSessionState(params: {
         selectedHistoryIndex,
         reviewPresentation.tailEntries,
         reviewPresentation,
+        selectedRetainedLiveEntries,
       ),
     [
       reviewPresentation,
       selectedHistoryIndex,
       selectedSession?.loadedHistory,
+      selectedRetainedLiveEntries,
     ]
   );
 


### PR DESCRIPTION
## Summary

- add a regression scenario with a completed turn in segmented history and a newer in-progress turn in the current tail
- index loaded history pages by turn without flattening or copying retained history
- project a late completed activity back beside its owning historical turn when it has fallen behind a newer tail item

## Root cause

The segmented transcript merge treated retained live aggregates as tail-only
entries. Once the owning turn had moved into a history page, the tail merge
could no longer see that turn's ordering anchor and appended the old work after
the newer active turn.

The new per-turn page index limits placement work to pages containing the
owning turn. Ordinary live-tail updates still do not traverse loaded history.

## Testing

```bash
pnpm test apps/desktop/src/renderer/src/lib/__tests__/segmented-transcript.test.ts \
  apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
pnpm --filter @pwragent/desktop typecheck
pnpm lint:eslint
```

All relevant tests and typechecking pass. ESLint reports zero errors and only
the existing warning baseline.
