### PR TITLE
fix(desktop): stop the boot Codex probe from racing startup discovery

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6467,6 +6467,49 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("marks the durable Codex summary pending while startup discovery runs", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+      resolveCodexDiscoveryPending: () => true,
+    });
+
+    const response = await registry.listBackends({ includeUnavailable: true });
+
+    // "Not selected yet" and "not configured" both read as `available: false`
+    // here, and a startup surface that cannot tell them apart sends a working
+    // profile through provider setup. Only the pending flag separates them.
+    expect(
+      response.backends.find((backend) => backend.kind === "codex"),
+    ).toMatchObject({
+      available: false,
+      discoveryPending: true,
+    });
+
+    await registry.close();
+  });
+
+  it("leaves the Codex summary unpending once discovery has answered", async () => {
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+      resolveCodexDiscoveryPending: () => false,
+    });
+
+    const response = await registry.listBackends({ includeUnavailable: true });
+
+    expect(
+      response.backends.find((backend) => backend.kind === "codex"),
+    ).toMatchObject({ available: false });
+    expect(
+      response.backends.find((backend) => backend.kind === "codex"),
+    ).not.toHaveProperty("discoveryPending");
+
+    await registry.close();
+  });
+
   it("does not report banned ACP adapters as backend summaries", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({}),

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -48,6 +48,7 @@ import type {
   BackendAcpRuntimeCapabilities,
   BackendAcpRuntimeOptionSource,
   BackendAcpSessionRuntimeState,
+  BackendSummary,
   BackendModelOption,
   BackendRateLimitSummary,
   CodexThreadEnvironmentRuntime,
@@ -6486,6 +6487,44 @@ describe("DesktopBackendRegistry", () => {
       available: false,
       discoveryPending: true,
     });
+
+    await registry.close();
+  });
+
+  it("keeps a cached Codex summary pending while discovery is outstanding", async () => {
+    let pending = true;
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({}),
+      overlayStore: createOverlayStoreMock(),
+      acpAgentStore: createAcpAgentStoreMock([]),
+      resolveCodexDiscoveryPending: () => pending,
+    });
+    const internals = registry as unknown as {
+      codexBackendSummary?: BackendSummary;
+    };
+
+    // What a Settings "Re-check" or `completeOnboardingCodexBootstrap` caches
+    // when it lands mid-discovery. `discoverCodexBackend` writes no pending
+    // flag, and a failing summary is invalidated only by a provider
+    // fingerprint change, so returning it verbatim made the renderer read a
+    // mid-discovery cache as a settled "no provider" for the whole process.
+    const {
+      discoveryPending: _unflagged,
+      ...cachedSummary
+    } = (await registry.listBackends({ includeUnavailable: true })).backends
+      .find((backend) => backend.kind === "codex") as BackendSummary;
+    internals.codexBackendSummary = cachedSummary;
+
+    const whilePending = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends.find((backend) => backend.kind === "codex");
+    expect(whilePending).toMatchObject({ discoveryPending: true });
+
+    pending = false;
+    const afterAnswer = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends.find((backend) => backend.kind === "codex");
+    expect(afterAnswer).not.toHaveProperty("discoveryPending");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1212,6 +1212,99 @@ describe("DesktopSettingsService", () => {
     expect(service.isCodexDiscoveryPending()).toBe(false);
   });
 
+  it("keeps Codex discovery pending until the selection is published", async () => {
+    const configPath = path.join(createTempRoot(), "config.toml");
+    fs.writeFileSync(configPath, [
+      "[experimental]",
+      "token_miser_enabled = true",
+      "",
+    ].join("\n"));
+    let releaseDiscovery: (() => void) | undefined;
+    const discoveryGate = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover: vi.fn(async (configuredCommand?: string) => {
+          await discoveryGate;
+          const command = configuredCommand ?? "/managed/codex";
+          return {
+            candidates: [{
+              command,
+              executable: true,
+              selected: true,
+              source: "config" as const,
+            }],
+            selectedCommand: command,
+            selectedSource: "config" as const,
+          };
+        }),
+        invalidate: vi.fn(),
+        resolve: vi.fn(),
+      },
+      configPath,
+      ensureManagedCodexRuntime: vi.fn(async () => ({
+        appServerCommand: "/managed/codex-app-server",
+        codeModeHostCommand: "/managed/codex-code-mode-host",
+        command: "/managed/codex",
+        metadata: {
+          asset: "pwragent-codex-0.200.0-pwragent.1-linux-x86_64.tar.gz",
+          checkedAt: 1,
+          installedAt: 1,
+          repository: "pwrdrvr/codex",
+          schemaVersion: 1,
+          sha256: "a".repeat(64),
+          tag: "pwragent-v0.200.0-pwragent.1",
+          version: "0.200.0-pwragent.1",
+        },
+      })),
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const startupDiscovery = service.refreshStartupDiscovery(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    // Yield past `resolveManagedCodexRuntime`, which assigns the managed
+    // runtime long before `recordProviderDiscovery` publishes lastKnownGood.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The backend summary derives `available` from the published
+    // lastKnownGood, so a pending signal that answered from the managed
+    // runtime instead dropped mid-discovery and left the summary reading as a
+    // settled "no provider" — the exact window this flag exists to cover.
+    expect(service.isCodexDiscoveryPending()).toBe(true);
+
+    releaseDiscovery?.();
+    await startupDiscovery;
+    expect(service.isCodexDiscoveryPending()).toBe(false);
+  });
+
+  it("stops reporting Codex discovery pending when startup will never run one", async () => {
+    const configPath = path.join(createTempRoot(), "config.toml");
+    fs.writeFileSync(configPath, "");
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover: vi.fn(),
+        invalidate: vi.fn(),
+        resolve: vi.fn(),
+      },
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect(service.isCodexDiscoveryPending()).toBe(true);
+    // A bootstrap or onboarding-incomplete boot never requests startup
+    // discovery and nothing re-requests it when the wizard finishes in the
+    // same process, so without this the flag would never clear and every
+    // consumer would wait for an answer that was never scheduled.
+    service.markStartupCodexDiscoverySkipped();
+    expect(service.isCodexDiscoveryPending()).toBe(false);
+  });
+
   it("stops reporting Codex discovery pending once an attempt found nothing", async () => {
     const configPath = path.join(createTempRoot(), "config.toml");
     fs.writeFileSync(configPath, "");
@@ -1240,7 +1333,6 @@ describe("DesktopSettingsService", () => {
       "Refresh Codex in Settings",
     );
   });
-
 
   it("returns to ordinary Codex discovery without checking managed releases when disabled", async () => {
     const root = createTempRoot();

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -1152,6 +1152,96 @@ describe("DesktopSettingsService", () => {
     expect(resolve).not.toHaveBeenCalled();
   });
 
+  it("waits for the in-flight startup discovery instead of reporting no executable", async () => {
+    const configPath = path.join(createTempRoot(), "config.toml");
+    fs.writeFileSync(configPath, [
+      "[models.codex]",
+      'path = "/operator/codex"',
+      "",
+    ].join("\n"));
+    let releaseDiscovery: (() => void) | undefined;
+    const discoveryGate = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    const discover = vi.fn(async (configuredCommand?: string) => {
+      await discoveryGate;
+      const command = configuredCommand ?? "/operator/codex";
+      return {
+        candidates: [{
+          command,
+          executable: true,
+          selected: true,
+          source: "config" as const,
+        }],
+        selectedCommand: command,
+        selectedSource: "config" as const,
+      };
+    });
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover,
+        invalidate: vi.fn(),
+        resolve: vi.fn(),
+      },
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    // The durable last-known-good this resolver reads first is empty for the
+    // whole window between process start and the first published discovery —
+    // several seconds when a managed runtime has to be verified. Callers that
+    // land inside it (the boot Token Miser probe, archived binding cleanup)
+    // used to be told to "Refresh Codex in Settings" for a Codex that was
+    // about to resolve normally, which also left Token Miser recorded as
+    // unavailable for the rest of the session.
+    expect(service.isCodexDiscoveryPending()).toBe(true);
+    const startupDiscovery = service.refreshStartupDiscovery(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    const resolved = service.resolveCodexCommand();
+    expect(service.isCodexDiscoveryPending()).toBe(true);
+
+    releaseDiscovery?.();
+    await startupDiscovery;
+
+    await expect(resolved).resolves.toMatchObject({
+      command: "/operator/codex",
+      source: "config",
+    });
+    expect(service.isCodexDiscoveryPending()).toBe(false);
+  });
+
+  it("stops reporting Codex discovery pending once an attempt found nothing", async () => {
+    const configPath = path.join(createTempRoot(), "config.toml");
+    fs.writeFileSync(configPath, "");
+    const service = new DesktopSettingsService({
+      codexDiscoveryCoordinator: {
+        discover: vi.fn(async () => {
+          throw new Error("no codex on this machine");
+        }),
+        invalidate: vi.fn(),
+        resolve: vi.fn(),
+      },
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    expect(service.isCodexDiscoveryPending()).toBe(true);
+    await service.refreshStartupDiscovery(
+      issueProviderDiscoveryPermit("startup"),
+    );
+
+    // A discovery that ran and found nothing is a real answer. Reporting it as
+    // still pending would leave a startup surface waiting forever for one.
+    expect(service.isCodexDiscoveryPending()).toBe(false);
+    await expect(service.resolveCodexCommand()).rejects.toThrow(
+      "Refresh Codex in Settings",
+    );
+  });
+
+
   it("returns to ordinary Codex discovery without checking managed releases when disabled", async () => {
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10302,7 +10302,13 @@ export class DesktopBackendRegistry {
    * managed runtime happened to change.
    */
   async prepareTokenMiserRuntimeAtStartup(): Promise<void> {
-    if (!this.tokenMiserStore || !this.resolveTokenMiserEnabledFn()) {
+    // Deferring this behind startup discovery means a quit can land first —
+    // a managed-runtime download holds discovery open for many seconds.
+    // Preparation opens the app-server, so without this guard a shutdown
+    // could be followed by a fresh Codex child process and writes to a store
+    // `close()` already finalized. `maybeRestartCodexForManagedRuntimeChange`
+    // guards on `closed` for the same reason.
+    if (this.closed || !this.resolveTokenMiserEnabledFn()) {
       return;
     }
     await this.prepareTokenMiserRuntime({ prune: true });
@@ -23796,7 +23802,12 @@ export class DesktopBackendRegistry {
 
   private readCodexBackendSummary(): BackendSummary {
     if (this.codexBackendSummary) {
-      return this.codexBackendSummary;
+      // A summary cached by `discoverCodexBackend` carries no pending flag, and
+      // a failing one is invalidated only by a provider fingerprint change —
+      // which a later successful discovery does not produce. Re-deriving the
+      // flag here keeps a summary cached mid-discovery from reading as a
+      // settled "no provider" for the rest of the process.
+      return this.withCodexDiscoveryPending(this.codexBackendSummary);
     }
     const provider = this.configStore?.read("providers").codex;
     const lastKnownGood = provider
@@ -23804,12 +23815,6 @@ export class DesktopBackendRegistry {
       ? provider.lastKnownGood
       : undefined;
     const available = Boolean(lastKnownGood?.selectedCommand);
-    // "Not selected yet" and "not configured" read identically in this
-    // projection, and a durable last-known-good is legitimately absent for the
-    // whole window between process start and the first published discovery.
-    // Startup surfaces must be able to tell those apart before concluding a
-    // configured profile has no provider.
-    const discoveryPending = !available && this.resolveCodexDiscoveryPendingFn();
     const methods: string[] = [];
     const capabilities = buildCapabilities(methods, "codex");
     if (
@@ -23819,13 +23824,19 @@ export class DesktopBackendRegistry {
     ) {
       capabilities.startReview = true;
     }
+    // Only claim discovery is outstanding when it actually is. A discovery
+    // that ran and selected nothing records no `validation.error`, so this
+    // default used to describe a completed discovery as incomplete — and the
+    // no-backend notice renders this string as its operator-facing detail and
+    // copy text.
     const unavailableReason = provider?.validation.error
-      ?? "Codex discovery has not completed yet.";
-    return {
+      ?? (this.resolveCodexDiscoveryPendingFn()
+        ? "Codex discovery has not completed yet."
+        : "No Codex executable was found on this machine.");
+    return this.withCodexDiscoveryPending({
       kind: "codex",
       label: BACKEND_LABELS.codex,
       available,
-      ...(discoveryPending ? { discoveryPending } : {}),
       serverVersion: lastKnownGood?.selectedVersion,
       methods,
       capabilities,
@@ -23846,7 +23857,27 @@ export class DesktopBackendRegistry {
         },
       ],
       ...(available ? {} : { unavailableReason }),
-    };
+    });
+  }
+
+  /**
+   * Stamp `discoveryPending` onto a Codex summary that is unavailable only
+   * because discovery has not answered yet.
+   *
+   * Applied at every return of `readCodexBackendSummary`, including the cached
+   * one, so "not selected yet" and "not configured" never read alike to a
+   * startup surface deciding whether the profile has a provider at all.
+   */
+  private withCodexDiscoveryPending(summary: BackendSummary): BackendSummary {
+    const pending = !summary.available && this.resolveCodexDiscoveryPendingFn();
+    if (pending === Boolean(summary.discoveryPending)) {
+      return summary;
+    }
+    if (pending) {
+      return { ...summary, discoveryPending: true };
+    }
+    const { discoveryPending: _settled, ...settledSummary } = summary;
+    return settledSummary;
   }
 
   private async discoverCodexBackend(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8314,6 +8314,7 @@ export class DesktopBackendRegistry {
   private readonly resolveTokenMiserEnabledFn: () => boolean;
   private readonly resolveTokenMiserDefaultEnabledFn: () => boolean;
   private readonly resolveManagedTokenMiserActivationRequiredFn: () => boolean;
+  private readonly resolveCodexDiscoveryPendingFn: () => boolean;
   private readonly markManagedCodexRuntimeSwitchCompleteFn: () => void;
   private readonly resolveSpendAlertPolicyFn: () => DesktopSpendAlertPolicy;
   private readonly resolveToolOutputAlertPolicyFn: () => DesktopToolOutputAlertPolicy;
@@ -8425,6 +8426,7 @@ export class DesktopBackendRegistry {
     resolveSpendAlertPolicy?: () => DesktopSpendAlertPolicy;
     resolveToolOutputAlertPolicy?: () => DesktopToolOutputAlertPolicy;
     resolveManagedTokenMiserActivationRequired?: () => boolean;
+    resolveCodexDiscoveryPending?: () => boolean;
     markManagedCodexRuntimeSwitchComplete?: () => void;
     watchManagedCodexRuntime?: (
       listener: (
@@ -8608,6 +8610,12 @@ export class DesktopBackendRegistry {
     this.markManagedCodexRuntimeSwitchCompleteFn =
       options?.markManagedCodexRuntimeSwitchComplete
       ?? (() => settingsService?.markManagedCodexRuntimeSwitchComplete());
+    // A replay or test registry has no settings service and therefore no
+    // startup discovery to wait for: its summary is final the moment it is
+    // read, never pending.
+    this.resolveCodexDiscoveryPendingFn =
+      options?.resolveCodexDiscoveryPending
+      ?? (() => settingsService?.isCodexDiscoveryPending() ?? false);
     this.resolveToolOutputAlertPolicyFn =
       options?.resolveToolOutputAlertPolicy ??
       (() => {
@@ -8878,12 +8886,6 @@ export class DesktopBackendRegistry {
             error: error instanceof Error ? error.message : String(error),
           });
         });
-      // Bring the gate up at boot when the feature is on, so a resumed thread
-      // is covered from its first tool call rather than from whenever a new
-      // thread happens to be created. Retention pruning rides this one call.
-      if (this.resolveTokenMiserEnabledFn()) {
-        void this.prepareTokenMiserRuntime({ prune: true });
-      }
     }
     this.gitDirectoryService =
       options?.gitDirectoryService ??
@@ -10283,6 +10285,27 @@ export class DesktopBackendRegistry {
       threadCount: threads.length,
     });
     return threads;
+  }
+
+  /**
+   * Bring the Token Miser gate up at boot when the feature is on, so a resumed
+   * thread is covered from its first tool call rather than from whenever a new
+   * thread happens to be created. Retention pruning rides this one call.
+   *
+   * The caller must run this AFTER the one permitted startup Codex discovery
+   * has published a selection. Preparation opens the app-server to read its
+   * capabilities, and the registry is constructed before startup discovery is
+   * even requested, so doing this from the constructor raced discovery: the
+   * capability probe resolved no executable, `prepareTokenMiserRuntime` caught
+   * a "Refresh Codex in Settings" error and recorded Token Miser as
+   * unavailable, and nothing re-ran it for the rest of the session unless the
+   * managed runtime happened to change.
+   */
+  async prepareTokenMiserRuntimeAtStartup(): Promise<void> {
+    if (!this.tokenMiserStore || !this.resolveTokenMiserEnabledFn()) {
+      return;
+    }
+    await this.prepareTokenMiserRuntime({ prune: true });
   }
 
   refreshProvidersAtStartup(permit: ProviderDiscoveryPermit): Promise<void> {
@@ -23781,6 +23804,12 @@ export class DesktopBackendRegistry {
       ? provider.lastKnownGood
       : undefined;
     const available = Boolean(lastKnownGood?.selectedCommand);
+    // "Not selected yet" and "not configured" read identically in this
+    // projection, and a durable last-known-good is legitimately absent for the
+    // whole window between process start and the first published discovery.
+    // Startup surfaces must be able to tell those apart before concluding a
+    // configured profile has no provider.
+    const discoveryPending = !available && this.resolveCodexDiscoveryPendingFn();
     const methods: string[] = [];
     const capabilities = buildCapabilities(methods, "codex");
     if (
@@ -23796,6 +23825,7 @@ export class DesktopBackendRegistry {
       kind: "codex",
       label: BACKEND_LABELS.codex,
       available,
+      ...(discoveryPending ? { discoveryPending } : {}),
       serverVersion: lastKnownGood?.selectedVersion,
       methods,
       capabilities,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -404,6 +404,11 @@ function logBootDecision(decision: ProfileBootDecision): void {
 function prewarmInitialThreadList(permit: ProviderDiscoveryPermit): void {
   if (!getDesktopConfigStore().read("onboarding").completed) {
     mainLog.info("startup thread list prewarm deferred until onboarding completes");
+    // Nothing re-enters this function when the wizard completes in the same
+    // process, so no startup Codex discovery is coming. Say so, or every
+    // surface that waits on `isCodexDiscoveryPending()` waits for the life of
+    // the process — the startup landing included.
+    getDesktopSettingsService().markStartupCodexDiscoverySkipped();
     recordStartupProfileEvent({
       type: "startup-thread-list-prewarm:deferred",
     });
@@ -417,12 +422,38 @@ function prewarmInitialThreadList(permit: ProviderDiscoveryPermit): void {
         error: error instanceof Error ? error.message : String(error),
       });
     });
-  // Same dependency as the provider refresh below: reading Token Miser's
-  // server capabilities opens the app-server, which cannot resolve an
-  // executable until startup discovery has published this profile's
-  // selection. Running it from the registry constructor raced that and left
-  // Token Miser recorded as unavailable for the whole session.
-  void startupSettingsDiscovery
+  // The durable thread snapshot painted below is allowed to appear
+  // immediately. A cold profile has no executable selection yet, though, so
+  // this live provider refresh must wait for the one permitted startup
+  // discovery to publish that selection. Keeping the dependency in the
+  // background preserves fast startup without racing the Codex transport.
+  //
+  // It must NOT hang off the prewarm `listThreads` result. This chain owns the
+  // only `navigation/providerThreads/refreshed` emit, which is the renderer's
+  // sole automatic trigger to re-read backend summaries; a rejected prewarm —
+  // a broken Codex being exactly when that happens — would otherwise leave the
+  // renderer holding a stale `discoveryPending` summary with nothing left to
+  // clear it.
+  const startupProviderRefresh = startupSettingsDiscovery
+    .then(async () =>
+      await getDesktopBackendRegistry().refreshProvidersAtStartup(permit),
+    )
+    .catch((error) => {
+      mainLog.warn("startup provider refresh failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  // Token Miser preparation carries the same dependency — reading its server
+  // capabilities opens the app-server, which cannot resolve an executable
+  // until startup discovery has published a selection. Running it from the
+  // registry constructor raced that and left Token Miser recorded as
+  // unavailable for the whole session.
+  //
+  // It queues behind the provider refresh rather than beside it: preparation
+  // spawns `codex plugin marketplace` subprocesses and a full retention prune,
+  // and the refresh above owns the event that releases the renderer's startup
+  // hold. Contending with it would delay first paint to no purpose.
+  void startupProviderRefresh
     .then(async () =>
       await getDesktopBackendRegistry().prepareTokenMiserRuntimeAtStartup(),
     )
@@ -439,18 +470,6 @@ function prewarmInitialThreadList(permit: ProviderDiscoveryPermit): void {
       skipArchivedMetadataRefresh: true,
     })
     .then((threads) => {
-      // The durable thread snapshot above is allowed to paint immediately.
-      // A cold profile has no executable selection yet, though, so its live
-      // provider refresh must wait for the one permitted startup discovery to
-      // publish that selection. Keeping this dependency in the background
-      // preserves fast startup without racing the Codex transport.
-      void startupSettingsDiscovery.then(() =>
-        getDesktopBackendRegistry().refreshProvidersAtStartup(permit),
-      ).catch((error) => {
-        mainLog.warn("startup provider refresh failed", {
-          error: error instanceof Error ? error.message : String(error),
-        });
-      });
       recordStartupProfileEvent({
         type: "startup-thread-list-prewarm:completed",
         detail: {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -417,6 +417,20 @@ function prewarmInitialThreadList(permit: ProviderDiscoveryPermit): void {
         error: error instanceof Error ? error.message : String(error),
       });
     });
+  // Same dependency as the provider refresh below: reading Token Miser's
+  // server capabilities opens the app-server, which cannot resolve an
+  // executable until startup discovery has published this profile's
+  // selection. Running it from the registry constructor raced that and left
+  // Token Miser recorded as unavailable for the whole session.
+  void startupSettingsDiscovery
+    .then(async () =>
+      await getDesktopBackendRegistry().prepareTokenMiserRuntimeAtStartup(),
+    )
+    .catch((error) => {
+      mainLog.warn("startup Token Miser preparation failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
   void getDesktopBackendRegistry()
     .listThreads({
       callerReason: "startup-prewarm",

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -556,7 +556,12 @@ export class DesktopSettingsService {
   private managedCodexRuntimeSwitchAttempt?: Promise<void>;
   private startupDiscoveryAttempted = false;
   private startupDiscoveryPromise?: Promise<void>;
-  private codexDiscoveryAttempted = false;
+  // The Codex leg of discovery, tracked apart from `startupDiscoveryPromise`
+  // (which also bundles gh, git, and the desktop-application scan). Codex
+  // callers must never wait on those, and the pending signal must not stay
+  // set while only they are outstanding.
+  private codexDiscoveryPromise?: Promise<void>;
+  private codexDiscoverySettled = false;
 
   constructor(private readonly options: DesktopSettingsServiceOptions) {
     this.env = options.env ?? process.env;
@@ -2193,14 +2198,17 @@ export class DesktopSettingsService {
     permit: ProviderDiscoveryPermit,
   ): Promise<void> {
     assertProviderDiscoveryPermit(permit);
-    try {
-      await this.runCodexDiscoveryAttempt(permit);
-    } finally {
-      // Marks the attempt, not its outcome. A discovery that ran and found
-      // nothing is a real answer that surfaces must be free to act on; only a
-      // discovery that has not run yet leaves them without one.
-      this.codexDiscoveryAttempted = true;
-    }
+    const attempt = this.runCodexDiscoveryAttempt(permit).finally(() => {
+      // Settled marks the attempt, not its outcome. A discovery that ran and
+      // found nothing is a real answer that surfaces must be free to act on;
+      // only a discovery that has not run yet leaves them without one.
+      this.codexDiscoverySettled = true;
+      if (this.codexDiscoveryPromise === attempt) {
+        this.codexDiscoveryPromise = undefined;
+      }
+    });
+    this.codexDiscoveryPromise = attempt;
+    await attempt;
   }
 
   private async runCodexDiscoveryAttempt(
@@ -2275,18 +2283,29 @@ export class DesktopSettingsService {
     if (resolved) {
       return resolved;
     }
-    // The one permitted startup discovery is the authority for this profile's
-    // selection, and it is already running. Waiting for the answer that is in
-    // flight is not a retry: the durable last-known-good read above is an
-    // optimization that is legitimately empty on a cold profile, after a
-    // provider fingerprint change, and for the whole window between process
-    // start and the first published discovery. Background callers that land
-    // inside that window — archived binding cleanup is the routine one — were
-    // otherwise told to "Refresh Codex in Settings" about a Codex that was
-    // seconds from resolving normally.
-    const startupDiscovery = this.startupDiscoveryPromise;
-    if (startupDiscovery) {
-      await startupDiscovery;
+    // A Codex discovery is already running and is the authority for this
+    // profile's selection. Waiting for the answer in flight is not a retry:
+    // the durable last-known-good read above is an optimization that is
+    // legitimately empty on a cold profile, after a provider fingerprint
+    // change, and for the whole window between process start and the first
+    // published discovery. Background callers that land inside that window —
+    // archived binding cleanup is the routine one — were otherwise told to
+    // "Refresh Codex in Settings" about a Codex that was seconds from
+    // resolving normally.
+    //
+    // This waits on the Codex leg alone, never on `startupDiscoveryPromise`,
+    // which also bundles gh, git, and the desktop-application scan: a Codex
+    // spawn must not block on probes it does not use.
+    //
+    // Re-entrancy: `publishManagedCodexSelectionChange` can reach this method
+    // from inside the discovery it would await. That is safe only because
+    // `readSelectedCodexCommand()` above returns the managed runtime, which
+    // `runCodexDiscoveryAttempt` assigns before publishing. Any future caller
+    // reached earlier in that function would await its own discovery — resolve
+    // it from state, not by awaiting here.
+    const codexDiscovery = this.codexDiscoveryPromise;
+    if (codexDiscovery) {
+      await codexDiscovery;
       const discovered = this.readSelectedCodexCommand();
       if (discovered) {
         return discovered;
@@ -2327,21 +2346,39 @@ export class DesktopSettingsService {
   }
 
   /**
-   * Whether this profile is still owed a Codex selection. True until some
-   * discovery has published one or has run and found none. The desktop uses
-   * it to keep a startup surface pending rather than reporting a configured
-   * profile as having no provider.
+   * Whether a Codex discovery still owes this profile an answer. The desktop
+   * uses it to keep a startup surface pending rather than reporting a
+   * configured profile as having no provider.
+   *
+   * Deliberately keyed on discovery state alone, never on
+   * `readSelectedCodexCommand()`. That resolver answers from the managed
+   * runtime and the coordinator cache, which `runCodexDiscoveryAttempt`
+   * populates seconds before it publishes `lastKnownGood` — and
+   * `lastKnownGood` is what `readCodexBackendSummary` derives `available`
+   * from. Consulting the resolver here made the two disagree for the length
+   * of a version probe, dropping the pending flag while the summary was still
+   * unavailable: exactly the window this flag exists to cover.
    */
   isCodexDiscoveryPending(): boolean {
-    if (this.readSelectedCodexCommand()) {
-      return false;
+    return this.codexDiscoveryPromise !== undefined
+      || !this.codexDiscoverySettled;
+  }
+
+  /**
+   * Record that no startup Codex discovery is coming in this process, so
+   * surfaces stop waiting for one.
+   *
+   * A bootstrap or onboarding-incomplete boot never requests startup
+   * discovery, and nothing re-requests it when the wizard completes in the
+   * same process. Without this, `isCodexDiscoveryPending()` would stay true
+   * for the life of that process and every consumer would wait forever for an
+   * answer that was never scheduled.
+   */
+  markStartupCodexDiscoverySkipped(): void {
+    if (this.codexDiscoveryPromise) {
+      return;
     }
-    if (this.startupDiscoveryPromise) {
-      return true;
-    }
-    // No discovery has run in this process, so the empty durable projection
-    // above is the absence of an answer rather than an answer of "none".
-    return !this.codexDiscoveryAttempted;
+    this.codexDiscoverySettled = true;
   }
 
   /**

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -556,6 +556,7 @@ export class DesktopSettingsService {
   private managedCodexRuntimeSwitchAttempt?: Promise<void>;
   private startupDiscoveryAttempted = false;
   private startupDiscoveryPromise?: Promise<void>;
+  private codexDiscoveryAttempted = false;
 
   constructor(private readonly options: DesktopSettingsServiceOptions) {
     this.env = options.env ?? process.env;
@@ -2192,6 +2193,19 @@ export class DesktopSettingsService {
     permit: ProviderDiscoveryPermit,
   ): Promise<void> {
     assertProviderDiscoveryPermit(permit);
+    try {
+      await this.runCodexDiscoveryAttempt(permit);
+    } finally {
+      // Marks the attempt, not its outcome. A discovery that ran and found
+      // nothing is a real answer that surfaces must be free to act on; only a
+      // discovery that has not run yet leaves them without one.
+      this.codexDiscoveryAttempted = true;
+    }
+  }
+
+  private async runCodexDiscoveryAttempt(
+    permit: ProviderDiscoveryPermit,
+  ): Promise<void> {
     this.codexSpawnEnvHydratedAt = undefined;
     const config = this.readConfig().config;
     const checkMode = permit.intent === "startup" ? "ttl" : "force";
@@ -2257,6 +2271,39 @@ export class DesktopSettingsService {
   }
 
   async resolveCodexCommand(): Promise<ResolvedCodexCommandCandidate> {
+    const resolved = this.readSelectedCodexCommand();
+    if (resolved) {
+      return resolved;
+    }
+    // The one permitted startup discovery is the authority for this profile's
+    // selection, and it is already running. Waiting for the answer that is in
+    // flight is not a retry: the durable last-known-good read above is an
+    // optimization that is legitimately empty on a cold profile, after a
+    // provider fingerprint change, and for the whole window between process
+    // start and the first published discovery. Background callers that land
+    // inside that window — archived binding cleanup is the routine one — were
+    // otherwise told to "Refresh Codex in Settings" about a Codex that was
+    // seconds from resolving normally.
+    const startupDiscovery = this.startupDiscoveryPromise;
+    if (startupDiscovery) {
+      await startupDiscovery;
+      const discovered = this.readSelectedCodexCommand();
+      if (discovered) {
+        return discovered;
+      }
+    }
+    throw new Error(
+      "Codex discovery has not selected an executable. Refresh Codex in Settings.",
+    );
+  }
+
+  /**
+   * The currently selected Codex executable, or `undefined` when no discovery
+   * has published one yet. Never probes the machine.
+   */
+  private readSelectedCodexCommand():
+    | ResolvedCodexCommandCandidate
+    | undefined {
     const managedRuntime = this.managedCodexRuntime;
     if (managedRuntime) {
       return {
@@ -2270,15 +2317,31 @@ export class DesktopSettingsService {
       ?? codexDiscoveryFromProvider(this.configStore.read("providers").codex);
     const selected = cached.candidates.find((candidate) => candidate.selected);
     if (!selected) {
-      throw new Error(
-        "Codex discovery has not selected an executable. Refresh Codex in Settings.",
-      );
+      return undefined;
     }
     return {
       command: selected.command,
       source: selected.source,
       ...(selected.version ? { version: selected.version } : {}),
     };
+  }
+
+  /**
+   * Whether this profile is still owed a Codex selection. True until some
+   * discovery has published one or has run and found none. The desktop uses
+   * it to keep a startup surface pending rather than reporting a configured
+   * profile as having no provider.
+   */
+  isCodexDiscoveryPending(): boolean {
+    if (this.readSelectedCodexCommand()) {
+      return false;
+    }
+    if (this.startupDiscoveryPromise) {
+      return true;
+    }
+    // No discovery has run in this process, so the empty durable projection
+    // above is the absence of an answer rather than an answer of "none".
+    return !this.codexDiscoveryAttempted;
   }
 
   /**

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -2035,14 +2035,24 @@ function DesktopAppShell(props: {
         startupLandingStateRef.current = "notice-shown";
         showAppNotice(
           buildNoStartupBackendNotice({
-            codex: backendSummaries.backends.find(
-              (backend) => backend.kind === "codex",
-            ),
-            onOpenCodexSettings: () => {
+            backends: backendSummaries.backends,
+            // Every exit from the notice returns the landing decision to
+            // "pending". Without that, closing the toast — or opening setup
+            // and cancelling it — left a provider-less window with nothing on
+            // screen and no way to get the notice back, which the modal wizard
+            // this replaced could not do. A notice-supplied `onDismiss`
+            // replaces the stack's own removal, so it has to dismiss too.
+            onDismiss: () => {
+              startupLandingStateRef.current = "pending";
               dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
-              openSettingsSection("models", "codex");
+            },
+            onOpenProviderSettings: (registryId) => {
+              startupLandingStateRef.current = "pending";
+              dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
+              openSettingsSection("models", registryId);
             },
             onRunSetup: () => {
+              startupLandingStateRef.current = "pending";
               dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
               setOnboardingOpen("replay");
             },
@@ -2053,14 +2063,15 @@ function DesktopAppShell(props: {
     }
 
     // A provider that showed up late clears the notice it caused.
-    if (startupLandingStateRef.current === "notice-shown") {
-      dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
-    }
+    dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
     startupLandingStateRef.current = "complete";
-    if (navigation.selectedThreadKey) {
+    // Landing is for a window that is still sitting on the startup view. The
+    // notice sends operators into Settings to fix exactly this, so a provider
+    // appearing while they are mid-edit there must not navigate away from the
+    // pane that repaired it.
+    if (navigation.selectedThreadKey || mainView !== "thread") {
       return;
     }
-    setMainView("thread");
     void openWorkspaceLaunchpad(startupBackend.kind);
   }, [
     backendSummaries.backends,
@@ -2068,6 +2079,7 @@ function DesktopAppShell(props: {
     backendSummaries.loaded,
     desktopApi,
     dismissAppNotice,
+    mainView,
     navigation.loaded,
     navigation.selectedThreadKey,
     onboardingOpen,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -112,6 +112,10 @@ import { resolveThreadWorkingStatePath } from "./lib/thread-working-state-path";
 import { CodexConfigWarningBanner } from "./features/codex-config/CodexConfigWarningBanner";
 import type { AppNoticeToastNotice } from "./features/notifications/AppNoticeToast";
 import { AppNoticeStack } from "./features/notifications/AppNoticeStack";
+import {
+  buildNoStartupBackendNotice,
+  NO_STARTUP_BACKEND_NOTICE_ID,
+} from "./features/notifications/provider-startup-notice";
 import { QuitBlockerQueueToast } from "./features/notifications/QuitBlockerQueueToast";
 import {
   appNoticeReducer,
@@ -342,20 +346,31 @@ function DesktopAppShell(props: {
   const [settingsInitialSection, setSettingsInitialSection] = useState<
     SettingsSection | undefined
   >(undefined);
+  // Sub-screen within `settingsInitialSection` (a provider registry id under
+  // "models", a platform kind under "messaging"). Always written together with
+  // the section through `openSettingsSection` so a deep link can never carry a
+  // previous link's sub-screen into a different section.
+  const [settingsInitialSubsection, setSettingsInitialSubsection] = useState<
+    string | undefined
+  >(undefined);
   const [threadViewReady, setThreadViewReady] = useState(false);
-  // Onboarding wizard overlay state. Two paths into it:
+  // Onboarding wizard overlay state. Three paths into it:
   //  (1) auto-launch on first snapshot if `onboarding.completed` is
   //      false for the active profile;
   //  (2) explicit replay via Help → Replay Onboarding (main process
-  //      menu push → renderer subscribes below).
-  // The auto-launch leans on `autoOpenSeen` so we don't re-open after
+  //      menu push → renderer subscribes below);
+  //  (3) the "Run setup" action on the no-backend startup notice.
+  // A completed profile that lands with no provider gets that notice, never
+  // an unrequested wizard: it has already answered every question the wizard
+  // asks, so a missing provider is a health problem to point at, not setup to
+  // redo. The auto-launch leans on `autoOpenSeen` so we don't re-open after
   // the user dismisses without persisting (snapshot refresh case).
   const [onboardingOpen, setOnboardingOpen] = useState<
     "auto" | "replay" | null
   >(null);
   const [autoOpenSeen, setAutoOpenSeen] = useState(false);
   const startupLandingStateRef = useRef<
-    "pending" | "onboarding-opened" | "complete"
+    "pending" | "notice-shown" | "complete"
   >("pending");
   // Boot info is fetched once on mount and is stable across the
   // renderer's lifetime (the main process recorded it before this
@@ -562,10 +577,17 @@ function DesktopAppShell(props: {
   const openMessagingActivityWindow = useCallback(() => {
     void desktopApi?.openMessagingActivityWindow?.();
   }, [desktopApi]);
+  const openSettingsSection = useCallback(
+    (section: SettingsSection | undefined, subsection?: string) => {
+      setSettingsInitialSection(section);
+      setSettingsInitialSubsection(section ? subsection : undefined);
+      setMainView("settings");
+    },
+    [],
+  );
   const openMessagingSettings = useCallback(() => {
-    setSettingsInitialSection("messaging");
-    setMainView("settings");
-  }, []);
+    openSettingsSection("messaging");
+  }, [openSettingsSection]);
   const dismissGithubPrSamlNotice = useCallback(() => {
     dispatchAppNotice({ type: "dismiss-prefix", prefix: "github-pr-saml:" });
     setGithubPrSamlEvents((current) => current.slice(1));
@@ -577,9 +599,8 @@ function DesktopAppShell(props: {
       prefix: "github-pr-authentication-failure",
     });
     setGithubPrAuthenticationFailure(undefined);
-    setSettingsInitialSection("git");
-    setMainView("settings");
-  }, [dismissGithubPrSamlNotice]);
+    openSettingsSection("git");
+  }, [dismissGithubPrSamlNotice, openSettingsSection]);
   const githubPrSamlNotice = useMemo(() => {
     const event = githubPrSamlEvents[0];
     return event
@@ -1915,12 +1936,9 @@ function DesktopAppShell(props: {
       return;
     }
     return desktopApi.onOpenSettingsRequested((section) => {
-      setSettingsInitialSection(
-        isSettingsSection(section) ? section : undefined,
-      );
-      setMainView("settings");
+      openSettingsSection(isSettingsSection(section) ? section : undefined);
     });
-  }, [desktopApi]);
+  }, [desktopApi, openSettingsSection]);
   useEffect(() => {
     if (!desktopApi?.onOpenNewThreadRequested) {
       return;
@@ -2002,13 +2020,42 @@ function DesktopAppShell(props: {
       if (backendSummaries.error) {
         return;
       }
+      // Nor is a discovery that has not answered yet. The Codex summary is
+      // derived from a durable last-known-good that is legitimately empty for
+      // the whole window between process start and the first published startup
+      // discovery — several seconds when a managed runtime has to be verified.
+      // `navigation/providerThreads/refreshed` re-runs this effect with the
+      // real answer once that discovery lands.
+      if (
+        backendSummaries.backends.some((backend) => backend.discoveryPending)
+      ) {
+        return;
+      }
       if (startupLandingStateRef.current === "pending") {
-        startupLandingStateRef.current = "onboarding-opened";
-        setOnboardingOpen("replay");
+        startupLandingStateRef.current = "notice-shown";
+        showAppNotice(
+          buildNoStartupBackendNotice({
+            codex: backendSummaries.backends.find(
+              (backend) => backend.kind === "codex",
+            ),
+            onOpenCodexSettings: () => {
+              dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
+              openSettingsSection("models", "codex");
+            },
+            onRunSetup: () => {
+              dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
+              setOnboardingOpen("replay");
+            },
+          }),
+        );
       }
       return;
     }
 
+    // A provider that showed up late clears the notice it caused.
+    if (startupLandingStateRef.current === "notice-shown") {
+      dismissAppNotice(NO_STARTUP_BACKEND_NOTICE_ID);
+    }
     startupLandingStateRef.current = "complete";
     if (navigation.selectedThreadKey) {
       return;
@@ -2016,15 +2063,19 @@ function DesktopAppShell(props: {
     setMainView("thread");
     void openWorkspaceLaunchpad(startupBackend.kind);
   }, [
+    backendSummaries.backends,
     backendSummaries.error,
     backendSummaries.loaded,
     desktopApi,
+    dismissAppNotice,
     navigation.loaded,
     navigation.selectedThreadKey,
     onboardingOpen,
+    openSettingsSection,
     openWorkspaceLaunchpad,
     remoteReadsSuspended,
     settings.snapshot?.onboarding?.completed.value,
+    showAppNotice,
     startupBackend,
   ]);
   const loadThreadDetail = threadViewReady && mainView === "thread";
@@ -2092,8 +2143,7 @@ function DesktopAppShell(props: {
       setMainView("automations");
     },
     onOpenSettings: () => {
-      setSettingsInitialSection(undefined);
-      setMainView("settings");
+      openSettingsSection(undefined);
     },
     onToggleThreadSearch: () => {
       toggleGlobalThreadSearch();
@@ -2618,8 +2668,7 @@ function DesktopAppShell(props: {
             await navigation.openDirectoryLaunchpad(directory, preferredBackend);
           }}
           onOpenSettings={() => {
-            setSettingsInitialSection(undefined);
-            setMainView("settings");
+            openSettingsSection(undefined);
           }}
           onOpenProfile={profiles.openProfile}
           onSelectThread={(thread) => {
@@ -2853,6 +2902,7 @@ function DesktopAppShell(props: {
                 cachedBackends={backendSummaries.backends}
                 desktopApi={desktopApi}
                 initialSection={settingsInitialSection}
+                initialSubsection={settingsInitialSubsection}
                 profiles={profiles}
                 settings={settings}
                 onClose={() => setMainView("thread")}
@@ -2962,8 +3012,7 @@ function DesktopAppShell(props: {
                 setOnboardingOpen(null);
               }}
               onOpenMessagingSettings={() => {
-                setSettingsInitialSection("messaging");
-                setMainView("settings");
+                openSettingsSection("messaging");
               }}
             />
           </Suspense>

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3299,7 +3299,7 @@ describe("App", () => {
     expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
   });
 
-  it("reopens onboarding when a stale selection has no usable backend", async () => {
+  it("points a completed profile with no usable backend at provider settings", async () => {
     const ensureDirectoryLaunchpad = vi.fn();
 
     Object.defineProperty(window, "pwragent", {
@@ -3380,11 +3380,148 @@ describe("App", () => {
 
     render(<App />);
 
+    // `[onboarding] completed = true` says this operator already answered every
+    // question the wizard asks. A missing provider is a health problem to point
+    // at, not setup to redo, so the wizard must stay closed.
     expect(
-      await screen.findByRole("heading", { name: /A few short choices/i }),
+      await screen.findByText("No agent backend is available"),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Open AI Providers" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("heading", { name: /A few short choices/i }),
+    ).not.toBeInTheDocument();
     expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
   });
+
+  it("holds the startup landing while Codex discovery has not answered", async () => {
+    const ensureDirectoryLaunchpad = vi.fn();
+
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        readSettings: async () => ({
+          snapshot: {
+            general: {
+              appearance: {
+                theme: { value: "system", source: "default" },
+                density: { value: "mission-control", source: "default" },
+                sidebarTextSize: { value: "md", source: "default" },
+                transcriptTextSize: { value: "md", source: "default" },
+              },
+              codexProfileModel: { value: "shared", source: "default" },
+            },
+            onboarding: {
+              completed: { value: true, source: "config" },
+              completedSource: { value: "migrated", source: "default" },
+            },
+            imageUploads: {
+              pastedImageMaxPatches: { value: 1536, source: "default" },
+            },
+            models: {
+              codex: {
+                path: { value: "", source: "default" },
+                profile: { value: "", source: "default" },
+                discovery: {
+                  selectedCommand: undefined,
+                  candidates: [],
+                },
+                profiles: {
+                  profileRoot: "/home/example/.codex/profiles",
+                  effectiveCodexHome: "/home/example/.codex",
+                  profiles: [],
+                },
+              },
+            },
+            experimental: {
+              fullAccessRiskWarningDismissed: {
+                value: false,
+                source: "default",
+              },
+            },
+          } as unknown as DesktopSettingsSnapshot,
+        }),
+        // What the main process reports for the several seconds between
+        // process start and the first published startup discovery. Reading it
+        // as "no provider configured" is what used to hijack a working
+        // profile's window with the first-run wizard.
+        listBackends: async () => ({
+          fetchedAt: Date.now(),
+          backends: [
+            {
+              kind: "codex" as const,
+              source: "builtin" as const,
+              label: "Codex",
+              available: false,
+              discoveryPending: true,
+              unavailableReason: "Codex discovery has not completed yet.",
+              methods: [],
+              capabilities: {
+                listThreads: false,
+                createThread: false,
+                resumeThread: false,
+                renameThread: false,
+                readThread: false,
+                startTurn: false,
+                interruptTurn: false,
+                steerTurn: false,
+                transcriptPagination: false,
+                toolUse: false,
+                approvalRequests: false,
+                multiDirectoryThreads: false,
+              },
+              executionModes: [],
+            },
+          ],
+        }),
+        getNavigationSnapshot: async () => ({
+          backend: "all" as const,
+          fetchedAt: Date.now(),
+          unchanged: false,
+          inboxThreadKeys: ["codex:pending-thread"],
+          threads: [{
+            id: "pending-thread",
+            title: "Existing thread",
+            titleSource: "explicit" as const,
+            source: "codex" as const,
+            linkedDirectories: [],
+            inbox: {
+              inInbox: true,
+              reason: "new-thread" as const,
+            },
+            updatedAt: 1,
+          }],
+          directories: [],
+          launchpadDefaults: {
+            backend: "codex" as const,
+            executionMode: "default" as const,
+          },
+        }),
+        ensureDirectoryLaunchpad,
+        onAgentEvent: () => () => undefined,
+      },
+    });
+
+    render(<App />);
+
+    expect(
+      await screen.findByRole("button", { name: "Existing thread" }),
+    ).toBeInTheDocument();
+    await flushReactUpdates();
+    await flushReactUpdates();
+
+    expect({
+      noticeVisible: Boolean(
+        screen.queryByText("No agent backend is available"),
+      ),
+      onboardingVisible: Boolean(
+        screen.queryByRole("heading", { name: /A few short choices/i }),
+      ),
+    }).toEqual({ noticeVisible: false, onboardingVisible: false });
+    expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
+  });
+
 
   it("routes the new-thread menu push into the existing launchpad flow", async () => {
     let openNewThreadListener: (() => void) | undefined;

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -3522,7 +3522,6 @@ describe("App", () => {
     expect(ensureDirectoryLaunchpad).not.toHaveBeenCalled();
   });
 
-
   it("routes the new-thread menu push into the existing launchpad flow", async () => {
     let openNewThreadListener: (() => void) | undefined;
     const ensureDirectoryLaunchpad = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/provider-startup-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/provider-startup-notice.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
-import type { BackendSummary } from "@pwragent/shared";
+import type { AppServerBackendKind, BackendSummary } from "@pwragent/shared";
 import {
   buildNoStartupBackendNotice,
   NO_STARTUP_BACKEND_NOTICE_ID,
 } from "../provider-startup-notice";
 
-function codexSummary(unavailableReason?: string): BackendSummary {
+function summary(params: {
+  kind: AppServerBackendKind;
+  label: string;
+  unavailableReason?: string;
+}): BackendSummary {
   return {
-    kind: "codex",
-    source: "builtin",
-    label: "Codex",
+    kind: params.kind,
+    source: params.kind.startsWith("acp:") ? "acp" : "builtin",
+    label: params.label,
     available: false,
     methods: [],
     capabilities: {
@@ -27,18 +31,27 @@ function codexSummary(unavailableReason?: string): BackendSummary {
       multiDirectoryThreads: false,
     },
     executionModes: [],
-    ...(unavailableReason ? { unavailableReason } : {}),
+    ...(params.unavailableReason
+      ? { unavailableReason: params.unavailableReason }
+      : {}),
   };
 }
 
 describe("buildNoStartupBackendNotice", () => {
   it("leads with provider settings and keeps setup as the secondary answer", () => {
-    const onOpenCodexSettings = vi.fn();
+    const onOpenProviderSettings = vi.fn();
     const onRunSetup = vi.fn();
 
     const notice = buildNoStartupBackendNotice({
-      codex: codexSummary("Codex CLI 0.1.0 is older than the minimum."),
-      onOpenCodexSettings,
+      backends: [
+        summary({
+          kind: "codex",
+          label: "Codex",
+          unavailableReason: "Codex CLI 0.1.0 is older than the minimum.",
+        }),
+      ],
+      onDismiss: vi.fn(),
+      onOpenProviderSettings,
       onRunSetup,
     });
 
@@ -60,18 +73,60 @@ describe("buildNoStartupBackendNotice", () => {
 
     notice.actions?.[0]?.onClick();
     notice.actions?.[1]?.onClick();
-    expect(onOpenCodexSettings).toHaveBeenCalledTimes(1);
+    expect(onOpenProviderSettings).toHaveBeenCalledWith("codex");
     expect(onRunSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("names the provider that reported a reason, not whichever came first", () => {
+    const onOpenProviderSettings = vi.fn();
+
+    const notice = buildNoStartupBackendNotice({
+      backends: [
+        summary({ kind: "codex", label: "Codex" }),
+        summary({
+          kind: "acp:gemini",
+          label: "Gemini",
+          unavailableReason: "gemini CLI is not installed.",
+        }),
+      ],
+      onDismiss: vi.fn(),
+      onOpenProviderSettings,
+      onRunSetup: vi.fn(),
+    });
+
+    // `!startupBackend` means "nothing is selectable", not "Codex is broken".
+    // Hardcoding Codex sent operators on an ACP-only profile to a provider
+    // they never configured while the missing one went unnamed.
+    expect(notice.detail).toBe("Gemini: gemini CLI is not installed.");
+    notice.actions?.[0]?.onClick();
+    expect(onOpenProviderSettings).toHaveBeenCalledWith("gemini");
   });
 
   it("omits the detail line when no provider reported a reason", () => {
     const notice = buildNoStartupBackendNotice({
-      codex: codexSummary(),
-      onOpenCodexSettings: vi.fn(),
+      backends: [summary({ kind: "codex", label: "Codex" })],
+      onDismiss: vi.fn(),
+      onOpenProviderSettings: vi.fn(),
       onRunSetup: vi.fn(),
     });
 
     expect(notice).not.toHaveProperty("detail");
     expect(notice).not.toHaveProperty("copyText");
+  });
+
+  it("dismisses through the caller so the landing decision can reset", () => {
+    const onDismiss = vi.fn();
+
+    const notice = buildNoStartupBackendNotice({
+      backends: [],
+      onDismiss,
+      onOpenProviderSettings: vi.fn(),
+      onRunSetup: vi.fn(),
+    });
+
+    // A notice-supplied `onDismiss` replaces the stack's own removal, so the
+    // caller owns both resetting the ref and dropping the notice.
+    notice.onDismiss?.();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/provider-startup-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/provider-startup-notice.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import type { BackendSummary } from "@pwragent/shared";
+import {
+  buildNoStartupBackendNotice,
+  NO_STARTUP_BACKEND_NOTICE_ID,
+} from "../provider-startup-notice";
+
+function codexSummary(unavailableReason?: string): BackendSummary {
+  return {
+    kind: "codex",
+    source: "builtin",
+    label: "Codex",
+    available: false,
+    methods: [],
+    capabilities: {
+      listThreads: false,
+      createThread: false,
+      resumeThread: false,
+      renameThread: false,
+      readThread: false,
+      startTurn: false,
+      interruptTurn: false,
+      steerTurn: false,
+      transcriptPagination: false,
+      toolUse: false,
+      approvalRequests: false,
+      multiDirectoryThreads: false,
+    },
+    executionModes: [],
+    ...(unavailableReason ? { unavailableReason } : {}),
+  };
+}
+
+describe("buildNoStartupBackendNotice", () => {
+  it("leads with provider settings and keeps setup as the secondary answer", () => {
+    const onOpenCodexSettings = vi.fn();
+    const onRunSetup = vi.fn();
+
+    const notice = buildNoStartupBackendNotice({
+      codex: codexSummary("Codex CLI 0.1.0 is older than the minimum."),
+      onOpenCodexSettings,
+      onRunSetup,
+    });
+
+    expect(notice).toMatchObject({
+      autoDismiss: false,
+      detail: "Codex: Codex CLI 0.1.0 is older than the minimum.",
+      id: NO_STARTUP_BACKEND_NOTICE_ID,
+      title: "No agent backend is available",
+      tone: "warning",
+    });
+    // The operator has already completed onboarding, so the first answer must
+    // be the pane that reports provider health, not a wizard that asks them to
+    // redo choices they already made.
+    expect(notice.actions?.map((action) => action.label)).toEqual([
+      "Open AI Providers",
+      "Run setup",
+    ]);
+    expect(notice.actions?.[0]?.tone).toBe("primary");
+
+    notice.actions?.[0]?.onClick();
+    notice.actions?.[1]?.onClick();
+    expect(onOpenCodexSettings).toHaveBeenCalledTimes(1);
+    expect(onRunSetup).toHaveBeenCalledTimes(1);
+  });
+
+  it("omits the detail line when no provider reported a reason", () => {
+    const notice = buildNoStartupBackendNotice({
+      codex: codexSummary(),
+      onOpenCodexSettings: vi.fn(),
+      onRunSetup: vi.fn(),
+    });
+
+    expect(notice).not.toHaveProperty("detail");
+    expect(notice).not.toHaveProperty("copyText");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/provider-startup-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/provider-startup-notice.ts
@@ -1,0 +1,50 @@
+import type { BackendSummary } from "@pwragent/shared";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export const NO_STARTUP_BACKEND_NOTICE_ID = "provider-startup:no-backend";
+
+/**
+ * Shown when a profile that has already completed onboarding lands with no
+ * selectable provider.
+ *
+ * This case used to reopen the first-run wizard, which is wrong twice over:
+ * `[onboarding] completed = true` says the operator already made every choice
+ * that wizard asks for, and the condition that triggers it is a provider
+ * health problem, not a missing setup. The wizard also takes the whole window,
+ * so a Codex that failed to launch looked like a profile that had been reset.
+ *
+ * The notice keeps the operator on their threads, names what is actually
+ * wrong, and points at the pane that can fix it. Setup stays reachable as a
+ * secondary action for the genuine case of an operator who skipped the wizard
+ * and never installed a CLI.
+ */
+export function buildNoStartupBackendNotice(params: {
+  codex?: BackendSummary;
+  onOpenCodexSettings: () => void;
+  onRunSetup: () => void;
+}): AppNoticeToastNotice {
+  const reason = params.codex?.unavailableReason?.trim();
+  return {
+    actions: [
+      {
+        label: "Open AI Providers",
+        onClick: params.onOpenCodexSettings,
+        tone: "primary",
+      },
+      {
+        label: "Run setup",
+        onClick: params.onRunSetup,
+        tone: "secondary",
+      },
+    ],
+    autoDismiss: false,
+    id: NO_STARTUP_BACKEND_NOTICE_ID,
+    title: "No agent backend is available",
+    message:
+      "PwrAgent could not start a coding agent for this profile. Your threads"
+      + " are still here — check the provider's status in Settings.",
+    ...(reason ? { detail: `Codex: ${reason}` } : {}),
+    ...(reason ? { copyText: reason } : {}),
+    tone: "warning",
+  };
+}

--- a/apps/desktop/src/renderer/src/features/notifications/provider-startup-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/provider-startup-notice.ts
@@ -3,6 +3,29 @@ import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
 export const NO_STARTUP_BACKEND_NOTICE_ID = "provider-startup:no-backend";
 
+/** Settings sub-screen for a backend kind, under Settings → AI Providers. */
+function providerSettingsRoute(kind: BackendSummary["kind"]): string {
+  return kind.startsWith("acp:") ? kind.slice("acp:".length) : kind;
+}
+
+/**
+ * The provider this notice should speak for: the one that reported a reason
+ * for being unavailable, else whichever backend the profile has at all.
+ *
+ * Naming a provider matters because `!startupBackend` means "nothing is
+ * selectable", not "Codex is broken". On a profile whose only agent is an ACP
+ * one, hardcoding Codex would send the operator to a provider they never
+ * configured while the actually-missing agent went unnamed.
+ */
+function resolveNoticeProvider(
+  backends: readonly BackendSummary[],
+): BackendSummary | undefined {
+  return (
+    backends.find((backend) => backend.unavailableReason?.trim())
+    ?? backends[0]
+  );
+}
+
 /**
  * Shown when a profile that has already completed onboarding lands with no
  * selectable provider.
@@ -11,7 +34,8 @@ export const NO_STARTUP_BACKEND_NOTICE_ID = "provider-startup:no-backend";
  * `[onboarding] completed = true` says the operator already made every choice
  * that wizard asks for, and the condition that triggers it is a provider
  * health problem, not a missing setup. The wizard also takes the whole window,
- * so a Codex that failed to launch looked like a profile that had been reset.
+ * so a provider that failed to launch looked like a profile that had been
+ * reset.
  *
  * The notice keeps the operator on their threads, names what is actually
  * wrong, and points at the pane that can fix it. Setup stays reachable as a
@@ -19,16 +43,19 @@ export const NO_STARTUP_BACKEND_NOTICE_ID = "provider-startup:no-backend";
  * and never installed a CLI.
  */
 export function buildNoStartupBackendNotice(params: {
-  codex?: BackendSummary;
-  onOpenCodexSettings: () => void;
+  backends: readonly BackendSummary[];
+  onDismiss: () => void;
+  onOpenProviderSettings: (settingsRoute: string) => void;
   onRunSetup: () => void;
 }): AppNoticeToastNotice {
-  const reason = params.codex?.unavailableReason?.trim();
+  const provider = resolveNoticeProvider(params.backends);
+  const reason = provider?.unavailableReason?.trim();
+  const route = providerSettingsRoute(provider?.kind ?? "codex");
   return {
     actions: [
       {
         label: "Open AI Providers",
-        onClick: params.onOpenCodexSettings,
+        onClick: () => params.onOpenProviderSettings(route),
         tone: "primary",
       },
       {
@@ -39,12 +66,14 @@ export function buildNoStartupBackendNotice(params: {
     ],
     autoDismiss: false,
     id: NO_STARTUP_BACKEND_NOTICE_ID,
+    onDismiss: params.onDismiss,
     title: "No agent backend is available",
     message:
       "PwrAgent could not start a coding agent for this profile. Your threads"
       + " are still here — check the provider's status in Settings.",
-    ...(reason ? { detail: `Codex: ${reason}` } : {}),
-    ...(reason ? { copyText: reason } : {}),
+    ...(reason && provider
+      ? { copyText: reason, detail: `${provider.label}: ${reason}` }
+      : {}),
     tone: "warning",
   };
 }

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -217,6 +217,16 @@ export type BackendSummary = {
   source?: BackendSourceKind;
   label: string;
   available: boolean;
+  /**
+   * This backend is unavailable only because the one permitted startup
+   * discovery has not published a selection yet. A surface that decides
+   * whether the profile has any usable provider must keep that decision
+   * pending instead of reading `available: false` as "not configured" — the
+   * durable last-known-good it is derived from is legitimately empty on a cold
+   * profile and for the whole window between process start and first
+   * discovery. Never set alongside `available: true`.
+   */
+  discoveryPending?: boolean;
   acp?: BackendAcpSummary;
   account?: BackendAccountSummary;
   rateLimits?: BackendRateLimitSummary[];


### PR DESCRIPTION
## What happened

A boot-time Codex capability probe fires from the `DesktopBackendRegistry`
constructor, which runs before `prewarmInitialThreadList` even requests the one
permitted startup discovery. In that window the only thing that can resolve an
executable is the durable last-known-good projection — an optimization that is
legitimately empty on a cold profile, after a provider dependency-fingerprint
change, and until the first discovery publishes a selection.

From an affected boot log:

```
07:23:18.590 (backend-registry) Codex code-mode output reducer capability probe failed open
             error="Codex discovery has not selected an executable. Refresh Codex in Settings."
07:23:18.594 (backend-registry) Token Miser runtime preparation failed open
             error="Managed Codex runtime lacks the complete Token Miser activation ... contract."
07:23:21.301 (codex-transport)  launch app-server command=.../pwragent-v0.149.0-pwragent.2/codex
```

The same profile on a warm cache launches the app-server **1 ms** after the
login-shell env merge and logs nothing. So this is a cache-warmth race, not a
broken install — and notably PwrAgent never started the *wrong* Codex: there is
exactly one `launch app-server`, with the correct managed binary, 2.7s later.

Three separate failures fell out of that one ordering defect:

1. `resolveCodexCommand()` told the operator to "Refresh Codex in Settings"
   about a Codex that was seconds from resolving normally. Other early callers
   hit it too — `archived bound binding cleanup failed backend=codex` appears
   with the identical message on another affected boot.
2. `prepareTokenMiserRuntime` caught that error and recorded Token Miser as
   unavailable, attributing it to a managed-capability contract that was not
   the real cause. Nothing re-runs it for the rest of the session unless the
   managed runtime happens to change, so **Token Miser stayed off all session**.
3. The renderer read the same empty projection as "this profile has no
   provider" and opened the **first-run wizard** over a fully configured
   install with 50 threads already loaded.

## Fixes

**Ordering (the root cause).** The boot Token Miser preparation moves out of the
registry constructor into the startup chain, behind `startupSettingsDiscovery` —
the same dependency `refreshProvidersAtStartup` already declares two lines away.

**Honesty.** `resolveCodexCommand()` now awaits an in-flight startup discovery
before reporting no executable. This is not a retry: it waits on the authority
that is already running, and still throws when no discovery is in flight.

**Pending vs unconfigured.** `BackendSummary.discoveryPending` distinguishes
"startup discovery has not answered yet" from "not configured" — the two were
indistinguishable in the projection. The startup landing decision holds while
it is set, exactly as it already held for `backendSummaries.error`.
`navigation/providerThreads/refreshed` re-runs the decision with the real answer.

**No more wizard hijack.** A profile with `[onboarding] completed = true` has
already answered every question the wizard asks, so a missing provider is a
health problem to point at, not setup to redo. It now gets a durable notice
that deep-links to Settings → AI Providers → Codex, with "Run setup" kept as a
secondary action for the operator who genuinely skipped the wizard and never
installed a CLI.

Settings deep links now carry a subsection (written together with the section,
so a link can never inherit a previous link's sub-screen) and that is what lands
the notice on the Codex screen rather than the top of AI Providers.

## After

Before: the first-run wizard took the whole window. After — contrived fixture
content, rendered from the shipped `app.css` primitives:

![no-backend notice](https://github.com/user-attachments/assets/1e26ac80-5baa-46ba-b6eb-2404180d1fa8)

## Tests

- `desktop-settings-service`: `resolveCodexCommand()` resolves through an
  in-flight startup discovery instead of throwing; a discovery that ran and
  found nothing stops reporting pending (so a surface never waits forever).
- `backend-registry`: the durable Codex summary carries `discoveryPending`
  while discovery is outstanding and omits it once it has answered.
- `app-shell`: the startup landing holds while `discoveryPending` is set, and a
  completed profile with no usable backend gets the notice — the wizard stays
  closed. This replaces the old "reopens onboarding when a stale selection has
  no usable backend" expectation.
- `provider-startup-notice`: action order/tone and the detail line.

Full workspace suite green (9968 passed, 6 skipped), `lint:eslint` 0 errors,
`lint:boundaries` and `lint:codex-storage` clean.

Not reproduced live — the trigger is a cold durable cache at boot, which I could
not force on the reporting machine without disturbing running instances. The
ordering defect and its three consequences are established from the boot logs
and covered by the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
