### PR TITLE
fix(desktop): keep prompt in transcript window

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -1497,6 +1497,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             pendingStatusText={session.pendingStatusText}
             pendingRemoteWork={isThreadRemoteWorkHere(thread)}
             pendingUserInput={session.pendingUserInput}
+            prependAnchorId={transcriptWindow.contiguousStartEntry?.id}
             runningTurnUsageText={session.runningTurnUsageText}
             threadId={thread.id}
             transientMessages={session.transientMessages}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3588,6 +3588,7 @@ export function ThreadView(props: ThreadViewProps) {
               pendingUserInput={props.pendingUserInput}
               pendingStatusText={props.pendingStatusText}
               pendingRemoteWork={transcriptRemoteWork}
+              prependAnchorId={transcriptWindow.contiguousStartEntry?.id}
               runningTurnUsageText={props.runningTurnUsageText}
               expandedActivityIds={props.expandedTranscriptActivityIds}
               expandedWorkPhaseGroupIds={

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -112,6 +112,8 @@ type TranscriptListProps = {
    * `isThreadRemoteWorkHere`).
    */
   pendingRemoteWork?: boolean;
+  /** First entry in the contiguous window when an earlier prompt is pinned. */
+  prependAnchorId?: string;
   runningTurnUsageText?: string;
   pagination?: AppServerThreadReplayPagination;
   parentThreadId?: string;
@@ -1055,7 +1057,8 @@ export function TranscriptList(props: TranscriptListProps) {
       return undefined;
     }
 
-    const firstMessageId = transcriptEntries[0]?.id;
+    const firstMessageId =
+      props.prependAnchorId ?? transcriptEntries[0]?.id;
     const lastMessageId = transcriptEntries[transcriptEntries.length - 1]?.id;
     const distanceFromBottom = Math.max(
       container.scrollHeight - container.clientHeight - container.scrollTop,
@@ -1076,6 +1079,7 @@ export function TranscriptList(props: TranscriptListProps) {
     };
   }, [
     props.pendingStatusText,
+    props.prependAnchorId,
     props.runningTurnUsageText,
     props.threadId,
     transcriptEntries,
@@ -1279,7 +1283,8 @@ export function TranscriptList(props: TranscriptListProps) {
     const restoredViewport =
       props.restoredViewport ??
       (props.threadId ? savedViewportsRef.current.get(props.threadId) : undefined);
-    const firstMessageId = transcriptEntries[0]?.id;
+    const firstMessageId =
+      props.prependAnchorId ?? transcriptEntries[0]?.id;
     const lastMessageId = transcriptEntries[transcriptEntries.length - 1]?.id;
     const hasPrependedMessages = Boolean(
       previousSnapshot &&
@@ -1363,6 +1368,7 @@ export function TranscriptList(props: TranscriptListProps) {
     props.pendingMcpInteraction,
     props.pendingUserInput,
     props.pendingStatusText,
+    props.prependAnchorId,
     props.runningTurnUsageText,
     props.restoredViewport,
     props.threadId,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -3313,6 +3313,74 @@ Implementation notes remain in a readable bubble.`;
     expect(list.scrollTop).toBe(240);
   });
 
+  it("preserves the reader position when entries expand behind a pinned prompt", () => {
+    const prompt = {
+      type: "message" as const,
+      id: "message-prompt",
+      role: "user" as const,
+      text: "Prompt pinned outside the contiguous window",
+    };
+    const lastMessage = {
+      type: "message" as const,
+      id: "message-last",
+      role: "assistant" as const,
+      text: "Newest response",
+    };
+    const { rerender } = render(
+      <TranscriptList
+        entries={[
+          prompt,
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Old contiguous boundary",
+          },
+          lastMessage,
+        ]}
+        loading={false}
+        loadingMore={false}
+        prependAnchorId="message-2"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    const list = screen.getByRole("list");
+    list.scrollTop = 80;
+    fireEvent.scroll(list);
+
+    scrollHeight = 640;
+
+    rerender(
+      <TranscriptList
+        entries={[
+          prompt,
+          {
+            type: "message",
+            id: "message-1",
+            role: "assistant",
+            text: "New contiguous boundary",
+          },
+          {
+            type: "message",
+            id: "message-2",
+            role: "assistant",
+            text: "Old contiguous boundary",
+          },
+          lastMessage,
+        ]}
+        loading={false}
+        loadingMore={false}
+        prependAnchorId="message-1"
+        threadId="thread-1"
+        onLoadOlder={async () => undefined}
+      />
+    );
+
+    expect(list.scrollTop).toBe(240);
+  });
+
   it("shows the jump-to-latest control only when the newest entry is below the viewport", () => {
     render(
       <TranscriptList

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx
@@ -87,6 +87,7 @@ describe("useTranscriptWindow", () => {
     expect(
       result.current.visibleEntries.filter((entry) => entry.role === "user"),
     ).toEqual([prompt]);
+    expect(result.current.contiguousStartEntry?.id).toBe("assistant-0");
     expect(result.current.visibleEntries.at(-1)?.id).toBe("assistant-39");
   });
 
@@ -119,6 +120,34 @@ describe("useTranscriptWindow", () => {
     expect(
       result.current.visibleEntries.filter((entry) => entry.role === "user"),
     ).toEqual([authoritativePrompt]);
+  });
+
+  it("reports the moving contiguous boundary behind a pinned prompt", () => {
+    const prompt: MessageEntry = {
+      id: "user-prompt",
+      role: "user",
+      text: "Investigate the noisy canary error logs.",
+      type: "message",
+    };
+    const transcriptEntries = [prompt, ...assistantEntries(100)];
+    const { result, rerender } = renderHook(
+      ({ limit }) =>
+        useTranscriptWindow({
+          entries: transcriptEntries,
+          limit,
+          onLoadOlder: vi.fn(),
+          threadKey: "expanding-first-turn",
+        }),
+      { initialProps: { limit: 40 } },
+    );
+
+    expect(result.current.visibleEntries[0]).toBe(prompt);
+    expect(result.current.contiguousStartEntry?.id).toBe("assistant-60");
+
+    rerender({ limit: 90 });
+
+    expect(result.current.visibleEntries[0]).toBe(prompt);
+    expect(result.current.contiguousStartEntry?.id).toBe("assistant-10");
   });
 
   it("claims a previous page while entries are held back locally", () => {
@@ -188,6 +217,41 @@ describe("useTranscriptWindow", () => {
     expect(onLimitChange).toHaveBeenCalledWith(
       DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT + THREAD_HISTORY_PAGE_LIMIT,
     );
+  });
+
+  it("reserves server-page capacity for the prompt pinned outside the limit", async () => {
+    const onLoadOlder = vi.fn();
+    const onLimitChange = vi.fn();
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: [
+          {
+            id: "user-prompt",
+            role: "user",
+            text: "Investigate the noisy canary error logs.",
+            type: "message",
+          } satisfies MessageEntry,
+          ...assistantEntries(90),
+        ],
+        limit: 90,
+        onLimitChange,
+        onLoadOlder,
+        pagination: SERVER_HAS_MORE,
+        threadKey: "server-page-after-pinned-prompt",
+      }),
+    );
+
+    expect(result.current.hiddenCount).toBe(0);
+    expect(result.current.visibleEntries).toHaveLength(91);
+
+    await act(async () => {
+      await result.current.loadOlder();
+    });
+
+    expect(onLimitChange).toHaveBeenCalledWith(
+      90 + THREAD_HISTORY_PAGE_LIMIT + 1,
+    );
+    expect(onLoadOlder).toHaveBeenCalledTimes(1);
   });
 
   it("owns the limit itself when nobody else does", async () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx
@@ -10,6 +10,22 @@ function entries(count: number): string[] {
   return Array.from({ length: count }, (_, index) => `e${index}`);
 }
 
+type MessageEntry = {
+  id: string;
+  role: "assistant" | "user";
+  text: string;
+  type: "message";
+};
+
+function assistantEntries(count: number): MessageEntry[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `assistant-${index}`,
+    role: "assistant",
+    text: `Assistant entry ${index}`,
+    type: "message",
+  }));
+}
+
 const SERVER_HAS_MORE = {
   supportsPagination: true,
   hasPreviousPage: true,
@@ -48,6 +64,61 @@ describe("useTranscriptWindow", () => {
     expect(result.current.visibleEntries).toHaveLength(3);
     expect(result.current.hiddenCount).toBe(0);
     expect(result.current.hasMoreHistory).toBe(false);
+  });
+
+  it("keeps the latest user prompt visible when one long turn crosses the render limit", () => {
+    const prompt: MessageEntry = {
+      id: "user-prompt",
+      role: "user",
+      text: "Investigate the noisy canary error logs.",
+      type: "message",
+    };
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: [
+          prompt,
+          ...assistantEntries(DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT),
+        ],
+        onLoadOlder: vi.fn(),
+        threadKey: "long-first-turn",
+      }),
+    );
+
+    expect(
+      result.current.visibleEntries.filter((entry) => entry.role === "user"),
+    ).toEqual([prompt]);
+    expect(result.current.visibleEntries.at(-1)?.id).toBe("assistant-39");
+  });
+
+  it("pins only the newest copy when optimistic and authoritative prompts precede the window", () => {
+    const promptText = "Investigate the noisy canary error logs.";
+    const optimisticPrompt: MessageEntry = {
+      id: "optimistic-launchpad-thread-1",
+      role: "user",
+      text: promptText,
+      type: "message",
+    };
+    const authoritativePrompt: MessageEntry = {
+      id: "authoritative-user-message",
+      role: "user",
+      text: promptText,
+      type: "message",
+    };
+    const { result } = renderHook(() =>
+      useTranscriptWindow({
+        entries: [
+          optimisticPrompt,
+          authoritativePrompt,
+          ...assistantEntries(DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT),
+        ],
+        onLoadOlder: vi.fn(),
+        threadKey: "reconciled-first-turn",
+      }),
+    );
+
+    expect(
+      result.current.visibleEntries.filter((entry) => entry.role === "user"),
+    ).toEqual([authoritativePrompt]);
   });
 
   it("claims a previous page while entries are held back locally", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/useTranscriptWindow.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useTranscriptWindow.ts
@@ -40,6 +40,31 @@ export type TranscriptWindow<Entry> = {
   loadOlder: () => Promise<void>;
 };
 
+function isUserMessageEntry(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") {
+    return false;
+  }
+
+  const record = entry as { role?: unknown; type?: unknown };
+  return record.type === "message" && record.role === "user";
+}
+
+function newestUserMessageBeforeWindow<Entry>(
+  entries: readonly Entry[],
+  windowStart: number,
+): Entry | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!isUserMessageEntry(entry)) {
+      continue;
+    }
+
+    return index < windowStart ? entry : undefined;
+  }
+
+  return undefined;
+}
+
 export function useTranscriptWindow<Entry>(params: {
   entries: readonly Entry[];
   /**
@@ -64,10 +89,20 @@ export function useTranscriptWindow<Entry>(params: {
       ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT
     : DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
 
-  const visibleEntries = useMemo(
-    () => entries.slice(-limit),
-    [entries, limit],
-  );
+  const visibleEntries = useMemo(() => {
+    const windowStart = Math.max(0, entries.length - limit);
+    const newestEntries = entries.slice(windowStart);
+    const userMessage = newestUserMessageBeforeWindow(entries, windowStart);
+
+    // A busy first turn can cross the render cap before its first response
+    // finishes. Keep one context row outside the cap so the response never
+    // appears without the prompt that caused it. Choosing the newest hidden
+    // user row also avoids pinning both an optimistic launchpad placeholder
+    // and the authoritative item that replaced it.
+    return userMessage
+      ? [userMessage, ...newestEntries]
+      : newestEntries;
+  }, [entries, limit]);
   const entryCount = entries.length;
   const hiddenCount = entryCount - visibleEntries.length;
   const canLoadFromServer = Boolean(

--- a/apps/desktop/src/renderer/src/features/thread-detail/useTranscriptWindow.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/useTranscriptWindow.ts
@@ -20,7 +20,9 @@ import {
  * behaviour instead of a second implementation drifting away from this one.
  */
 export type TranscriptWindow<Entry> = {
-  /** The newest `limit` entries: what the transcript should mount. */
+  /** First entry in the contiguous tail, excluding any pinned prompt. */
+  contiguousStartEntry?: Entry;
+  /** The newest `limit` entries plus at most one pinned user prompt. */
   visibleEntries: Entry[];
   /**
    * Pagination as the transcript should see it. When entries are being held
@@ -89,7 +91,7 @@ export function useTranscriptWindow<Entry>(params: {
       ?? DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT
     : DEFAULT_RENDERED_TRANSCRIPT_ENTRY_LIMIT;
 
-  const visibleEntries = useMemo(() => {
+  const entryWindow = useMemo(() => {
     const windowStart = Math.max(0, entries.length - limit);
     const newestEntries = entries.slice(windowStart);
     const userMessage = newestUserMessageBeforeWindow(entries, windowStart);
@@ -99,10 +101,19 @@ export function useTranscriptWindow<Entry>(params: {
     // appears without the prompt that caused it. Choosing the newest hidden
     // user row also avoids pinning both an optimistic launchpad placeholder
     // and the authoritative item that replaced it.
-    return userMessage
-      ? [userMessage, ...newestEntries]
-      : newestEntries;
+    return {
+      contiguousStartEntry: newestEntries[0],
+      pinnedEntryCount: userMessage ? 1 : 0,
+      visibleEntries: userMessage
+        ? [userMessage, ...newestEntries]
+        : newestEntries,
+    };
   }, [entries, limit]);
+  const {
+    contiguousStartEntry,
+    pinnedEntryCount,
+    visibleEntries,
+  } = entryWindow;
   const entryCount = entries.length;
   const hiddenCount = entryCount - visibleEntries.length;
   const canLoadFromServer = Boolean(
@@ -154,7 +165,9 @@ export function useTranscriptWindow<Entry>(params: {
       // Reserve renderer capacity before the response prepends its page.
       // Otherwise the newly loaded entries would remain hidden behind the
       // existing tail window until a second upward scroll.
-      expandLimit(limit + THREAD_HISTORY_PAGE_LIMIT);
+      expandLimit(
+        limit + THREAD_HISTORY_PAGE_LIMIT + pinnedEntryCount,
+      );
     }
     await onLoadOlder();
   }, [
@@ -164,10 +177,12 @@ export function useTranscriptWindow<Entry>(params: {
     hiddenCount,
     limit,
     onLoadOlder,
+    pinnedEntryCount,
   ]);
 
   return {
     canLoadFromServer,
+    contiguousStartEntry,
     expandLimit,
     hasMoreHistory,
     hiddenCount,


### PR DESCRIPTION
## Summary

- keep the newest user prompt visible when a long turn crosses the 40-entry renderer window
- pin only the newest hidden user row, avoiding simultaneous optimistic and authoritative launch prompt copies
- expose the contiguous tail boundary so local expansion preserves the reader scroll anchor behind a pinned prompt
- reserve one additional renderer slot when a pinned prompt sits outside the numeric window before server pagination
- add regressions for the missing-prompt, duplicate-prompt, scroll-anchor, and server-capacity boundaries

## Root cause

Codex App Server retained the initial user message as item 0, but the renderer mounted only `entries.slice(-40)`. Once the first turn crossed that cap, the prompt alone could fall outside the mounted window while its assistant response remained visible.

The retained prompt is an extra context row rather than part of the contiguous tail. The transcript therefore tracks the real contiguous boundary separately for prepend anchoring and includes the one-row surplus when reserving capacity for an older server page.

## Test plan

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx apps/desktop/src/renderer/src/features/thread-detail/__tests__/use-transcript-window.test.tsx` (326 tests)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors)
- `git diff --check`

## Screenshots

Not attached: the observed reproduction contains non-contrived operator thread data.