### PR TITLE
fix(desktop): support Windows ripgrep checksums

### DIFF
--- a/apps/desktop/scripts/stage-ripgrep-bundle.mjs
+++ b/apps/desktop/scripts/stage-ripgrep-bundle.mjs
@@ -74,11 +74,25 @@ async function download(url, targetPath) {
 }
 
 export function expectedChecksum(checksumText, assetName) {
-  const match = /^([0-9a-fA-F]{64})\s+\*?(.+)$/u.exec(checksumText.trim());
-  if (!match || basename(match[2]) !== assetName) {
-    throw new Error(`Invalid checksum for ${assetName}`);
+  const trimmedChecksum = checksumText.trim();
+  const checksumMatch = /^([0-9a-fA-F]{64})\s+\*?(.+)$/u.exec(trimmedChecksum);
+  if (checksumMatch && basename(checksumMatch[2]) === assetName) {
+    return checksumMatch[1].toLowerCase();
   }
-  return match[1].toLowerCase();
+
+  const certUtilLines = trimmedChecksum
+    .split(/\r?\n/u)
+    .map((line) => line.trim());
+  if (
+    certUtilLines.length === 3
+    && certUtilLines[0] === `SHA256 hash of ${assetName}:`
+    && /^[0-9a-fA-F]{64}$/u.test(certUtilLines[1])
+    && certUtilLines[2] === "CertUtil: -hashfile command completed successfully."
+  ) {
+    return certUtilLines[1].toLowerCase();
+  }
+
+  throw new Error(`Invalid checksum for ${assetName}`);
 }
 
 async function sha256(path) {

--- a/apps/desktop/scripts/stage-ripgrep-bundle.test.mjs
+++ b/apps/desktop/scripts/stage-ripgrep-bundle.test.mjs
@@ -28,9 +28,25 @@ describe("ripgrep bundle staging", () => {
       `${digest}  ripgrep-15.2.0-aarch64-apple-darwin.tar.gz\n`,
       "ripgrep-15.2.0-aarch64-apple-darwin.tar.gz",
     )).toBe(digest);
+    expect(expectedChecksum(
+      [
+        "SHA256 hash of ripgrep-15.2.0-x86_64-pc-windows-msvc.zip:",
+        digest.toUpperCase(),
+        "CertUtil: -hashfile command completed successfully.",
+      ].join("\r\n"),
+      "ripgrep-15.2.0-x86_64-pc-windows-msvc.zip",
+    )).toBe(digest);
     expect(() => expectedChecksum(
       `${digest}  another-asset.tar.gz\n`,
       "ripgrep.tar.gz",
+    )).toThrow("Invalid checksum");
+    expect(() => expectedChecksum(
+      [
+        "SHA256 hash of another-asset.zip:",
+        digest,
+        "CertUtil: -hashfile command completed successfully.",
+      ].join("\r\n"),
+      "ripgrep.zip",
     )).toThrow("Invalid checksum");
   });
 });


### PR DESCRIPTION
## Summary

- Accept the official three-line Windows CertUtil checksum sidecar format.
- Preserve GNU sha256sum parsing and strict asset-name, 64-hex digest, and CertUtil success-line validation.
- Cover both accepted formats and filename mismatch rejection.

## Background

On Windows, pnpm dev failed before Electron startup because the ripgrep 15.2.0 Windows .sha256 assets use CertUtil output rather than GNU sha256sum format. The staging parser only recognized the GNU form.

## Test evidence

- pnpm test apps/desktop/scripts/stage-ripgrep-bundle.test.mjs — 3 tests passed.
- pnpm exec eslint apps/desktop/scripts/stage-ripgrep-bundle.mjs apps/desktop/scripts/stage-ripgrep-bundle.test.mjs — passed.
- node --check on both changed modules — passed.
- Parent Windows verification against the real official asset passed end to end: the staged ZIP digest was 71b2fef860abe467217a538ff31de02f5258807c0129f771846f87bd029aafc5, and the staged rg.exe reported ripgrep 15.2.0.