### PR TITLE
fix(desktop): follow the installed build's release feed, and show all four slots

### DIFF
--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -484,6 +484,64 @@ describe("auto updater", () => {
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
   });
 
+  it("names the missing manifest instead of dumping the raw HttpError", async () => {
+    // electron-updater reports a 404 on the channel file as one multi-KB
+    // string — request URL, every response header, a stack of packaged file
+    // paths — and Settings rendered it verbatim. It is also not a transport
+    // failure: the GitHub release exists and the release matrix shows its
+    // version, but this platform has nothing installable in that slot.
+    resolveUpdateTrainMock.mockReturnValue("beta");
+    resolveUpdateChannelMock.mockReturnValue("prerelease");
+    mockGitHubReleases([githubRelease("v1.1.0-alpha.2", { prerelease: true })]);
+    autoUpdaterMock.currentVersion = { version: "1.1.0-alpha.1" };
+    checkForUpdatesMock.mockRejectedValue(
+      new Error(
+        'Cannot find channel "latest.yml" update info: HttpError: 404 "method: GET url:'
+        + " https://github.com/pwrdrvr/PwrAgent/releases/download/v1.1.0-alpha.2/latest.yml"
+        + '\n\nPlease double check that your authentication token is correct."'
+        + ' Headers: { "cache-control": "no-cache", "content-encoding": "gzip" }'
+        + " at createHttpError (C:\\Users\\x\\httpExecutor.js:53:12)",
+      ),
+    );
+    const updater = await importAutoUpdater();
+
+    await expect(updater.checkForAppUpdatesNow("manual")).resolves.toEqual({
+      status: "error",
+      message:
+        "The Beta Prerelease release (v1.1.0-alpha.2) publishes no latest.yml"
+        + " for this platform, so there is nothing to install from it yet.",
+    });
+    // The whole error still reaches the log — diagnosing a feed failure from
+    // the reported sentence alone would be worse than having no summary.
+    expect(logWarnMock).toHaveBeenCalledWith(
+      "checkForUpdates failed",
+      expect.objectContaining({
+        message: expect.stringContaining("Headers: {"),
+        updateChannel: "prerelease",
+        updateTrain: "beta",
+      }),
+    );
+  });
+
+  it("truncates any other update failure to one line", async () => {
+    mockGitHubReleases([githubRelease("v1.0.0-beta.8")]);
+    checkForUpdatesMock.mockRejectedValue(
+      new Error(
+        `HttpError: 500 ${"very long body ".repeat(40)}`
+        + '\nHeaders: { "server": "github.com" }',
+      ),
+    );
+    const updater = await importAutoUpdater();
+
+    const result = await updater.checkForAppUpdatesNow("manual");
+    expect(result.status).toBe("error");
+    const message = result.status === "error" ? result.message : "";
+    expect(message.length).toBeLessThanOrEqual(200);
+    expect(message.startsWith("HttpError: 500 very long body")).toBe(true);
+    expect(message.endsWith("…")).toBe(true);
+    expect(message).not.toContain("Headers");
+  });
+
   it("does not treat an unreadable release tag as a switch back", async () => {
     // compareSemver sorts a tag it cannot parse below every real version, so
     // an unreadable tag must not reach the downgrade path and pin the feed.

--- a/apps/desktop/src/main/__tests__/auto-updater.test.ts
+++ b/apps/desktop/src/main/__tests__/auto-updater.test.ts
@@ -37,8 +37,13 @@ const autoUpdaterMock = {
   setFeedURL: setFeedURLMock,
 };
 
+// The version of the binary doing the reading. It is what an unpinned
+// selection resolves from, so a test that exercises inference has to be able
+// to move it.
+const appVersionMock = vi.fn(() => "1.0.0-beta.7");
+
 vi.mock("electron", () => ({
-  app: { getVersion: () => "1.0.0-beta.7", isPackaged: false },
+  app: { getVersion: () => appVersionMock(), isPackaged: false },
   BrowserWindow: {
     getAllWindows: vi.fn(() => [
       {
@@ -65,11 +70,20 @@ vi.mock("electron-updater", () => ({
   },
 }));
 
+const updateSelectionSourceMock = vi.fn<() => string | undefined>(
+  () => "user",
+);
+
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopConfigStore: vi.fn(() => ({
     read: vi.fn(() => ({
       channel: resolveUpdateChannelMock(),
       train: resolveUpdateTrainMock(),
+      // These tests state the slot the operator is on, so they default to a
+      // pin. Without it the stored pair goes back through the version
+      // inference and a test that says "on Beta Prerelease" would silently
+      // be testing whatever `app.getVersion()` infers instead.
+      selectionSource: updateSelectionSourceMock(),
     })),
     subscribe: subscribeConfigStoreMock,
   })),
@@ -209,6 +223,10 @@ describe("auto updater", () => {
     resolveUpdateChannelMock.mockReturnValue("latest");
     resolveUpdateTrainMock.mockReset();
     resolveUpdateTrainMock.mockReturnValue("stable");
+    updateSelectionSourceMock.mockReset();
+    updateSelectionSourceMock.mockReturnValue("user");
+    appVersionMock.mockReset();
+    appVersionMock.mockReturnValue("1.0.0-beta.7");
     updateDomainListeners.clear();
     subscribeConfigStoreMock.mockClear();
     logInfoMock.mockReset();
@@ -482,6 +500,66 @@ describe("auto updater", () => {
       version: "1.1.0-alpha.2",
     });
     expect(autoUpdaterMock.allowDowngrade).toBe(false);
+  });
+
+  it("follows the running build's feed when the stored selection is a guess", async () => {
+    // The feed and the Settings snapshot must resolve through the SAME rule.
+    // They used to each carry a copy, and the copy here still read a legacy
+    // half pair as a deliberate Stable pin: Settings showed Beta Prerelease
+    // on a 1.1.0-alpha install while this path polled Stable Latest forever.
+    // The exact config an older build left behind: `channel` alone, because
+    // `channel` shipped before `train` did.
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    resolveUpdateTrainMock.mockReturnValue(undefined);
+    updateSelectionSourceMock.mockReturnValue(undefined);
+    appVersionMock.mockReturnValue("1.1.0-alpha.7");
+    autoUpdaterMock.currentVersion = { version: "1.1.0-alpha.7" };
+    mockGitHubReleases([
+      githubRelease("v1.1.0-alpha.9", { prerelease: true }),
+      githubRelease("v1.0.3"),
+    ]);
+    checkForUpdatesMock.mockResolvedValue({
+      updateInfo: { version: "1.1.0-alpha.9" },
+    });
+    const updater = await importAutoUpdater();
+
+    await updater.checkForAppUpdatesNow("manual");
+
+    // Read as a pin, the half pair would resolve to Stable Latest and this
+    // alpha install would be offered v1.0.3 forever. Re-inferred from the
+    // running binary it follows the alpha feed it came from.
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "configured auto-update channel",
+      expect.objectContaining({
+        updateChannel: "prerelease",
+        updateTrain: "beta",
+      }),
+    );
+    expect(autoUpdaterMock.allowPrerelease).toBe(true);
+  });
+
+  it("honors a pinned selection over the running build's own feed", async () => {
+    // The mirror of the case above: an alpha binary whose operator picked
+    // Stable stays on Stable, because the pin is on disk to say so.
+    resolveUpdateChannelMock.mockReturnValue("latest");
+    resolveUpdateTrainMock.mockReturnValue("stable");
+    updateSelectionSourceMock.mockReturnValue("user");
+    appVersionMock.mockReturnValue("1.1.0-alpha.7");
+    mockGitHubReleases([
+      githubRelease("v1.1.0-alpha.9", { prerelease: true }),
+      githubRelease("v1.0.3"),
+    ]);
+    const updater = await importAutoUpdater();
+
+    await updater.checkForAppUpdatesNow("manual");
+
+    expect(logInfoMock).toHaveBeenCalledWith(
+      "configured auto-update channel",
+      expect.objectContaining({
+        updateChannel: "latest",
+        updateTrain: "stable",
+      }),
+    );
   });
 
   it("names the missing manifest instead of dumping the raw HttpError", async () => {

--- a/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-patch-translator.test.ts
@@ -554,6 +554,11 @@ describe("desktopSettingsPatchToEdits — updates", () => {
         path: ["updates", "channel"],
         value: "prerelease",
       },
+      {
+        op: "set",
+        path: ["updates", "selection_source"],
+        value: "user",
+      },
     ]);
   });
 
@@ -569,6 +574,11 @@ describe("desktopSettingsPatchToEdits — updates", () => {
         op: "set",
         path: ["updates", "channel"],
         value: "latest",
+      },
+      {
+        op: "set",
+        path: ["updates", "selection_source"],
+        value: "user",
       },
     ]);
   });
@@ -586,6 +596,11 @@ describe("desktopSettingsPatchToEdits — updates", () => {
         path: ["updates", "train"],
         value: "beta",
       },
+      {
+        op: "set",
+        path: ["updates", "selection_source"],
+        value: "user",
+      },
     ]);
   });
 
@@ -602,7 +617,32 @@ describe("desktopSettingsPatchToEdits — updates", () => {
         path: ["updates", "train"],
         value: "stable",
       },
+      {
+        op: "set",
+        path: ["updates", "selection_source"],
+        value: "user",
+      },
     ]);
+  });
+
+  it("derives the pin marker once for a patch naming both axes", () => {
+    // `selection_source` is main-owned: it is absent from the patch type and
+    // derived here, so no renderer can pin — or un-pin — a selection nobody
+    // picked, and no call site can persist a slot the next read would
+    // silently re-infer away.
+    expect(
+      desktopSettingsPatchToEdits({
+        updates: { channel: "prerelease", train: "beta" },
+      }),
+    ).toEqual([
+      { op: "set", path: ["updates", "channel"], value: "prerelease" },
+      { op: "set", path: ["updates", "train"], value: "beta" },
+      { op: "set", path: ["updates", "selection_source"], value: "user" },
+    ]);
+  });
+
+  it("writes no pin marker for a patch that names neither axis", () => {
+    expect(desktopSettingsPatchToEdits({ updates: {} })).toEqual([]);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -184,6 +184,8 @@ describe("DesktopSettingsService", () => {
         "",
         "[updates]",
         'channel = "prerelease"',
+        'train = "stable"',
+        'selection_source = "user"',
         "",
         "[federation]",
         'mode = "gateway"',
@@ -288,8 +290,9 @@ describe("DesktopSettingsService", () => {
     });
     expect(snapshot.updates.train).toEqual({
       value: "stable",
-      source: "default",
+      source: "config",
     });
+    expect(snapshot.updates.selectionSource).toBe("user");
     expect(snapshot.federation).toMatchObject({
       mode: { value: "gateway", source: "config" },
       listenHost: { value: "127.0.0.1", source: "config" },
@@ -521,6 +524,7 @@ describe("DesktopSettingsService", () => {
     });
 
     const snapshot = await service.readSettingsProjection();
+    expect(snapshot.updates.selectionSource).toBe("inferred");
     expect(snapshot.updates.train).toEqual({
       value: "beta",
       source: "default",
@@ -533,7 +537,12 @@ describe("DesktopSettingsService", () => {
     expect(service.resolveUpdateChannel()).toBe("prerelease");
   });
 
-  it("keeps a legacy prerelease config on the Stable train", async () => {
+  it("re-infers a legacy half-pair config from the running build", async () => {
+    // `channel` shipped before `train` did, so every config written by an
+    // older build carries `channel` alone. Reading that half pair as a
+    // deliberate Stable pin is what offered a 1.1.0-alpha install the last
+    // stable release forever and never told it about the newer alpha its own
+    // binary came from. A half pair is indistinguishable from "never chose".
     const root = createTempRoot();
     const configPath = path.join(root, "config.toml");
     fs.writeFileSync(
@@ -548,16 +557,136 @@ describe("DesktopSettingsService", () => {
     });
 
     const snapshot = await service.readSettingsProjection();
-    expect(snapshot.updates.channel).toEqual({
-      value: "prerelease",
-      source: "config",
-    });
+    expect(snapshot.updates.selectionSource).toBe("inferred");
     expect(snapshot.updates.train).toEqual({
-      value: "stable",
+      value: "beta",
       source: "default",
     });
-    expect(service.resolveUpdateTrain()).toBe("stable");
-    expect(service.resolveUpdateChannel()).toBe("prerelease");
+    expect(snapshot.updates.channel).toEqual({
+      value: "latest",
+      source: "default",
+    });
+    expect(service.resolveUpdateTrain()).toBe("beta");
+    expect(service.resolveUpdateChannel()).toBe("latest");
+  });
+
+  it("honors a legacy complete non-default pair as an existing pin", async () => {
+    // A complete pair that is not the historical unchosen pair could only
+    // have been written by a deliberate click, so it survives the migration
+    // without a `selection_source` key to prove it.
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      ["[updates]", 'channel = "latest"', 'train = "beta"', ""].join("\n"),
+    );
+    const service = new DesktopSettingsService({
+      appVersion: "1.0.3",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettingsProjection();
+    expect(snapshot.updates.selectionSource).toBe("user");
+    expect(snapshot.updates.train).toEqual({ value: "beta", source: "config" });
+    expect(snapshot.updates.channel).toEqual({
+      value: "latest",
+      source: "config",
+    });
+  });
+
+  it("re-infers a legacy config holding only the shipped default pair", async () => {
+    // Stable/Latest is what every pre-`selection_source` config landed on
+    // when nobody had chosen, so it carries no evidence of a choice.
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      ["[updates]", 'channel = "latest"', 'train = "stable"', ""].join("\n"),
+    );
+    const service = new DesktopSettingsService({
+      appVersion: "1.1.0-alpha.7",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettingsProjection();
+    expect(snapshot.updates.selectionSource).toBe("inferred");
+    expect(snapshot.updates.train.value).toBe("beta");
+    expect(snapshot.updates.channel.value).toBe("prerelease");
+  });
+
+  it("pins the pair once the operator picks a slot, and follows the binary until then", async () => {
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    const options = {
+      appVersion: "1.1.0-alpha.7",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    };
+    const service = new DesktopSettingsService(options);
+
+    expect((await service.readSettingsProjection()).updates.selectionSource)
+      .toBe("inferred");
+
+    await service.writeConfigPatchTargeted({
+      updates: { channel: "latest", train: "stable" },
+    });
+
+    // `selection_source` is derived by the write path, not sent by the
+    // caller — naming either axis is what makes the pair a pin.
+    expect(fs.readFileSync(configPath, "utf8")).toContain(
+      'selection_source = "user"',
+    );
+    const pinned = await service.readSettingsProjection();
+    expect(pinned.updates.selectionSource).toBe("user");
+    expect(pinned.updates.train).toEqual({ value: "stable", source: "config" });
+    expect(pinned.updates.channel).toEqual({
+      value: "latest",
+      source: "config",
+    });
+
+    // The pin survives a reopen on the same alpha binary — the whole point
+    // of persisting it is that inference no longer runs.
+    const reopened = new DesktopSettingsService(options);
+    expect(reopened.resolveUpdateTrain()).toBe("stable");
+    expect(reopened.resolveUpdateChannel()).toBe("latest");
+  });
+
+  it("keeps a pin whose other axis did not survive the round trip", async () => {
+    // Re-inferring the whole pair on a half-written pin would discard the
+    // axis that IS valid and silently un-pin the selection.
+    const root = createTempRoot();
+    const configPath = path.join(root, "config.toml");
+    fs.writeFileSync(
+      configPath,
+      [
+        "[updates]",
+        'train = "stable"',
+        'selection_source = "user"',
+        "",
+      ].join("\n"),
+    );
+    const service = new DesktopSettingsService({
+      appVersion: "1.1.0-alpha.7",
+      configPath,
+      env: {},
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+
+    const snapshot = await service.readSettingsProjection();
+    expect(snapshot.updates.selectionSource).toBe("user");
+    expect(snapshot.updates.train).toEqual({
+      value: "stable",
+      source: "config",
+    });
+    expect(snapshot.updates.channel).toEqual({
+      value: "latest",
+      source: "default",
+    });
   });
 
   it("keeps an explicit Stable choice on a Beta binary", async () => {

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -213,6 +213,68 @@ function downgradeOfferAllowed(trigger: UpdateCheckTrigger): boolean {
   return trigger === "manual" || trigger === "menu";
 }
 
+const UPDATE_TRAIN_LABEL: Record<DesktopUpdateTrain, string> = {
+  stable: "Stable",
+  beta: "Beta",
+};
+
+const UPDATE_CHANNEL_LABEL: Record<DesktopUpdateChannel, string> = {
+  latest: "Latest",
+  prerelease: "Prerelease",
+};
+
+/** Longest error we will put on screen. Past this the operator is reading
+ *  diagnostics, not a report they can act on. */
+const UPDATE_ERROR_MESSAGE_MAX = 200;
+
+/**
+ * electron-updater reports a failed feed read as ONE multi-kilobyte string:
+ * the request URL, every response header, and a stack of packaged file
+ * paths. Settings renders that message verbatim, so a single 404 filled the
+ * pane with a wall of text an operator cannot act on — and response headers
+ * are not ours to put on screen either. The whole error still goes to the
+ * log; this is what the UI gets.
+ */
+function summarizeUpdateError(err: unknown): string {
+  const raw = (err instanceof Error ? err.message : String(err)).trim();
+  // Both suffixes are appended to the same single line as the message, so a
+  // plain first-line cut is not enough to drop them.
+  const head = raw.split("\n")[0].split(" Headers: ")[0].trim();
+  if (head.length <= UPDATE_ERROR_MESSAGE_MAX) {
+    return head;
+  }
+  return `${head.slice(0, UPDATE_ERROR_MESSAGE_MAX - 1).trimEnd()}…`;
+}
+
+/**
+ * The 404 above is worth naming rather than truncating, because it is not a
+ * transport failure and a shorter version of the raw text would not say so.
+ * `Cannot find channel "<file>" update info` means the GitHub release we
+ * pointed the feed at carries no update manifest for THIS platform: the
+ * release exists, the Settings matrix shows its version, and there is still
+ * nothing installable in that slot. Saying which manifest is missing is the
+ * one detail that makes the gap fixable.
+ */
+function describeUpdateCheckFailure(
+  err: unknown,
+  context: {
+    channel: DesktopUpdateChannel;
+    train: DesktopUpdateTrain;
+    tag?: string;
+  },
+): string {
+  const raw = err instanceof Error ? err.message : String(err);
+  const missingManifest = /^Cannot find channel "([^"]+)" update info/.exec(
+    raw,
+  )?.[1];
+  if (!missingManifest) {
+    return summarizeUpdateError(err);
+  }
+  const slot = `${UPDATE_TRAIN_LABEL[context.train]} ${UPDATE_CHANNEL_LABEL[context.channel]}`;
+  const release = context.tag === undefined ? "" : ` (${context.tag})`;
+  return `The ${slot} release${release} publishes no ${missingManifest} for this platform, so there is nothing to install from it yet.`;
+}
+
 function configureAutoUpdaterFeedForRelease(release: GitHubRelease): void {
   const tag = release.tag_name;
   if (!tag) {
@@ -363,12 +425,25 @@ export async function checkForAppUpdatesNow(
     return updateCheckInFlight;
   }
 
+  // What the catch below needs to name the slot it failed on, filled in as
+  // the check learns each part. It reuses the selection the check already
+  // read rather than reading settings a second time — one settings read per
+  // check is an invariant the suite asserts.
+  let failureContext:
+    | {
+        channel: DesktopUpdateChannel;
+        train: DesktopUpdateTrain;
+        tag?: string;
+      }
+    | undefined;
+
   updateCheckInFlight = (async () => {
     try {
       const {
         channel: updateChannel,
         train: updateTrain,
       } = currentUpdateSelection();
+      failureContext = { channel: updateChannel, train: updateTrain };
       const updateSelection = updateSelectionKey(updateTrain, updateChannel);
       reconcileDownloadedUpdateEligibility(updateSelection);
       const downloadedResult = downloadedUpdateMatchesChannel(updateSelection);
@@ -451,6 +526,7 @@ export async function checkForAppUpdatesNow(
         });
       }
       configureAutoUpdaterFeedForRelease(release);
+      failureContext = { ...failureContext, tag: release.tag_name };
       updateCheckChannelInFlight = updateSelection;
       const result = await autoUpdater.checkForUpdates();
       if (result?.updateInfo?.version !== currentVersion) {
@@ -476,12 +552,23 @@ export async function checkForAppUpdatesNow(
     } catch (err) {
       const result = {
         status: "error",
-        message: err instanceof Error ? err.message : String(err),
+        message:
+          failureContext === undefined
+            // Reading the selection itself failed, so there is no slot to
+            // name — the generic summary is all the truth there is.
+            ? summarizeUpdateError(err)
+            : describeUpdateCheckFailure(err, failureContext),
       } as const;
       setUpdateStatusUnlessDownloaded(result);
+      // The log keeps the whole error — URL, headers, stack. `result.message`
+      // is only what Settings shows, and diagnosing a feed failure from the
+      // truncated copy would be worse than having no summary at all.
       log.warn("checkForUpdates failed", {
-        message: result.message,
+        message: err instanceof Error ? err.message : String(err),
+        reported: result.message,
         trigger,
+        updateChannel: failureContext?.channel,
+        updateTrain: failureContext?.train,
       });
       return result;
     } finally {
@@ -962,8 +1049,8 @@ export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVe
       },
     };
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    const unavailable = { unavailableReason: message };
+    // Rendered inside a release slot tile, which has room for a sentence.
+    const unavailable = { unavailableReason: summarizeUpdateError(err) };
     return {
       fetchedAt: Date.now(),
       stable: { latest: unavailable, prerelease: unavailable },
@@ -1063,8 +1150,13 @@ export function initAutoUpdater(): void {
     reconcileDownloadedUpdateEligibility();
   });
   autoUpdater.on("error", (err: Error) => {
+    // Same multi-kilobyte shape as a failed check — this handler is where a
+    // download failure arrives, and it reaches the same Settings row.
     log.warn("auto-update error", { message: err.message });
-    setUpdateStatusUnlessDownloaded({ status: "error", message: err.message });
+    setUpdateStatusUnlessDownloaded({
+      status: "error",
+      message: summarizeUpdateError(err),
+    });
   });
 
   startPeriodicUpdateChecks();

--- a/apps/desktop/src/main/auto-updater.ts
+++ b/apps/desktop/src/main/auto-updater.ts
@@ -19,8 +19,9 @@ import type {
 import {
   DESKTOP_UPDATE_CHANNEL_DEFAULT,
   DESKTOP_UPDATE_TRAIN_DEFAULT,
-  inferDesktopUpdateSelection,
+  resolveDesktopUpdateSelection,
   type DesktopUpdateChannel,
+  type DesktopUpdateSelection,
   type DesktopUpdateTrain,
 } from "@pwragent/shared";
 import { getMainLogger } from "./log";
@@ -119,18 +120,16 @@ function currentUpdateTrain(): DesktopUpdateTrain {
   }
 }
 
-function currentUpdateSelection(): {
-  channel: DesktopUpdateChannel;
-  train: DesktopUpdateTrain;
-} {
-  const updates = getDesktopConfigStore().read("updates");
-  if (updates.channel === undefined && updates.train === undefined) {
-    return inferDesktopUpdateSelection(app.getVersion());
-  }
-  return {
-    channel: updates.channel ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
-    train: updates.train ?? DESKTOP_UPDATE_TRAIN_DEFAULT,
-  };
+// The feed resolves through the SAME function as the Settings snapshot.
+// This used to carry its own copy of the rule, and a copy is how the two
+// come apart: fixing the half-pair case in the settings service alone left
+// Settings showing Beta Prerelease on a 1.1.0-alpha install while this
+// function still answered Stable Latest and polled that feed forever.
+function currentUpdateSelection(): DesktopUpdateSelection {
+  return resolveDesktopUpdateSelection(
+    getDesktopConfigStore().read("updates"),
+    app.getVersion(),
+  );
 }
 
 function updateSelectionKey(
@@ -240,6 +239,13 @@ function summarizeUpdateError(err: unknown): string {
   // Both suffixes are appended to the same single line as the message, so a
   // plain first-line cut is not enough to drop them.
   const head = raw.split("\n")[0].split(" Headers: ")[0].trim();
+  // A thrown `new Error()` carries an empty message, and returning it would
+  // render "Update check failed:" with nothing after the colon. This is the
+  // one choke point every update error passes through, so the fallback
+  // belongs here rather than at each call site.
+  if (head.length === 0) {
+    return "The update check failed without reporting a reason.";
+  }
   if (head.length <= UPDATE_ERROR_MESSAGE_MAX) {
     return head;
   }
@@ -263,7 +269,10 @@ function describeUpdateCheckFailure(
     tag?: string;
   },
 ): string {
-  const raw = err instanceof Error ? err.message : String(err);
+  // Trimmed before matching: `summarizeUpdateError` trims and this must
+  // agree with it, or a message that arrives with a leading newline falls
+  // through to the raw-text branch this function exists to avoid.
+  const raw = (err instanceof Error ? err.message : String(err)).trim();
   const missingManifest = /^Cannot find channel "([^"]+)" update info/.exec(
     raw,
   )?.[1];
@@ -1049,7 +1058,13 @@ export async function readAppUpdateReleaseVersions(): Promise<AppUpdateReleaseVe
       },
     };
   } catch (err) {
-    // Rendered inside a release slot tile, which has room for a sentence.
+    // Rendered inside a release slot tile, which has room for a sentence —
+    // so the log has to keep the rest. Without this the summary destroys the
+    // only copy of a long GitHub error instead of relocating it, which the
+    // other two `summarizeUpdateError` call sites are careful not to do.
+    log.warn("failed to read app update release versions", {
+      message: err instanceof Error ? err.message : String(err),
+    });
     const unavailable = { unavailableReason: summarizeUpdateError(err) };
     return {
       fetchedAt: Date.now(),

--- a/apps/desktop/src/main/settings/desktop-config.ts
+++ b/apps/desktop/src/main/settings/desktop-config.ts
@@ -28,6 +28,7 @@ import type {
   DesktopTextSize,
   DesktopToolOutputAlertPolicy,
   DesktopUpdateChannel,
+  DesktopUpdateSelectionSource,
   DesktopUpdateTrain,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
@@ -50,6 +51,7 @@ import {
   isDesktopIntegratedTerminalWindowsShell,
   isDesktopOnboardingCompletedSource,
   isDesktopWorktreeStorageLocation,
+  isDesktopUpdateSelectionSource,
   isDesktopUpdateTrain,
   parseDesktopUpdateChannel,
   sanitizeMessagingContactHandle,
@@ -142,6 +144,10 @@ export type DesktopSettingsConfig = {
   updates?: {
     channel?: DesktopUpdateChannel;
     train?: DesktopUpdateTrain;
+    /** Derived by the write path, never accepted from a patch — see
+     *  `DesktopUpdateSelectionSource`. Absent in every file written before
+     *  this key existed; `resolveUpdateSelection` classifies those. */
+    selectionSource?: DesktopUpdateSelectionSource;
   };
   integratedTerminal?: {
     windowsShell?: DesktopIntegratedTerminalWindowsShell;
@@ -893,6 +899,19 @@ export function desktopSettingsPatchToEdits(
 
   if (patch.updates?.train !== undefined) {
     set(["updates", "train"], patch.updates.train);
+  }
+
+  // `selection_source` is derived here rather than accepted from the patch:
+  // naming EITHER axis is what makes a selection an operator's pin. Deriving
+  // it means no call site can persist a slot that the next read would
+  // silently re-infer away, and no renderer can pin (or un-pin) a selection
+  // nobody picked — `DesktopSettingsConfigPatch["updates"]` has no such key,
+  // and this writer only emits keys it names.
+  if (
+    patch.updates?.channel !== undefined
+    || patch.updates?.train !== undefined
+  ) {
+    set(["updates", "selection_source"], "user");
   }
 
   if (patch.integratedTerminal?.windowsShell !== undefined) {
@@ -1779,6 +1798,7 @@ function normalizeDesktopConfig(
     updates: {
       channel: readUpdateChannel(updates?.channel),
       train: readUpdateTrain(updates?.train),
+      selectionSource: readUpdateSelectionSource(updates?.selection_source),
     },
     integratedTerminal: {
       windowsShell: readIntegratedTerminalWindowsShell(
@@ -2392,6 +2412,12 @@ function readUpdateTrain(
   return typeof value === "string" && isDesktopUpdateTrain(value)
     ? value
     : undefined;
+}
+
+function readUpdateSelectionSource(
+  value: TomlScalar | undefined,
+): DesktopUpdateSelectionSource | undefined {
+  return isDesktopUpdateSelectionSource(value) ? value : undefined;
 }
 
 function readAppearanceTheme(

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -32,6 +32,8 @@ import type {
   DesktopSettingsSnapshot,
   DesktopSettingsValue,
   DesktopUpdateChannel,
+  DesktopUpdateSelectionSource,
+  DesktopUpdateSettingsSnapshot,
   DesktopUpdateTrain,
   DesktopWorktreeStorageLocation,
   MessagingToolUpdateMode,
@@ -419,6 +421,55 @@ const FEISHU_DEFAULT_TENANT_URL = "https://open.feishu.cn";
 const LARK_DEFAULT_TENANT_URL = "https://open.larksuite.com";
 const FEISHU_DEFAULT_CALLBACK_BASE_URL = "http://127.0.0.1:47823";
 const settingsLog = getMainLogger("pwragent:settings");
+
+/** The pair every pre-`selection_source` config landed on when nobody had
+ *  chosen: the shape the defaults shipped as, and what the old
+ *  `resolveUpdateSelection` filled a missing axis with. This is a
+ *  HISTORICAL FACT about files already on disk, so it is frozen here rather
+ *  than read from `DESKTOP_UPDATE_*_DEFAULT` — moving the shipped default
+ *  later must not retroactively reclassify those files as deliberate pins
+ *  and freeze that population on Stable Latest forever. */
+const LEGACY_UNCHOSEN_UPDATE_PAIR: {
+  channel: DesktopUpdateChannel;
+  train: DesktopUpdateTrain;
+} = {
+  channel: "latest",
+  train: "stable",
+};
+
+/** Classify an `[updates]` table written before `selection_source` existed.
+ *  A complete pair that is NOT the historical unchosen pair could only have
+ *  been written by a deliberate click, and that means "leave it alone" — so
+ *  it reads as `"user"`. Everything else (no pair, a half pair, or that
+ *  pair) is indistinguishable from "never chose", so it reads as
+ *  `"inferred"` and gets re-derived from the running binary.
+ *
+ *  A half pair is the case this fix exists for: `channel` shipped before
+ *  `train` did, so every config written by an older build carries `channel`
+ *  alone. Reading that as a Stable pin is what offered a 1.1.0-alpha
+ *  install the last stable release forever and never told it about the
+ *  newer alpha it came from.
+ *
+ *  The one behavior change this can produce: an operator who deliberately
+ *  pinned Stable/Latest while running an alpha is moved back onto
+ *  Beta/Prerelease once. That is the same state as the bug it fixes, and
+ *  nothing on disk separates the two. Their next click writes `"user"` and
+ *  pins for good. */
+function legacyUpdateSelectionSource(
+  channel: DesktopUpdateChannel | undefined,
+  train: DesktopUpdateTrain | undefined,
+): DesktopUpdateSelectionSource {
+  if (channel === undefined || train === undefined) {
+    return "inferred";
+  }
+  if (
+    channel === LEGACY_UNCHOSEN_UPDATE_PAIR.channel
+    && train === LEGACY_UNCHOSEN_UPDATE_PAIR.train
+  ) {
+    return "inferred";
+  }
+  return "user";
+}
 
 function clampInteger(value: number, maxValue: number): number {
   return Math.min(Math.max(value, 0), maxValue);
@@ -2967,30 +3018,39 @@ export class DesktopSettingsService {
   private resolveUpdateSelection(updates?: {
     channel?: DesktopUpdateChannel;
     train?: DesktopUpdateTrain;
-  }): {
-    channel: DesktopSettingsValue<DesktopUpdateChannel>;
-    train: DesktopSettingsValue<DesktopUpdateTrain>;
-  } {
-    // Infer the version-derived pair only when neither key exists. A
-    // pre-train config with only `channel = "prerelease"` must stay on
-    // Stable so installing a 1.1.0-beta binary does not silently move
-    // that operator onto Beta Prerelease / alphas.
-    if (updates?.channel === undefined && updates?.train === undefined) {
-      const inferred = inferDesktopUpdateSelection(this.currentAppVersion());
+    selectionSource?: DesktopUpdateSelectionSource;
+  }): DesktopUpdateSettingsSnapshot {
+    const selectionSource =
+      updates?.selectionSource
+      ?? legacyUpdateSelectionSource(updates?.channel, updates?.train);
+    if (selectionSource === "user") {
+      // A pin is honored even when one axis did not survive the round trip
+      // (a truncated write, a hand edit that misspelled a value).
+      // Re-inferring the whole pair there would discard the axis that IS
+      // valid and un-pin the selection — on an alpha binary that quietly
+      // moves a deliberate Stable pin onto the alpha feed. Fall back per
+      // axis instead.
       return {
-        channel: { value: inferred.channel, source: "default" },
-        train: { value: inferred.train, source: "default" },
+        channel: {
+          value: updates?.channel ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
+          source: updates?.channel === undefined ? "default" : "config",
+        },
+        train: {
+          value: updates?.train ?? DESKTOP_UPDATE_TRAIN_DEFAULT,
+          source: updates?.train === undefined ? "default" : "config",
+        },
+        selectionSource: "user",
       };
     }
+    // An inferred selection is RE-DERIVED on every read from the version of
+    // the binary doing the reading, so installing an alpha over a stable
+    // build (or the reverse) moves the feed with it instead of stranding
+    // the install on a slot it can never advance from.
+    const inferred = inferDesktopUpdateSelection(this.currentAppVersion());
     return {
-      channel: {
-        value: updates.channel ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
-        source: updates.channel === undefined ? "default" : "config",
-      },
-      train: {
-        value: updates.train ?? DESKTOP_UPDATE_TRAIN_DEFAULT,
-        source: updates.train === undefined ? "default" : "config",
-      },
+      channel: { value: inferred.channel, source: "default" },
+      train: { value: inferred.train, source: "default" },
+      selectionSource: "inferred",
     };
   }
 

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -60,9 +60,7 @@ import {
   DESKTOP_HOT_CPU_PROFILE_START_DELAY_DEFAULT_MS,
   DESKTOP_HOT_CPU_PROFILE_TRIGGER_MODE_DEFAULT,
   DESKTOP_INTEGRATED_TERMINAL_WINDOWS_SHELL_DEFAULT,
-  DESKTOP_UPDATE_CHANNEL_DEFAULT,
-  DESKTOP_UPDATE_TRAIN_DEFAULT,
-  inferDesktopUpdateSelection,
+  resolveDesktopUpdateSelection,
   DESKTOP_WORKTREE_STORAGE_DEFAULT,
   MANAGED_GROK_BUILD_CHANNEL_DEFAULT,
   MAX_PR_AUTO_DISPATCH_BUDGET_CAPACITY,
@@ -421,55 +419,6 @@ const FEISHU_DEFAULT_TENANT_URL = "https://open.feishu.cn";
 const LARK_DEFAULT_TENANT_URL = "https://open.larksuite.com";
 const FEISHU_DEFAULT_CALLBACK_BASE_URL = "http://127.0.0.1:47823";
 const settingsLog = getMainLogger("pwragent:settings");
-
-/** The pair every pre-`selection_source` config landed on when nobody had
- *  chosen: the shape the defaults shipped as, and what the old
- *  `resolveUpdateSelection` filled a missing axis with. This is a
- *  HISTORICAL FACT about files already on disk, so it is frozen here rather
- *  than read from `DESKTOP_UPDATE_*_DEFAULT` — moving the shipped default
- *  later must not retroactively reclassify those files as deliberate pins
- *  and freeze that population on Stable Latest forever. */
-const LEGACY_UNCHOSEN_UPDATE_PAIR: {
-  channel: DesktopUpdateChannel;
-  train: DesktopUpdateTrain;
-} = {
-  channel: "latest",
-  train: "stable",
-};
-
-/** Classify an `[updates]` table written before `selection_source` existed.
- *  A complete pair that is NOT the historical unchosen pair could only have
- *  been written by a deliberate click, and that means "leave it alone" — so
- *  it reads as `"user"`. Everything else (no pair, a half pair, or that
- *  pair) is indistinguishable from "never chose", so it reads as
- *  `"inferred"` and gets re-derived from the running binary.
- *
- *  A half pair is the case this fix exists for: `channel` shipped before
- *  `train` did, so every config written by an older build carries `channel`
- *  alone. Reading that as a Stable pin is what offered a 1.1.0-alpha
- *  install the last stable release forever and never told it about the
- *  newer alpha it came from.
- *
- *  The one behavior change this can produce: an operator who deliberately
- *  pinned Stable/Latest while running an alpha is moved back onto
- *  Beta/Prerelease once. That is the same state as the bug it fixes, and
- *  nothing on disk separates the two. Their next click writes `"user"` and
- *  pins for good. */
-function legacyUpdateSelectionSource(
-  channel: DesktopUpdateChannel | undefined,
-  train: DesktopUpdateTrain | undefined,
-): DesktopUpdateSelectionSource {
-  if (channel === undefined || train === undefined) {
-    return "inferred";
-  }
-  if (
-    channel === LEGACY_UNCHOSEN_UPDATE_PAIR.channel
-    && train === LEGACY_UNCHOSEN_UPDATE_PAIR.train
-  ) {
-    return "inferred";
-  }
-  return "user";
-}
 
 function clampInteger(value: number, maxValue: number): number {
   return Math.min(Math.max(value, 0), maxValue);
@@ -3015,42 +2964,31 @@ export class DesktopSettingsService {
       ?? "";
   }
 
+  /** Provenance wrapper over the shared resolver — the resolution rule
+   *  itself lives in `resolveDesktopUpdateSelection` so this and the
+   *  auto-updater's feed cannot drift apart. An axis reads as `"config"`
+   *  only when the file supplied it AND the pair is a pin: a value the
+   *  resolver re-derived is not something the config chose. */
   private resolveUpdateSelection(updates?: {
     channel?: DesktopUpdateChannel;
     train?: DesktopUpdateTrain;
     selectionSource?: DesktopUpdateSelectionSource;
   }): DesktopUpdateSettingsSnapshot {
-    const selectionSource =
-      updates?.selectionSource
-      ?? legacyUpdateSelectionSource(updates?.channel, updates?.train);
-    if (selectionSource === "user") {
-      // A pin is honored even when one axis did not survive the round trip
-      // (a truncated write, a hand edit that misspelled a value).
-      // Re-inferring the whole pair there would discard the axis that IS
-      // valid and un-pin the selection — on an alpha binary that quietly
-      // moves a deliberate Stable pin onto the alpha feed. Fall back per
-      // axis instead.
-      return {
-        channel: {
-          value: updates?.channel ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
-          source: updates?.channel === undefined ? "default" : "config",
-        },
-        train: {
-          value: updates?.train ?? DESKTOP_UPDATE_TRAIN_DEFAULT,
-          source: updates?.train === undefined ? "default" : "config",
-        },
-        selectionSource: "user",
-      };
-    }
-    // An inferred selection is RE-DERIVED on every read from the version of
-    // the binary doing the reading, so installing an alpha over a stable
-    // build (or the reverse) moves the feed with it instead of stranding
-    // the install on a slot it can never advance from.
-    const inferred = inferDesktopUpdateSelection(this.currentAppVersion());
+    const resolved = resolveDesktopUpdateSelection(
+      updates,
+      this.currentAppVersion(),
+    );
+    const pinned = resolved.selectionSource === "user";
     return {
-      channel: { value: inferred.channel, source: "default" },
-      train: { value: inferred.train, source: "default" },
-      selectionSource: "inferred",
+      channel: {
+        value: resolved.channel,
+        source: pinned && updates?.channel !== undefined ? "config" : "default",
+      },
+      train: {
+        value: resolved.train,
+        source: pinned && updates?.train !== undefined ? "config" : "default",
+      },
+      selectionSource: resolved.selectionSource,
     };
   }
 

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1570,6 +1570,7 @@ describe("App", () => {
       updates: {
         channel: { value: "latest", source: "default" },
         train: { value: "stable", source: "default" },
+        selectionSource: "inferred",
       },
       integratedTerminal: {
         windowsShell: { value: "auto", source: "default" },

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -6,7 +6,6 @@ import type {
 } from "@pwragent/shared";
 import type {
   AppUpdateCheckResult,
-  AppUpdateReleaseInfo,
   AppUpdateReleaseVersions,
   AppUpdateStatus,
 } from "../../../../shared/app-metadata";
@@ -28,6 +27,7 @@ import {
   ToggleField,
   useSettingsFieldPending,
 } from "./SettingsLayout";
+import { ReleaseSlotMatrix } from "./ReleaseSlotMatrix";
 import { sourceBadge } from "./settings-fields";
 
 const THEME_OPTIONS: Array<{
@@ -123,40 +123,6 @@ const PASTED_IMAGE_PATCH_OPTIONS: Array<{
   },
 ];
 
-const UPDATE_TRAIN_OPTIONS: Array<{
-  label: string;
-  value: DesktopUpdateTrain;
-}> = [
-  { label: "Stable", value: "stable" },
-  { label: "Beta", value: "beta" },
-];
-
-const UPDATE_CHANNEL_OPTIONS: Array<{
-  label: string;
-  value: DesktopUpdateChannel;
-}> = [
-  { label: "Latest", value: "latest" },
-  { label: "Prerelease", value: "prerelease" },
-];
-
-function releaseVersionText(release: AppUpdateReleaseInfo | undefined): string {
-  return release?.version ?? "Unavailable";
-}
-
-function releaseHelpText(
-  releases: AppUpdateReleaseVersions | undefined,
-): string {
-  if (!releases) {
-    return "Release versions are loading.";
-  }
-  return [
-    `Stable latest: ${releaseVersionText(releases.stable.latest)}`,
-    `Stable prerelease: ${releaseVersionText(releases.stable.prerelease)}`,
-    `Beta latest: ${releaseVersionText(releases.beta.latest)}`,
-    `Beta prerelease: ${releaseVersionText(releases.beta.prerelease)}`,
-  ].join(". ");
-}
-
 function updateResultText(result: AppUpdateCheckResult): string {
   if (result.status === "skipped") {
     return result.reason;
@@ -189,19 +155,28 @@ export function GeneralSettings(props: {
   onAttentionPromoteOnTurnEndChange: (value: boolean) => Promise<void>;
   onPdfAnalysisEnabledChange: (value: boolean) => Promise<void>;
   onPastedImageMaxPatchesChange: (value: number) => Promise<void>;
-  onUpdateChannelChange: (value: DesktopUpdateChannel) => Promise<void>;
-  onUpdateTrainChange: (value: DesktopUpdateTrain) => Promise<void>;
+  /** Both axes travel together: naming either one is what tells main the
+   *  selection is a pin rather than a guess, so a tile click writes the
+   *  whole pair in one patch. */
+  onUpdateSelectionChange: (value: {
+    channel: DesktopUpdateChannel;
+    train: DesktopUpdateTrain;
+  }) => Promise<void>;
   onNotificationsEnabledChange: (value: boolean) => Promise<void>;
   onClearMessagingAcknowledgment: () => Promise<void>;
 }) {
   const [releaseVersions, setReleaseVersions] = useState<
     AppUpdateReleaseVersions | undefined
   >();
+  // Whether the release read has ANSWERED, not whether it succeeded. A read
+  // that fails still settles, and the tiles must fall through to Unavailable
+  // rather than claim a read is in flight for the rest of the window's life.
+  const [releasesSettled, setReleasesSettled] = useState(false);
+  const [installedVersion, setInstalledVersion] = useState<string>();
   const [updateChecking, setUpdateChecking] = useState(false);
-  // The track group sits inside a composite control with its own buttons, so
-  // the field cannot own the tracker — the indicator goes last in the button
-  // row, where arriving mid-save displaces nothing.
-  const updateChannelPending = useSettingsFieldPending();
+  // The slot matrix is a grid, so it has no room for the indicator beside it
+  // the way a segmented control does — the field renders it underneath.
+  const updateSelectionPending = useSettingsFieldPending();
   const [updateResult, setUpdateResult] = useState<
     AppUpdateCheckResult | undefined
   >();
@@ -222,6 +197,7 @@ export function GeneralSettings(props: {
   const notificationsEnabled = props.snapshot.general.notificationsEnabled;
   const updateChannel = props.snapshot.updates.channel;
   const updateTrain = props.snapshot.updates.train;
+  const updateSelectionSource = props.snapshot.updates.selectionSource;
   const messagingAcknowledgment =
     props.snapshot.general.messagingAcknowledgment;
   const activeOption = PASTED_IMAGE_PATCH_OPTIONS.find(
@@ -230,11 +206,52 @@ export function GeneralSettings(props: {
 
   useEffect(() => {
     let canceled = false;
-    void props.desktopApi?.readAppUpdateReleaseVersions?.().then((versions) => {
-      if (!canceled) {
+    const read = props.desktopApi?.readAppUpdateReleaseVersions;
+    // A build without the reader settles immediately: every slot is
+    // Unavailable, which is the honest report, and "Loading…" forever is not.
+    if (!read) {
+      setReleasesSettled(true);
+      return;
+    }
+    void read().then(
+      (versions) => {
+        if (canceled) {
+          return;
+        }
         setReleaseVersions(versions);
-      }
-    });
+        setReleasesSettled(true);
+      },
+      () => {
+        if (!canceled) {
+          setReleasesSettled(true);
+        }
+      },
+    );
+    return () => {
+      canceled = true;
+    };
+  }, [props.desktopApi]);
+
+  // The running build's own version, for the matrix's "Installed" chip. The
+  // slot it lands in is the one an inferred selection is derived from, so
+  // seeing it marked is how an operator checks that inference agreed.
+  useEffect(() => {
+    let canceled = false;
+    const read = props.desktopApi?.readAppMetadata;
+    if (!read) {
+      return;
+    }
+    void read().then(
+      (metadata) => {
+        if (!canceled) {
+          setInstalledVersion(metadata.applicationVersion);
+        }
+      },
+      () => {
+        // Cosmetic: without it no tile carries the chip, which is the same
+        // as a build whose version matches no published slot.
+      },
+    );
     return () => {
       canceled = true;
     };
@@ -291,6 +308,7 @@ export function GeneralSettings(props: {
           await props.desktopApi?.readAppUpdateReleaseVersions?.();
         if (versions) {
           setReleaseVersions(versions);
+          setReleasesSettled(true);
         }
       } catch {
         // Keep the check result the operator just asked for.
@@ -455,25 +473,43 @@ export function GeneralSettings(props: {
         }
       >
         <div className="settings-fields">
-          <SegmentedField
+          <SettingsField
             label="Release channel"
-            sub="Stable is the smoke-checked train. Beta follows main and stays selectable even when its versions are still Unavailable."
-            help={releaseHelpText(releaseVersions)}
-            error={updateTrain.error}
+            sub="Two trains, two tracks. Stable is the smoke-checked feed; Beta follows main. Latest is smoke-checked within its train; Prerelease is newer and may not install."
+            help={
+              // The inference rule is only worth explaining while it is
+              // still live — once an operator pins a slot, saying "we
+              // guessed" is noise.
+              updateSelectionSource === "inferred"
+                ? "Following the build you installed. Pick a slot to pin it."
+                : undefined
+            }
+            error={updateTrain.error ?? updateChannel.error}
             source={sourceBadge(updateTrain)}
-            disabled={props.saving}
-            options={UPDATE_TRAIN_OPTIONS.map((option) => ({
-              ...option,
-              meta: releaseVersionText(releaseVersions?.[option.value]?.latest),
-            }))}
-            value={updateTrain.value}
-            onChange={(value) => {
-              return props.onUpdateTrainChange(value);
-            }}
+            actions={
+              <SettingsPendingIndicator
+                pending={updateSelectionPending.pending}
+              />
+            }
+            control={
+              <ReleaseSlotMatrix
+                channel={updateChannel.value}
+                disabled={props.saving}
+                installedVersion={installedVersion}
+                releaseVersions={releaseVersions}
+                releasesSettled={releasesSettled}
+                train={updateTrain.value}
+                onSelect={(next) => {
+                  const result = props.onUpdateSelectionChange(next);
+                  updateSelectionPending.track(result);
+                  return result;
+                }}
+              />
+            }
           />
           <SettingsField
-            label="Update track"
-            sub="Latest is smoke-checked. Prerelease is newer and may not install."
+            label="Check for updates"
+            sub="PwrAgent also checks on its own. A build older than the one you are running only installs when you ask for it here."
             help={
               updateResult ? (
                 <span
@@ -490,26 +526,9 @@ export function GeneralSettings(props: {
                 </span>
               ) : undefined
             }
-            error={updateChannel.error}
-            source={sourceBadge(updateChannel)}
             control={
               <div className="settings-update-channel">
                 <div className="settings-update-channel__controls">
-                  <SegmentedControl
-                    disabled={props.saving}
-                    label="Update track"
-                    options={UPDATE_CHANNEL_OPTIONS.map((option) => ({
-                      ...option,
-                      meta: releaseVersionText(
-                        releaseVersions?.[updateTrain.value]?.[option.value],
-                      ),
-                    }))}
-                    pending={updateChannelPending}
-                    value={updateChannel.value}
-                    onChange={(value) => {
-                      return props.onUpdateChannelChange(value);
-                    }}
-                  />
                   {downloadedVersion ? (
                     <button
                       aria-label={`${restartActionLabel} (${downloadedVersion})`}
@@ -538,9 +557,6 @@ export function GeneralSettings(props: {
                   >
                     {updateChecking ? "Checking..." : "Check for Update"}
                   </button>
-                  <SettingsPendingIndicator
-                    pending={updateChannelPending.pending}
-                  />
                 </div>
                 {downloadedVersion ? (
                   <>

--- a/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/GeneralSettings.tsx
@@ -485,7 +485,15 @@ export function GeneralSettings(props: {
                 : undefined
             }
             error={updateTrain.error ?? updateChannel.error}
-            source={sourceBadge(updateTrain)}
+            source={
+              // One field now covers both axes, so it reports whichever axis
+              // the config actually supplied. Reading only the train badge
+              // showed "default" for a pin whose train fell back, disagreeing
+              // with the section chip directly above it.
+              updateTrain.source === "config"
+                ? sourceBadge(updateTrain)
+                : sourceBadge(updateChannel)
+            }
             actions={
               <SettingsPendingIndicator
                 pending={updateSelectionPending.pending}

--- a/apps/desktop/src/renderer/src/features/settings/ReleaseSlotMatrix.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ReleaseSlotMatrix.tsx
@@ -51,17 +51,27 @@ const SLOT_SUB: Record<`${DesktopUpdateTrain}:${DesktopUpdateChannel}`, string> 
     "beta:prerelease": "Newest alpha off main. May not install.",
   };
 
-/** Render and arrow-walk order, derived from the shared axis lists so the
- *  headers, the tiles, and the keyboard walk can never disagree about the
- *  grid's shape. */
-const SLOT_ORDER: ReadonlyArray<{
-  train: DesktopUpdateTrain;
-  channel: DesktopUpdateChannel;
-}> = DESKTOP_UPDATE_TRAINS.flatMap((train) =>
-  DESKTOP_UPDATE_CHANNELS.map((channel) => ({ train, channel })),
-);
-
+/** Grid shape, derived from the shared axis lists so the headers, the tiles,
+ *  and the arrow-key walk can never disagree about it: trains are rows,
+ *  tracks are columns, in the order those lists declare. */
 const COLUMNS = DESKTOP_UPDATE_CHANNELS.length;
+const SLOT_COUNT = DESKTOP_UPDATE_TRAINS.length * COLUMNS;
+
+/** Flat position of a slot in that grid. One definition, used by the render
+ *  loop, the selected/tabbable test, and the ref array — recovering it with a
+ *  `findIndex` per tile per render made those agree by coincidence rather
+ *  than by construction. Returns -1 for a pair on neither axis list. */
+function slotIndex(
+  train: DesktopUpdateTrain,
+  channel: DesktopUpdateChannel,
+): number {
+  const row = DESKTOP_UPDATE_TRAINS.indexOf(train);
+  const column = DESKTOP_UPDATE_CHANNELS.indexOf(channel);
+  if (row < 0 || column < 0) {
+    return -1;
+  }
+  return row * COLUMNS + column;
+}
 
 /** Release tags carry a leading `v`; `AppMetadata.applicationVersion` does
  *  not, so the "Installed" chip compares the cores. */
@@ -166,12 +176,14 @@ export function ReleaseSlotMatrix(props: {
   }) => Promise<unknown>;
 }) {
   const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
-  const selectedIndex = Math.max(
-    0,
-    SLOT_ORDER.findIndex(
-      (slot) => slot.train === props.train && slot.channel === props.channel,
-    ),
-  );
+  // -1 when the pair names no published slot — a peer instance on a build
+  // that added a train, or a hand-edited config that slipped past validation.
+  // Left as -1 deliberately: painting slot 0 as Selected would show the
+  // operator a pin they never made, and put the only tabbable tile on the
+  // wrong slot. No tile is checked, and the first tile carries the tab stop
+  // so the control stays reachable.
+  const selectedIndex = slotIndex(props.train, props.channel);
+  const tabbableIndex = selectedIndex >= 0 ? selectedIndex : 0;
 
   // Roving tabindex plus arrow keys — the radiogroup contract, which the
   // pane's `SegmentedControl` leaves to native tab order because its
@@ -196,8 +208,9 @@ export function ReleaseSlotMatrix(props: {
           return;
         }
         event.preventDefault();
-        const count = SLOT_ORDER.length;
-        slotRefs.current[(index + delta + count) % count]?.focus();
+        slotRefs.current[
+          (index + delta + SLOT_COUNT) % SLOT_COUNT
+        ]?.focus();
       },
     [],
   );
@@ -227,10 +240,7 @@ export function ReleaseSlotMatrix(props: {
             {TRAIN_LABEL[rowTrain]}
           </div>
           {DESKTOP_UPDATE_CHANNELS.map((slotChannel) => {
-            const index = SLOT_ORDER.findIndex(
-              (slot) =>
-                slot.train === rowTrain && slot.channel === slotChannel,
-            );
+            const index = slotIndex(rowTrain, slotChannel);
             const release = props.releaseVersions?.[rowTrain]?.[slotChannel];
             return (
               <SlotTile
@@ -247,7 +257,7 @@ export function ReleaseSlotMatrix(props: {
                 }}
                 release={release}
                 selected={index === selectedIndex}
-                tabbable={index === selectedIndex}
+                tabbable={index === tabbableIndex}
                 train={rowTrain}
                 onKeyDown={onSlotKeyDown(index)}
                 onSelect={() => {

--- a/apps/desktop/src/renderer/src/features/settings/ReleaseSlotMatrix.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ReleaseSlotMatrix.tsx
@@ -1,0 +1,272 @@
+import { Fragment, useCallback, useRef } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import {
+  DESKTOP_UPDATE_CHANNELS,
+  DESKTOP_UPDATE_TRAINS,
+} from "@pwragent/shared";
+import type {
+  DesktopUpdateChannel,
+  DesktopUpdateTrain,
+} from "@pwragent/shared";
+import type {
+  AppUpdateReleaseInfo,
+  AppUpdateReleaseVersions,
+} from "../../../../shared/app-metadata";
+
+/**
+ * All four published release slots at once — trains as rows, tracks as
+ * columns.
+ *
+ * This replaces two stacked segmented controls that had a reporting bug
+ * baked into their shape: each control could only label itself with the
+ * slot the OTHER control was currently on. With the track control on
+ * Latest, the Beta button read "Beta — Unavailable" while Beta/Prerelease
+ * held a shipped alpha one click away. A control cannot report an empty
+ * slot without hiding a populated sibling when it only has one label per
+ * axis, so the fix is to stop asking it to: every tile states its own
+ * resolved version, selected or not.
+ *
+ * The selection is still two independent axes on the wire
+ * (`updates.train` + `updates.channel`); a tile click writes both in one
+ * patch, and main derives `updates.selection_source = "user"` from that
+ * write. See `resolveUpdateSelection` in
+ * main/settings/desktop-settings-service.ts.
+ */
+
+const TRAIN_LABEL: Record<DesktopUpdateTrain, string> = {
+  stable: "Stable",
+  beta: "Beta",
+};
+
+const CHANNEL_LABEL: Record<DesktopUpdateChannel, string> = {
+  latest: "Latest",
+  prerelease: "Prerelease",
+};
+
+const SLOT_SUB: Record<`${DesktopUpdateTrain}:${DesktopUpdateChannel}`, string> =
+  {
+    "stable:latest": "Smoke-checked. The default for everyone.",
+    "stable:prerelease": "Release candidates for the stable line.",
+    "beta:latest": "Beta builds off main.",
+    "beta:prerelease": "Newest alpha off main. May not install.",
+  };
+
+/** Render and arrow-walk order, derived from the shared axis lists so the
+ *  headers, the tiles, and the keyboard walk can never disagree about the
+ *  grid's shape. */
+const SLOT_ORDER: ReadonlyArray<{
+  train: DesktopUpdateTrain;
+  channel: DesktopUpdateChannel;
+}> = DESKTOP_UPDATE_TRAINS.flatMap((train) =>
+  DESKTOP_UPDATE_CHANNELS.map((channel) => ({ train, channel })),
+);
+
+const COLUMNS = DESKTOP_UPDATE_CHANNELS.length;
+
+/** Release tags carry a leading `v`; `AppMetadata.applicationVersion` does
+ *  not, so the "Installed" chip compares the cores. */
+function isSameVersion(
+  left: string | undefined,
+  right: string | undefined,
+): boolean {
+  if (left === undefined || right === undefined) {
+    return false;
+  }
+  return (
+    left.trim().replace(/^v/i, "") === right.trim().replace(/^v/i, "")
+  );
+}
+
+function SlotTile(props: {
+  train: DesktopUpdateTrain;
+  channel: DesktopUpdateChannel;
+  release: AppUpdateReleaseInfo | undefined;
+  /** The release read has not answered yet. Distinct from a slot that
+   *  answered and has nothing — "Loading" and "Unavailable" are not the
+   *  same claim. */
+  loading: boolean;
+  selected: boolean;
+  installed: boolean;
+  disabled: boolean;
+  /** Roving tabindex: exactly one tile is in the tab order, per the
+   *  radiogroup contract. */
+  tabbable: boolean;
+  onSelect: () => void;
+  onKeyDown: (event: ReactKeyboardEvent<HTMLButtonElement>) => void;
+  registerRef: (element: HTMLButtonElement | null) => void;
+}) {
+  const version = props.release?.version;
+  const label = `${TRAIN_LABEL[props.train]} ${CHANNEL_LABEL[props.channel]}`;
+  const headline = version ?? (props.loading ? "Loading…" : "Unavailable");
+  const sub =
+    version !== undefined
+      ? SLOT_SUB[`${props.train}:${props.channel}`]
+      : props.loading
+        ? "Reading published releases."
+        // An empty slot says why it is empty rather than going blank and
+        // leaving the reader to guess whether the feed broke or the slot
+        // simply has nothing yet. It stays clickable either way: a train
+        // with no build today still gets one tomorrow.
+        : (props.release?.unavailableReason ?? "Nothing published here yet.");
+
+  return (
+    <button
+      ref={props.registerRef}
+      aria-checked={props.selected}
+      aria-label={`${label} — ${headline}`}
+      className={`settings-release-slot${props.selected ? " is-selected" : ""}`}
+      disabled={props.disabled}
+      role="radio"
+      tabIndex={props.tabbable ? 0 : -1}
+      type="button"
+      onClick={props.onSelect}
+      onKeyDown={props.onKeyDown}
+    >
+      <span
+        className={`settings-release-slot__version${
+          version === undefined ? " is-empty" : ""
+        }`}
+      >
+        {headline}
+      </span>
+      <span className="settings-release-slot__sub">{sub}</span>
+      {props.selected || props.installed ? (
+        <span className="settings-release-slot__chips">
+          {props.selected ? (
+            <span className="settings-release-slot__chip is-selected">
+              Selected
+            </span>
+          ) : null}
+          {props.installed ? (
+            <span className="settings-release-slot__chip is-installed">
+              Installed
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+    </button>
+  );
+}
+
+export function ReleaseSlotMatrix(props: {
+  channel: DesktopUpdateChannel;
+  train: DesktopUpdateTrain;
+  disabled?: boolean;
+  /** Undefined until the release read answers; see `releasesSettled`. */
+  releaseVersions: AppUpdateReleaseVersions | undefined;
+  /** The release read has answered, successfully or not. A read that fails
+   *  still settles, and the tiles must fall through to Unavailable rather
+   *  than claim a read is in flight for the rest of the window's life. */
+  releasesSettled: boolean;
+  /** Running build, for the "Installed" chip. */
+  installedVersion: string | undefined;
+  onSelect: (next: {
+    train: DesktopUpdateTrain;
+    channel: DesktopUpdateChannel;
+  }) => Promise<unknown>;
+}) {
+  const slotRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const selectedIndex = Math.max(
+    0,
+    SLOT_ORDER.findIndex(
+      (slot) => slot.train === props.train && slot.channel === props.channel,
+    ),
+  );
+
+  // Roving tabindex plus arrow keys — the radiogroup contract, which the
+  // pane's `SegmentedControl` leaves to native tab order because its
+  // options sit on one axis. Selection deliberately does NOT follow focus:
+  // picking a slot rewrites which build PwrAgent installs, so a stray arrow
+  // press must not change the feed. The operator commits with Space/Enter
+  // (the button's own activation) or a click.
+  const onSlotKeyDown = useCallback(
+    (index: number) =>
+      (event: ReactKeyboardEvent<HTMLButtonElement>): void => {
+        const delta =
+          event.key === "ArrowRight"
+            ? 1
+            : event.key === "ArrowLeft"
+              ? -1
+              : event.key === "ArrowDown"
+                ? COLUMNS
+                : event.key === "ArrowUp"
+                  ? -COLUMNS
+                  : 0;
+        if (delta === 0) {
+          return;
+        }
+        event.preventDefault();
+        const count = SLOT_ORDER.length;
+        slotRefs.current[(index + delta + count) % count]?.focus();
+      },
+    [],
+  );
+
+  return (
+    <div
+      className="settings-release-slots"
+      role="radiogroup"
+      aria-label="Release channel"
+    >
+      {/* Header cells are decoration: every tile's accessible name already
+          spells out "Stable Latest", so exposing the headers inside the
+          radiogroup would interleave duplicate text with the options. */}
+      <div className="settings-release-slots__rowhdr" aria-hidden="true" />
+      {DESKTOP_UPDATE_CHANNELS.map((headerChannel) => (
+        <div
+          key={headerChannel}
+          className="settings-release-slots__colhdr"
+          aria-hidden="true"
+        >
+          {CHANNEL_LABEL[headerChannel]}
+        </div>
+      ))}
+      {DESKTOP_UPDATE_TRAINS.map((rowTrain) => (
+        <Fragment key={rowTrain}>
+          <div className="settings-release-slots__rowhdr" aria-hidden="true">
+            {TRAIN_LABEL[rowTrain]}
+          </div>
+          {DESKTOP_UPDATE_CHANNELS.map((slotChannel) => {
+            const index = SLOT_ORDER.findIndex(
+              (slot) =>
+                slot.train === rowTrain && slot.channel === slotChannel,
+            );
+            const release = props.releaseVersions?.[rowTrain]?.[slotChannel];
+            return (
+              <SlotTile
+                key={slotChannel}
+                channel={slotChannel}
+                disabled={props.disabled ?? false}
+                installed={isSameVersion(
+                  release?.version,
+                  props.installedVersion,
+                )}
+                loading={!props.releasesSettled}
+                registerRef={(element) => {
+                  slotRefs.current[index] = element;
+                }}
+                release={release}
+                selected={index === selectedIndex}
+                tabbable={index === selectedIndex}
+                train={rowTrain}
+                onKeyDown={onSlotKeyDown(index)}
+                onSelect={() => {
+                  // Re-picking the current slot is not a change, and the
+                  // write path bails on an unchanged patch anyway — so
+                  // tracking it would announce "Saving…" for no write.
+                  if (index === selectedIndex) {
+                    return;
+                  }
+                  void props.onSelect({
+                    train: rowTrain,
+                    channel: slotChannel,
+                  });
+                }}
+              />
+            );
+          })}
+        </Fragment>
+      ))}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/SettingsScreen.tsx
@@ -646,21 +646,11 @@ function SettingsSectionBody(props: {
             general: { pdfAnalysisEnabled },
           });
         }}
-        onUpdateChannelChange={async (channel: DesktopUpdateChannel) => {
-          await props.settings.writeConfig({
-            updates: {
-              channel,
-              train: props.snapshot.updates.train.value,
-            },
-          });
-        }}
-        onUpdateTrainChange={async (train: DesktopUpdateTrain) => {
-          await props.settings.writeConfig({
-            updates: {
-              train,
-              channel: props.snapshot.updates.channel.value,
-            },
-          });
+        onUpdateSelectionChange={async (updates: {
+          channel: DesktopUpdateChannel;
+          train: DesktopUpdateTrain;
+        }) => {
+          await props.settings.writeConfig({ updates });
         }}
         onPastedImageMaxPatchesChange={async (pastedImageMaxPatches) => {
           await props.settings.writeConfig({

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/ReleaseSlotMatrix.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/ReleaseSlotMatrix.test.tsx
@@ -1,0 +1,179 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AppUpdateReleaseVersions } from "../../../../../shared/app-metadata";
+import { ReleaseSlotMatrix } from "../ReleaseSlotMatrix";
+
+const RELEASES: AppUpdateReleaseVersions = {
+  fetchedAt: 1,
+  stable: {
+    latest: { version: "v1.0.3" },
+    prerelease: { version: "v1.0.3" },
+  },
+  beta: {
+    // The shape the two-control UI could not report: an empty Beta Latest
+    // sitting beside a populated Beta Prerelease.
+    latest: { unavailableReason: "No beta release found." },
+    prerelease: { version: "v1.1.0-alpha.2" },
+  },
+};
+
+function renderMatrix(
+  overrides: Partial<Parameters<typeof ReleaseSlotMatrix>[0]> = {},
+) {
+  const onSelect = vi.fn(async () => undefined);
+  render(
+    <ReleaseSlotMatrix
+      channel="prerelease"
+      installedVersion="1.1.0-alpha.2"
+      releaseVersions={RELEASES}
+      releasesSettled
+      train="beta"
+      onSelect={onSelect}
+      {...overrides}
+    />,
+  );
+  return { onSelect };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReleaseSlotMatrix", () => {
+  it("states every slot's own version, not the one the selection sits on", () => {
+    // The bug this replaced: each segmented control labelled itself with the
+    // slot the OTHER control was currently on, so with the track control on
+    // Latest the Beta button read "Beta — Unavailable" while Beta Prerelease
+    // held a shipped alpha one click away.
+    renderMatrix({ channel: "latest", train: "stable" });
+
+    expect(
+      screen.getByRole("radio", { name: "Stable Latest — v1.0.3" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "Stable Prerelease — v1.0.3" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "Beta Prerelease — v1.1.0-alpha.2" }),
+    ).toBeInTheDocument();
+  });
+
+  it("says why an empty slot is empty, and keeps it selectable", () => {
+    const { onSelect } = renderMatrix();
+
+    const betaLatest = screen.getByRole("radio", {
+      name: "Beta Latest — Unavailable",
+    });
+    // The reason comes from the release read, so a feed that broke and a
+    // train that simply has nothing yet do not read the same.
+    expect(betaLatest).toHaveTextContent("No beta release found.");
+    expect(betaLatest).not.toBeDisabled();
+
+    fireEvent.click(betaLatest);
+    expect(onSelect).toHaveBeenCalledWith({
+      train: "beta",
+      channel: "latest",
+    });
+  });
+
+  it("falls back to a generic reason when the read reported none", () => {
+    renderMatrix({
+      releaseVersions: {
+        ...RELEASES,
+        beta: { latest: {}, prerelease: { version: "v1.1.0-alpha.2" } },
+      },
+    });
+
+    expect(
+      screen.getByRole("radio", { name: "Beta Latest — Unavailable" }),
+    ).toHaveTextContent("Nothing published here yet.");
+  });
+
+  it("separates a read still in flight from a slot that answered empty", () => {
+    renderMatrix({ releaseVersions: undefined, releasesSettled: false });
+
+    expect(
+      screen.getAllByRole("radio", { name: /— Loading…$/ }),
+    ).toHaveLength(4);
+    expect(
+      screen.queryByRole("radio", { name: /Unavailable/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("marks the running build's slot and the selected slot separately", () => {
+    // They are usually the same tile and must still be distinguishable: an
+    // operator who pinned Stable while running an alpha needs to see both.
+    renderMatrix({ channel: "latest", train: "stable" });
+
+    const installed = screen.getByRole("radio", {
+      name: "Beta Prerelease — v1.1.0-alpha.2",
+    });
+    expect(installed).toHaveTextContent("Installed");
+    expect(installed).toHaveAttribute("aria-checked", "false");
+
+    const selected = screen.getByRole("radio", {
+      name: "Stable Latest — v1.0.3",
+    });
+    expect(selected).toHaveAttribute("aria-checked", "true");
+    expect(selected).not.toHaveTextContent("Installed");
+  });
+
+  it("writes both axes in one patch so main can derive the pin", () => {
+    const { onSelect } = renderMatrix({ channel: "latest", train: "stable" });
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Beta Prerelease — v1.1.0-alpha.2" }),
+    );
+    expect(onSelect).toHaveBeenCalledWith({
+      train: "beta",
+      channel: "prerelease",
+    });
+  });
+
+  it("does not write when the operator re-picks the current slot", () => {
+    const { onSelect } = renderMatrix();
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Beta Prerelease — v1.1.0-alpha.2" }),
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps exactly the selected tile in the tab order", () => {
+    renderMatrix();
+
+    const tabbable = screen
+      .getAllByRole("radio")
+      .filter((tile) => tile.getAttribute("tabindex") === "0");
+    expect(tabbable).toHaveLength(1);
+    expect(tabbable[0]).toHaveAccessibleName(
+      "Beta Prerelease — v1.1.0-alpha.2",
+    );
+  });
+
+  it("moves focus with the arrows without changing the selection", () => {
+    // Picking a slot rewrites which build the app installs, so selection
+    // must not follow focus — the operator commits with Space, Enter, or a
+    // click.
+    const { onSelect } = renderMatrix({ channel: "latest", train: "stable" });
+
+    const stableLatest = screen.getByRole("radio", {
+      name: "Stable Latest — v1.0.3",
+    });
+    stableLatest.focus();
+    fireEvent.keyDown(stableLatest, { key: "ArrowDown" });
+    expect(document.activeElement).toHaveAccessibleName(
+      "Beta Latest — Unavailable",
+    );
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, {
+      key: "ArrowRight",
+    });
+    expect(document.activeElement).toHaveAccessibleName(
+      "Beta Prerelease — v1.1.0-alpha.2",
+    );
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(stableLatest).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -216,6 +216,7 @@ function createSnapshot(
     updates: {
       channel: { value: "latest", source: "default" },
       train: { value: "stable", source: "default" },
+      selectionSource: "inferred",
     },
     integratedTerminal: {
       windowsShell: { value: "auto", source: "default" },
@@ -1012,10 +1013,9 @@ describe("SettingsScreen", () => {
     );
 
     expect(screen.getByRole("heading", { name: "Updates" })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /Latest/ })).toHaveAttribute(
-      "aria-checked",
-      "true",
-    );
+    expect(
+      await screen.findByRole("radio", { name: "Stable Latest — v1.0.0" }),
+    ).toHaveAttribute("aria-checked", "true");
     expect(
       screen.getByRole("switch", {
         name: "Confirm quit when threads or terminals are active",
@@ -1140,11 +1140,15 @@ describe("SettingsScreen", () => {
     });
 
     expect(await screen.findByText("v1.0.0-beta.7")).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /Stable/ })).toHaveAttribute(
-      "aria-checked",
-      "true",
+    expect(
+      screen.getByRole("radio", { name: "Stable Latest — v1.0.0" }),
+    ).toHaveAttribute("aria-checked", "true");
+    // One tile, both axes — the two-control shape needed two clicks and two
+    // writes to reach a slot, and each write had to re-send the axis the
+    // operator had not touched.
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Beta Latest — v1.1.0-beta.2" }),
     );
-    fireEvent.click(screen.getByRole("radio", { name: /Beta/ }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {
@@ -1153,7 +1157,9 @@ describe("SettingsScreen", () => {
         },
       });
     });
-    fireEvent.click(screen.getByRole("radio", { name: /Prerelease/ }));
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Stable Prerelease — v1.0.0-beta.7" }),
+    );
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {
@@ -6619,6 +6625,7 @@ describe("SettingsScreen", () => {
         updates: {
           channel: { value: "latest", source: "config" },
           train: { value: "stable", source: "config" },
+          selectionSource: "user",
         },
       }),
     );
@@ -6677,6 +6684,7 @@ describe("SettingsScreen", () => {
         updates: {
           channel: { value: "prerelease", source: "config" },
           train: { value: "stable", source: "default" },
+          selectionSource: "user",
         },
       }),
     );
@@ -6964,12 +6972,13 @@ describe("SettingsScreen", () => {
     ).toBeInTheDocument();
   });
 
-  it("keeps an inferred Beta train when the operator picks Latest", async () => {
+  it("pins both axes from one tile click, and reports each slot's own version", async () => {
     const settings = createSettingsState(
       createSnapshot({
         updates: {
           channel: { value: "prerelease", source: "default" },
           train: { value: "beta", source: "default" },
+          selectionSource: "inferred",
         },
       }),
     );
@@ -6995,11 +7004,32 @@ describe("SettingsScreen", () => {
       />,
     );
 
-    expect(screen.getByRole("radio", { name: /Beta/ })).toHaveAttribute(
-      "aria-checked",
-      "true",
+    // Every slot states its own version. The two-control shape could not:
+    // with the track control on Prerelease, the Stable button labelled
+    // itself from `stable.latest` and the track buttons from the selected
+    // train, so no reading of the pane showed all four at once.
+    expect(
+      await screen.findByRole("radio", { name: "Beta Prerelease — v1.1.0-alpha.7" }),
+    ).toHaveAttribute("aria-checked", "true");
+    expect(
+      screen.getByRole("radio", { name: "Beta Latest — v1.1.0-beta.2" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "Stable Latest — v1.0.1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "Stable Prerelease — v1.0.1" }),
+    ).toBeInTheDocument();
+
+    // While the selection is inferred the pane says so; a click pins it and
+    // main derives `selection_source` from the patch naming both axes.
+    expect(
+      screen.getByText("Following the build you installed. Pick a slot to pin it."),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Beta Latest — v1.1.0-beta.2" }),
     );
-    fireEvent.click(screen.getByRole("radio", { name: /Latest/ }));
     await waitFor(() => {
       expect(settings.writeConfig).toHaveBeenCalledWith({
         updates: {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9349,11 +9349,13 @@ a.button {
   gap: 6px;
 }
 
-/* The three controls (track segmented, Restart, Check) read as one row of
-   equal-height chiclets. `stretch` sizes both buttons to the segmented
-   control, which is the tallest because its options are two-line. Status
-   text is a SIBLING of this row, never a member of it — as a member its
-   own height fed back into `stretch` and inflated the buttons. */
+/* Restart and Check read as one row of equal-height chiclets. The track
+   segmented control used to sit here too and was the tallest member, which
+   is what `stretch` was sizing the buttons against; the release slot matrix
+   replaced it and lives in its own field now, so `stretch` only equalizes
+   the two buttons against each other. Status text is a SIBLING of this row,
+   never a member of it — as a member its own height fed back into `stretch`
+   and inflated the buttons. */
 .settings-update-channel__controls {
   display: flex;
   flex-wrap: wrap;
@@ -9361,15 +9363,15 @@ a.button {
   gap: 8px;
 }
 
-/* Match the segmented control's label register (12px/650). Without this the
-   two buttons fall back to the browser-default inherited size and read a
-   full step larger than the chiclets beside them.
+/* Keep the settings label register (12px/650). Without this the two buttons
+   fall back to the browser-default inherited size and read a full step
+   larger than the rest of the pane.
 
-   Do NOT reintroduce `min-height: 0` here. `stretch` already sizes these to
-   the segmented control on a shared line, so the override bought nothing
-   there — but once the row wraps and a button lands on a line alone it has
-   nothing to stretch against, and the override collapsed it to a 16px
-   sliver. The `.button` base floor of 34px is what catches that case. */
+   Do NOT reintroduce `min-height: 0` here. It collapsed a button that had
+   nothing to stretch against to a 16px sliver — originally when the row
+   wrapped and a button landed on a line alone, and now for any button
+   whenever Restart is absent and Check is the row's only member. The
+   `.button` base floor of 34px is what catches that. */
 .settings-update-channel__button,
 .settings-update-channel__restart-button {
   font-size: 12px;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -9403,6 +9403,145 @@ a.button {
   color: var(--danger-text);
 }
 
+/* Release slot matrix — all four published slots at once, trains as rows and
+   tracks as columns. It replaced two segmented controls that could only label
+   themselves with the slot the OTHER control was on, so a populated
+   Beta Prerelease read as "Beta — Unavailable" whenever the track control sat
+   on Latest. Every tile now carries its own version, selected or not. */
+.settings-release-slots {
+  display: grid;
+  grid-template-columns: 76px minmax(0, 1fr) minmax(0, 1fr);
+  align-items: stretch;
+  gap: 8px;
+  width: 100%;
+}
+
+.settings-release-slots__colhdr,
+.settings-release-slots__rowhdr {
+  display: flex;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.settings-release-slots__colhdr {
+  padding-left: 2px;
+}
+
+/* The train name is a row label, not a column kicker — it reads as a word
+   beside the tiles rather than as another eyebrow above them. */
+.settings-release-slots__rowhdr {
+  color: var(--text-secondary);
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: none;
+}
+
+.settings-release-slot {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  min-width: 0;
+  padding: 10px 12px;
+  appearance: none;
+  cursor: pointer;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  text-align: left;
+}
+
+.settings-release-slot:hover {
+  border-color: var(--accent-border);
+}
+
+/* The matrix is a roving-tabindex radiogroup: arrow keys move focus between
+   tiles WITHOUT selecting, because picking a slot rewrites which build the
+   app installs. Without a focus ring distinct from `.is-selected` there is
+   no way to see which tile Space would commit. */
+.settings-release-slot:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.settings-release-slot.is-selected {
+  border-color: var(--accent-border);
+  background: var(--bg-row-active);
+}
+
+.settings-release-slot:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.settings-release-slot__version {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.settings-release-slot.is-selected .settings-release-slot__version {
+  color: var(--accent-bright);
+}
+
+/* An empty slot is prose, not a version — the mono face would read as a tag
+   the operator could go look for. */
+.settings-release-slot__version.is-empty {
+  color: var(--text-muted);
+  font-family: inherit;
+  font-weight: 500;
+}
+
+.settings-release-slot__sub {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.35;
+}
+
+.settings-release-slot__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.settings-release-slot__chip {
+  display: inline-flex;
+  align-items: center;
+  height: 16px;
+  padding: 0 6px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 4px;
+  background: var(--bg-panel-elevated);
+  color: var(--text-muted);
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.settings-release-slot__chip.is-selected {
+  border-color: var(--accent-border);
+  background: var(--accent-soft);
+  color: var(--accent-bright);
+}
+
+.settings-release-slot__chip.is-installed {
+  border-color: var(--success-border);
+  background: var(--success-soft);
+  color: var(--success-text);
+}
+
 .settings-section__description {
   margin: 6px 0 0;
   color: var(--text-secondary);

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -6,6 +6,8 @@ import {
   inferDesktopUpdateSelection,
   isDesktopChatReplyComposer,
   isDesktopUpdateSelectionSource,
+  legacyDesktopUpdateSelectionSource,
+  resolveDesktopUpdateSelection,
 } from "../settings";
 
 describe("desktop settings contracts", () => {
@@ -495,5 +497,66 @@ describe("isDesktopUpdateSelectionSource", () => {
 
   it("defaults to inferring from the running binary", () => {
     expect(DESKTOP_UPDATE_SELECTION_SOURCE_DEFAULT).toBe("inferred");
+  });
+});
+
+describe("resolveDesktopUpdateSelection", () => {
+  const ALPHA = "1.1.0-alpha.7";
+
+  it("re-derives an inferred selection from the running binary", () => {
+    expect(
+      resolveDesktopUpdateSelection({ selectionSource: "inferred" }, ALPHA),
+    ).toEqual({ channel: "prerelease", train: "beta", selectionSource: "inferred" });
+    expect(resolveDesktopUpdateSelection(undefined, ALPHA)).toEqual({
+      channel: "prerelease",
+      train: "beta",
+      selectionSource: "inferred",
+    });
+  });
+
+  it("re-derives a legacy half pair rather than reading it as a Stable pin", () => {
+    // `channel` shipped before `train` did, so this is what every config
+    // written by an older build looks like. Reading it as a pin is what
+    // stranded alpha installs on the last stable release.
+    expect(resolveDesktopUpdateSelection({ channel: "latest" }, ALPHA)).toEqual({
+      channel: "prerelease",
+      train: "beta",
+      selectionSource: "inferred",
+    });
+  });
+
+  it("re-derives the historical unchosen pair", () => {
+    expect(
+      resolveDesktopUpdateSelection({ channel: "latest", train: "stable" }, ALPHA),
+    ).toEqual({ channel: "prerelease", train: "beta", selectionSource: "inferred" });
+  });
+
+  it("honors a legacy complete non-default pair as a pin", () => {
+    expect(
+      resolveDesktopUpdateSelection({ channel: "latest", train: "beta" }, "1.0.3"),
+    ).toEqual({ channel: "latest", train: "beta", selectionSource: "user" });
+  });
+
+  it("honors an explicit pin per axis when one axis is missing", () => {
+    // Re-inferring the whole pair would discard the axis that IS valid and
+    // move a deliberate Stable pin onto the alpha feed.
+    expect(
+      resolveDesktopUpdateSelection(
+        { train: "stable", selectionSource: "user" },
+        ALPHA,
+      ),
+    ).toEqual({ channel: "latest", train: "stable", selectionSource: "user" });
+  });
+});
+
+describe("legacyDesktopUpdateSelectionSource", () => {
+  it("treats anything short of a complete non-default pair as unchosen", () => {
+    expect(legacyDesktopUpdateSelectionSource(undefined, undefined)).toBe("inferred");
+    expect(legacyDesktopUpdateSelectionSource("prerelease", undefined)).toBe("inferred");
+    expect(legacyDesktopUpdateSelectionSource(undefined, "beta")).toBe("inferred");
+    expect(legacyDesktopUpdateSelectionSource("latest", "stable")).toBe("inferred");
+    expect(legacyDesktopUpdateSelectionSource("prerelease", "stable")).toBe("user");
+    expect(legacyDesktopUpdateSelectionSource("latest", "beta")).toBe("user");
+    expect(legacyDesktopUpdateSelectionSource("prerelease", "beta")).toBe("user");
   });
 });

--- a/packages/shared/src/contracts/__tests__/settings.test.ts
+++ b/packages/shared/src/contracts/__tests__/settings.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from "vitest";
 
 import type { DesktopSettingsSnapshot } from "../settings";
 import {
+  DESKTOP_UPDATE_SELECTION_SOURCE_DEFAULT,
   inferDesktopUpdateSelection,
   isDesktopChatReplyComposer,
+  isDesktopUpdateSelectionSource,
 } from "../settings";
 
 describe("desktop settings contracts", () => {
@@ -147,6 +149,7 @@ describe("desktop settings contracts", () => {
       updates: {
         channel: { value: "latest", source: "default" },
         train: { value: "stable", source: "default" },
+        selectionSource: "inferred",
       },
       integratedTerminal: {
         windowsShell: { value: "auto", source: "default" },
@@ -475,5 +478,22 @@ describe("inferDesktopUpdateSelection", () => {
       train: "stable",
       channel: "latest",
     });
+  });
+});
+
+describe("isDesktopUpdateSelectionSource", () => {
+  it("accepts only the two derived sources", () => {
+    expect(isDesktopUpdateSelectionSource("inferred")).toBe(true);
+    expect(isDesktopUpdateSelectionSource("user")).toBe(true);
+    // The guard is what a hand-edited config passes through, so anything
+    // else must re-derive rather than be trusted as a pin.
+    expect(isDesktopUpdateSelectionSource("User")).toBe(false);
+    expect(isDesktopUpdateSelectionSource("config")).toBe(false);
+    expect(isDesktopUpdateSelectionSource(undefined)).toBe(false);
+    expect(isDesktopUpdateSelectionSource(true)).toBe(false);
+  });
+
+  it("defaults to inferring from the running binary", () => {
+    expect(DESKTOP_UPDATE_SELECTION_SOURCE_DEFAULT).toBe("inferred");
   });
 });

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -177,6 +177,106 @@ export function inferDesktopUpdateSelection(version: string): {
   return { channel: "prerelease", train: DESKTOP_UPDATE_TRAIN_DEFAULT };
 }
 
+/** The pair every pre-`selection_source` config landed on when nobody had
+ *  chosen: the shape the defaults shipped as, and what the old resolver
+ *  filled a missing axis with. This is a HISTORICAL FACT about files already
+ *  on disk, so it is frozen here rather than read from
+ *  `DESKTOP_UPDATE_*_DEFAULT` — moving the shipped default later must not
+ *  retroactively reclassify those files as deliberate pins and freeze that
+ *  population on Stable Latest forever. */
+const LEGACY_UNCHOSEN_UPDATE_PAIR: {
+  channel: DesktopUpdateChannel;
+  train: DesktopUpdateTrain;
+} = {
+  channel: "latest",
+  train: "stable",
+};
+
+/** Classify an `[updates]` table written before `selection_source` existed.
+ *  A complete pair that is NOT the historical unchosen pair could only have
+ *  been written by a deliberate click, and that means "leave it alone" — so
+ *  it reads as `"user"`. Everything else (no pair, a half pair, or that
+ *  pair) is indistinguishable from "never chose", so it reads as
+ *  `"inferred"` and gets re-derived from the running binary.
+ *
+ *  A half pair is the case this exists for: `channel` shipped before `train`
+ *  did, so every config written by an older build carries `channel` alone.
+ *  Reading that as a Stable pin is what offered a 1.1.0-alpha install the
+ *  last stable release forever and never told it about the newer alpha it
+ *  came from.
+ *
+ *  The one behavior change this can produce: an operator who deliberately
+ *  pinned Stable/Latest while running an alpha is moved back onto
+ *  Beta/Prerelease once. That is the same state as the bug it fixes, and
+ *  nothing on disk separates the two. Their next click writes `"user"` and
+ *  pins for good. */
+export function legacyDesktopUpdateSelectionSource(
+  channel: DesktopUpdateChannel | undefined,
+  train: DesktopUpdateTrain | undefined,
+): DesktopUpdateSelectionSource {
+  if (channel === undefined || train === undefined) {
+    return "inferred";
+  }
+  if (
+    channel === LEGACY_UNCHOSEN_UPDATE_PAIR.channel
+    && train === LEGACY_UNCHOSEN_UPDATE_PAIR.train
+  ) {
+    return "inferred";
+  }
+  return "user";
+}
+
+export type DesktopUpdateSelection = {
+  channel: DesktopUpdateChannel;
+  train: DesktopUpdateTrain;
+  selectionSource: DesktopUpdateSelectionSource;
+};
+
+/**
+ * Turn a persisted `[updates]` table plus the running binary's version into
+ * the train/track pair the app should follow.
+ *
+ * This is THE resolver — the settings snapshot and the auto-updater's feed
+ * both go through it. They must not each carry their own copy: when they did,
+ * fixing the half-pair rule in one of them left the other offering a
+ * 1.1.0-alpha install the last stable release while Settings showed Beta,
+ * which is worse than the original bug because the two now disagree.
+ *
+ * A pin is honored per axis, so a pin whose other axis did not survive the
+ * round trip (a truncated write, a hand edit that misspelled a value) keeps
+ * the axis that IS valid instead of being silently un-pinned onto the feed
+ * the binary happens to come from.
+ */
+export function resolveDesktopUpdateSelection(
+  stored:
+    | {
+        channel?: DesktopUpdateChannel;
+        train?: DesktopUpdateTrain;
+        selectionSource?: DesktopUpdateSelectionSource;
+      }
+    | undefined,
+  appVersion: string,
+): DesktopUpdateSelection {
+  const selectionSource =
+    stored?.selectionSource
+    ?? legacyDesktopUpdateSelectionSource(stored?.channel, stored?.train);
+  if (selectionSource === "user") {
+    return {
+      channel: stored?.channel ?? DESKTOP_UPDATE_CHANNEL_DEFAULT,
+      train: stored?.train ?? DESKTOP_UPDATE_TRAIN_DEFAULT,
+      selectionSource: "user",
+    };
+  }
+  // An inferred selection is RE-DERIVED on every read from the version of the
+  // binary doing the reading, so installing an alpha over a stable build (or
+  // the reverse) moves the feed with it instead of stranding the install on a
+  // slot it can never advance from.
+  return {
+    ...inferDesktopUpdateSelection(appVersion),
+    selectionSource: "inferred",
+  };
+}
+
 export const DESKTOP_APPEARANCE_THEMES = ["system", "dark", "light"] as const;
 export type DesktopAppearanceTheme = (typeof DESKTOP_APPEARANCE_THEMES)[number];
 export const DESKTOP_APPEARANCE_THEME_DEFAULT: DesktopAppearanceTheme = "system";

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -72,6 +72,41 @@ export type DesktopUpdateTrain = (typeof DESKTOP_UPDATE_TRAINS)[number];
 
 export const DESKTOP_UPDATE_TRAIN_DEFAULT: DesktopUpdateTrain = "stable";
 
+export const DESKTOP_UPDATE_SELECTION_SOURCES = ["inferred", "user"] as const;
+
+/**
+ * Where the persisted train/track pair came from.
+ *
+ * `"inferred"` means nobody has picked a slot yet, so the pair is derived
+ * from the RUNNING BINARY's version on every settings read — install an
+ * alpha and you follow the alpha feed, install a stable build and you
+ * follow Stable Latest. `"user"` means somebody picked a slot in Settings
+ * and the pair is pinned until they pick another one.
+ *
+ * Without this flag the two states are indistinguishable on disk, and a
+ * pre-`train` config carrying only `channel = "latest"` read as a
+ * deliberate Stable pin. That is what stranded 1.1.0-alpha installs on the
+ * Stable Latest feed: PwrAgent offered them the last stable release and
+ * never mentioned the newer alpha their own binary came from.
+ *
+ * Main-owned. It is not part of `DesktopSettingsConfigPatch`, and the write
+ * path derives it from whether a patch named either axis.
+ */
+export type DesktopUpdateSelectionSource =
+  (typeof DESKTOP_UPDATE_SELECTION_SOURCES)[number];
+
+export const DESKTOP_UPDATE_SELECTION_SOURCE_DEFAULT: DesktopUpdateSelectionSource =
+  "inferred";
+
+export function isDesktopUpdateSelectionSource(
+  value: unknown,
+): value is DesktopUpdateSelectionSource {
+  return (
+    typeof value === "string"
+    && (DESKTOP_UPDATE_SELECTION_SOURCES as readonly string[]).includes(value)
+  );
+}
+
 // Last 1.0 core that used `-beta.N` as the Stable prerelease line. Builds
 // at this core stay on Stable so a website Beta download cannot be confused
 // with `v1.0.0-beta.50`.
@@ -95,10 +130,18 @@ function parseDesktopUpdateVersion(
 }
 
 /**
- * Map a desktop app version onto the Settings update train/track.
- * Used only when both `updates.train` and `updates.channel` are unset so a
- * GitHub or website download of Beta/Prerelease follows that feed. A
- * pre-train config that only set `channel` stays on Stable.
+ * Map an installed desktop app version onto the Settings update
+ * train/track, so a GitHub or website download follows the feed it came
+ * from. This is the whole rule for a selection whose
+ * {@link DesktopUpdateSelectionSource} is still `"inferred"`: an `-alpha`
+ * binary is evidence of Beta/Prerelease, a `-beta` binary is evidence of
+ * Beta/Latest, an `-rc` / `-prerelease` binary is evidence of
+ * Stable/Prerelease, and a plain release means Stable/Latest. Once an
+ * operator picks a slot in Settings the source flips to `"user"` and this
+ * function is no longer consulted.
+ *
+ * `v1.0.0-beta.N` is the one exception: those tags were the STABLE
+ * prerelease line before the trains split, so they stay on Stable.
  */
 export function inferDesktopUpdateSelection(version: string): {
   channel: DesktopUpdateChannel;
@@ -495,6 +538,12 @@ export type DesktopImageUploadSettingsSnapshot = {
 export type DesktopUpdateSettingsSnapshot = {
   channel: DesktopSettingsValue<DesktopUpdateChannel>;
   train: DesktopSettingsValue<DesktopUpdateTrain>;
+  /** Whether the pair above is a pin or a guess. A bare scalar rather than
+   *  a `DesktopSettingsValue`: it has no provenance of its own to report —
+   *  it IS the provenance, and main derives it on every read. The renderer
+   *  uses it to say "following the build you installed" only while that
+   *  claim is still true. */
+  selectionSource: DesktopUpdateSelectionSource;
 };
 
 export type DesktopIntegratedTerminalSettingsSnapshot = {
@@ -1160,6 +1209,12 @@ export type DesktopSettingsConfigPatch = {
   imageUploads?: {
     pastedImageMaxPatches?: number;
   };
+  /** Only the two selectable axes. `selectionSource` is main-owned derived
+   *  state: the write path sets it to `"user"` whenever a patch names
+   *  either axis, so a renderer can neither forget to send it nor forge
+   *  it. Leaving it off the patch type is what enforces that — the TOML
+   *  writer only emits the keys it names explicitly, so an extra field on
+   *  a patch object reaches no file. */
   updates?: {
     channel?: DesktopUpdateChannel;
     train?: DesktopUpdateTrain;


### PR DESCRIPTION
Ports the release-channel fix from [pwrdrvr/PwrSnap#559](https://github.com/pwrdrvr/PwrSnap/pull/559) to PwrAgent's Settings → Updates. Both PwrSnap bugs were verified against PwrAgent's own code before anything changed — the implementations are not identical, and one of them is worse here. A third bug turned up while testing on Windows and is fixed too.

## Bug 1 — the installed build's tag is ignored once any older config exists

`resolveUpdateSelection` seeded the train/track pair from the running app version **only** when both `updates.channel` and `updates.train` were absent. `channel` shipped before `train` did, so every config written by an older build carries `channel` alone — a half pair, which read as a deliberate Stable pin. A 1.1.0-alpha install was then offered the last stable release forever and never told about the newer alpha its own binary came from. An `-alpha` / `-beta` tag is supposed to be evidence of the Beta train.

Adds a main-owned `updates.selection_source`:

- while it reads `"inferred"`, the pair is **re-derived from the running binary on every settings read**;
- the write path derives `"user"` from any patch naming either axis, so no call site can persist a slot the next read would silently re-infer away;
- it is absent from `DesktopSettingsConfigPatch`, and `desktopSettingsPatchToEdits` only emits keys it names explicitly, so a renderer can neither forge it nor forget it. PwrAgent has no field-rejecting settings validator the way PwrSnap does — this structural property is what replaces it, and there is a test asserting the derivation and that an axis-free patch writes nothing;
- legacy configs are classified once: a complete non-default pair is an existing pin, anything else (no pair, a half pair, or the historical `latest`/`stable` default pair) re-infers.

`LEGACY_UNCHOSEN_UPDATE_PAIR` is frozen rather than read from `DESKTOP_UPDATE_*_DEFAULT`, so moving the shipped default later cannot retroactively reclassify those files as deliberate pins.

**One accepted behavior change:** an operator who deliberately pinned Stable/Latest while running an alpha is moved back onto Beta/Prerelease once. That is the same state on disk as the bug being fixed and nothing separates the two. Their next click writes `"user"` and pins for good.

## Bug 2 — the UI cannot report an empty slot without hiding a populated sibling

Each segmented control labelled itself from the slot the **other** control was on: the train buttons from `[train].latest`, the track buttons from the selected train. So on an alpha install Beta read "Beta — Unavailable" while Beta Prerelease held a shipped alpha one click away — visible in the Before shot, where the help line directly under the "Unavailable" button names `v1.1.0-alpha.2`.

Replaced with a 2×2 matrix of the four published slots, trains as rows and tracks as columns. Every tile states its own resolved version whether or not it is selected; an empty slot says *why* it is empty (from the release read's `unavailableReason`) and stays clickable; the tile matching the running binary carries an Installed chip; a tile click writes both axes in one patch. It is a roving-tabindex radiogroup whose selection does **not** follow focus, because picking a slot rewrites which build the app installs.

`Selected` and `Installed` are separate chips because they are separate claims — the case that matters is an operator who pinned Stable while running an alpha, where the pane has to be able to say they disagree.

### Before

![Updates before](https://github.com/user-attachments/assets/2e30a211-9c09-426c-8753-f0cf00568be2)

### After

![Updates after](https://github.com/user-attachments/assets/917e38aa-1bbc-46f6-9d56-281ef37472ed)

Same fixture data in both, rendered headlessly from the real `GeneralSettings` against `app.css` — the pre-change files were checked out to capture the Before, so it is the actual old component and not a mock of it.

## Bug 3 — a failed update check dumped its raw HttpError into the pane

Found while testing this on Windows: clicking **Check for Update** filled the Updates section with ~1.5 KB of electron-updater diagnostics — the request URL, every response header, and a stack of packaged file paths. Now summarized to one line, with the whole error kept in the log.

The 404 case is named rather than truncated, because it is not a transport failure. `Cannot find channel "<file>" update info` means the GitHub release the feed points at publishes no update manifest for this platform, so the slot has nothing installable even though the matrix shows its version:

> Update check failed: The Beta Prerelease release (v1.1.0-alpha.2) publishes no latest.yml for this platform, so there is nothing to install from it yet.

The same summarizer covers `autoUpdater.on("error")` (where download failures arrive at the same row) and the release read whose failure becomes every tile's `unavailableReason`.

**Not fixed here, deliberately:** the underlying gap is that *no* release publishes `latest.yml` — v1.0.3, v1.1.0-alpha.1 and v1.1.0-alpha.2 all carry `latest-mac.yml` only. Windows and Linux have never had an update manifest, so auto-update 404s on every slot there once a check gets past the "selected release is newer" guard. That is a release-pipeline change and belongs in its own PR. Making the failure legible does not make the update installable.

## Notes

- **No new theme tokens.** The tiles and chips reuse the existing accent, success, and surface tokens; PwrSnap's `--border-default` does not exist here, so the tiles use `--border-subtle`. `lint:colors` passes.
- The matrix is a new `ReleaseSlotMatrix` component so it is testable on its own; the Updates section stays inside `GeneralSettings` and the settings navigation is unchanged (PwrSnap moved Updates to its own page in a separate commit — that is not ported).
- `SettingsScreen` now has one `onUpdateSelectionChange` handler instead of two per-axis handlers that each had to re-send the axis the operator had not touched.
- PwrAgent's Claude Design project has a matching **Settings Release Channel Shipped** page recording the before/after, the config classification table, and the open finding 4.

## Verification

- `pnpm test` — 10,024 passed / 6 skipped across 678 files
- `pnpm lint` — 0 errors (45 pre-existing warnings, none in changed files); dependency-cruiser clean over 1,710 modules
- axe (WCAG 2.1 AA) on the matrix: 0 violations in dark and light
- roving tabindex verified in the DOM: exactly 1 of 4 tiles tabbable
- New coverage: 9 `ReleaseSlotMatrix` tests, 5 settings-service migration/pin tests, 2 patch-translator derivation tests, 2 auto-updater error-summary tests, 1 contract guard test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
