### PR TITLE
feat(desktop): stream federated jump search results

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -9,6 +9,8 @@ import type {
   AppServerListThreadsRequest,
   AppServerReadThreadResponse,
   AppServerThreadSummary,
+  FederationJumpSearchProgress,
+  FederationJumpSearchRequest,
   GetNavigationSnapshotRequest,
   HandoffThreadWorkspaceRequest,
   MarkThreadSeenRequest,
@@ -113,7 +115,12 @@ const federationMock = vi.hoisted(() => {
         archived: [],
       }),
     ),
-    searchForJump: vi.fn(async () => ({ results: [] })),
+    searchForJump: vi.fn(
+      async (
+        _request: FederationJumpSearchRequest,
+        _onProgress?: (progress: FederationJumpSearchProgress) => void,
+      ) => ({ results: [] }),
+    ),
     threadFromPeer: vi.fn(async (): Promise<unknown> => undefined),
     rememberThreadNames: vi.fn(),
     reserveThreadNameObservation: vi.fn(() => (nextThreadNameObservation += 1)),
@@ -1206,6 +1213,10 @@ describe("app server ipc", () => {
     federationMock.runtime.remoteNavigationSnapshot.mockReset();
     federationMock.runtime.ungroupRemoteChildrenOfArchivedThread.mockClear();
     federationMock.remoteThreadSummaries.invalidate.mockClear();
+    federationMock.remoteThreadSummaries.searchForJump.mockReset();
+    federationMock.remoteThreadSummaries.searchForJump.mockResolvedValue({
+      results: [],
+    });
     listRemoteThreadPins.mockReset();
     listRemoteThreadPins.mockResolvedValue([]);
     updateRemoteThreadPinSnapshots.mockClear();
@@ -1328,6 +1339,51 @@ describe("app server ipc", () => {
     await disposeAppServerIpcHandlers();
 
     expect(backendRegistryLifecycle.get).not.toHaveBeenCalled();
+  });
+
+  it("delivers jump-search progress only to the invoking renderer and request", async () => {
+    const {
+      FEDERATION_JUMP_SEARCH_CHANNEL,
+      FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL,
+    } = await import("../../shared/ipc");
+    const searchForJump = federationMock.remoteThreadSummaries.searchForJump;
+    searchForJump.mockImplementation(async (request, onProgress) => {
+      onProgress?.({
+        results: [],
+        completedPeerCount: 1,
+        totalPeerCount: 2,
+        complete: false,
+      });
+      return { results: [] };
+    });
+    const firstSend = vi.fn();
+    const secondSend = vi.fn();
+    const firstSender = { isDestroyed: () => false, send: firstSend };
+    const secondSender = { isDestroyed: () => false, send: secondSend };
+    registerAppServerIpcHandlers();
+    const handler = handlers.get(FEDERATION_JUMP_SEARCH_CHANNEL);
+
+    await Promise.all([
+      handler?.(
+        { sender: firstSender },
+        41,
+        { query: "first", limit: 8 },
+      ),
+      handler?.(
+        { sender: secondSender },
+        73,
+        { query: "second", limit: 8 },
+      ),
+    ]);
+
+    expect(firstSend).toHaveBeenCalledExactlyOnceWith(
+      FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL,
+      expect.objectContaining({ requestId: 41 }),
+    );
+    expect(secondSend).toHaveBeenCalledExactlyOnceWith(
+      FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL,
+      expect.objectContaining({ requestId: 73 }),
+    );
   });
 
   it("invalidates the GraphQL token during an auth recheck", async () => {

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -243,6 +243,153 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     expect(response.results.map((thread) => thread.id)).toEqual(["new"]);
   });
 
+  it("publishes a fast peer before a slow peer settles", async () => {
+    let resolveSlow:
+      | ((threads: NavigationThreadSummary[]) => void)
+      | undefined;
+    const searchPeer = vi.fn(async (target: FederationRemoteTarget) => {
+      if (target.instanceId === "peer-slow") {
+        return await new Promise<NavigationThreadSummary[]>((resolve) => {
+          resolveSlow = resolve;
+        });
+      }
+      return [
+        stampedThread({
+          instanceId: "peer-fast",
+          threadId: "fast",
+          title: "match fast",
+          updatedAt: 1,
+        }),
+      ];
+    });
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-slow"), peer("peer-fast")],
+      fetchSnapshot: async () => snapshotOf([]),
+      searchPeer,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+    const onProgress = vi.fn();
+
+    const pending = cache.searchForJump(
+      { query: "match" },
+      onProgress,
+    );
+
+    await vi.waitFor(() => expect(onProgress).toHaveBeenCalledTimes(1));
+    expect(onProgress).toHaveBeenLastCalledWith({
+      results: [expect.objectContaining({ id: "fast" })],
+      completedPeerCount: 1,
+      totalPeerCount: 2,
+      complete: false,
+    });
+
+    let settled = false;
+    void pending.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+    expect(settled).toBe(false);
+
+    resolveSlow?.([
+      stampedThread({
+        instanceId: "peer-slow",
+        threadId: "slow",
+        title: "match slow",
+        updatedAt: 2,
+      }),
+    ]);
+    await expect(pending).resolves.toMatchObject({
+      results: [{ id: "slow" }, { id: "fast" }],
+    });
+    expect(onProgress).toHaveBeenLastCalledWith({
+      results: [
+        expect.objectContaining({ id: "slow" }),
+        expect.objectContaining({ id: "fast" }),
+      ],
+      completedPeerCount: 2,
+      totalPeerCount: 2,
+      complete: true,
+    });
+  });
+
+  it("keeps successful peer results when another peer fails", async () => {
+    let rejectFailed: ((error: Error) => void) | undefined;
+    const searchPeer = vi.fn(async (target: FederationRemoteTarget) => {
+      if (target.instanceId === "peer-error") {
+        return await new Promise<NavigationThreadSummary[]>((_, reject) => {
+          rejectFailed = reject;
+        });
+      }
+      return [
+        stampedThread({
+          instanceId: "peer-fast",
+          threadId: "fast",
+          title: "match fast",
+        }),
+      ];
+    });
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-error"), peer("peer-fast")],
+      fetchSnapshot: async () => snapshotOf([]),
+      searchPeer,
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+    const onProgress = vi.fn();
+    const pending = cache.searchForJump({ query: "match" }, onProgress);
+
+    await vi.waitFor(() => expect(onProgress).toHaveBeenCalledTimes(1));
+    rejectFailed?.(new Error("peer unavailable"));
+
+    await expect(pending).resolves.toMatchObject({
+      results: [{ id: "fast" }],
+    });
+    expect(onProgress).toHaveBeenLastCalledWith({
+      results: [expect.objectContaining({ id: "fast" })],
+      completedPeerCount: 2,
+      totalPeerCount: 2,
+      complete: true,
+    });
+  });
+
+  it("deduplicates globally before applying the result limit", async () => {
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      searchPeer: async () => [
+        stampedThread({
+          instanceId: "peer-a",
+          threadId: "duplicate",
+          title: "match old",
+          updatedAt: 1,
+        }),
+        stampedThread({
+          instanceId: "peer-a",
+          threadId: "duplicate",
+          title: "match new",
+          updatedAt: 2,
+        }),
+        stampedThread({
+          instanceId: "peer-a",
+          threadId: "unique",
+          title: "match unique",
+          updatedAt: 0,
+        }),
+      ],
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+
+    const response = await cache.searchForJump({ query: "match", limit: 2 });
+
+    expect(response.results.map((thread) => thread.id)).toEqual([
+      "duplicate",
+      "unique",
+    ]);
+    expect(response.results[0].title).toBe("match new");
+  });
+
   it("ranks an exact attached PR ahead of newer substring matches", async () => {
     const threads = [
       stampedThread({
@@ -408,9 +555,16 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
       peerStatus: () => ({}),
       peerTimeoutMs: 20,
     });
+    const onProgress = vi.fn();
 
-    const response = await cache.searchForJump({ query: "match" });
+    const response = await cache.searchForJump({ query: "match" }, onProgress);
     expect(response.results.map((thread) => thread.id)).toEqual(["t1"]);
+    expect(onProgress).toHaveBeenLastCalledWith({
+      results: [expect.objectContaining({ id: "t1" })],
+      completedPeerCount: 2,
+      totalPeerCount: 2,
+      complete: true,
+    });
   });
 
   it("ignores peers without the thread_navigation capability", async () => {

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -1,6 +1,7 @@
 import type {
   CelestialIconId,
   FederationCapability,
+  FederationJumpSearchProgress,
   FederationJumpSearchRequest,
   FederationJumpSearchResponse,
   FederationPeerSummary,
@@ -12,8 +13,10 @@ import type {
 } from "@pwragent/shared";
 import {
   buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   rankThreadJumpMatches,
 } from "@pwragent/shared";
+import { IterableMapper } from "@shutterstock/p-map-iterable";
 import { ThreadInfoStore } from "../app-server/thread-info-store";
 
 export type RemoteThreadSummaryPeer = {
@@ -62,6 +65,7 @@ const REMOTE_SNAPSHOT_TTL_MS = 15_000;
 const REMOTE_SNAPSHOT_PEER_TIMEOUT_MS = 10_000;
 const DEFAULT_JUMP_SEARCH_LIMIT = 8;
 const MAX_JUMP_SEARCH_LIMIT = 50;
+const JUMP_SEARCH_PEER_CONCURRENCY = 8;
 
 function threadSelection(
   refs: ReadonlyArray<Pick<RemoteThreadPin["ref"], "backend" | "threadId">>,
@@ -258,6 +262,7 @@ export class RemoteThreadSummaryCache {
 
   async searchForJump(
     request: FederationJumpSearchRequest,
+    onProgress?: (progress: FederationJumpSearchProgress) => void,
   ): Promise<FederationJumpSearchResponse> {
     const query = request.query.trim();
     if (!query) {
@@ -267,19 +272,62 @@ export class RemoteThreadSummaryCache {
       1,
       Math.min(request.limit ?? DEFAULT_JUMP_SEARCH_LIMIT, MAX_JUMP_SEARCH_LIMIT),
     );
-    const groups = await Promise.all(
-      this.navigationPeers().map(async (peer) => {
+    const peers = this.navigationPeers();
+    const groups = new Map<string, NavigationThreadSummary[]>();
+    let completedPeerCount = 0;
+
+    const publishProgress = (): FederationJumpSearchResponse => {
+      const response = {
+        results: rankUniqueThreadJumpMatches(
+          [...groups.values()].flat(),
+          query,
+          limit,
+        ),
+      };
+      onProgress?.({
+        ...response,
+        completedPeerCount,
+        totalPeerCount: peers.length,
+        complete: completedPeerCount === peers.length,
+      });
+      return response;
+    };
+
+    if (peers.length === 0) {
+      return publishProgress();
+    }
+
+    const concurrency = Math.min(JUMP_SEARCH_PEER_CONCURRENCY, peers.length);
+    const searches = new IterableMapper(
+      peers,
+      async (peer) => {
         try {
-          return await this.searchPeerForJump(peer.target, { query, limit });
+          return {
+            instanceId: peer.target.instanceId,
+            results: await this.searchPeerForJump(peer.target, { query, limit }),
+          };
         } catch {
           // ⌘K is a jump surface, not a diagnostics surface: a slow or
           // failing peer contributes nothing rather than an error row.
-          return [];
+          return {
+            instanceId: peer.target.instanceId,
+            results: [],
+          };
         }
-      }),
+      },
+      {
+        concurrency,
+        maxUnread: concurrency,
+      },
     );
-    const results = rankThreadJumpMatches(groups.flat(), query).slice(0, limit);
-    return { results };
+
+    let response: FederationJumpSearchResponse = { results: [] };
+    for await (const group of searches) {
+      groups.set(group.instanceId, group.results);
+      completedPeerCount += 1;
+      response = publishProgress();
+    }
+    return response;
   }
 
   /**
@@ -1038,4 +1086,24 @@ function hasFederationErrorCode(error: unknown, code: string): boolean {
     && "code" in error
     && error.code === code
   );
+}
+
+function rankUniqueThreadJumpMatches(
+  threads: readonly NavigationThreadSummary[],
+  query: string,
+  limit: number,
+): NavigationThreadSummary[] {
+  const seen = new Set<string>();
+  return rankThreadJumpMatches(threads, query)
+    .filter((thread) => {
+      const key = thread.federation?.ref
+        ? federatedThreadIdentityKey(thread.federation.ref)
+        : buildThreadIdentityKey(thread.source, thread.id);
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .slice(0, limit);
 }

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -99,6 +99,7 @@ import {
   type AddRemoteThreadPinRequest,
   type AddRemoteThreadPinResponse,
   type FederatedThreadRef,
+  type FederationJumpSearchProgress,
   type FederationJumpSearchRequest,
   type FederationJumpSearchResponse,
   type RemoveRemoteThreadPinRequest,
@@ -246,6 +247,7 @@ import {
   NAVIGATION_LIST_WORKTREE_UNPUBLISHED_COMMITS_CHANNEL,
   NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
   FEDERATION_JUMP_SEARCH_CHANNEL,
+  FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL,
   NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL,
   NAVIGATION_DETACH_DIRECTORY_FROM_THREAD_CHANNEL,
@@ -6473,10 +6475,11 @@ class DesktopAppServerService {
 
   async jumpSearchRemoteThreads(
     request: FederationJumpSearchRequest,
+    onProgress?: (progress: FederationJumpSearchProgress) => void,
   ): Promise<FederationJumpSearchResponse> {
     return await getDesktopFederationRuntime()
       .remoteThreadSummaries()
-      .searchForJump(request);
+      .searchForJump(request, onProgress);
   }
 
   async setThreadParent(
@@ -7981,10 +7984,24 @@ export function registerAppServerIpcHandlers(): void {
   ipcMain.handle(
     FEDERATION_JUMP_SEARCH_CHANNEL,
     async (
-      _event,
+      event,
+      requestId: number,
       request: FederationJumpSearchRequest,
     ): Promise<FederationJumpSearchResponse> => {
-      return await appServerService.jumpSearchRemoteThreads(request);
+      return await appServerService.jumpSearchRemoteThreads(
+        request,
+        (progress) => {
+          // Search progress belongs to this invoke, not the global window
+          // event bus. The request id disambiguates overlapping searches in
+          // the same renderer; event.sender keeps it out of every other one.
+          if (!event.sender?.isDestroyed?.()) {
+            event.sender?.send?.(FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL, {
+              requestId,
+              progress,
+            });
+          }
+        },
+      );
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_PARENT_CHANNEL);

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -135,6 +135,7 @@ import type {
   AddRemoteThreadPinRequest,
   AddRemoteThreadPinResponse,
   FederationJumpSearchRequest,
+  FederationJumpSearchProgress,
   FederationJumpSearchResponse,
   MarkThreadSeenRequest,
   MarkThreadSeenResponse,
@@ -671,6 +672,7 @@ import {
   NAVIGATION_MENTION_SOURCES_CHANGED_EVENT_CHANNEL,
   NAVIGATION_GET_WORKTREE_UNPUBLISHED_COMMIT_DIFF_CHANNEL,
   FEDERATION_JUMP_SEARCH_CHANNEL,
+  FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL,
   NAVIGATION_ADD_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
@@ -865,6 +867,8 @@ const subscribeToAgentEvent = createEventSubscriptionMultiplexer<AgentEvent>(
     };
   },
 );
+
+let federationJumpSearchRequestSequence = 0;
 
 const desktopApi = Object.freeze({
   ping: () => "pong",
@@ -1838,8 +1842,32 @@ const desktopApi = Object.freeze({
     ),
   jumpSearchRemoteThreads: async (
     request: FederationJumpSearchRequest,
-  ): Promise<FederationJumpSearchResponse> =>
-    await ipcRenderer.invoke(FEDERATION_JUMP_SEARCH_CHANNEL, request),
+    onProgress?: (progress: FederationJumpSearchProgress) => void,
+  ): Promise<FederationJumpSearchResponse> => {
+    federationJumpSearchRequestSequence += 1;
+    const requestId = federationJumpSearchRequestSequence;
+    const listener = (
+      _event: Electron.IpcRendererEvent,
+      payload: {
+        requestId: number;
+        progress: FederationJumpSearchProgress;
+      },
+    ): void => {
+      if (payload.requestId === requestId) {
+        onProgress?.(payload.progress);
+      }
+    };
+    ipcRenderer.on(FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL, listener);
+    try {
+      return await ipcRenderer.invoke(
+        FEDERATION_JUMP_SEARCH_CHANNEL,
+        requestId,
+        request,
+      );
+    } finally {
+      ipcRenderer.off(FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL, listener);
+    }
+  },
   setThreadParent: async (
     request: SetThreadParentRequest,
   ): Promise<SetThreadParentResponse> =>

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -3673,10 +3673,13 @@ describe("Composer", () => {
     const remoteOption = await within(listbox).findByRole("option", {
       name: /#Remote fix/,
     });
-    expect(jumpSearchRemoteThreads).toHaveBeenCalledWith({
-      query: "Remote",
-      limit: 8,
-    });
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledWith(
+      {
+        query: "Remote",
+        limit: 8,
+      },
+      expect.any(Function),
+    );
     expect(within(listbox).getByText("Other instances")).toBeInTheDocument();
     expect(within(remoteOption).getByLabelText("Runs on Laptop"))
       .toBeInTheDocument();
@@ -3744,10 +3747,13 @@ describe("Composer", () => {
     expect(await screen.findByText("Searching other instances…"))
       .toBeInTheDocument();
     await waitFor(() => {
-      expect(jumpSearchRemoteThreads).toHaveBeenCalledWith({
-        query: "Remote",
-        limit: 8,
-      });
+      expect(jumpSearchRemoteThreads).toHaveBeenCalledWith(
+        {
+          query: "Remote",
+          limit: 8,
+        },
+        expect.any(Function),
+      );
     });
 
     fireEvent.keyDown(textbox, { key: "Enter" });

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarSearchPopup.tsx
@@ -97,8 +97,10 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
 
   const {
     available: remoteSearchAvailable,
+    completedPeerCount: remoteCompletedPeerCount,
     loading: remoteLoading,
     results: remoteResults,
+    totalPeerCount: remoteTotalPeerCount,
   } = useFederatedThreadSearch({
     query: trimmed,
     limit: FEDERATED_THREAD_SEARCH_LIMIT,
@@ -396,6 +398,9 @@ export function SidebarSearchPopup(props: SidebarSearchPopupProps): ReactElement
           {remoteLoading ? (
             <span className="jump-palette__foot-remote">
               Searching other instances…
+              {remoteTotalPeerCount > 0
+                ? ` ${remoteCompletedPeerCount}/${remoteTotalPeerCount}`
+                : ""}
             </span>
           ) : null}
           {trimmed ? (

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx
@@ -3,15 +3,18 @@ import { act, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildFederatedThreadRef,
+  type FederationJumpSearchProgress,
+  type FederationJumpSearchRequest,
   type NavigationThreadSummary,
   type PrSummary,
 } from "@pwragent/shared";
 import { SidebarSearchPopup } from "../SidebarSearchPopup";
 
 const jumpSearchRemoteThreads = vi.fn(
-  async (): Promise<{ results: NavigationThreadSummary[] }> => ({
-    results: [],
-  }),
+  async (
+    _request: FederationJumpSearchRequest,
+    _onProgress?: (progress: FederationJumpSearchProgress) => void,
+  ): Promise<{ results: NavigationThreadSummary[] }> => ({ results: [] }),
 );
 const readRendererFederationTarget = vi.fn<
   () => { scope: "remote"; instanceId: string } | undefined
@@ -154,13 +157,79 @@ describe("SidebarSearchPopup", () => {
 
     await settleRemoteSearch();
 
-    expect(jumpSearchRemoteThreads).toHaveBeenCalledWith({
-      query: "fix",
-      limit: 8,
-    });
+    expect(jumpSearchRemoteThreads).toHaveBeenCalledWith(
+      {
+        query: "fix",
+        limit: 8,
+      },
+      expect.any(Function),
+    );
     expect(screen.getByText("Other instances")).toBeInTheDocument();
     expect(screen.getByText("Remote fix")).toBeInTheDocument();
     expect(screen.getByLabelText("Runs on Laptop")).toBeInTheDocument();
+  });
+
+  it("renders a fast peer result while a slower peer is still pending", async () => {
+    let resolveSearch:
+      | ((value: { results: NavigationThreadSummary[] }) => void)
+      | undefined;
+    let publishProgress:
+      | ((progress: FederationJumpSearchProgress) => void)
+      | undefined;
+    const fast = remoteThread({ threadId: "r1", title: "Fast peer fix" });
+    jumpSearchRemoteThreads.mockImplementationOnce(
+      (_request, onProgress) => {
+        publishProgress = onProgress;
+        return new Promise((resolve) => {
+          resolveSearch = resolve;
+        });
+      },
+    );
+
+    render(
+      <SidebarSearchPopup
+        threads={[]}
+        onJumpToThread={vi.fn()}
+        onJumpToRemoteThread={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByRole("textbox", { name: "Jump to thread" }), {
+      target: { value: "fix" },
+    });
+    await settleRemoteSearch();
+
+    await act(async () => {
+      publishProgress?.({
+        results: [fast],
+        completedPeerCount: 1,
+        totalPeerCount: 2,
+        complete: false,
+      });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText("Fast peer fix")).toBeInTheDocument();
+    expect(
+      screen.getByText("Searching other instances… 1/2"),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      publishProgress?.({
+        results: [fast],
+        completedPeerCount: 2,
+        totalPeerCount: 2,
+        complete: true,
+      });
+      resolveSearch?.({ results: [fast] });
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.queryByText(/Searching other instances/),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("1 result")).toBeInTheDocument();
   });
 
   it("prioritizes exact PRs and describes numeric substring matches", async () => {
@@ -394,12 +463,17 @@ describe("SidebarSearchPopup", () => {
     let resolveFirst:
       | ((value: { results: NavigationThreadSummary[] }) => void)
       | undefined;
+    let publishFirst:
+      | ((progress: FederationJumpSearchProgress) => void)
+      | undefined;
     jumpSearchRemoteThreads
       .mockImplementationOnce(
-        () =>
-          new Promise((resolve) => {
+        (_request, onProgress) => {
+          publishFirst = onProgress;
+          return new Promise((resolve) => {
             resolveFirst = resolve;
-          }),
+          });
+        },
       )
       .mockResolvedValueOnce({
         results: [remoteThread({ threadId: "r2", title: "Second query hit" })],
@@ -421,12 +495,19 @@ describe("SidebarSearchPopup", () => {
     await settleRemoteSearch();
 
     await act(async () => {
+      publishFirst?.({
+        results: [remoteThread({ threadId: "r1", title: "Stale progress" })],
+        completedPeerCount: 1,
+        totalPeerCount: 2,
+        complete: false,
+      });
       resolveFirst?.({
         results: [remoteThread({ threadId: "r1", title: "Stale hit" })],
       });
       await Promise.resolve();
     });
 
+    expect(screen.queryByText("Stale progress")).not.toBeInTheDocument();
     expect(screen.queryByText("Stale hit")).not.toBeInTheDocument();
     expect(screen.getByText("Second query hit")).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -146,6 +146,7 @@ import type {
   AddRemoteThreadPinRequest,
   AddRemoteThreadPinResponse,
   FederationJumpSearchRequest,
+  FederationJumpSearchProgress,
   FederationJumpSearchResponse,
   RemoveRemoteThreadPinRequest,
   RemoveRemoteThreadPinResponse,
@@ -1041,7 +1042,8 @@ export type DesktopApi = {
   ) => Promise<SetRemoteThreadLocalPinResponse>;
   /** ⌘K federated jump search across connected peers. */
   jumpSearchRemoteThreads?: (
-    request: FederationJumpSearchRequest
+    request: FederationJumpSearchRequest,
+    onProgress?: (progress: FederationJumpSearchProgress) => void,
   ) => Promise<FederationJumpSearchResponse>;
   setThreadParent?: (
     request: SetThreadParentRequest

--- a/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
@@ -14,6 +14,7 @@ export function useFederatedThreadSearch(params: {
   search?: RemoteThreadSearch;
 }): {
   available: boolean;
+  completedPeerCount: number;
   loading: boolean;
   results: NavigationThreadSummary[];
   /**
@@ -27,10 +28,13 @@ export function useFederatedThreadSearch(params: {
    * instead.
    */
   settledQuery: string;
+  totalPeerCount: number;
 } {
   const [results, setResults] = useState<NavigationThreadSummary[]>([]);
   const [loading, setLoading] = useState(false);
   const [settledQuery, setSettledQuery] = useState("");
+  const [completedPeerCount, setCompletedPeerCount] = useState(0);
+  const [totalPeerCount, setTotalPeerCount] = useState(0);
   const generationRef = useRef(0);
   const query = params.query.trim();
   const search = params.search ?? getDesktopApi()?.jumpSearchRemoteThreads;
@@ -46,17 +50,35 @@ export function useFederatedThreadSearch(params: {
     if (!query || !available || !search) {
       setResults([]);
       setLoading(false);
+      setCompletedPeerCount(0);
+      setTotalPeerCount(0);
       // Nothing to ask, so this query is answered the moment it arrives.
       setSettledQuery(query);
       return;
     }
 
     setLoading(true);
+    setCompletedPeerCount(0);
+    setTotalPeerCount(0);
     const timer = setTimeout(() => {
-      search({
-        query,
-        limit: params.limit ?? FEDERATED_THREAD_SEARCH_LIMIT,
-      })
+      search(
+        {
+          query,
+          limit: params.limit ?? FEDERATED_THREAD_SEARCH_LIMIT,
+        },
+        (progress) => {
+          if (generationRef.current !== generation) {
+            return;
+          }
+          setResults(progress.results);
+          setCompletedPeerCount(progress.completedPeerCount);
+          setTotalPeerCount(progress.totalPeerCount);
+          if (progress.complete) {
+            setLoading(false);
+            setSettledQuery(query);
+          }
+        },
+      )
         .then((response) => {
           if (generationRef.current !== generation) {
             return;
@@ -74,8 +96,20 @@ export function useFederatedThreadSearch(params: {
           setSettledQuery(query);
         });
     }, FEDERATED_THREAD_SEARCH_DEBOUNCE_MS);
-    return () => clearTimeout(timer);
+    return () => {
+      clearTimeout(timer);
+      if (generationRef.current === generation) {
+        generationRef.current += 1;
+      }
+    };
   }, [available, params.limit, query, search]);
 
-  return { available, loading, results, settledQuery };
+  return {
+    available,
+    completedPeerCount,
+    loading,
+    results,
+    settledQuery,
+    totalPeerCount,
+  };
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -183,6 +183,8 @@ export const NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL =
 export const NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL =
   "navigation:set-remote-thread-local-pin";
 export const FEDERATION_JUMP_SEARCH_CHANNEL = "federation:jump-search";
+export const FEDERATION_JUMP_SEARCH_PROGRESS_CHANNEL =
+  "federation:jump-search-progress";
 export const NAVIGATION_SET_THREAD_PARENT_CHANNEL =
   "navigation:set-thread-parent";
 export const NAVIGATION_UPDATE_SUBTHREAD_ORDER_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1575,6 +1575,16 @@ export type FederationJumpSearchResponse = {
   results: NavigationThreadSummary[];
 };
 
+/** Cumulative Cmd+K results after one more connected peer settles. */
+export type FederationJumpSearchProgress = FederationJumpSearchResponse & {
+  /** Peers that have replied, failed, or reached their existing deadline. */
+  completedPeerCount: number;
+  /** Navigation-capable peers included in this search request. */
+  totalPeerCount: number;
+  /** True once every included peer has settled. */
+  complete: boolean;
+};
+
 export type SetThreadAgentRequest = {
   backend?: AppServerBackendKind;
   threadId: ThreadIdentifier;


### PR DESCRIPTION
## Stack

Base: #1969 (`fix/desktop-bounded-federated-jump-search`)

## Summary

- consume connected-peer Cmd+K searches as a bounded completion-order async iterable
- publish cumulative globally ranked and deduplicated remote rows after each peer settles
- scope progress to the invoking renderer and request through sender-targeted IPC
- preserve bounded owner RPCs, legacy snapshot fallback, PR chips, debounce, and stale-query protection
- show peer completion counts while the jump palette remains in its loading state

## Regression coverage

- fast peer results render before a slow peer settles
- superseded queries ignore late incremental and final results
- peer failures preserve already successful rows
- loading completes after all peers settle or reach the existing timeout
- IPC progress is isolated by renderer sender and request id

## Verification

- `pnpm test apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts apps/desktop/src/renderer/src/features/navigation/__tests__/SidebarSearchPopup.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx`
- `pnpm test apps/desktop/src/main/__tests__/federation-runtime.test.ts apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts`
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warning baseline remains)
- `pnpm lint:boundaries`
