### PR TITLE
feat(desktop): report the Codex version and who built it

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -92,6 +92,7 @@ import type {
   CodexServerCapabilities,
 } from "../codex-app-server/client";
 import type { ManagedCodexSelectionChange } from "../settings/desktop-settings-service";
+import { managedCodexRoot } from "../codex-build-channel";
 import { DesktopConfigStore } from "../settings/config-store/desktop-config-store";
 import { issueProviderDiscoveryPermit } from "../settings/provider-discovery-permit";
 import type { AcpAvailableCommandsRecord } from "../acp/acp-available-commands-store";
@@ -1771,6 +1772,7 @@ class MockBackendClient {
           version?: string;
         };
         methods?: string[];
+        userAgent?: string;
       };
       initializeError?: Error;
       serverCapabilities?: CodexServerCapabilities;
@@ -6254,6 +6256,104 @@ describe("DesktopBackendRegistry", () => {
           supportsFastMode: true,
         },
       },    ]);
+
+    await registry.close();
+  });
+
+  it.each([
+    {
+      command: path.join("/opt", "homebrew", "bin", "codex"),
+      provenance: "an OpenAI release",
+      runtimeBuild: { channel: "vendor", publisher: "OpenAI" },
+      version: "0.149.1",
+    },
+    {
+      command: path.join(
+        managedCodexRoot(),
+        "versions",
+        "pwragent-v0.149.0-pwragent.2",
+        "codex",
+      ),
+      provenance: "a PwrDrvr build",
+      runtimeBuild: { channel: "pwragent", publisher: "PwrDrvr" },
+      version: "0.149.0-pwragent.2",
+    },
+  ])(
+    "reports the running Codex version and names it $provenance",
+    async ({ command, runtimeBuild, version }) => {
+      const tempRoot = await mkdtemp(
+        path.join(os.tmpdir(), "pwragent-codex-runtime-build-"),
+      );
+      const configStore = new DesktopConfigStore({
+        configPath: path.join(tempRoot, "config.toml"),
+      });
+      configStore.recordProviderDiscovery("codex", {
+        candidates: [{ command, source: "path", version }],
+        selectedCommand: command,
+        selectedVersion: version,
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient: new MockBackendClient({
+          initializeResult: {
+            methods: ["thread/list"],
+            // `initialize` carries no server version of its own — only the
+            // `userAgent`, whose first token names the client and the version
+            // of the App Server answering it.
+            userAgent: `pwragent/${version} (Mac OS 26.6.2; arm64) unknown`,
+          },
+        }),
+        configStore,
+        overlayStore: createOverlayStoreMock(),
+      });
+
+      await registry.refreshProvidersAtStartup(
+        issueProviderDiscoveryPermit("startup"),
+      );
+      const response = await registry.listBackends({ includeUnavailable: true });
+
+      expect(response.backends[0]).toMatchObject({
+        kind: "codex",
+        runtimeBuild,
+        serverVersion: version,
+      });
+
+      await registry.close();
+      configStore.dispose();
+      await rm(tempRoot, { recursive: true, force: true });
+    },
+  );
+
+  it("names a managed Codex build discovery never recorded", async () => {
+    // A profile on the PwrAgent channel reaches the App Server through the
+    // managed runtime without a provider observation ever being written, so
+    // the durable projection cannot answer who built the running Codex.
+    const command = path.join(
+      managedCodexRoot(),
+      "versions",
+      "pwragent-v0.149.0-pwragent.2",
+      "codex",
+    );
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+      }),
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexRuntimeCommand: async () => ({
+        command,
+        version: "0.149.0-pwragent.2",
+      }),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    const response = await registry.listBackends({ includeUnavailable: true });
+
+    expect(response.backends[0]).toMatchObject({
+      kind: "codex",
+      runtimeBuild: { channel: "pwragent", publisher: "PwrDrvr" },
+      serverVersion: "0.149.0-pwragent.2",
+    });
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6260,6 +6260,82 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("prefers the running App Server's version over the next launch's", async () => {
+    // The two disagree while a managed switch is pending: the connection is
+    // still answering from the old build while resolution already names the
+    // one a fresh launch would pick. The running server owns its own version.
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: {
+          methods: ["thread/list"],
+          userAgent: "pwragent-desktop/0.149.1 (Mac OS 26.6.2; arm64) unknown",
+        },
+      }),
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexRuntimeCommand: async () => ({
+        command: path.join("/opt", "homebrew", "bin", "codex"),
+        version: "0.150.0",
+      }),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    const response = await registry.listBackends({ includeUnavailable: true });
+
+    expect(response.backends[0]).toMatchObject({ serverVersion: "0.149.1" });
+
+    await registry.close();
+  });
+
+  it("re-describes the cached runtime when the managed build turns over", async () => {
+    // Nothing else invalidates the cached summary on this path, so without the
+    // re-description the panel keeps naming the replaced build.
+    let notify:
+      | ((change: ManagedCodexSelectionChange) => Promise<unknown> | unknown)
+      | undefined;
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        initializeResult: { methods: ["thread/list"] },
+      }),
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexRuntimeCommand: async () => ({
+        command: path.join(
+          managedCodexRoot(),
+          "versions",
+          "pwragent-v0.149.0-pwragent.2",
+          "codex",
+        ),
+        version: "0.149.0-pwragent.2",
+      }),
+      watchManagedCodexRuntime: (listener) => {
+        notify = listener;
+        return () => {};
+      },
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    expect(
+      (await registry.listBackends({ includeUnavailable: true })).backends[0],
+    ).toMatchObject({
+      runtimeBuild: { channel: "pwragent", publisher: "PwrDrvr" },
+      serverVersion: "0.149.0-pwragent.2",
+    });
+
+    await notify?.({ enabled: false, reason: "availability" });
+
+    // No managed runtime left: the fields go quiet rather than naming a
+    // publisher nothing has resolved yet.
+    const afterDisable =
+      (await registry.listBackends({ includeUnavailable: true })).backends[0];
+    expect(afterDisable.runtimeBuild).toBeUndefined();
+    expect(afterDisable.serverVersion).toBeUndefined();
+
+    await registry.close();
+  });
+
   it.each([
     {
       command: path.join("/opt", "homebrew", "bin", "codex"),

--- a/apps/desktop/src/main/__tests__/codex-build-channel.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-build-channel.test.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { managedCodexTagForCommand } from "../codex-build-channel";
+
+const managedRoot = path.join("/tmp", "pwragent-root", "agents", "codex");
+const options = { managedRoot };
+
+describe("managedCodexTagForCommand", () => {
+  it("recovers the release tag from a managed install path", () => {
+    expect(managedCodexTagForCommand(
+      path.join(managedRoot, "versions", "pwragent-v0.149.0-pwragent.2", "codex"),
+      options,
+    )).toBe("pwragent-v0.149.0-pwragent.2");
+  });
+
+  it("claims a superseded managed version, not only the newest", () => {
+    // Provenance is a property of the binary. An operator pinned to an older
+    // tag is still on the PwrAgent channel, and must not be described as
+    // running OpenAI's release because the channel moved on without them.
+    expect(managedCodexTagForCommand(
+      path.join(managedRoot, "versions", "pwragent-v0.148.0-pwragent.1", "codex"),
+      options,
+    )).toBe("pwragent-v0.148.0-pwragent.1");
+  });
+
+  it("has no tag for the version directory itself or anything outside it", () => {
+    expect(managedCodexTagForCommand(
+      path.join(managedRoot, "versions", "pwragent-v0.149.0-pwragent.2"),
+      options,
+    )).toBeUndefined();
+    expect(managedCodexTagForCommand(
+      path.join(managedRoot, "managed-release.json"),
+      options,
+    )).toBeUndefined();
+    expect(managedCodexTagForCommand("/opt/homebrew/bin/codex", options))
+      .toBeUndefined();
+    // A sibling directory whose name merely starts with the managed root's.
+    expect(managedCodexTagForCommand(
+      `${managedRoot}-backup/versions/pwragent-v0.149.0-pwragent.2/codex`,
+      options,
+    )).toBeUndefined();
+    expect(managedCodexTagForCommand(undefined, options)).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
@@ -92,6 +92,11 @@ describe("Codex App Server protocol compatibility", () => {
       expected: "0.149.0-pwragent.2",
       userAgent: "pwragent-desktop/0.149.0-pwragent.2 (Linux; x86_64) unknown",
     },
+    {
+      // A client name may carry a slash; the version never does.
+      expected: "0.149.1",
+      userAgent: "acme/tool/0.149.1 (Mac OS 26.6.2; arm64) unknown",
+    },
     { expected: undefined, userAgent: undefined },
     { expected: undefined, userAgent: "   " },
     // A client name with no version after it, and a version-shaped string

--- a/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-protocol-compatibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  codexVersionFromUserAgent,
   resolveCodexProtocolCompatibility,
   usesGeneratedCodexModelListResponse,
 } from "../codex-app-server/protocol-compatibility";
@@ -75,4 +76,32 @@ describe("Codex App Server protocol compatibility", () => {
       expect(usesGeneratedCodexModelListResponse(version)).toBe(expected);
     },
   );
+
+  it.each([
+    {
+      // Captured verbatim from a `codex app-server` handshake answering
+      // PwrAgent's own `clientInfo`.
+      expected: "0.149.1",
+      userAgent:
+        "pwragent-desktop/0.149.1 (Mac OS 26.6.2; arm64) unknown"
+        + " (pwragent-desktop; 1.4.0)",
+    },
+    {
+      // The suffix is the whole point: it is what separates a PwrAgent build
+      // from OpenAI's release of the same upstream version.
+      expected: "0.149.0-pwragent.2",
+      userAgent: "pwragent-desktop/0.149.0-pwragent.2 (Linux; x86_64) unknown",
+    },
+    { expected: undefined, userAgent: undefined },
+    { expected: undefined, userAgent: "   " },
+    // A client name with no version after it, and a version-shaped string
+    // that never named a client, are both unreadable rather than a guess.
+    { expected: undefined, userAgent: "pwragent-desktop (Mac OS 26.6.2; arm64)" },
+    { expected: undefined, userAgent: "0.149.1 (Mac OS 26.6.2; arm64)" },
+  ])("reads the App Server version out of $userAgent", ({
+    expected,
+    userAgent,
+  }) => {
+    expect(codexVersionFromUserAgent(userAgent)).toBe(expected);
+  });
 });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -125,6 +125,7 @@ import {
   type BackendLaunchpadOptions,
   type BackendModelOption,
   type BackendRateLimitSummary,
+  type BackendRuntimeBuild,
   type BackendSummary,
   type DesktopProviderModelDefaults,
   type DesktopProviderThreadModelMigration,
@@ -373,6 +374,7 @@ import {
   isCodexInvalidResponseMessageIdError,
   type CodexInvalidResponseMessageIdRecoveryResult,
 } from "../codex-app-server/invalid-response-message-id-recovery";
+import { codexVersionFromUserAgent } from "../codex-app-server/protocol-compatibility";
 import { ProviderTranscriptThreadSearchAdapter } from "../thread-search/thread-search-provider-adapters";
 import { ThreadSearchService } from "../thread-search/thread-search-service";
 import { ThreadSearchStore } from "../thread-search/thread-search-store";
@@ -553,6 +555,7 @@ import {
   assertProviderDiscoveryPermit,
   type ProviderDiscoveryPermit,
 } from "../settings/provider-discovery-permit";
+import { managedCodexTagForCommand } from "../codex-build-channel";
 import {
   PROVIDER_IDS,
   providerLastKnownGoodMatchesConfig,
@@ -1915,6 +1918,24 @@ function normalizeWorktreePathForComparison(worktreePath: string): string {
 const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
   codex: "OpenAI",
 };
+
+/**
+ * Who built the Codex executable PwrAgent launches. Decided from the resolved
+ * command's path: a managed download lives under the PwrAgent Codex channel's
+ * `versions/<tag>/` root, and anything else on this machine is OpenAI's own
+ * release. Returns `undefined` until a command has been resolved — "OpenAI" is
+ * a claim about a specific binary, not a fallback.
+ */
+function codexRuntimeBuild(
+  selectedCommand?: string,
+): BackendRuntimeBuild | undefined {
+  if (!selectedCommand) {
+    return undefined;
+  }
+  return managedCodexTagForCommand(selectedCommand) === undefined
+    ? { channel: "vendor", publisher: BACKEND_LABELS.codex }
+    : { channel: "pwragent", publisher: "PwrDrvr" };
+}
 
 const OPENAI_REASONING_EFFORTS = ["none", "low", "medium", "high", "xhigh"];
 const OPENAI_GPT56_REASONING_EFFORTS = ["low", "medium", "high", "xhigh", "max"];
@@ -8346,6 +8367,20 @@ export class DesktopBackendRegistry {
     codexCommand: string;
     codexEnv: NodeJS.ProcessEnv;
   }>;
+  /**
+   * The Codex executable a launch would use right now — the same resolution
+   * the stdio transport performs, so the summary describes the runtime that
+   * actually answers, not one a later discovery pass might select.
+   *
+   * It is the only reliable source for a managed build: `resolveCodexCommand`
+   * returns the PwrAgent-managed runtime before it consults discovery, so a
+   * profile running one can reach the App Server without ever recording a
+   * provider observation, leaving the durable projection empty.
+   */
+  private readonly resolveCodexRuntimeCommandFn?: () => Promise<{
+    command: string;
+    version?: string;
+  }>;
   private readonly mcpConnectionService?: Pick<
     PwrSnapConnectionService,
     "registerBridge"
@@ -8426,6 +8461,11 @@ export class DesktopBackendRegistry {
     resolveToolOutputAlertPolicy?: () => DesktopToolOutputAlertPolicy;
     resolveManagedTokenMiserActivationRequired?: () => boolean;
     markManagedCodexRuntimeSwitchComplete?: () => void;
+    /** Overrides the settings service's Codex executable resolution. */
+    resolveCodexRuntimeCommand?: () => Promise<{
+      command: string;
+      version?: string;
+    }>;
     watchManagedCodexRuntime?: (
       listener: (
         change: ManagedCodexSelectionChange,
@@ -8681,6 +8721,11 @@ export class DesktopBackendRegistry {
       codexEnv,
       tokenMiserBridgeDescriptorPath,
     );
+    this.resolveCodexRuntimeCommandFn =
+      options?.resolveCodexRuntimeCommand
+      ?? (settingsService
+        ? async () => await settingsService.resolveCodexCommand()
+        : undefined);
     this.resolveTokenMiserCodexRuntimeFn = settingsService
       ? async () => {
           const [resolvedCommand, resolvedEnv] = await Promise.all([
@@ -23771,15 +23816,27 @@ export class DesktopBackendRegistry {
     );
   }
 
+  /**
+   * The durable Codex executable observation, when it still describes the
+   * current configuration. The pre-discovery summary is built entirely from
+   * it; the discovered summary falls back to it for the version and
+   * provenance that live runtime resolution could not name.
+   */
+  private readCodexProviderLastKnownGood():
+    | ConfigDomainMap["providers"]["codex"]["lastKnownGood"]
+    | undefined {
+    const provider = this.configStore?.read("providers").codex;
+    return provider && providerLastKnownGoodMatchesConfig(provider)
+      ? provider.lastKnownGood
+      : undefined;
+  }
+
   private readCodexBackendSummary(): BackendSummary {
     if (this.codexBackendSummary) {
       return this.codexBackendSummary;
     }
     const provider = this.configStore?.read("providers").codex;
-    const lastKnownGood = provider
-      && providerLastKnownGoodMatchesConfig(provider)
-      ? provider.lastKnownGood
-      : undefined;
+    const lastKnownGood = this.readCodexProviderLastKnownGood();
     const available = Boolean(lastKnownGood?.selectedCommand);
     const methods: string[] = [];
     const capabilities = buildCapabilities(methods, "codex");
@@ -23797,6 +23854,7 @@ export class DesktopBackendRegistry {
       label: BACKEND_LABELS.codex,
       available,
       serverVersion: lastKnownGood?.selectedVersion,
+      runtimeBuild: codexRuntimeBuild(lastKnownGood?.selectedCommand),
       methods,
       capabilities,
       launchpadOptions: buildLaunchpadOptions("codex", []),
@@ -23824,17 +23882,26 @@ export class DesktopBackendRegistry {
   ): Promise<BackendSummary> {
     assertProviderDiscoveryPermit(permit);
     const previousSummary = this.readCodexBackendSummary();
+    const lastKnownGood = this.readCodexProviderLastKnownGood();
     const [
       initializeResult,
       defaultModelsResult,
       accountResult,
       rateLimitsResult,
+      runtimeCommandResult,
     ] = await Promise.allSettled([
       this.codexClient.getInitializeResult(),
       this.readCodexDefaultModelsOnce("backend-summary"),
       readClientAccount(this.codexClient),
       readClientRateLimits(this.codexClient),
+      this.resolveCodexRuntimeCommandFn?.(),
     ]);
+    // Resolution rejects when nothing is selected yet; the durable observation
+    // is then the only thing left that can name a command.
+    const runtimeCommand =
+      runtimeCommandResult.status === "fulfilled"
+        ? runtimeCommandResult.value
+        : undefined;
     const successful =
       initializeResult.status === "fulfilled" ? [initializeResult.value] : [];
     const methods = mergeMethods(successful);
@@ -23886,7 +23953,17 @@ export class DesktopBackendRegistry {
           ? rateLimitsResult.value
           : undefined,
       serverName: successful[0]?.serverInfo?.name,
-      serverVersion: successful[0]?.serverInfo?.version,
+      // Today's `initialize` carries no `serverInfo` at all; the App Server's
+      // version reaches us inside the `userAgent` it does report. The resolved
+      // executable stands in when this connection never handshook.
+      serverVersion:
+        successful[0]?.serverInfo?.version
+        ?? codexVersionFromUserAgent(successful[0]?.userAgent)
+        ?? runtimeCommand?.version
+        ?? lastKnownGood?.selectedVersion,
+      runtimeBuild: codexRuntimeBuild(
+        runtimeCommand?.command ?? lastKnownGood?.selectedCommand,
+      ),
       methods,
       capabilities,
       launchpadOptions: buildLaunchpadOptions("codex", discoveredModels),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1919,6 +1919,12 @@ const BACKEND_LABELS: Record<AppServerBackendKind, string> = {
   codex: "OpenAI",
 };
 
+/** Who publishes each Codex channel's builds. Deliberately not
+ *  `BACKEND_LABELS.codex`: that names the backend in the UI, and renaming a
+ *  display label must never change a claim about who built a binary. */
+const CODEX_VENDOR_PUBLISHER = "OpenAI";
+const CODEX_MANAGED_PUBLISHER = "PwrDrvr";
+
 /**
  * Who built the Codex executable PwrAgent launches. Decided from the resolved
  * command's path: a managed download lives under the PwrAgent Codex channel's
@@ -1933,8 +1939,8 @@ function codexRuntimeBuild(
     return undefined;
   }
   return managedCodexTagForCommand(selectedCommand) === undefined
-    ? { channel: "vendor", publisher: BACKEND_LABELS.codex }
-    : { channel: "pwragent", publisher: "PwrDrvr" };
+    ? { channel: "vendor", publisher: CODEX_VENDOR_PUBLISHER }
+    : { channel: "pwragent", publisher: CODEX_MANAGED_PUBLISHER };
 }
 
 const OPENAI_REASONING_EFFORTS = ["none", "low", "medium", "high", "xhigh"];
@@ -8795,6 +8801,7 @@ export class DesktopBackendRegistry {
           });
           this.codexRuntimeRestartPending = true;
           this.managedCodexRuntimeSwitchPending = true;
+          this.redescribeCachedCodexRuntime(change.runtime);
           return this.maybeRestartCodexForManagedRuntimeChange();
         }),
       );
@@ -23817,26 +23824,60 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * The durable Codex executable observation, when it still describes the
-   * current configuration. The pre-discovery summary is built entirely from
-   * it; the discovered summary falls back to it for the version and
-   * provenance that live runtime resolution could not name.
+   * Re-describe the cached summary's runtime identity after a managed Codex
+   * selection change.
+   *
+   * Nothing else invalidates that cache on this path: it is cleared only when
+   * a `providers.*` fingerprint changes, and the managed channel turns over
+   * without one. A passive `listBackends` therefore keeps serving the summary
+   * built for the executable that was just replaced, so the providers panel
+   * would name the superseded build's publisher and version.
+   *
+   * A change that leaves no managed runtime drops both fields rather than
+   * guessing at the vendor executable taking over — the next discovery names
+   * it, and until then silence beats the wrong publisher.
    */
-  private readCodexProviderLastKnownGood():
-    | ConfigDomainMap["providers"]["codex"]["lastKnownGood"]
-    | undefined {
+  private redescribeCachedCodexRuntime(
+    runtime?: ManagedCodexSelectionChange["runtime"],
+  ): void {
+    if (!this.codexBackendSummary) {
+      return;
+    }
+    this.codexBackendSummary = {
+      ...this.codexBackendSummary,
+      runtimeBuild: runtime ? codexRuntimeBuild(runtime.command) : undefined,
+      serverVersion: runtime?.metadata.version,
+    };
+  }
+
+  /**
+   * The Codex provider projection and its durable executable observation, the
+   * observation dropped when it no longer describes the current
+   * configuration. One snapshot read serves both, so a summary cannot pair a
+   * validation error with a `lastKnownGood` from a different revision.
+   *
+   * The pre-discovery summary is built entirely from this; the discovered
+   * summary falls back to it for the version and provenance that live runtime
+   * resolution could not name.
+   */
+  private readCodexProvider(): {
+    lastKnownGood?: ConfigDomainMap["providers"]["codex"]["lastKnownGood"];
+    provider?: ConfigDomainMap["providers"]["codex"];
+  } {
     const provider = this.configStore?.read("providers").codex;
-    return provider && providerLastKnownGoodMatchesConfig(provider)
-      ? provider.lastKnownGood
-      : undefined;
+    return {
+      ...(provider && providerLastKnownGoodMatchesConfig(provider)
+        ? { lastKnownGood: provider.lastKnownGood }
+        : {}),
+      ...(provider ? { provider } : {}),
+    };
   }
 
   private readCodexBackendSummary(): BackendSummary {
     if (this.codexBackendSummary) {
       return this.codexBackendSummary;
     }
-    const provider = this.configStore?.read("providers").codex;
-    const lastKnownGood = this.readCodexProviderLastKnownGood();
+    const { lastKnownGood, provider } = this.readCodexProvider();
     const available = Boolean(lastKnownGood?.selectedCommand);
     const methods: string[] = [];
     const capabilities = buildCapabilities(methods, "codex");
@@ -23882,7 +23923,7 @@ export class DesktopBackendRegistry {
   ): Promise<BackendSummary> {
     assertProviderDiscoveryPermit(permit);
     const previousSummary = this.readCodexBackendSummary();
-    const lastKnownGood = this.readCodexProviderLastKnownGood();
+    const { lastKnownGood } = this.readCodexProvider();
     const [
       initializeResult,
       defaultModelsResult,

--- a/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
+++ b/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
@@ -70,8 +70,9 @@ export function resolveCodexProtocolCompatibility(
 /**
  * The App Server's own version, read out of the `userAgent` it reports from
  * `initialize`. That string is shaped `<client name>/<server version> (<os>;
- * <arch>) …`, so the version is the first slash-delimited token — and the
- * *whole* token, prerelease suffix included: `0.149.0-pwragent.2` is what
+ * <arch>) …`, so the version follows the LAST slash of the leading token — a
+ * client name may itself contain one, a version never does — and it is taken
+ * *whole*, prerelease suffix included: `0.149.0-pwragent.2` is what
  * distinguishes a PwrAgent Codex build from OpenAI's 0.149.0 release, and
  * truncating it to a bare `x.y.z` would describe one as the other.
  *
@@ -84,7 +85,7 @@ export function codexVersionFromUserAgent(
   userAgent?: string,
 ): string | undefined {
   const token = userAgent?.trim().split(/\s+/, 1)[0];
-  const version = token?.slice(token.indexOf("/") + 1);
+  const version = token?.slice(token.lastIndexOf("/") + 1);
   return token?.includes("/") && version && /^\d+\.\d+\.\d+/.test(version)
     ? version
     : undefined;

--- a/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
+++ b/apps/desktop/src/main/codex-app-server/protocol-compatibility.ts
@@ -67,6 +67,29 @@ export function resolveCodexProtocolCompatibility(
   };
 }
 
+/**
+ * The App Server's own version, read out of the `userAgent` it reports from
+ * `initialize`. That string is shaped `<client name>/<server version> (<os>;
+ * <arch>) …`, so the version is the first slash-delimited token — and the
+ * *whole* token, prerelease suffix included: `0.149.0-pwragent.2` is what
+ * distinguishes a PwrAgent Codex build from OpenAI's 0.149.0 release, and
+ * truncating it to a bare `x.y.z` would describe one as the other.
+ *
+ * The running server is the authority on its own version. Executable
+ * discovery's `codex --version` answers a different question — what a fresh
+ * launch would pick — and the two disagree while a managed runtime switch is
+ * pending.
+ */
+export function codexVersionFromUserAgent(
+  userAgent?: string,
+): string | undefined {
+  const token = userAgent?.trim().split(/\s+/, 1)[0];
+  const version = token?.slice(token.indexOf("/") + 1);
+  return token?.includes("/") && version && /^\d+\.\d+\.\d+/.test(version)
+    ? version
+    : undefined;
+}
+
 export function usesGeneratedCodexModelListResponse(
   serverVersion?: string,
 ): boolean {

--- a/apps/desktop/src/main/codex-build-channel.ts
+++ b/apps/desktop/src/main/codex-build-channel.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+import { resolvePwragentRoot } from "./profile.js";
+
+/** `agents/codex` under the PwrAgent root — the machine-wide managed root. */
+export const MANAGED_CODEX_ROOT_SEGMENTS = ["agents", "codex"] as const;
+
+export type CodexBuildChannelOptions = {
+  /** Overrides `<pwragent root>/agents/codex`. Tests and alternate roots. */
+  managedRoot?: string;
+};
+
+export function managedCodexRoot(options?: CodexBuildChannelOptions): string {
+  return options?.managedRoot
+    ?? path.join(resolvePwragentRoot(), ...MANAGED_CODEX_ROOT_SEGMENTS);
+}
+
+/**
+ * The release tag a Codex command was installed under, or `undefined` when the
+ * command is not a managed install. `installRelease` lays every download out as
+ * `<managed root>/versions/<tag>/<executable>`, so the tag is recoverable from
+ * the path alone — which is what lets an *older* managed version still be
+ * recognized as one after the channel has moved on.
+ *
+ * Deliberately decided from the path rather than from equality with whatever
+ * command the current release check resolved: provenance is a property of the
+ * binary, while "is it the newest one" is a separate question.
+ */
+export function managedCodexTagForCommand(
+  command: string | undefined,
+  options?: CodexBuildChannelOptions,
+): string | undefined {
+  if (!command) {
+    return undefined;
+  }
+  const relative = path.relative(
+    path.resolve(managedCodexRoot(options), "versions"),
+    path.resolve(command),
+  );
+  if (
+    relative === ""
+    || relative.startsWith("..")
+    || path.isAbsolute(relative)
+  ) {
+    return undefined;
+  }
+  const [tag, ...rest] = relative.split(path.sep);
+  // `versions/<tag>` alone is the directory, not an executable inside it.
+  return tag && rest.length > 0 ? tag : undefined;
+}

--- a/apps/desktop/src/main/codex-managed-runtime.ts
+++ b/apps/desktop/src/main/codex-managed-runtime.ts
@@ -30,7 +30,7 @@ import {
   verifyMacosCodeModeHostJitEntitlements,
   verifyMatchingPlatformSignature,
 } from "./managed-runtime-signature.js";
-import { resolvePwragentRoot } from "./profile.js";
+import { managedCodexRoot } from "./codex-build-channel.js";
 
 const execFile = promisify(execFileCallback);
 const managedCodexLog = getMainLogger("pwragent:codex-managed-runtime");
@@ -243,11 +243,7 @@ const MANAGED_CODEX_ARTIFACT_TARGETS = [
 export async function ensureManagedCodexRuntime(
   options: ManagedCodexRuntimeOptions = {},
 ): Promise<ManagedCodexRuntime> {
-  const rootDir = options.rootDir ?? path.join(
-    resolvePwragentRoot(),
-    "agents",
-    "codex",
-  );
+  const rootDir = options.rootDir ?? managedCodexRoot();
   const checkMode = options.checkMode ?? "ttl";
   if (checkMode === "ttl" && !options.waitForUpdate) {
     const cached = await readCachedRuntime(rootDir, options);

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
@@ -47,10 +47,7 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
               </p>
               {backend.available && hasProviderMetadata(backend) ? (
                 <div className="backend-status-list__metadata">
-                  {backendVersion(backend)
-                  || backend.runtimeBuild
-                  || backend.acp
-                  || backend.account ? (
+                  {hasIdentityMetadata(backend) ? (
                     <dl className="backend-status-list__metadata-grid">
                       {backendVersion(backend) ? (
                         <div>
@@ -106,12 +103,16 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
 }
 
 function hasProviderMetadata(backend: BackendSummary): boolean {
+  return hasIdentityMetadata(backend) || Boolean(backend.rateLimits?.length);
+}
+
+/** Whether anything belongs in the identity grid above the rate limits. */
+function hasIdentityMetadata(backend: BackendSummary): boolean {
   return Boolean(
     backendVersion(backend)
     || backend.runtimeBuild
     || backend.acp
-    || backend.account
-    || backend.rateLimits?.length,
+    || backend.account,
   );
 }
 
@@ -119,11 +120,25 @@ function hasProviderMetadata(backend: BackendSummary): boolean {
  * Who supplied the runtime, in the operator's terms. The version alone cannot
  * answer it: `0.149.0` and `0.149.0-pwragent.2` differ by a suffix that reads
  * as noise until something names who published it.
+ *
+ * A channel this build has never heard of — a federated peer can be newer than
+ * the viewer — falls back to the publisher alone. Naming it a release or a
+ * build would describe an unknown channel in a known one's terms, which is the
+ * confusion the row exists to remove.
  */
 function formatRuntimeBuild(build: BackendRuntimeBuild): string {
-  return build.channel === "pwragent"
-    ? `${build.publisher} build`
-    : `${build.publisher} release`;
+  switch (build.channel) {
+    case "pwragent":
+      return `${build.publisher} build`;
+    case "vendor":
+      return `${build.publisher} release`;
+    default: {
+      // Exhaustiveness gate: adding a channel is a compile error here.
+      const unhandled: never = build.channel;
+      void unhandled;
+      return build.publisher;
+    }
+  }
 }
 
 function backendVersion(backend: BackendSummary): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import type { BackendSummary } from "@pwragent/shared";
+import type { BackendRuntimeBuild, BackendSummary } from "@pwragent/shared";
 import {
   formatBackendAccountText,
   formatRateLimitLine,
@@ -47,12 +47,21 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
               </p>
               {backend.available && hasProviderMetadata(backend) ? (
                 <div className="backend-status-list__metadata">
-                  {backendVersion(backend) || backend.acp || backend.account ? (
+                  {backendVersion(backend)
+                  || backend.runtimeBuild
+                  || backend.acp
+                  || backend.account ? (
                     <dl className="backend-status-list__metadata-grid">
                       {backendVersion(backend) ? (
                         <div>
                           <dt>Version</dt>
                           <dd>{backendVersion(backend)}</dd>
+                        </div>
+                      ) : null}
+                      {backend.runtimeBuild ? (
+                        <div>
+                          <dt>Build</dt>
+                          <dd>{formatRuntimeBuild(backend.runtimeBuild)}</dd>
                         </div>
                       ) : null}
                       {backend.acp ? (
@@ -99,10 +108,22 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
 function hasProviderMetadata(backend: BackendSummary): boolean {
   return Boolean(
     backendVersion(backend)
+    || backend.runtimeBuild
     || backend.acp
     || backend.account
     || backend.rateLimits?.length,
   );
+}
+
+/**
+ * Who supplied the runtime, in the operator's terms. The version alone cannot
+ * answer it: `0.149.0` and `0.149.0-pwragent.2` differ by a suffix that reads
+ * as noise until something names who published it.
+ */
+function formatRuntimeBuild(build: BackendRuntimeBuild): string {
+  return build.channel === "pwragent"
+    ? `${build.publisher} build`
+    : `${build.publisher} release`;
 }
 
 function backendVersion(backend: BackendSummary): string | undefined {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
@@ -121,6 +121,42 @@ describe("ProviderStatusPanel", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
+  it("names the version and publisher of the Codex runtime in effect", () => {
+    render(
+      <ProviderStatusPanel
+        backends={[
+          {
+            ...codexBackend,
+            runtimeBuild: { channel: "vendor", publisher: "OpenAI" },
+            serverVersion: "0.149.1",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("0.149.1")).toBeInTheDocument();
+    expect(screen.getByText("OpenAI release")).toBeInTheDocument();
+  });
+
+  it("names a PwrDrvr build rather than leaving it to the version suffix", () => {
+    // `0.149.0-pwragent.2` is the only thing separating this from OpenAI's
+    // 0.149.0, and a suffix alone reads as noise.
+    render(
+      <ProviderStatusPanel
+        backends={[
+          {
+            ...codexBackend,
+            runtimeBuild: { channel: "pwragent", publisher: "PwrDrvr" },
+            serverVersion: "0.149.0-pwragent.2",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("0.149.0-pwragent.2")).toBeInTheDocument();
+    expect(screen.getByText("PwrDrvr build")).toBeInTheDocument();
+  });
+
   it("renders account, plan, and rate limits for an available backend", () => {
     render(<ProviderStatusPanel backends={[codexBackend]} />);
 

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -212,12 +212,36 @@ export type BackendRateLimitSummary = {
   windowMinutes?: number;
 };
 
+/**
+ * Which channel published the provider runtime PwrAgent is talking to.
+ * `vendor` is the provider's own release; `pwragent` is a build PwrAgent
+ * downloads, verifies and installs itself.
+ *
+ * Two products can answer to one provider name — an OpenAI Codex release and a
+ * `-pwragent` Codex build carry different version strings and different
+ * release pages — so a surface that cannot tell them apart ends up describing
+ * one in the other's terms.
+ */
+export type BackendRuntimeBuildChannel = "vendor" | "pwragent";
+
+export type BackendRuntimeBuild = {
+  channel: BackendRuntimeBuildChannel;
+  /** Who publishes this channel's builds, e.g. `OpenAI` or `PwrDrvr`. */
+  publisher: string;
+};
+
 export type BackendSummary = {
   kind: AppServerBackendKind;
   source?: BackendSourceKind;
   label: string;
   available: boolean;
   acp?: BackendAcpSummary;
+  /**
+   * Provenance of the executable serving this backend. Absent until PwrAgent
+   * has resolved one — never guessed, because "vendor" is a claim about a
+   * specific binary, not a default.
+   */
+  runtimeBuild?: BackendRuntimeBuild;
   account?: BackendAccountSummary;
   rateLimits?: BackendRateLimitSummary[];
   serverName?: string;


### PR DESCRIPTION
The AI providers panel names Grok's runtime version and says nothing at all about Codex — no version, and no way to tell an OpenAI release from a PwrDrvr build. On this machine that difference is live: the app is running `~/.pwragent/agents/codex/versions/pwragent-v0.149.0-pwragent.2/codex` and the panel reads exactly like a stock OpenAI install.

Two separate gaps behind that.

## The version was read from a field the protocol does not have

`discoverCodexBackend` set `serverVersion` from `initialize`'s `serverInfo.version`. The generated protocol's `InitializeResponse` is `{ userAgent, codexHome, platformFamily, platformOs }` — there is no `serverInfo`, so the field was always undefined, and because discovery caches its summary it also overwrote the durable `codex --version` observation the pre-discovery path did report. Unit tests never caught it: the mock client returns a `serverInfo` the real server never sends.

The version now comes out of the `userAgent`, whose first token is `<client name>/<server version>`. Captured from a real handshake:

```
pwragent-desktop/0.149.1 (Mac OS 26.6.2; arm64) unknown (pwragent-desktop; 1.4.0)
```

The running server is the authority on its own version, and the parse keeps the **whole** token rather than a bare `x.y.z` — `0.149.0-pwragent.2` and `0.149.0` differ only by that suffix, and truncating it would describe one build as the other. Falls back to the resolved executable's version, then to discovery's, when a connection never handshook.

## Provenance is a property of the binary

Decided from the resolved command's path, mirroring `grok-build-channel.ts`: a managed download lives at `<pwragent root>/agents/codex/versions/<tag>/`, so an older pinned managed build is still recognized as one after the channel moves on. `codex-managed-runtime.ts` now takes its own root from the same helper, so the two cannot drift.

It reads the command from the same resolution the stdio transport launches with, **not** from the durable provider projection. `resolveCodexCommand` returns a managed runtime *before* it consults discovery, so a Token Miser profile reaches the App Server without a provider observation ever being recorded — verified on this machine, where the durable projection's `lastKnownGood` is empty while the transport log reads:

```
launch app-server command=/Users/…/agents/codex/versions/pwragent-v0.149.0-pwragent.2/codex source=config version=0.149.0-pwragent.2
```

That is the case that most needs naming, and the projection cannot answer it. `source=config` is also why provenance is not read from the discovery candidate's source — a managed runtime and a manual path override are indistinguishable there.

## What the panel shows

A `Build` row next to `Version`: **OpenAI release** or **PwrDrvr build**. `BackendSummary.runtimeBuild` carries `channel` (machine-readable) and `publisher` (display), and is absent until a command has actually been resolved — "OpenAI" is a claim about a specific binary, not a default.

| | Before | After |
|---|---|---|
| Version | *(absent)* | `0.149.0-pwragent.2` |
| Build | *(absent)* | `PwrDrvr build` |

## Verification

- `pnpm test` — 676 files, 9990 passing.
- `pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:boundaries`, `pnpm lint:codex-storage`.
- The `userAgent` shape and the managed install layout were both captured from live runs on this machine, not assumed — the committed parse fixture is a verbatim `codex app-server` handshake.
- No UI screenshot: two other PwrAgent Electron instances are running, and `apps/desktop/CLAUDE.md` says to stop rather than target an ambiguous `com.github.Electron`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
