### PR TITLE
fix(desktop): refresh Codex usage limits

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6261,6 +6261,103 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("updates cached Codex rate limits from notifications without rewriting unchanged state", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        serverInfo: { name: "Codex App Server", version: "1.0.0" },
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+      rateLimits: [
+        {
+          name: "Weekly limit",
+          limitId: "codex",
+          usedPercent: 77,
+          remaining: 23,
+          resetAt: 1_788_748_108_000,
+          windowSeconds: 604_800,
+          windowMinutes: 10_080,
+        },
+        {
+          name: "GPT-5.3-Codex-Spark Weekly limit",
+          limitId: "codex_bengalfox",
+          usedPercent: 0,
+          remaining: 100,
+          resetAt: 1_789_090_523_000,
+          windowSeconds: 604_800,
+          windowMinutes: 10_080,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    const initialSummary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    let summarySeenByListener: BackendSummary | undefined;
+    const unsubscribe = registry.onEvent(async (event) => {
+      if (event.notification.method !== "account/rateLimits/updated") {
+        return;
+      }
+      summarySeenByListener = (
+        await registry.listBackends({ includeUnavailable: true })
+      ).backends[0];
+    });
+    const notification: AppServerNotification = {
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: "codex",
+          planType: "pro",
+          primary: {
+            usedPercent: 85,
+            windowDurationMins: 10_080,
+            resetsAt: 1_788_748_108,
+          },
+          secondary: null,
+        },
+      },
+    };
+
+    await codexClient.emit(notification);
+
+    const updatedSummary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(updatedSummary).not.toBe(initialSummary);
+    expect(summarySeenByListener).toBe(updatedSummary);
+    expect(updatedSummary?.rateLimits).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Weekly limit",
+          limitId: "codex",
+          usedPercent: 85,
+          remaining: 15,
+        }),
+        expect.objectContaining({
+          name: "GPT-5.3-Codex-Spark Weekly limit",
+          limitId: "codex_bengalfox",
+          remaining: 100,
+        }),
+      ]),
+    );
+
+    await codexClient.emit(notification);
+
+    const unchangedSummary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(unchangedSummary).toBe(updatedSummary);
+
+    unsubscribe();
+    await registry.close();
+  });
+
   it("prefers the running App Server's version over the next launch's", async () => {
     // The two disagree while a managed switch is pending: the connection is
     // still answering from the old build while resolution already names the

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1796,6 +1796,7 @@ class MockBackendClient {
       modelListErrors?: Error[];
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
+      rateLimitReadDelays?: Array<Promise<unknown> | undefined>;
       rateLimitReads?: BackendRateLimitSummary[][];
       listThreadsError?: Error;
       listThreadsDelay?: Promise<unknown>;
@@ -1978,7 +1979,13 @@ class MockBackendClient {
 
   async readRateLimits(): Promise<BackendRateLimitSummary[]> {
     this.readRateLimitsCallCount += 1;
-    return this.options.rateLimitReads?.shift() ?? this.options.rateLimits ?? [];
+    const rateLimits =
+      this.options.rateLimitReads?.shift() ?? this.options.rateLimits ?? [];
+    const delay = this.options.rateLimitReadDelays?.shift();
+    if (delay) {
+      await delay;
+    }
+    return rateLimits;
   }
 
   onNotification(
@@ -6551,6 +6558,219 @@ describe("DesktopBackendRegistry", () => {
         expect.objectContaining({ name: "Primary limit" }),
       ]),
     );
+
+    await registry.close();
+  });
+
+  it("refetches when a sparse Codex rate-limit window has no cached merge base", async () => {
+    const weeklyLimit: BackendRateLimitSummary = {
+      name: "Weekly limit",
+      limitId: "codex",
+      limitName: "Codex",
+      windowKey: "secondary",
+      usedPercent: 9,
+      remaining: 91,
+      windowMinutes: 10_080,
+    };
+    const refetchedRateLimits: BackendRateLimitSummary[] = [
+      {
+        name: "5h limit",
+        limitId: "codex",
+        limitName: "Codex",
+        windowKey: "primary",
+        usedPercent: 85,
+        remaining: 15,
+        windowMinutes: 300,
+      },
+      weeklyLimit,
+    ];
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      rateLimitReads: [[weeklyLimit], refetchedRateLimits],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    await codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: {
+            usedPercent: 85,
+            windowDurationMins: null,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+
+    const summary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(codexClient.readRateLimitsCallCount).toBe(2);
+    expect(summary.rateLimits).toEqual(refetchedRateLimits);
+    expect(summary.rateLimits).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Primary limit" }),
+      ]),
+    );
+
+    await registry.close();
+  });
+
+  it("retains a rate-limit notification that overtakes initial discovery", async () => {
+    const discoveryRelease = createDeferred<void>();
+    const initialRateLimits: BackendRateLimitSummary[] = [
+      {
+        name: "5h limit",
+        limitId: "codex",
+        limitName: "Codex",
+        windowKey: "primary",
+        usedPercent: 77,
+        remaining: 23,
+        windowMinutes: 300,
+      },
+    ];
+    const refetchedRateLimits: BackendRateLimitSummary[] = [
+      {
+        ...initialRateLimits[0],
+        usedPercent: 85,
+        remaining: 15,
+      },
+    ];
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      rateLimitReads: [initialRateLimits, refetchedRateLimits],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexRuntimeCommand: async () => {
+        await discoveryRelease.promise;
+        return {
+          command: path.join("/opt", "homebrew", "bin", "codex"),
+          version: "1.0.0",
+        };
+      },
+    });
+
+    const discovery = registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    await vi.waitFor(() => {
+      expect(codexClient.readRateLimitsCallCount).toBe(1);
+    });
+    await codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: "codex",
+          limitName: null,
+          primary: {
+            usedPercent: 85,
+            windowDurationMins: null,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+    expect(codexClient.readRateLimitsCallCount).toBe(2);
+    discoveryRelease.resolve();
+    await discovery;
+
+    const summary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(summary.rateLimits).toEqual(refetchedRateLimits);
+
+    await registry.close();
+  });
+
+  it("discards a sparse refetch when provider invalidation clears its summary", async () => {
+    const refetchRelease = createDeferred<void>();
+    const initialRateLimits: BackendRateLimitSummary[] = [
+      {
+        name: "5h limit",
+        limitId: "codex",
+        limitName: "Codex",
+        windowKey: "primary",
+        usedPercent: 77,
+        remaining: 23,
+        windowMinutes: 300,
+      },
+    ];
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      rateLimitReadDelays: [undefined, refetchRelease.promise],
+      rateLimitReads: [
+        initialRateLimits,
+        [
+          {
+            ...initialRateLimits[0],
+            usedPercent: 85,
+            remaining: 15,
+          },
+        ],
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    const notification = codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: null,
+          limitName: "Codex",
+          primary: {
+            usedPercent: 85,
+            windowDurationMins: null,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(codexClient.readRateLimitsCallCount).toBe(2);
+    });
+    await registry.invalidateProviderRuntimeSelections({
+      acp: false,
+      codex: true,
+    });
+    refetchRelease.resolve();
+
+    await expect(notification).resolves.toBeUndefined();
+    expect(
+      (await registry.listBackends({ includeUnavailable: true })).backends[0]
+        .rateLimits,
+    ).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1733,6 +1733,7 @@ class MockBackendClient {
   initializeCallCount = 0;
   listModelsCallCount = 0;
   readServerCapabilitiesCallCount = 0;
+  readRateLimitsCallCount = 0;
   steerTurnCallCount = 0;
   setThreadPermissionsCallCount = 0;
   lastListModelsDiagnostics?: {
@@ -1795,6 +1796,7 @@ class MockBackendClient {
       modelListErrors?: Error[];
       account?: BackendAccountSummary;
       rateLimits?: BackendRateLimitSummary[];
+      rateLimitReads?: BackendRateLimitSummary[][];
       listThreadsError?: Error;
       listThreadsDelay?: Promise<unknown>;
       respectThreadTitleFilter?: boolean;
@@ -1975,7 +1977,8 @@ class MockBackendClient {
   }
 
   async readRateLimits(): Promise<BackendRateLimitSummary[]> {
-    return this.options.rateLimits ?? [];
+    this.readRateLimitsCallCount += 1;
+    return this.options.rateLimitReads?.shift() ?? this.options.rateLimits ?? [];
   }
 
   onNotification(
@@ -6328,7 +6331,7 @@ describe("DesktopBackendRegistry", () => {
       params: {
         rateLimits: {
           limitId: "codex",
-          limitName: null,
+          limitName: "Codex",
           primary: {
             usedPercent,
             windowDurationMins: null,
@@ -6391,6 +6394,162 @@ describe("DesktopBackendRegistry", () => {
     expect(unchangedSummary).toBe(updatedSummary);
 
     unsubscribe();
+    await registry.close();
+  });
+
+  it("refetches Codex rate limits when a sparse notification omits its family ID", async () => {
+    const initialRateLimits: BackendRateLimitSummary[] = [
+      {
+        name: "5h limit",
+        limitId: "codex",
+        limitName: "Codex",
+        windowKey: "primary",
+        usedPercent: 77,
+        remaining: 23,
+        windowMinutes: 300,
+      },
+      {
+        name: "Weekly limit",
+        limitId: "codex",
+        limitName: "Codex",
+        windowKey: "secondary",
+        usedPercent: 9,
+        remaining: 91,
+        windowMinutes: 10_080,
+      },
+    ];
+    const refetchedRateLimits: BackendRateLimitSummary[] = [
+      {
+        ...initialRateLimits[0],
+        usedPercent: 85,
+        remaining: 15,
+      },
+      initialRateLimits[1],
+    ];
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+      rateLimitReads: [initialRateLimits, refetchedRateLimits],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    await codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: null,
+          limitName: "Codex",
+          primary: {
+            usedPercent: 85,
+            windowDurationMins: null,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+
+    const summary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(codexClient.readRateLimitsCallCount).toBe(2);
+    expect(summary.rateLimits).toEqual(refetchedRateLimits);
+    expect(summary.rateLimits).toHaveLength(2);
+    expect(summary.rateLimits).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Primary limit" }),
+      ]),
+    );
+
+    await registry.close();
+  });
+
+  it("preserves notification rate limits when concurrent discovery finishes later", async () => {
+    const discoveryRelease = createDeferred<void>();
+    let blockRuntimeResolution = false;
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+      rateLimits: [
+        {
+          name: "5h limit",
+          limitId: "codex",
+          limitName: "Codex",
+          windowKey: "primary",
+          usedPercent: 77,
+          remaining: 23,
+          windowMinutes: 300,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      resolveCodexRuntimeCommand: async () => {
+        if (blockRuntimeResolution) {
+          await discoveryRelease.promise;
+        }
+        return {
+          command: path.join("/opt", "homebrew", "bin", "codex"),
+          version: "1.0.0",
+        };
+      },
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    blockRuntimeResolution = true;
+    const discovery = discoverCodexBackendForTest(registry);
+    await vi.waitFor(() => {
+      expect(codexClient.readRateLimitsCallCount).toBe(2);
+    });
+    await codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: "codex",
+          limitName: null,
+          primary: {
+            usedPercent: 85,
+            windowDurationMins: null,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+    discoveryRelease.resolve();
+    await discovery;
+
+    const summary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(summary.rateLimits).toEqual([
+      expect.objectContaining({
+        name: "5h limit",
+        limitId: "codex",
+        usedPercent: 85,
+        remaining: 15,
+      }),
+    ]);
+
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6318,10 +6318,12 @@ describe("DesktopBackendRegistry", () => {
       await registry.listBackends({ includeUnavailable: true })
     ).backends[0];
     let summarySeenByListener: BackendSummary | undefined;
+    let rateLimitEventCount = 0;
     const unsubscribe = registry.onEvent(async (event) => {
       if (event.notification.method !== "account/rateLimits/updated") {
         return;
       }
+      rateLimitEventCount += 1;
       summarySeenByListener = (
         await registry.listBackends({ includeUnavailable: true })
       ).backends[0];
@@ -6352,6 +6354,7 @@ describe("DesktopBackendRegistry", () => {
       await registry.listBackends({ includeUnavailable: true })
     ).backends[0];
     expect(initiallyUnchangedSummary).toBe(initialSummary);
+    expect(rateLimitEventCount).toBe(0);
 
     await codexClient.emit(buildNotification(85));
 
@@ -6360,6 +6363,7 @@ describe("DesktopBackendRegistry", () => {
     ).backends[0];
     expect(updatedSummary).not.toBe(initialSummary);
     expect(summarySeenByListener).toBe(updatedSummary);
+    expect(rateLimitEventCount).toBe(1);
     expect(updatedSummary?.rateLimits).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -6392,9 +6396,85 @@ describe("DesktopBackendRegistry", () => {
       await registry.listBackends({ includeUnavailable: true })
     ).backends[0];
     expect(unchangedSummary).toBe(updatedSummary);
+    expect(rateLimitEventCount).toBe(1);
 
     unsubscribe();
     await registry.close();
+  });
+
+  it("coalesces changed Codex rate-limit broadcasts into a 20-second window", async () => {
+    vi.useFakeTimers();
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+      rateLimits: [
+        {
+          name: "5h limit",
+          limitId: "codex",
+          limitName: "Codex",
+          windowKey: "primary",
+          usedPercent: 77,
+          remaining: 23,
+          windowMinutes: 300,
+        },
+      ],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    try {
+      await registry.refreshProvidersAtStartup(
+        issueProviderDiscoveryPermit("startup"),
+      );
+      const broadcastValues: Array<number | undefined> = [];
+      registry.onEvent(async (event) => {
+        if (event.notification.method !== "account/rateLimits/updated") {
+          return;
+        }
+        const summary = (
+          await registry.listBackends({ includeUnavailable: true })
+        ).backends[0];
+        broadcastValues.push(summary.rateLimits?.[0]?.usedPercent);
+      });
+      const emitRateLimit = async (usedPercent: number): Promise<void> => {
+        await codexClient.emit({
+          method: "account/rateLimits/updated",
+          params: {
+            rateLimits: {
+              limitId: "codex",
+              limitName: null,
+              primary: {
+                usedPercent,
+                windowDurationMins: null,
+                resetsAt: null,
+              },
+              secondary: null,
+              individualLimit: null,
+              credits: null,
+              planType: null,
+              rateLimitReachedType: null,
+            },
+          },
+        });
+      };
+
+      await emitRateLimit(80);
+      await emitRateLimit(81);
+      await emitRateLimit(82);
+
+      expect(broadcastValues).toEqual([80]);
+      await vi.advanceTimersByTimeAsync(19_999);
+      expect(broadcastValues).toEqual([80]);
+      await vi.advanceTimersByTimeAsync(1);
+      expect(broadcastValues).toEqual([80, 82]);
+      expect(codexClient.readRateLimitsCallCount).toBe(1);
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
   });
 
   it("refetches Codex rate limits when a sparse notification omits its family ID", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6269,17 +6269,32 @@ describe("DesktopBackendRegistry", () => {
       },
       rateLimits: [
         {
-          name: "Weekly limit",
+          name: "5h limit",
           limitId: "codex",
+          limitName: "Codex",
+          windowKey: "primary",
           usedPercent: 77,
           remaining: 23,
           resetAt: 1_788_748_108_000,
+          windowSeconds: 18_000,
+          windowMinutes: 300,
+        },
+        {
+          name: "Weekly limit",
+          limitId: "codex",
+          limitName: "Codex",
+          windowKey: "secondary",
+          usedPercent: 9,
+          remaining: 91,
+          resetAt: 1_788_888_108_000,
           windowSeconds: 604_800,
           windowMinutes: 10_080,
         },
         {
           name: "GPT-5.3-Codex-Spark Weekly limit",
           limitId: "codex_bengalfox",
+          limitName: "GPT-5.3-Codex-Spark",
+          windowKey: "secondary",
           usedPercent: 0,
           remaining: 100,
           resetAt: 1_789_090_523_000,
@@ -6308,23 +6323,34 @@ describe("DesktopBackendRegistry", () => {
         await registry.listBackends({ includeUnavailable: true })
       ).backends[0];
     });
-    const notification: AppServerNotification = {
+    const buildNotification = (usedPercent: number): AppServerNotification => ({
       method: "account/rateLimits/updated",
       params: {
         rateLimits: {
           limitId: "codex",
-          planType: "pro",
+          limitName: null,
           primary: {
-            usedPercent: 85,
-            windowDurationMins: 10_080,
-            resetsAt: 1_788_748_108,
+            usedPercent,
+            windowDurationMins: null,
+            resetsAt: null,
           },
           secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
         },
       },
-    };
+    });
 
-    await codexClient.emit(notification);
+    await codexClient.emit(buildNotification(77));
+
+    const initiallyUnchangedSummary = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0];
+    expect(initiallyUnchangedSummary).toBe(initialSummary);
+
+    await codexClient.emit(buildNotification(85));
 
     const updatedSummary = (
       await registry.listBackends({ includeUnavailable: true })
@@ -6334,10 +6360,20 @@ describe("DesktopBackendRegistry", () => {
     expect(updatedSummary?.rateLimits).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: "Weekly limit",
+          name: "5h limit",
           limitId: "codex",
+          windowKey: "primary",
           usedPercent: 85,
           remaining: 15,
+          resetAt: 1_788_748_108_000,
+          windowMinutes: 300,
+        }),
+        expect.objectContaining({
+          name: "Weekly limit",
+          limitId: "codex",
+          windowKey: "secondary",
+          usedPercent: 9,
+          remaining: 91,
         }),
         expect.objectContaining({
           name: "GPT-5.3-Codex-Spark Weekly limit",
@@ -6347,7 +6383,7 @@ describe("DesktopBackendRegistry", () => {
       ]),
     );
 
-    await codexClient.emit(notification);
+    await codexClient.emit(buildNotification(85));
 
     const unchangedSummary = (
       await registry.listBackends({ includeUnavailable: true })

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2677,6 +2677,7 @@ describe("CodexAppServerClient", () => {
       {
         name: "Individual limit",
         limitId: "codex",
+        windowKey: "individual",
         limit: 100000,
         used: 3500.4,
         remaining: 96499.6,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5591,6 +5591,16 @@ function compareRateLimitSummaries(
   return rateLimitSummaryKey(left).localeCompare(rateLimitSummaryKey(right));
 }
 
+function rateLimitSummariesEqual(
+  left: BackendRateLimitSummary[],
+  right: BackendRateLimitSummary[],
+): boolean {
+  return isDeepStrictEqual(
+    [...left].sort(compareRateLimitSummaries),
+    [...right].sort(compareRateLimitSummaries),
+  );
+}
+
 function mergeRateLimitSummary(
   current: BackendRateLimitSummary,
   update: BackendRateLimitSummary,
@@ -7791,9 +7801,16 @@ export class DesktopBackendRegistry {
     "read" | "subscribe"
   >;
   private codexBackendSummary?: BackendSummary;
+  private codexBackendGeneration = 0;
   private codexRateLimitBroadcastTimer?: ReturnType<typeof setTimeout>;
   private codexRateLimitLastBroadcastAt?: number;
+  private codexRateLimitNotificationWork?: Promise<boolean>;
   private pendingCodexRateLimitBroadcast?: AgentEvent;
+  private pendingCodexRateLimits?: {
+    backendGeneration: number;
+    notificationVersion: number;
+    rateLimits: BackendRateLimitSummary[];
+  };
   private codexRateLimitsNotificationVersion = 0;
   private providerRuntimeFingerprints?: Readonly<Record<ProviderId, string>>;
   private providerRuntimeInvalidationPromise?: Promise<void>;
@@ -9928,7 +9945,15 @@ export class DesktopBackendRegistry {
     // not to discover or launch its replacement. The reconnectable client
     // resolves the new command only when the next permitted discovery or
     // ordinary provider operation initializes it.
+    this.codexBackendGeneration += 1;
     this.codexBackendSummary = undefined;
+    this.pendingCodexRateLimits = undefined;
+    this.pendingCodexRateLimitBroadcast = undefined;
+    this.codexRateLimitLastBroadcastAt = undefined;
+    if (this.codexRateLimitBroadcastTimer) {
+      clearTimeout(this.codexRateLimitBroadcastTimer);
+      this.codexRateLimitBroadcastTimer = undefined;
+    }
     this.modelCatalog.invalidate("codex");
     this.codexRuntimeRestartPending = true;
     await this.maybeRestartCodexForManagedRuntimeChange();
@@ -22325,9 +22350,15 @@ export class DesktopBackendRegistry {
           backend === "codex"
           && notification.method === "account/rateLimits/updated"
         ) {
-          const changed = await this.updateCachedCodexRateLimits(
+          const updateWork = this.updateCachedCodexRateLimits(
             notification.params.rateLimits,
           );
+          this.codexRateLimitNotificationWork = updateWork;
+          const changed = await updateWork.finally(() => {
+            if (this.codexRateLimitNotificationWork === updateWork) {
+              this.codexRateLimitNotificationWork = undefined;
+            }
+          });
           if (changed) {
             await this.scheduleCodexRateLimitBroadcast({
               backend,
@@ -24042,42 +24073,23 @@ export class DesktopBackendRegistry {
       return false;
     }
     const notificationVersion = ++this.codexRateLimitsNotificationVersion;
-    if (!this.codexBackendSummary) {
-      return false;
+    const backendGeneration = this.codexBackendGeneration;
+    const currentSummary = this.codexBackendSummary;
+    const currentRateLimits = currentSummary?.rateLimits ?? [];
+    const currentKeys = new Set(currentRateLimits.map(rateLimitSummaryKey));
+    if (
+      !currentSummary
+      || rateLimits.some(
+        (limit) =>
+          !limit.limitId?.trim()
+          || !currentKeys.has(rateLimitSummaryKey(limit)),
+      )
+    ) {
+      return await this.refetchCodexRateLimitsForNotification({
+        backendGeneration,
+        notificationVersion,
+      });
     }
-    if (rateLimits.some((limit) => !limit.limitId?.trim())) {
-      let refetchedRateLimits: BackendRateLimitSummary[];
-      try {
-        refetchedRateLimits = await readClientRateLimits(this.codexClient);
-      } catch (error) {
-        backendRegistryLog.warn(
-          "Codex rate-limit refetch after sparse notification failed",
-          { error: error instanceof Error ? error.message : String(error) },
-        );
-        return false;
-      }
-      if (
-        notificationVersion !== this.codexRateLimitsNotificationVersion
-        || refetchedRateLimits.length === 0
-      ) {
-        return false;
-      }
-      const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
-      if (
-        isDeepStrictEqual(
-          [...currentRateLimits].sort(compareRateLimitSummaries),
-          [...refetchedRateLimits].sort(compareRateLimitSummaries),
-        )
-      ) {
-        return false;
-      }
-      this.codexBackendSummary = {
-        ...this.codexBackendSummary,
-        rateLimits: refetchedRateLimits,
-      };
-      return true;
-    }
-    const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
     const updatesByKey = new Map(
       rateLimits.map((limit) => [rateLimitSummaryKey(limit), limit]),
     );
@@ -24090,19 +24102,62 @@ export class DesktopBackendRegistry {
       updatesByKey.delete(key);
       return mergeRateLimitSummary(current, update);
     });
-    mergedRateLimits.push(...updatesByKey.values());
-    if (
-      isDeepStrictEqual(
-        [...currentRateLimits].sort(compareRateLimitSummaries),
-        [...mergedRateLimits].sort(compareRateLimitSummaries),
-      )
-    ) {
+    if (rateLimitSummariesEqual(currentRateLimits, mergedRateLimits)) {
       return false;
     }
     this.codexBackendSummary = {
-      ...this.codexBackendSummary,
+      ...currentSummary,
       rateLimits: mergedRateLimits,
     };
+    if (
+      this.pendingCodexRateLimits?.backendGeneration === backendGeneration
+      && this.pendingCodexRateLimits.notificationVersion <= notificationVersion
+    ) {
+      this.pendingCodexRateLimits = undefined;
+    }
+    return true;
+  }
+
+  private async refetchCodexRateLimitsForNotification(params: {
+    backendGeneration: number;
+    notificationVersion: number;
+  }): Promise<boolean> {
+    let refetchedRateLimits: BackendRateLimitSummary[];
+    try {
+      refetchedRateLimits = await readClientRateLimits(this.codexClient);
+    } catch (error) {
+      backendRegistryLog.warn(
+        "Codex rate-limit refetch after sparse notification failed",
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return false;
+    }
+    if (
+      this.closed
+      || params.backendGeneration !== this.codexBackendGeneration
+      || params.notificationVersion !== this.codexRateLimitsNotificationVersion
+      || refetchedRateLimits.length === 0
+    ) {
+      return false;
+    }
+    const currentSummary = this.codexBackendSummary;
+    if (!currentSummary) {
+      this.pendingCodexRateLimits = {
+        backendGeneration: params.backendGeneration,
+        notificationVersion: params.notificationVersion,
+        rateLimits: refetchedRateLimits,
+      };
+      return false;
+    }
+    const currentRateLimits = currentSummary.rateLimits ?? [];
+    if (rateLimitSummariesEqual(currentRateLimits, refetchedRateLimits)) {
+      return false;
+    }
+    this.codexBackendSummary = {
+      ...currentSummary,
+      rateLimits: refetchedRateLimits,
+    };
+    this.pendingCodexRateLimits = undefined;
     return true;
   }
 
@@ -24170,6 +24225,7 @@ export class DesktopBackendRegistry {
   ): Promise<BackendSummary> {
     assertProviderDiscoveryPermit(permit);
     const previousSummary = this.readCodexBackendSummary();
+    const backendGeneration = this.codexBackendGeneration;
     const rateLimitsNotificationVersion = this.codexRateLimitsNotificationVersion;
     const { lastKnownGood } = this.readCodexProvider();
     const [
@@ -24185,6 +24241,21 @@ export class DesktopBackendRegistry {
       readClientRateLimits(this.codexClient),
       this.resolveCodexRuntimeCommandFn?.(),
     ]);
+    if (backendGeneration !== this.codexBackendGeneration) {
+      return this.readCodexBackendSummary();
+    }
+    let settledRateLimitsNotificationVersion = rateLimitsNotificationVersion;
+    while (
+      settledRateLimitsNotificationVersion
+      !== this.codexRateLimitsNotificationVersion
+    ) {
+      const observedVersion = this.codexRateLimitsNotificationVersion;
+      await this.codexRateLimitNotificationWork;
+      if (backendGeneration !== this.codexBackendGeneration) {
+        return this.readCodexBackendSummary();
+      }
+      settledRateLimitsNotificationVersion = observedVersion;
+    }
     // Resolution rejects when nothing is selected yet; the durable observation
     // is then the only thing left that can name a command.
     const runtimeCommand =
@@ -24232,10 +24303,17 @@ export class DesktopBackendRegistry {
       rateLimitsResult.status === "fulfilled"
         ? rateLimitsResult.value
         : undefined;
+    const pendingRateLimits =
+      this.pendingCodexRateLimits?.backendGeneration === backendGeneration
+      && this.pendingCodexRateLimits.notificationVersion
+        > rateLimitsNotificationVersion
+        ? this.pendingCodexRateLimits.rateLimits
+        : undefined;
     const rateLimits =
       rateLimitsNotificationVersion !== this.codexRateLimitsNotificationVersion
-      && this.codexBackendSummary
-        ? this.codexBackendSummary.rateLimits
+        ? pendingRateLimits
+          ?? this.codexBackendSummary?.rateLimits
+          ?? discoveredRateLimits
         : discoveredRateLimits;
     const summary: BackendSummary = {
       kind: "codex",
@@ -24290,6 +24368,9 @@ export class DesktopBackendRegistry {
       unavailableReason: available ? undefined : unavailableReason || "Codex unavailable",
     };
     this.codexBackendSummary = summary;
+    if (this.pendingCodexRateLimits?.backendGeneration === backendGeneration) {
+      this.pendingCodexRateLimits = undefined;
+    }
     return summary;
   }
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5576,7 +5576,10 @@ async function readClientRateLimits(client: BackendClient): Promise<BackendRateL
 }
 
 function rateLimitSummaryKey(limit: BackendRateLimitSummary): string {
-  return `${limit.limitId ?? ""}\u0000${limit.name}`;
+  return [
+    limit.limitId ?? "",
+    limit.windowKey ?? limit.name,
+  ].join("\u0000");
 }
 
 function compareRateLimitSummaries(
@@ -5584,6 +5587,31 @@ function compareRateLimitSummaries(
   right: BackendRateLimitSummary,
 ): number {
   return rateLimitSummaryKey(left).localeCompare(rateLimitSummaryKey(right));
+}
+
+function mergeRateLimitSummary(
+  current: BackendRateLimitSummary,
+  update: BackendRateLimitSummary,
+): BackendRateLimitSummary {
+  return {
+    ...current,
+    ...(update.limitId !== undefined ? { limitId: update.limitId } : {}),
+    ...(update.limitName !== undefined
+      ? { name: update.name, limitName: update.limitName }
+      : {}),
+    ...(update.windowKey !== undefined ? { windowKey: update.windowKey } : {}),
+    ...(update.remaining !== undefined ? { remaining: update.remaining } : {}),
+    ...(update.limit !== undefined ? { limit: update.limit } : {}),
+    ...(update.used !== undefined ? { used: update.used } : {}),
+    ...(update.usedPercent !== undefined ? { usedPercent: update.usedPercent } : {}),
+    ...(update.resetAt !== undefined ? { resetAt: update.resetAt } : {}),
+    ...(update.windowSeconds !== undefined
+      ? { windowSeconds: update.windowSeconds }
+      : {}),
+    ...(update.windowMinutes !== undefined
+      ? { windowMinutes: update.windowMinutes }
+      : {}),
+  };
 }
 
 type ModelSettings = {
@@ -23986,16 +24014,19 @@ export class DesktopBackendRegistry {
       return;
     }
     const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
-    const replacedLimitIds = new Set(
-      rateLimits.flatMap((limit) => limit.limitId ? [limit.limitId] : []),
+    const updatesByKey = new Map(
+      rateLimits.map((limit) => [rateLimitSummaryKey(limit), limit]),
     );
-    const replacedNames = new Set(rateLimits.map((limit) => limit.name));
-    const retainedRateLimits = currentRateLimits.filter(
-      (limit) =>
-        !(limit.limitId && replacedLimitIds.has(limit.limitId))
-        && !replacedNames.has(limit.name),
-    );
-    const mergedRateLimits = [...retainedRateLimits, ...rateLimits];
+    const mergedRateLimits = currentRateLimits.map((current) => {
+      const key = rateLimitSummaryKey(current);
+      const update = updatesByKey.get(key);
+      if (!update) {
+        return current;
+      }
+      updatesByKey.delete(key);
+      return mergeRateLimitSummary(current, update);
+    });
+    mergedRateLimits.push(...updatesByKey.values());
     if (
       isDeepStrictEqual(
         [...currentRateLimits].sort(compareRateLimitSummaries),

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -640,6 +640,7 @@ const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
 // changes, so this window can cover ordinary foreground idle time while
 // background polling catches external Codex changes on a slower cadence.
 const THREAD_LIST_REUSE_WINDOW_MS = 5 * 60_000;
+const CODEX_RATE_LIMIT_BROADCAST_WINDOW_MS = 20_000;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 const CODEX_WORKSPACE_CWD_SYNC_PENDING_WARNING =
@@ -7790,6 +7791,9 @@ export class DesktopBackendRegistry {
     "read" | "subscribe"
   >;
   private codexBackendSummary?: BackendSummary;
+  private codexRateLimitBroadcastTimer?: ReturnType<typeof setTimeout>;
+  private codexRateLimitLastBroadcastAt?: number;
+  private pendingCodexRateLimitBroadcast?: AgentEvent;
   private codexRateLimitsNotificationVersion = 0;
   private providerRuntimeFingerprints?: Readonly<Record<ProviderId, string>>;
   private providerRuntimeInvalidationPromise?: Promise<void>;
@@ -21161,6 +21165,11 @@ export class DesktopBackendRegistry {
       clearTimeout(this.missingCodexThreadEvaluationTimer);
       this.missingCodexThreadEvaluationTimer = undefined;
     }
+    if (this.codexRateLimitBroadcastTimer) {
+      clearTimeout(this.codexRateLimitBroadcastTimer);
+      this.codexRateLimitBroadcastTimer = undefined;
+    }
+    this.pendingCodexRateLimitBroadcast = undefined;
     await this.missingCodexThreadEvaluation;
     // Live usage and command output may each have one bounded window sitting
     // in memory. `closed` prevents either drain from re-arming its timer; the
@@ -22316,7 +22325,16 @@ export class DesktopBackendRegistry {
           backend === "codex"
           && notification.method === "account/rateLimits/updated"
         ) {
-          await this.updateCachedCodexRateLimits(notification.params.rateLimits);
+          const changed = await this.updateCachedCodexRateLimits(
+            notification.params.rateLimits,
+          );
+          if (changed) {
+            await this.scheduleCodexRateLimitBroadcast({
+              backend,
+              notification,
+            });
+          }
+          return;
         }
         if (
           backend === "codex" &&
@@ -24018,14 +24036,14 @@ export class DesktopBackendRegistry {
     });
   }
 
-  private async updateCachedCodexRateLimits(value: unknown): Promise<void> {
+  private async updateCachedCodexRateLimits(value: unknown): Promise<boolean> {
     const rateLimits = extractRateLimitSummaries(value);
     if (rateLimits.length === 0) {
-      return;
+      return false;
     }
     const notificationVersion = ++this.codexRateLimitsNotificationVersion;
     if (!this.codexBackendSummary) {
-      return;
+      return false;
     }
     if (rateLimits.some((limit) => !limit.limitId?.trim())) {
       let refetchedRateLimits: BackendRateLimitSummary[];
@@ -24036,13 +24054,13 @@ export class DesktopBackendRegistry {
           "Codex rate-limit refetch after sparse notification failed",
           { error: error instanceof Error ? error.message : String(error) },
         );
-        return;
+        return false;
       }
       if (
         notificationVersion !== this.codexRateLimitsNotificationVersion
         || refetchedRateLimits.length === 0
       ) {
-        return;
+        return false;
       }
       const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
       if (
@@ -24051,13 +24069,13 @@ export class DesktopBackendRegistry {
           [...refetchedRateLimits].sort(compareRateLimitSummaries),
         )
       ) {
-        return;
+        return false;
       }
       this.codexBackendSummary = {
         ...this.codexBackendSummary,
         rateLimits: refetchedRateLimits,
       };
-      return;
+      return true;
     }
     const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
     const updatesByKey = new Map(
@@ -24079,12 +24097,52 @@ export class DesktopBackendRegistry {
         [...mergedRateLimits].sort(compareRateLimitSummaries),
       )
     ) {
-      return;
+      return false;
     }
     this.codexBackendSummary = {
       ...this.codexBackendSummary,
       rateLimits: mergedRateLimits,
     };
+    return true;
+  }
+
+  private async scheduleCodexRateLimitBroadcast(event: AgentEvent): Promise<void> {
+    const now = Date.now();
+    this.pendingCodexRateLimitBroadcast = event;
+    const elapsed = this.codexRateLimitLastBroadcastAt === undefined
+      ? CODEX_RATE_LIMIT_BROADCAST_WINDOW_MS
+      : now - this.codexRateLimitLastBroadcastAt;
+    if (elapsed >= CODEX_RATE_LIMIT_BROADCAST_WINDOW_MS) {
+      if (this.codexRateLimitBroadcastTimer) {
+        clearTimeout(this.codexRateLimitBroadcastTimer);
+        this.codexRateLimitBroadcastTimer = undefined;
+      }
+      await this.flushPendingCodexRateLimitBroadcast(now);
+      return;
+    }
+    if (this.codexRateLimitBroadcastTimer) {
+      return;
+    }
+    this.codexRateLimitBroadcastTimer = setTimeout(() => {
+      this.codexRateLimitBroadcastTimer = undefined;
+      void this.flushPendingCodexRateLimitBroadcast().catch((error) => {
+        backendRegistryLog.error("Codex rate-limit broadcast failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    }, CODEX_RATE_LIMIT_BROADCAST_WINDOW_MS - elapsed);
+  }
+
+  private async flushPendingCodexRateLimitBroadcast(
+    broadcastAt = Date.now(),
+  ): Promise<void> {
+    const event = this.pendingCodexRateLimitBroadcast;
+    this.pendingCodexRateLimitBroadcast = undefined;
+    if (!event || this.closed) {
+      return;
+    }
+    this.codexRateLimitLastBroadcastAt = broadcastAt;
+    await this.emitToListeners(event);
   }
 
   /**
@@ -37548,10 +37606,12 @@ export class DesktopBackendRegistry {
   /**
    * Fan an event out to subscribers without running any of `emit`'s recording
    * stages. Only for events that are a *view* of something already recorded —
-   * a managed review's forwarded activity is the sole caller. Running those
-   * through `emit` would re-execute the whole pipeline against the parent
-   * thread id, which double-counts tool accounting (a sqlite write per item)
-   * and pollutes the file-change approval-context cache.
+   * managed-review forwarding and coalesced rate-limit cache broadcasts use
+   * this path. Running managed-review views through `emit` would re-execute
+   * the whole pipeline against the parent thread id, which double-counts tool
+   * accounting (a sqlite write per item) and pollutes the file-change
+   * approval-context cache. Rate-limit broadcasts have no thread recording
+   * semantics and likewise belong only at the listener boundary.
    */
   private async emitToListeners(event: AgentEvent): Promise<void> {
     for (const listener of this.eventListeners) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -7,7 +7,7 @@ import { mkdir, realpath, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { promisify } from "node:util";
+import { isDeepStrictEqual, promisify } from "node:util";
 import type {
   DynamicToolSpec as CodexDynamicToolSpec,
   ThreadForkParams as CodexThreadForkParams,
@@ -367,6 +367,7 @@ import {
 import {
   CodexAppServerClient,
   DEFAULT_CODEX_THREAD_TITLE_MODEL,
+  extractRateLimitSummaries,
   type CodexPwrdrvrTokenMiserActivation,
   type CodexServerCapabilities,
 } from "../codex-app-server/client";
@@ -5572,6 +5573,17 @@ async function readClientRateLimits(client: BackendClient): Promise<BackendRateL
     return [];
   }
   return await client.readRateLimits();
+}
+
+function rateLimitSummaryKey(limit: BackendRateLimitSummary): string {
+  return `${limit.limitId ?? ""}\u0000${limit.name}`;
+}
+
+function compareRateLimitSummaries(
+  left: BackendRateLimitSummary,
+  right: BackendRateLimitSummary,
+): number {
+  return rateLimitSummaryKey(left).localeCompare(rateLimitSummaryKey(right));
 }
 
 type ModelSettings = {
@@ -22260,6 +22272,12 @@ export class DesktopBackendRegistry {
       client.onNotification(async (notification) => {
         logBackendLifecycleNotification(backend, notification);
         if (
+          backend === "codex"
+          && notification.method === "account/rateLimits/updated"
+        ) {
+          this.updateCachedCodexRateLimits(notification.params.rateLimits);
+        }
+        if (
           backend === "codex" &&
           notification.method === "thread/codexSettings/observed"
         ) {
@@ -23957,6 +23975,39 @@ export class DesktopBackendRegistry {
       ],
       ...(available ? {} : { unavailableReason }),
     });
+  }
+
+  private updateCachedCodexRateLimits(value: unknown): void {
+    if (!this.codexBackendSummary) {
+      return;
+    }
+    const rateLimits = extractRateLimitSummaries(value);
+    if (rateLimits.length === 0) {
+      return;
+    }
+    const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
+    const replacedLimitIds = new Set(
+      rateLimits.flatMap((limit) => limit.limitId ? [limit.limitId] : []),
+    );
+    const replacedNames = new Set(rateLimits.map((limit) => limit.name));
+    const retainedRateLimits = currentRateLimits.filter(
+      (limit) =>
+        !(limit.limitId && replacedLimitIds.has(limit.limitId))
+        && !replacedNames.has(limit.name),
+    );
+    const mergedRateLimits = [...retainedRateLimits, ...rateLimits];
+    if (
+      isDeepStrictEqual(
+        [...currentRateLimits].sort(compareRateLimitSummaries),
+        [...mergedRateLimits].sort(compareRateLimitSummaries),
+      )
+    ) {
+      return;
+    }
+    this.codexBackendSummary = {
+      ...this.codexBackendSummary,
+      rateLimits: mergedRateLimits,
+    };
   }
 
   /**

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -368,6 +368,7 @@ import {
   CodexAppServerClient,
   DEFAULT_CODEX_THREAD_TITLE_MODEL,
   extractRateLimitSummaries,
+  formatRateLimitWindowName,
   type CodexPwrdrvrTokenMiserActivation,
   type CodexServerCapabilities,
 } from "../codex-app-server/client";
@@ -5593,11 +5594,11 @@ function mergeRateLimitSummary(
   current: BackendRateLimitSummary,
   update: BackendRateLimitSummary,
 ): BackendRateLimitSummary {
-  return {
+  const merged: BackendRateLimitSummary = {
     ...current,
     ...(update.limitId !== undefined ? { limitId: update.limitId } : {}),
     ...(update.limitName !== undefined
-      ? { name: update.name, limitName: update.limitName }
+      ? { limitName: update.limitName }
       : {}),
     ...(update.windowKey !== undefined ? { windowKey: update.windowKey } : {}),
     ...(update.remaining !== undefined ? { remaining: update.remaining } : {}),
@@ -5612,6 +5613,17 @@ function mergeRateLimitSummary(
       ? { windowMinutes: update.windowMinutes }
       : {}),
   };
+  if (merged.windowKey === "primary" || merged.windowKey === "secondary") {
+    merged.name = formatRateLimitWindowName({
+      limitId: merged.limitId,
+      limitName: merged.limitName,
+      windowKey: merged.windowKey,
+      windowMinutes: merged.windowMinutes,
+    });
+  } else if (update.limitName !== undefined) {
+    merged.name = update.name;
+  }
+  return merged;
 }
 
 type ModelSettings = {
@@ -7778,6 +7790,7 @@ export class DesktopBackendRegistry {
     "read" | "subscribe"
   >;
   private codexBackendSummary?: BackendSummary;
+  private codexRateLimitsNotificationVersion = 0;
   private providerRuntimeFingerprints?: Readonly<Record<ProviderId, string>>;
   private providerRuntimeInvalidationPromise?: Promise<void>;
   private readonly overlayStore: BackendRegistryOverlayStoreLike;
@@ -22303,7 +22316,7 @@ export class DesktopBackendRegistry {
           backend === "codex"
           && notification.method === "account/rateLimits/updated"
         ) {
-          this.updateCachedCodexRateLimits(notification.params.rateLimits);
+          await this.updateCachedCodexRateLimits(notification.params.rateLimits);
         }
         if (
           backend === "codex" &&
@@ -24005,12 +24018,45 @@ export class DesktopBackendRegistry {
     });
   }
 
-  private updateCachedCodexRateLimits(value: unknown): void {
+  private async updateCachedCodexRateLimits(value: unknown): Promise<void> {
+    const rateLimits = extractRateLimitSummaries(value);
+    if (rateLimits.length === 0) {
+      return;
+    }
+    const notificationVersion = ++this.codexRateLimitsNotificationVersion;
     if (!this.codexBackendSummary) {
       return;
     }
-    const rateLimits = extractRateLimitSummaries(value);
-    if (rateLimits.length === 0) {
+    if (rateLimits.some((limit) => !limit.limitId?.trim())) {
+      let refetchedRateLimits: BackendRateLimitSummary[];
+      try {
+        refetchedRateLimits = await readClientRateLimits(this.codexClient);
+      } catch (error) {
+        backendRegistryLog.warn(
+          "Codex rate-limit refetch after sparse notification failed",
+          { error: error instanceof Error ? error.message : String(error) },
+        );
+        return;
+      }
+      if (
+        notificationVersion !== this.codexRateLimitsNotificationVersion
+        || refetchedRateLimits.length === 0
+      ) {
+        return;
+      }
+      const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
+      if (
+        isDeepStrictEqual(
+          [...currentRateLimits].sort(compareRateLimitSummaries),
+          [...refetchedRateLimits].sort(compareRateLimitSummaries),
+        )
+      ) {
+        return;
+      }
+      this.codexBackendSummary = {
+        ...this.codexBackendSummary,
+        rateLimits: refetchedRateLimits,
+      };
       return;
     }
     const currentRateLimits = this.codexBackendSummary.rateLimits ?? [];
@@ -24066,6 +24112,7 @@ export class DesktopBackendRegistry {
   ): Promise<BackendSummary> {
     assertProviderDiscoveryPermit(permit);
     const previousSummary = this.readCodexBackendSummary();
+    const rateLimitsNotificationVersion = this.codexRateLimitsNotificationVersion;
     const { lastKnownGood } = this.readCodexProvider();
     const [
       initializeResult,
@@ -24123,6 +24170,15 @@ export class DesktopBackendRegistry {
       capabilities.startReview = true;
     }
 
+    const discoveredRateLimits =
+      rateLimitsResult.status === "fulfilled"
+        ? rateLimitsResult.value
+        : undefined;
+    const rateLimits =
+      rateLimitsNotificationVersion !== this.codexRateLimitsNotificationVersion
+      && this.codexBackendSummary
+        ? this.codexBackendSummary.rateLimits
+        : discoveredRateLimits;
     const summary: BackendSummary = {
       kind: "codex",
       label: BACKEND_LABELS.codex,
@@ -24132,10 +24188,7 @@ export class DesktopBackendRegistry {
         isMeaningfulAccountSummary(accountResult.value)
           ? accountResult.value
           : undefined,
-      rateLimits:
-        rateLimitsResult.status === "fulfilled"
-          ? rateLimitsResult.value
-          : undefined,
+      rateLimits,
       serverName: successful[0]?.serverInfo?.name,
       // Today's `initialize` carries no `serverInfo` at all; the App Server's
       // version reaches us inside the `userAgent` it does report. The resolved

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1454,7 +1454,7 @@ function findFirstNestedValue(value: unknown, keys: string[], depth = 0): unknow
   return undefined;
 }
 
-function formatRateLimitWindowName(params: {
+export function formatRateLimitWindowName(params: {
   limitId?: string;
   limitName?: string;
   windowKey: "primary" | "secondary";

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1511,6 +1511,8 @@ export function extractRateLimitSummaries(
     out.set(name, {
       name,
       limitId: params.limitId,
+      limitName: params.limitName,
+      windowKey: params.windowKey,
       usedPercent,
       remaining:
         typeof usedPercent === "number" ? Math.max(0, Math.round(100 - usedPercent)) : undefined,
@@ -1548,6 +1550,8 @@ export function extractRateLimitSummaries(
     out.set(name, {
       name,
       limitId: params.limitId,
+      limitName: params.limitName,
+      windowKey: "individual",
       limit,
       used,
       remaining:
@@ -1629,6 +1633,8 @@ export function extractRateLimitSummaries(
       out.set(name, {
         name,
         limitId: existing?.limitId,
+        limitName: existing?.limitName,
+        windowKey: existing?.windowKey,
         remaining: remaining ?? existing?.remaining,
         limit: limit ?? existing?.limit,
         used: used ?? existing?.used,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1483,7 +1483,9 @@ function formatRateLimitWindowName(params: {
   return `${rawName ?? rawId} ${windowLabel}`.trim();
 }
 
-function extractRateLimitSummaries(value: unknown): BackendRateLimitSummary[] {
+export function extractRateLimitSummaries(
+  value: unknown,
+): BackendRateLimitSummary[] {
   const out = new Map<string, BackendRateLimitSummary>();
   const addWindow = (
     windowValue: unknown,

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
@@ -19,6 +19,12 @@ describe("backend status formatting", () => {
         { name: "GPT-5.3-Codex-Spark 5h limit", usedPercent: 2 },
         { name: "5h limit", usedPercent: 26 },
         { name: "Individual limit", usedPercent: 4 },
+        {
+          name: "gpt-reserve Weekly limit",
+          limitId: "base_model_inference",
+          limitName: "gpt-reserve",
+          usedPercent: 0,
+        },
         { name: "other limit", usedPercent: 50 },
       ],
     };

--- a/apps/desktop/src/renderer/src/lib/backend-status-format.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-status-format.ts
@@ -34,6 +34,9 @@ export function selectVisibleRateLimits(
       if (backend.kind !== "codex") {
         return true;
       }
+      if (isHiddenCodexRateLimit(limit)) {
+        return false;
+      }
       const { label } = splitRateLimitName(limit.name);
       return label === "5h limit"
         || label === "Weekly limit"
@@ -111,6 +114,12 @@ function formatWholeNumber(value: number): string {
 
 function isSparkRateLimit(limit: BackendRateLimitSummary): boolean {
   return isSparkName(limit.limitId) || isSparkName(limit.name);
+}
+
+function isHiddenCodexRateLimit(limit: BackendRateLimitSummary): boolean {
+  return limit.limitId?.toLowerCase() === "base_model_inference"
+    || limit.limitName?.toLowerCase() === "gpt-reserve"
+    || limit.name.toLowerCase().startsWith("gpt-reserve ");
 }
 
 function isSparkName(value: string | undefined): boolean {

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -203,6 +203,10 @@ export type BackendAccountSummary = {
 export type BackendRateLimitSummary = {
   name: string;
   limitId?: string;
+  /** Provider label retained so a sparse update cannot erase it. */
+  limitName?: string;
+  /** Provider slot used to merge sparse rolling updates with a full snapshot. */
+  windowKey?: "primary" | "secondary" | "individual";
   remaining?: number;
   limit?: number;
   used?: number;


### PR DESCRIPTION
## Summary

- apply `account/rateLimits/updated` payloads to the in-memory Codex backend summary before event fan-out
- merge sparse updates by provider window while preserving unavailable metadata, secondary windows, and unrelated limit families
- derive display names from merged window metadata so omitted durations cannot hide cached limits
- refetch the authoritative snapshot when a sparse update omits its family ID or has no cached merge base
- retain authoritative notification snapshots that overtake initial provider discovery
- generation-guard refetches and discovery so provider invalidation cannot revive stale quota state
- skip cache replacement when the normalized values are unchanged
- suppress unchanged notification fan-out and coalesce changed broadcasts to one per 20-second window
- deliver quota refresh signals directly to listeners without entering thread recording or SQLite accounting
- keep live quota state out of SQLite and all other persistent stores
- hide the internal `base_model_inference` / `gpt-reserve` bucket so it does not appear as a duplicate weekly limit

## Root cause

PR #1925 changed passive `listBackends` calls from live Codex account reads to a cached backend summary as part of the targeted configuration-store work. The renderer still reacted to rate-limit notifications by calling `listBackends`, so it repeatedly received the original cached percentage.

A live protocol capture reproduced the report: `account/rateLimits/read` and `account/rateLimits/updated` both reported 85% used / 15% left while the PwrAgent UI remained at its cached 23% left.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/backend-registry.test.ts apps/desktop/src/main/__tests__/codex-client.test.ts` (800 passed)
- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts` (5 passed)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings only)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`
