### PR TITLE
fix(desktop): bound federated jump search payloads

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -261,6 +261,52 @@ describe("DesktopMessagingBackendBridge", () => {
     expect(readDirectoryStatuses).not.toHaveBeenCalled();
   });
 
+  it("caches a read-only owner projection for bounded navigation search", async () => {
+    const listedThreads: AppServerThreadSummary[] = [
+      {
+        id: "thread-alpha",
+        title: "Alpha federation work",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+        updatedAt: 2_000,
+      },
+      {
+        id: "thread-beta",
+        title: "Beta federation work",
+        titleSource: "explicit",
+        source: "codex",
+        linkedDirectories: [],
+        updatedAt: 1_000,
+      },
+    ];
+    const registry = {
+      canonicalizeNavigationThreadPullRequests: vi.fn(
+        async (threads: NavigationSnapshot["threads"]) => threads,
+      ),
+      getQueuedExecutionModesSnapshot: vi.fn(() => ({})),
+      getQueuedTurnsSnapshot: vi.fn(() => ({})),
+      listThreads: vi.fn(async () => listedThreads),
+    } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+    const reconcileCallsBefore = reconcileNavigationSnapshot.mock.calls.length;
+
+    await expect(bridge.searchNavigationThreads({ query: "alpha" }))
+      .resolves.toMatchObject({ results: [{ id: "thread-alpha" }] });
+    await expect(bridge.searchNavigationThreads({ query: "beta" }))
+      .resolves.toMatchObject({ results: [{ id: "thread-beta" }] });
+
+    expect(registry.listThreads).toHaveBeenCalledTimes(1);
+    expect(reconcileNavigationSnapshot).toHaveBeenCalledTimes(
+      reconcileCallsBefore + 1,
+    );
+    expect(reconcileNavigationSnapshot.mock.calls.at(-1)?.[0]).toMatchObject({
+      backend: "all",
+      partial: true,
+      threads: listedThreads,
+    });
+  });
+
   it("returns a broad snapshot before its stale directory batch finishes", async () => {
     reconcileNavigationSnapshot.mockResolvedValueOnce({
       backend: "all",

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -562,6 +562,83 @@ describe("federation backend bridge", () => {
     });
   });
 
+  it("filters and bounds jump-search navigation rows before crossing the wire", async () => {
+    const threads = Array.from({ length: 1_200 }, (_, index) => ({
+      id: `thread-${index}`,
+      title: `Unrelated ${index}`,
+      titleSource: "explicit" as const,
+      linkedDirectories: [],
+      source: "codex" as const,
+      inbox: { inInbox: false },
+      createdAt: index,
+      updatedAt: index,
+      ...(index === 553
+        ? {
+            prs: [{
+              provider: "github.com",
+              number: 553,
+              org: "pwrdrvr",
+              repo: "PwrAgent",
+              state: "pending" as const,
+              url: "https://github.com/pwrdrvr/PwrAgent/pull/553",
+            }],
+          }
+        : {}),
+    } satisfies NavigationThreadSummary));
+    const backend = {
+      getNavigationSnapshot: vi.fn(async () => ({
+        backend: "all" as const,
+        fetchedAt: 1_000,
+        unchanged: false,
+        threads,
+        inboxThreadKeys: [],
+        directories: [],
+        launchpadDefaults: {
+          backend: "codex" as const,
+          executionMode: "default" as const,
+        },
+      })),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "jump-search",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+        params: { query: "553", limit: 8 },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(replies[0]).toMatchObject({
+      kind: "response",
+      result: {
+        results: [{ id: "thread-553" }],
+      },
+    });
+    expect(JSON.stringify(replies[0]).length).toBeLessThan(
+      JSON.stringify(threads).length / 100,
+    );
+    expect(backend.getNavigationSnapshot).toHaveBeenCalledWith({
+      refreshMode: "full",
+    });
+  });
+
   it("sends unchanged and sparse navigation responses instead of full Federation payloads", async () => {
     const buildThread = (index: number): NavigationThreadSummary => ({
       id: `thread-${index}`,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -8,7 +8,10 @@ import type {
   NavigationThreadSummary,
   TrustCodexProjectRequest,
 } from "@pwragent/shared";
-import { buildFederatedThreadRef } from "@pwragent/shared";
+import {
+  buildFederatedThreadRef,
+  rankThreadJumpMatches,
+} from "@pwragent/shared";
 import {
   FEDERATION_BACKEND_METHODS,
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
@@ -598,6 +601,12 @@ describe("federation backend bridge", () => {
           executionMode: "default" as const,
         },
       })),
+      searchNavigationThreads: vi.fn(async (request) => ({
+        results: rankThreadJumpMatches(threads, request.query).slice(
+          0,
+          request.limit ?? 8,
+        ),
+      })),
     } as unknown as FederationBackendOperations;
     const replies: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({
@@ -634,9 +643,48 @@ describe("federation backend bridge", () => {
     expect(JSON.stringify(replies[0]).length).toBeLessThan(
       JSON.stringify(threads).length / 100,
     );
-    expect(backend.getNavigationSnapshot).toHaveBeenCalledWith({
-      refreshMode: "full",
+    expect(backend.searchNavigationThreads).toHaveBeenCalledWith({
+      query: "553",
+      limit: 8,
     });
+    expect(backend.getNavigationSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("reports bounded search as unsupported without building a full snapshot", async () => {
+    const backend = {
+      getNavigationSnapshot: vi.fn(),
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["thread_navigation"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "jump-search-unsupported",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+        params: { query: "553", limit: 8 },
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(replies[0]).toMatchObject({
+      kind: "error",
+      error: { code: "method_not_found" },
+    });
+    expect(backend.getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
   it("sends unchanged and sparse navigation responses instead of full Federation payloads", async () => {

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -25,6 +25,7 @@ import {
   findPreferredReviewWorkspaceCwd,
 } from "@pwragent/shared";
 import {
+  FEDERATION_BACKEND_METHODS,
   FEDERATION_BACKEND_EVENT_METHOD,
   FEDERATION_ENVIRONMENT_SETUP_PROGRESS_METHOD,
 } from "../federation/federation-backend-bridge";
@@ -2393,7 +2394,61 @@ describe("DesktopFederationRuntime", () => {
 
     expect(invalidated).toEqual([]);
   });
-  it("subscribes Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
+  it("does not retain navigation subscriptions for bounded Cmd+K searches", async () => {
+    const sent: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({ localInstanceId: "viewer_one" });
+    router.registerConnection(createConnection({
+      peerId: "owner_one",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+      sendEnvelope: (envelope) => sent.push(envelope),
+    }));
+    const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+    runtime.localInstanceId = "viewer_one";
+    runtime.router = router;
+    runtime.connectedPeerTargets = () => [{
+      target: { scope: "remote", instanceId: "owner_one" },
+      label: "Owner",
+      capabilities: ["thread_navigation", "event_subscriptions"],
+    }];
+
+    const cache = runtime.remoteThreadSummaries();
+    try {
+      const pending = cache.searchForJump({ query: "49" });
+      const request = sent.find(
+        (envelope) =>
+          envelope.kind === "request"
+          && envelope.method
+            === FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+      );
+      if (!request || request.kind !== "request") {
+        throw new Error("Expected a bounded navigation search request.");
+      }
+      await runtime.receiveEnvelope(
+        {
+          id: "jump-response",
+          kind: "response",
+          requestId: request.id,
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: "owner_one",
+          targetInstanceId: "viewer_one",
+          createdAt: 1_100,
+          result: { results: [] },
+        },
+        "owner_one",
+      );
+      await pending;
+
+      expect(sent.filter(
+        (envelope) =>
+          envelope.kind === "notification"
+          && envelope.method === "federation.eventSubscription",
+      )).toEqual([]);
+    } finally {
+      cache.dispose();
+    }
+  });
+
+  it("subscribes legacy Cmd+K snapshot peers to navigation updates for the cache TTL", async () => {
     vi.useFakeTimers();
     const sent: FederationProtocolEnvelope[] = [];
     const router = new FederationRouter({ localInstanceId: "viewer_one" });
@@ -2425,8 +2480,39 @@ describe("DesktopFederationRuntime", () => {
 
     const cache = runtime.remoteThreadSummaries();
     try {
-      await cache.searchForJump({ query: "49" });
-      expect(sent).toMatchObject([{
+      const pending = cache.searchForJump({ query: "49" });
+      const request = sent.find(
+        (envelope) =>
+          envelope.kind === "request"
+          && envelope.method
+            === FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+      );
+      if (!request || request.kind !== "request") {
+        throw new Error("Expected a bounded navigation search request.");
+      }
+      await runtime.receiveEnvelope(
+        {
+          id: "jump-method-missing",
+          kind: "error",
+          requestId: request.id,
+          protocolVersion: FEDERATION_PROTOCOL_VERSION,
+          sourceInstanceId: "owner_one",
+          targetInstanceId: "viewer_one",
+          createdAt: 1_100,
+          error: {
+            code: "method_not_found",
+            message: "Older peer",
+          },
+        },
+        "owner_one",
+      );
+      await pending;
+      const subscriptions = sent.filter(
+        (envelope) =>
+          envelope.kind === "notification"
+          && envelope.method === "federation.eventSubscription",
+      );
+      expect(subscriptions).toMatchObject([{
         kind: "notification",
         method: "federation.eventSubscription",
         params: { eventClasses: ["navigation"] },

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -33,6 +33,7 @@ import {
   DesktopFederationRuntime,
   disposeDesktopFederationRuntime,
   getDesktopFederationRuntime,
+  navigationWireResponseThreadCount,
 } from "../federation/federation-runtime";
 import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
@@ -510,6 +511,36 @@ describe("DesktopFederationRuntime", () => {
         selection: { kind: "all" },
       },
     });
+  });
+
+  it("counts every upsert in batched navigation changes for diagnostics", () => {
+    const change = (
+      baseRevision: string,
+      revision: string,
+      count: number,
+    ) => ({
+      kind: "delta" as const,
+      baseRevision,
+      revision,
+      fetchedAt: 1_000,
+      removedThreadKeys: [],
+      upsertedThreads: Array.from(
+        { length: count },
+        () => ({} as NavigationSnapshot["threads"][number]),
+      ),
+      removedDirectoryKeys: [],
+      upsertedDirectories: [],
+    });
+
+    expect(navigationWireResponseThreadCount({
+      kind: "changes",
+      baseRevision: "revision-1",
+      revision: "revision-3",
+      changes: [
+        change("revision-1", "revision-2", 300),
+        change("revision-2", "revision-3", 300),
+      ],
+    })).toBe(600);
   });
 
   it("uses full snapshots when an older owner does not advertise delta support", async () => {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -90,6 +90,13 @@
     "rowsChanged": 2,
     "statements": 2
   },
+  "federated-navigation-search-projection": {
+    "commits": 0,
+    "note": "one owner-side bounded navigation search projection",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "idle-hour-runtime-leases": {
     "commits": 0,
     "note": "one idle hour: PID-owned messaging and federation leases",

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -102,6 +102,65 @@ function pin(params: {
 }
 
 describe("RemoteThreadSummaryCache — searchForJump", () => {
+  it("asks each peer for bounded matches instead of fetching its full snapshot", async () => {
+    const fetchSnapshot = vi.fn(async () => snapshotOf([]));
+    const searchPeer = vi.fn(async () => [
+      stampedThread({
+        instanceId: "peer-a",
+        threadId: "t1",
+        title: "Matching thread",
+      }),
+    ]);
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      searchPeer,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    const response = await cache.searchForJump({ query: "match", limit: 3 });
+
+    expect(response.results.map((thread) => thread.id)).toEqual(["t1"]);
+    expect(searchPeer).toHaveBeenCalledWith(
+      remoteTarget("peer-a"),
+      { query: "match", limit: 3 },
+    );
+    expect(fetchSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a full snapshot when an older peer lacks bounded search", async () => {
+    const unavailable = Object.assign(new Error("method not found"), {
+      code: "method_not_found",
+    });
+    const searchPeer = vi.fn(async () => {
+      throw unavailable;
+    });
+    const fetchSnapshot = vi.fn(async () =>
+      snapshotOf([
+        stampedThread({
+          instanceId: "peer-a",
+          threadId: "legacy-match",
+          title: "Legacy match",
+        }),
+      ]),
+    );
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      searchPeer,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    const response = await cache.searchForJump({ query: "match" });
+
+    expect(response.results.map((thread) => thread.id)).toEqual([
+      "legacy-match",
+    ]);
+    expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+  });
+
   it("matches remote threads by PR number, title, and branch with local parity", async () => {
     const threads = [
       stampedThread({

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -161,6 +161,39 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     expect(fetchSnapshot).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps an older peer's fallback inside the original peer deadline", async () => {
+    vi.useFakeTimers();
+    const unavailable = Object.assign(new Error("method not found"), {
+      code: "method_not_found",
+    });
+    const searchPeer = vi.fn(() =>
+      new Promise<NavigationThreadSummary[]>((_, reject) => {
+        setTimeout(() => reject(unavailable), 80);
+      }),
+    );
+    const fetchSnapshot = vi.fn(() => new Promise<NavigationSnapshot>(() => {}));
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot,
+      searchPeer,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+      peerTimeoutMs: 100,
+    });
+
+    try {
+      const pending = cache.searchForJump({ query: "match" });
+      await vi.advanceTimersByTimeAsync(80);
+      expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(20);
+      await expect(pending).resolves.toEqual({ results: [] });
+    } finally {
+      cache.dispose();
+      vi.useRealTimers();
+    }
+  });
+
   it("matches remote threads by PR number, title, and branch with local parity", async () => {
     const threads = [
       stampedThread({

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -61,6 +61,32 @@ afterEach(() => {
 });
 
 describe("sqlite write metrics", () => {
+  it("keeps partial navigation search reconciliation read-only", async () => {
+    const thread: AppServerThreadSummary = {
+      id: "thread-search",
+      title: "Federation search result",
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      updatedAt: 1_000,
+    };
+
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.reconcileNavigationSnapshot({
+        backend: "all",
+        fetchedAt: 1_000,
+        partial: true,
+        threads: [thread],
+      });
+    });
+
+    expectSqliteWriteBudget({
+      note: "one owner-side bounded navigation search projection",
+      scenario: "federated-navigation-search-projection",
+      writes,
+    });
+  });
+
   it("attributes commits and rows to the table that took them", async () => {
     await store.upsertThreadToolInvocation({
       invocation: buildInvocation("tool-1"),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -152,7 +152,6 @@ import type {
 import {
   encodeNavigationSnapshotThreadKeysForProtocolV1,
   normalizeNavigationSnapshotThreadKeys,
-  rankThreadJumpMatches,
 } from "@pwragent/shared";
 import { NavigationSnapshotTransport } from "../navigation-snapshot-transport";
 import type { FederationRouter } from "./federation-router";
@@ -559,8 +558,9 @@ export type FederationBackendOperations = {
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
   /**
-   * Optional because test doubles and non-desktop adapters can let the bridge
-   * derive this from getNavigationSnapshot. The remote client implements it.
+   * Optional for test doubles and non-desktop adapters. When absent, the RPC
+   * handler is omitted so callers receive method_not_found and may use their
+   * bounded legacy fallback without forcing a persistent owner refresh.
    */
   searchNavigationThreads?(
     request: FederationJumpSearchRequest,
@@ -820,26 +820,19 @@ export function registerFederationBackendHandlers(params: {
       });
     },
   );
-  params.router.registerHandler(
-    FEDERATION_BACKEND_METHODS.searchNavigationThreads,
-    async (envelope) => {
-      const request = envelope.params as FederationJumpSearchRequest;
-      if (params.backend.searchNavigationThreads) {
-        return await params.backend.searchNavigationThreads(request);
-      }
-      const query = request.query.trim();
-      if (!query) {
-        return { results: [] } satisfies FederationJumpSearchResponse;
-      }
-      const limit = Math.max(1, Math.min(request.limit ?? 8, 50));
-      const snapshot = await params.backend.getNavigationSnapshot({
-        refreshMode: "full",
-      });
-      return {
-        results: rankThreadJumpMatches(snapshot.threads, query).slice(0, limit),
-      } satisfies FederationJumpSearchResponse;
-    },
-  );
+  if (params.backend.searchNavigationThreads) {
+    params.router.registerHandler(
+      FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+      async (envelope) => {
+        if (!params.backend.searchNavigationThreads) {
+          throw new Error("Bounded navigation search became unavailable.");
+        }
+        return await params.backend.searchNavigationThreads(
+          envelope.params as FederationJumpSearchRequest,
+        );
+      },
+    );
+  }
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.listThreads,
     async (envelope) =>

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -31,6 +31,8 @@ import type {
   DetachThreadPullRequestRequest,
   DetachThreadPullRequestResponse,
   FederationCapability,
+  FederationJumpSearchRequest,
+  FederationJumpSearchResponse,
   FederationInstanceId,
   FederatedThreadRef,
   FederationLoadStatus,
@@ -150,6 +152,7 @@ import type {
 import {
   encodeNavigationSnapshotThreadKeysForProtocolV1,
   normalizeNavigationSnapshotThreadKeys,
+  rankThreadJumpMatches,
 } from "@pwragent/shared";
 import { NavigationSnapshotTransport } from "../navigation-snapshot-transport";
 import type { FederationRouter } from "./federation-router";
@@ -351,6 +354,7 @@ function authenticateScheduledTurnOrigin<
 
 export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
+  searchNavigationThreads: "backend.searchNavigationThreads",
   listThreads: "backend.listThreads",
   resolveThread: "backend.resolveThread",
   resolveThreadAdmissionState: "backend.resolveThreadAdmissionState",
@@ -447,6 +451,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   FederationCapability
 > = {
   [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.searchNavigationThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThread]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState]: "messaging_route",
@@ -553,6 +558,13 @@ export type FederationBackendOperations = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
   ): Promise<NavigationSnapshot>;
+  /**
+   * Optional because test doubles and non-desktop adapters can let the bridge
+   * derive this from getNavigationSnapshot. The remote client implements it.
+   */
+  searchNavigationThreads?(
+    request: FederationJumpSearchRequest,
+  ): Promise<FederationJumpSearchResponse>;
   listThreads(
     request?: AppServerListThreadsRequest,
   ): Promise<AppServerListThreadsResponse>;
@@ -806,6 +818,26 @@ export function registerFederationBackendHandlers(params: {
         selection,
         snapshot,
       });
+    },
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+    async (envelope) => {
+      const request = envelope.params as FederationJumpSearchRequest;
+      if (params.backend.searchNavigationThreads) {
+        return await params.backend.searchNavigationThreads(request);
+      }
+      const query = request.query.trim();
+      if (!query) {
+        return { results: [] } satisfies FederationJumpSearchResponse;
+      }
+      const limit = Math.max(1, Math.min(request.limit ?? 8, 50));
+      const snapshot = await params.backend.getNavigationSnapshot({
+        refreshMode: "full",
+      });
+      return {
+        results: rankThreadJumpMatches(snapshot.threads, query).slice(0, limit),
+      } satisfies FederationJumpSearchResponse;
     },
   );
   params.router.registerHandler(
@@ -1512,6 +1544,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
       NavigationSnapshot | NavigationSnapshotTransportResponse
     >({
       method: FEDERATION_BACKEND_METHODS.getNavigationSnapshot,
+      params: request,
+    });
+  }
+
+  async searchNavigationThreads(
+    request: FederationJumpSearchRequest,
+  ): Promise<FederationJumpSearchResponse> {
+    return await this.rpc.request<FederationJumpSearchResponse>({
+      method: FEDERATION_BACKEND_METHODS.searchNavigationThreads,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -301,6 +301,28 @@ import { noiseKeyPairFromRawPrivate } from "./federation-noise";
 import { federationReconnectDelayMs } from "./federation-reconnect-policy";
 
 const log = getMainLogger("pwragent:federation-runtime");
+
+export function navigationWireResponseThreadCount(
+  response: NavigationSnapshot | NavigationSnapshotTransportResponse,
+): number {
+  if ("threads" in response) {
+    return response.threads.length;
+  }
+  switch (response.kind) {
+    case "full":
+      return response.snapshot.threads.length;
+    case "delta":
+      return response.upsertedThreads.length;
+    case "changes":
+      return response.changes.reduce(
+        (count, change) => count + change.upsertedThreads.length,
+        0,
+      );
+    case "unchanged":
+      return 0;
+  }
+}
+
 const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
 const GATEWAY_PUBLIC_KEY_META_KEY = "federation_gateway_public_key_pem";
@@ -2009,13 +2031,7 @@ export class DesktopFederationRuntime {
     const responseKind = "threads" in params.response
       ? "legacy-full"
       : params.response.kind;
-    const threadCount = "threads" in params.response
-      ? params.response.threads.length
-      : params.response.kind === "full"
-        ? params.response.snapshot.threads.length
-        : params.response.kind === "delta"
-          ? params.response.upsertedThreads.length
-          : 0;
+    const threadCount = navigationWireResponseThreadCount(params.response);
     // Exact size requires serialization. Avoid adding that work to ordinary
     // small responses; a large collection or an already-slow response earns
     // the diagnostic cost.
@@ -4877,10 +4893,13 @@ async function mountRemoteParentForLocalChild(
 }
 
 function localBackendOperations(): FederationBackendOperations {
+  const messagingBridge = new DesktopMessagingBackendBridge();
   return {
     async getNavigationSnapshot(request = {}): Promise<NavigationSnapshot> {
-      return await new DesktopMessagingBackendBridge()
-        .getNavigationSnapshot(request);
+      return await messagingBridge.getNavigationSnapshot(request);
+    },
+    async searchNavigationThreads(request) {
+      return await messagingBridge.searchNavigationThreads(request);
     },
     async listThreads(
       request: AppServerListThreadsRequest = {},

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -148,6 +148,7 @@ import {
   type ReorderThreadPinsRequest,
   type ReorderThreadPinsResponse,
   type NavigationSnapshot,
+  type NavigationSnapshotTransportResponse,
   type NavigationThreadSummary,
   type OpenDesktopApplicationRequest,
   type QueueThreadExecutionModeRequest,
@@ -1881,11 +1882,21 @@ export class DesktopFederationRuntime {
         "navigation_snapshot_deltas",
       )
     ) {
+      const startedAt = Date.now();
+      const legacyResponse = await backend.getNavigationSnapshot(
+        snapshotRequest,
+      );
+      this.logRemoteNavigationWireResponse({
+        target,
+        startedAt,
+        response: legacyResponse,
+        selection: "legacy-all",
+      });
       return await this.stampRemoteNavigationSnapshot(
         target,
         projectNavigationSnapshot(
           normalizeNavigationSnapshotThreadKeys(
-            await backend.getNavigationSnapshot(snapshotRequest),
+            legacyResponse,
           ),
           snapshotRequest,
         ),
@@ -1916,6 +1927,7 @@ export class DesktopFederationRuntime {
       cacheable && cachedTransport?.selectionKey === selectionKey
         ? cachedTransport.state
         : undefined;
+    let startedAt = Date.now();
     let transportResponse = await backend.getNavigationSnapshotTransport({
       transport: {
         protocol: 1,
@@ -1924,6 +1936,12 @@ export class DesktopFederationRuntime {
           ? { baseRevision: previousTransportState.revision }
           : {}),
       },
+    });
+    this.logRemoteNavigationWireResponse({
+      target,
+      startedAt,
+      response: transportResponse,
+      selection: selection.kind,
     });
     if ("threads" in transportResponse) {
       return await this.stampRemoteNavigationSnapshot(
@@ -1939,8 +1957,15 @@ export class DesktopFederationRuntime {
       transportResponse,
     );
     if (!nextTransportState) {
+      startedAt = Date.now();
       transportResponse = await backend.getNavigationSnapshotTransport({
         transport: { protocol: 1, selection },
+      });
+      this.logRemoteNavigationWireResponse({
+        target,
+        startedAt,
+        response: transportResponse,
+        selection: selection.kind,
       });
       if ("threads" in transportResponse) {
         return await this.stampRemoteNavigationSnapshot(
@@ -1974,6 +1999,46 @@ export class DesktopFederationRuntime {
     return await this.stampRemoteNavigationSnapshot(target, response);
   }
 
+  private logRemoteNavigationWireResponse(params: {
+    target: FederationRemoteTarget;
+    startedAt: number;
+    response: NavigationSnapshot | NavigationSnapshotTransportResponse;
+    selection: string;
+  }): void {
+    const durationMs = Date.now() - params.startedAt;
+    const responseKind = "threads" in params.response
+      ? "legacy-full"
+      : params.response.kind;
+    const threadCount = "threads" in params.response
+      ? params.response.threads.length
+      : params.response.kind === "full"
+        ? params.response.snapshot.threads.length
+        : params.response.kind === "delta"
+          ? params.response.upsertedThreads.length
+          : 0;
+    // Exact size requires serialization. Avoid adding that work to ordinary
+    // small responses; a large collection or an already-slow response earns
+    // the diagnostic cost.
+    if (durationMs < 1_000 && threadCount < 500) {
+      return;
+    }
+    const responseBytes = Buffer.byteLength(
+      JSON.stringify(params.response),
+      "utf8",
+    );
+    if (durationMs < 1_000 && responseBytes < 512 * 1024) {
+      return;
+    }
+    log.info("remote navigation wire response was slow or large", {
+      durationMs,
+      instanceId: params.target.instanceId,
+      responseBytes,
+      responseKind,
+      selection: params.selection,
+      threadCount,
+    });
+  }
+
   private remotePeerAdvertisesCapability(
     instanceId: FederationInstanceId,
     capability: FederationCapability,
@@ -1996,6 +2061,33 @@ export class DesktopFederationRuntime {
     target: FederationRemoteTarget,
     response: NavigationSnapshot,
   ): Promise<NavigationSnapshot> {
+    const stamped = this.stampRemoteNavigationThreads(target, response.threads);
+    return {
+      ...response,
+      federationTarget: target,
+      unchanged: false,
+      threads: stamped.threads,
+      inboxThreadKeys: response.inboxThreadKeys.map(
+        (threadKey) =>
+          stamped.threadKeyBySourceKey.get(threadKey) ?? threadKey,
+      ),
+      directories: response.directories.map((directory) => ({
+        ...directory,
+        threadKeys: directory.threadKeys.map(
+          (threadKey) =>
+            stamped.threadKeyBySourceKey.get(threadKey) ?? threadKey,
+        ),
+      })),
+    };
+  }
+
+  private stampRemoteNavigationThreads(
+    target: FederationRemoteTarget,
+    responseThreads: readonly NavigationThreadSummary[],
+  ): {
+    threads: NavigationThreadSummary[];
+    threadKeyBySourceKey: Map<string, string>;
+  } {
     // visiblePeers reads the app-state db (local instance id); during
     // early boot or in store-injected test harnesses that db may be
     // absent — fall back to the bare store record (mirrors the menu's
@@ -2020,8 +2112,8 @@ export class DesktopFederationRuntime {
       visiblePeer,
     );
     const peerStatus = visiblePeer?.status ?? peer?.status;
-    const stampedThreadKeyBySourceKey = new Map<string, string>();
-    const threads = response.threads.map((thread) => {
+    const threadKeyBySourceKey = new Map<string, string>();
+    const threads = responseThreads.map((thread) => {
       const sourceKey = thread.federation?.ref
         ? federatedThreadIdentityKey(thread.federation.ref)
         : buildThreadIdentityKey(thread.source, thread.id);
@@ -2045,7 +2137,7 @@ export class DesktopFederationRuntime {
         instanceId: ownerInstanceId,
         threadId: thread.id,
       });
-      stampedThreadKeyBySourceKey.set(
+      threadKeyBySourceKey.set(
         sourceKey,
         federatedThreadIdentityKey(ref),
       );
@@ -2066,21 +2158,7 @@ export class DesktopFederationRuntime {
         },
       };
     });
-    return {
-      ...response,
-      federationTarget: target,
-      unchanged: false,
-      threads,
-      inboxThreadKeys: response.inboxThreadKeys.map(
-        (threadKey) => stampedThreadKeyBySourceKey.get(threadKey) ?? threadKey,
-      ),
-      directories: response.directories.map((directory) => ({
-        ...directory,
-        threadKeys: directory.threadKeys.map(
-          (threadKey) => stampedThreadKeyBySourceKey.get(threadKey) ?? threadKey,
-        ),
-      })),
-    };
+    return { threads, threadKeyBySourceKey };
   }
 
   /**
@@ -2107,16 +2185,67 @@ export class DesktopFederationRuntime {
   }
 
   /**
-   * Shared cache of stamped peer navigation summaries, serving the ⌘K
-   * federated jump search and the pinned-remote-thread snapshot merge.
-   * Snapshot-based (not `listThreads`) so remote rows carry PR chips and
-   * the shared `threadMatchesQuery` gives local/remote matching parity.
+   * Stamped peer navigation summaries for bounded Cmd+K search, its
+   * older-peer snapshot fallback, and the pinned-remote-thread merge.
+   * Navigation-based (not `listThreads`) so remote rows carry PR chips and
+   * share local matching semantics without sending a full snapshot per query.
    */
   remoteThreadSummaries(): RemoteThreadSummaryCache {
     this.remoteThreadSummaryCache ??= new RemoteThreadSummaryCache({
       peers: () => this.connectedPeerTargets(),
       fetchSnapshot: (target, selection) =>
         this.remoteNavigationSnapshot(target, {}, selection),
+      searchPeer: async (target, request) => {
+        const startedAt = Date.now();
+        const backend = this.remoteBackend(target);
+        if (!backend.searchNavigationThreads) {
+          const unavailable = new Error(
+            "Remote peer does not support bounded navigation search.",
+          ) as Error & { code?: string };
+          unavailable.code = "method_not_found";
+          throw unavailable;
+        }
+        try {
+          const response = await backend.searchNavigationThreads(request);
+          const durationMs = Date.now() - startedAt;
+          if (durationMs >= 1_000) {
+            const responseBytes = Buffer.byteLength(
+              JSON.stringify(response),
+              "utf8",
+            );
+            log.info("remote bounded navigation search was slow", {
+              durationMs,
+              instanceId: target.instanceId,
+              queryLength: request.query.length,
+              responseBytes,
+              resultCount: response.results.length,
+            });
+          }
+          return this.stampRemoteNavigationThreads(
+            target,
+            response.results,
+          ).threads;
+        } catch (error) {
+          const durationMs = Date.now() - startedAt;
+          const code =
+            typeof error === "object"
+            && error !== null
+            && "code" in error
+            && typeof error.code === "string"
+              ? error.code
+              : undefined;
+          if (code !== "method_not_found" || durationMs >= 1_000) {
+            log.warn("remote bounded navigation search failed", {
+              code,
+              durationMs,
+              error: error instanceof Error ? error.message : String(error),
+              instanceId: target.instanceId,
+              queryLength: request.query.length,
+            });
+          }
+          throw error;
+        }
+      },
       fetchArchivedThreads: async (target, backend) =>
         (
           await this.remoteBackend(target).listThreads({

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -12,8 +12,7 @@ import type {
 } from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
-  threadHasExactPrNumberMatch,
-  threadMatchesQuery,
+  rankThreadJumpMatches,
 } from "@pwragent/shared";
 import { ThreadInfoStore } from "../app-server/thread-info-store";
 
@@ -51,11 +50,12 @@ export type ResolvedRemotePins = {
 };
 
 /**
- * Peer navigation snapshots are the only remote summary shape that carries
- * PR chips (the owner merges its overlay `prs` before serving), so both the
- * ⌘K jump search and the pinned-thread merge read through this cache rather
- * than `listThreads`. The TTL keeps keystroke-debounced jump queries and
- * back-to-back snapshot merges from re-fetching full snapshots per call.
+ * Peer navigation summaries are the only remote row shape that carries PR
+ * chips (the owner merges its overlay `prs` before serving). Pinned-thread
+ * merges and the older-peer Cmd+K fallback read full snapshots through this
+ * cache; current peers filter and bound Cmd+K rows on the owner. The TTL keeps
+ * compatibility searches and back-to-back pin merges from re-fetching full
+ * snapshots per call.
  */
 const REMOTE_SNAPSHOT_TTL_MS = 15_000;
 /** Mirrors the federated-search per-peer deadline. */
@@ -177,6 +177,14 @@ export class RemoteThreadSummaryCache {
         target: FederationRemoteTarget,
         selection: FederationThreadSelection,
       ) => Promise<NavigationSnapshot>;
+      /**
+       * Bounded owner-side Cmd+K search. Older peers reject the new method;
+       * those alone fall back to the full-snapshot compatibility path.
+       */
+      searchPeer?: (
+        target: FederationRemoteTarget,
+        request: FederationJumpSearchRequest,
+      ) => Promise<NavigationThreadSummary[]>;
       /** Archived threads for one backend on a connected peer. */
       fetchArchivedThreads: (
         target: FederationRemoteTarget,
@@ -262,11 +270,7 @@ export class RemoteThreadSummaryCache {
     const groups = await Promise.all(
       this.navigationPeers().map(async (peer) => {
         try {
-          return await this.threadsForPeer(
-            peer.target,
-            { kind: "all" },
-            "jump-search",
-          );
+          return await this.searchPeerForJump(peer.target, { query, limit });
         } catch {
           // ⌘K is a jump surface, not a diagnostics surface: a slow or
           // failing peer contributes nothing rather than an error row.
@@ -274,22 +278,7 @@ export class RemoteThreadSummaryCache {
         }
       }),
     );
-    const results = groups
-      .flat()
-      .filter((thread) => threadMatchesQuery(thread, query))
-      .sort((left, right) => {
-        const exactPrPriority =
-          Number(threadHasExactPrNumberMatch(right, query))
-          - Number(threadHasExactPrNumberMatch(left, query));
-        if (exactPrPriority !== 0) {
-          return exactPrPriority;
-        }
-        return (
-          (right.updatedAt ?? right.createdAt ?? 0)
-          - (left.updatedAt ?? left.createdAt ?? 0)
-        );
-      })
-      .slice(0, limit);
+    const results = rankThreadJumpMatches(groups.flat(), query).slice(0, limit);
     return { results };
   }
 
@@ -786,6 +775,32 @@ export class RemoteThreadSummaryCache {
       .filter((peer) => peer.capabilities.includes("thread_navigation"));
   }
 
+  private async searchPeerForJump(
+    target: FederationRemoteTarget,
+    request: FederationJumpSearchRequest,
+  ): Promise<NavigationThreadSummary[]> {
+    if (this.options.searchPeer) {
+      const timeoutMs =
+        this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
+      try {
+        return await withTimeout(
+          this.options.searchPeer(target, request),
+          timeoutMs,
+          `Remote thread search timed out after ${Math.round(timeoutMs / 1000)}s.`,
+        );
+      } catch (error) {
+        if (!hasFederationErrorCode(error, "method_not_found")) {
+          throw error;
+        }
+      }
+    }
+    return await this.threadsForPeer(
+      target,
+      { kind: "all" },
+      "jump-search",
+    );
+  }
+
   private async threadsForPeer(
     target: FederationRemoteTarget,
     selection: FederationThreadSelection,
@@ -984,4 +999,13 @@ function withTimeout<T>(
       },
     );
   });
+}
+
+function hasFederationErrorCode(error: unknown, code: string): boolean {
+  return (
+    typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === code
+  );
 }

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -779,9 +779,10 @@ export class RemoteThreadSummaryCache {
     target: FederationRemoteTarget,
     request: FederationJumpSearchRequest,
   ): Promise<NavigationThreadSummary[]> {
+    const timeoutMs =
+      this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
+    const deadlineAt = Date.now() + timeoutMs;
     if (this.options.searchPeer) {
-      const timeoutMs =
-        this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
       try {
         return await withTimeout(
           this.options.searchPeer(target, request),
@@ -798,6 +799,7 @@ export class RemoteThreadSummaryCache {
       target,
       { kind: "all" },
       "jump-search",
+      deadlineAt,
     );
   }
 
@@ -805,6 +807,7 @@ export class RemoteThreadSummaryCache {
     target: FederationRemoteTarget,
     selection: FederationThreadSelection,
     interestKey: string,
+    deadlineAt?: number,
   ): Promise<NavigationThreadSummary[]> {
     const now = this.options.now?.() ?? Date.now();
     const ttlMs = this.options.ttlMs ?? REMOTE_SNAPSHOT_TTL_MS;
@@ -828,31 +831,41 @@ export class RemoteThreadSummaryCache {
       pending?.generation === generation
       && selectionIncludes(pending.selection, selection)
     ) {
-      return await pending.promise;
+      return await this.awaitPeerSnapshot(
+        pending.promise,
+        deadlineAt,
+      );
     }
     if (pending?.generation === generation) {
       try {
-        await pending.promise;
+        await this.awaitPeerSnapshot(pending.promise, deadlineAt);
       } catch {
         // The next read below gets its own attempt for the wider/different
         // collection; an unrelated sparse failure must not answer it.
       }
-      return await this.threadsForPeer(target, selection, interestKey);
+      return await this.threadsForPeer(
+        target,
+        selection,
+        interestKey,
+        deadlineAt,
+      );
     }
     // Reserved before the fetch, not after it: a snapshot that starts first and
     // finishes last must not overwrite the names a later refresh already
     // recorded.
     const nameObservationSequence = this.reserveThreadNameObservation();
     const promise = (async () => {
-      const timeoutMs =
-        this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
-      const snapshot = await withTimeout(
+      const snapshot = await this.awaitPeerSnapshot(
         this.options.fetchSnapshot(target, selection),
-        timeoutMs,
-        `Remote thread summaries timed out after ${Math.round(timeoutMs / 1000)}s.`,
+        deadlineAt,
       );
       if (this.generationFor(target.instanceId) !== generation) {
-        return await this.threadsForPeer(target, selection, interestKey);
+        return await this.threadsForPeer(
+          target,
+          selection,
+          interestKey,
+          deadlineAt,
+        );
       }
       const threads = snapshot.threads;
       this.cache.set(target.instanceId, {
@@ -886,6 +899,23 @@ export class RemoteThreadSummaryCache {
         this.inFlight.delete(target.instanceId);
       }
     }
+  }
+
+  private async awaitPeerSnapshot<T>(
+    promise: Promise<T>,
+    deadlineAt?: number,
+  ): Promise<T> {
+    const defaultTimeoutMs =
+      this.options.peerTimeoutMs ?? REMOTE_SNAPSHOT_PEER_TIMEOUT_MS;
+    const timeoutMs = deadlineAt === undefined
+      ? defaultTimeoutMs
+      : Math.max(0, deadlineAt - Date.now());
+    const message =
+      `Remote thread summaries timed out after ${Math.round(defaultTimeoutMs / 1000)}s.`;
+    if (timeoutMs <= 0) {
+      throw new Error(message);
+    }
+    return await withTimeout(promise, timeoutMs, message);
   }
 
   private async archivedThreadKeysForPeer(

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -19,6 +19,8 @@ import type {
   FederationEventSubscription,
   FederationHealthStatus,
   FederationInstanceId,
+  FederationJumpSearchRequest,
+  FederationJumpSearchResponse,
   FederationRemoteTarget,
   FederationTarget,
   FederationThreadSelection,
@@ -65,6 +67,7 @@ import {
   buildThreadIdentityKey,
   buildFederatedThreadRef,
   isRemoteFederationTarget,
+  rankThreadJumpMatches,
 } from "@pwragent/shared";
 import type {
   MessagingBackendBridge,
@@ -110,10 +113,17 @@ export type DesktopMessagingFederationBridge = {
 };
 
 export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
+  private static readonly navigationSearchCacheTtlMs = 15_000;
+
   private readonly assistantImageResolutions = new Map<
     string,
     Promise<MessagingImagePart[]>
   >();
+  private navigationSearchCache?: {
+    expiresAt: number;
+    threads: NavigationThreadSummary[];
+  };
+  private navigationSearchInFlight?: Promise<NavigationThreadSummary[]>;
 
   constructor(
     private readonly registry: DesktopBackendRegistry = getDesktopBackendRegistry(),
@@ -423,6 +433,72 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         ...availableRemoteSnapshots.flatMap((remote) => remote.inboxThreadKeys),
       ],
     };
+  }
+
+  /**
+   * Serve owner-side Cmd+K matching from a short-lived, read-only projection.
+   * A full navigation reconciliation persists its baseline, which is correct
+   * for navigation refreshes but would turn every debounced search query into
+   * a SQLite commit. The partial projection reads overlays without updating
+   * them, and the cache preserves the former 15-second remote-search cadence.
+   */
+  async searchNavigationThreads(
+    request: FederationJumpSearchRequest,
+  ): Promise<FederationJumpSearchResponse> {
+    const query = request.query.trim();
+    if (!query) {
+      return { results: [] };
+    }
+    const limit = Math.max(1, Math.min(request.limit ?? 8, 50));
+    const threads = await this.navigationThreadsForSearch();
+    return {
+      results: rankThreadJumpMatches(threads, query).slice(0, limit),
+    };
+  }
+
+  private async navigationThreadsForSearch(): Promise<NavigationThreadSummary[]> {
+    const now = Date.now();
+    if (this.navigationSearchCache && this.navigationSearchCache.expiresAt > now) {
+      return this.navigationSearchCache.threads;
+    }
+    if (this.navigationSearchInFlight) {
+      return await this.navigationSearchInFlight;
+    }
+
+    const pending = (async () => {
+      const listedThreads = await this.registry.listThreads({
+        callerReason: "messaging-navigation-snapshot",
+      });
+      const snapshot = await getDesktopOverlayStore().reconcileNavigationSnapshot({
+        backend: "all",
+        fetchedAt: Date.now(),
+        messagingBindingsByThreadKey:
+          await buildMessagingBindingsByThreadKey(listedThreads),
+        partial: true,
+        queuedExecutionModesByThreadKey:
+          this.registry.getQueuedExecutionModesSnapshot(),
+        queuedTurnsByThreadKey: this.registry.getQueuedTurnsSnapshot(),
+        threads: listedThreads,
+        workspaceRoots: resolveScratchProjectsRoots(),
+      });
+      return await this.registry.canonicalizeNavigationThreadPullRequests(
+        snapshot.threads,
+      );
+    })();
+    this.navigationSearchInFlight = pending;
+    try {
+      const threads = await pending;
+      this.navigationSearchCache = {
+        expiresAt:
+          Date.now() + DesktopMessagingBackendBridge.navigationSearchCacheTtlMs,
+        threads,
+      };
+      return threads;
+    } finally {
+      if (this.navigationSearchInFlight === pending) {
+        this.navigationSearchInFlight = undefined;
+      }
+    }
   }
 
   async resolveThreadTarget(request: {

--- a/packages/shared/src/thread-jump-match.ts
+++ b/packages/shared/src/thread-jump-match.ts
@@ -108,3 +108,28 @@ export function threadMatchesQuery(
     (directory.label ?? "").toLowerCase().includes(needle),
   );
 }
+
+/**
+ * Apply the shared Cmd+K match and ordering rules to a navigation collection.
+ * Owners use this before returning bounded Federation search results, while
+ * viewers use it to merge results from multiple peers without semantic drift.
+ */
+export function rankThreadJumpMatches(
+  threads: readonly NavigationThreadSummary[],
+  query: string,
+): NavigationThreadSummary[] {
+  return threads
+    .filter((thread) => threadMatchesQuery(thread, query))
+    .sort((left, right) => {
+      const exactPrPriority =
+        Number(threadHasExactPrNumberMatch(right, query))
+        - Number(threadHasExactPrNumberMatch(left, query));
+      if (exactPrPriority !== 0) {
+        return exactPrPriority;
+      }
+      return (
+        (right.updatedAt ?? right.createdAt ?? 0)
+        - (left.updatedAt ?? left.createdAt ?? 0)
+      );
+    });
+}


### PR DESCRIPTION
## Summary

- execute Cmd+K navigation matching on each peer and return at most the requested rows
- preserve PR-number, title, branch, directory, agent, and thread-id matching parity
- fall back to the full navigation snapshot only when an older peer lacks the new RPC
- log slow bounded searches and slow or large navigation wire responses with peer IDs and byte counts

## Tests

- `pnpm test packages/shared/src/__tests__/thread-jump-match.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts`
- `pnpm test packages/shared/src/__tests__/thread-jump-match.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts apps/desktop/src/main/__tests__/git-working-state-service.test.ts --maxWorkers=1`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`

The full parallel Vitest run reached 9,977 passing tests and hit three unrelated timing/race failures. All three passed in the focused single-worker rerun above.