### PR TITLE
fix(desktop): narrow federation compatibility fallbacks

### DIFF
--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -74,7 +74,9 @@ describe("FederatedSearchService", () => {
           label: "Older Mac",
           backend: {
             resolveThread: vi.fn(async () => {
-              throw new Error("Unsupported federation method");
+              throw Object.assign(new Error("Unsupported federation method"), {
+                code: "method_not_found",
+              });
             }),
             listThreads: vi.fn(async () => ({
               backend: "codex" as const,
@@ -99,6 +101,40 @@ describe("FederatedSearchService", () => {
       ],
       failures: [],
     });
+  });
+
+  it("does not amplify a resolve failure into full active and archive scans", async () => {
+    const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
+    const listThreads = vi.fn();
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_broken",
+        label: "Broken Mac",
+        backend: {
+          resolveThread: vi.fn(async () => {
+            throw Object.assign(new Error("Remote handler failed"), {
+              code: "handler_failed",
+            });
+          }),
+          listThreads,
+        },
+      }],
+    });
+
+    await expect(service.search({
+      query: threadId,
+      backend: "codex",
+      includeArchived: true,
+    })).resolves.toMatchObject({
+      results: [],
+      failures: [{
+        instanceId: "pwr_broken",
+        error: "Remote handler failed",
+      }],
+    });
+    expect(listThreads).not.toHaveBeenCalled();
   });
 
   it("fans out to local and remote peers and preserves source identity", async () => {

--- a/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-message-service.test.ts
@@ -50,7 +50,10 @@ function buildRuntime(params: {
       };
       const resolveThread = vi.fn(async () => {
         if (peer.resolveUnsupported) {
-          throw new Error("Unsupported federation method: backend.resolveThread");
+          throw Object.assign(
+            new Error("Unsupported federation method: backend.resolveThread"),
+            { code: "method_not_found" },
+          );
         }
         return peer.ownsThread ? { thread: ownedThread } : {};
       });
@@ -275,7 +278,10 @@ describe("federated thread message service", () => {
       }],
       remoteBackend: () => ({
         resolveThread: vi.fn(async () => {
-          throw new Error("Unsupported federation method: backend.resolveThread");
+          throw Object.assign(
+            new Error("Unsupported federation method: backend.resolveThread"),
+            { code: "method_not_found" },
+          );
         }),
         listThreads,
         startTurn,
@@ -517,6 +523,31 @@ describe("federated thread message service", () => {
     expect(backends.get("pwr_older")?.listThreads).toHaveBeenCalledWith({
       backend: "codex",
     });
+  });
+
+  it("does not amplify a resolve failure into a full thread-list scan", async () => {
+    const listThreads = vi.fn();
+    const runtime = {
+      connectedPeerTargets: () => [{
+        target: { scope: "remote" as const, instanceId: "pwr_broken" },
+        label: "Broken Mac",
+        capabilities: ["thread_navigation", "turn_control"],
+      }],
+      remoteBackend: () => ({
+        resolveThread: vi.fn(async () => {
+          throw Object.assign(new Error("Remote handler failed"), {
+            code: "handler_failed",
+          });
+        }),
+        listThreads,
+      }),
+    } as unknown as DesktopFederationRuntime;
+    const handler = createFederatedThreadMessageHandler({
+      runtime: () => runtime,
+    });
+
+    await expect(handler(request)).rejects.toThrow("Remote handler failed");
+    expect(listThreads).not.toHaveBeenCalled();
   });
 
   it("refuses an ambiguous UUID reported by multiple peers", async () => {

--- a/apps/desktop/src/main/__tests__/federated-thread-target-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-thread-target-service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import type { AppServerThreadSummary } from "@pwragent/shared";
+import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
+import {
+  resolveFederatedThreadTarget,
+  type FederatedThreadTargetRuntime,
+} from "../federation/federated-thread-target-service";
+
+const thread: AppServerThreadSummary = {
+  id: "019fd821-1450-7952-85ca-3bb8e5d150da",
+  title: "Federated owner",
+  titleSource: "explicit",
+  source: "codex",
+  linkedDirectories: [],
+};
+
+function runtimeWithBackend(
+  backend: FederationBackendOperations,
+): FederatedThreadTargetRuntime {
+  return {
+    connectedPeerTargets: () => [{
+      target: { scope: "remote", instanceId: "pwr_remote" },
+      label: "Remote Mac",
+      capabilities: ["thread_navigation"],
+    }],
+    health: vi.fn(),
+    remoteBackend: () => backend,
+  } as unknown as FederatedThreadTargetRuntime;
+}
+
+describe("resolveFederatedThreadTarget", () => {
+  it("uses exact list scanning only when an older peer lacks resolveThread", async () => {
+    const listThreads = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: 1_000,
+      threads: [thread],
+    }));
+    const runtime = runtimeWithBackend({
+      resolveThread: vi.fn(async () => {
+        throw Object.assign(new Error("Unsupported federation method"), {
+          code: "method_not_found",
+        });
+      }),
+      listThreads,
+    } as unknown as FederationBackendOperations);
+
+    await expect(resolveFederatedThreadTarget({
+      runtime,
+      request: {
+        backend: "codex",
+        instanceId: "pwr_remote",
+        threadId: thread.id,
+      },
+    })).resolves.toMatchObject({ thread: { id: thread.id } });
+    expect(listThreads).toHaveBeenCalledExactlyOnceWith({ backend: "codex" });
+  });
+
+  it.each([
+    {
+      label: "handler failure",
+      error: Object.assign(new Error("Remote handler failed"), {
+        code: "handler_failed",
+      }),
+    },
+    {
+      label: "timeout",
+      error: new Error("Federation request timed out: backend.resolveThread"),
+    },
+  ])("does not amplify a $label into full thread-list scans", async ({ error }) => {
+    const listThreads = vi.fn();
+    const runtime = runtimeWithBackend({
+      resolveThread: vi.fn(async () => {
+        throw error;
+      }),
+      listThreads,
+    } as unknown as FederationBackendOperations);
+
+    await expect(resolveFederatedThreadTarget({
+      runtime,
+      request: {
+        backend: "codex",
+        instanceId: "pwr_remote",
+        threadId: thread.id,
+      },
+    })).rejects.toThrow(error.message);
+    expect(listThreads).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -11,6 +11,7 @@ import {
   buildThreadIdentityKey,
 } from "@pwragent/shared";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
+import { hasFederationErrorCode } from "./federation-rpc";
 
 export type FederatedSearchPeer = {
   instanceId: FederationInstanceId;
@@ -208,7 +209,10 @@ export class FederatedSearchService {
       if (!request.includeArchived) {
         return null;
       }
-    } catch {
+    } catch (error) {
+      if (!hasFederationErrorCode(error, "method_not_found")) {
+        throw error;
+      }
       // Mixed-version peers may not expose the exact lookup RPC yet. Fall
       // through to exact list scans rather than using fuzzy UUID filtering.
     }

--- a/apps/desktop/src/main/federation/federated-thread-message-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-message-service.ts
@@ -19,6 +19,7 @@ import { getMainLogger } from "../log";
 import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
 import { isFederationPeerUnavailableError } from "./federation-peer-unavailable-error";
+import { hasFederationErrorCode } from "./federation-rpc";
 import {
   getDesktopFederationRuntime,
   type DesktopFederationRuntime,
@@ -221,7 +222,10 @@ async function resolveThreadOnPeer(
         threadId: request.threadId,
       })
     ).thread;
-  } catch {
+  } catch (error) {
+    if (!hasFederationErrorCode(error, "method_not_found")) {
+      throw error;
+    }
     // Mixed-version peers may predate backend.resolveThread. Their unfiltered
     // list still provides an exact-ID compatibility path.
     thread = (

--- a/apps/desktop/src/main/federation/federated-thread-target-service.ts
+++ b/apps/desktop/src/main/federation/federated-thread-target-service.ts
@@ -11,6 +11,7 @@ import { formatFederationPeerDisplayLabel } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import type { RemoteThreadTargetStore } from "../state/remote-thread-target-store";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
+import { hasFederationErrorCode } from "./federation-rpc";
 
 export type FederatedThreadTargetRuntime = {
   connectedPeerTargets(): Array<{
@@ -169,7 +170,10 @@ async function resolveThreadOnPeer(
         threadId: request.threadId,
       })
     ).thread;
-  } catch {
+  } catch (error) {
+    if (!hasFederationErrorCode(error, "method_not_found")) {
+      throw error;
+    }
     // Mixed-version peers may predate backend.resolveThread. Their unfiltered
     // list still provides an exact-ID compatibility path.
     thread = (

--- a/apps/desktop/src/main/federation/federation-rpc.ts
+++ b/apps/desktop/src/main/federation/federation-rpc.ts
@@ -14,6 +14,18 @@ type PendingRequest = {
   timer: ReturnType<typeof setTimeout>;
 };
 
+export function hasFederationErrorCode(
+  error: unknown,
+  code: string,
+): boolean {
+  return (
+    typeof error === "object"
+    && error !== null
+    && "code" in error
+    && error.code === code
+  );
+}
+
 export class FederationRpcEndpoint {
   private readonly pending = new Map<string, PendingRequest>();
 

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -18,6 +18,7 @@ import {
 } from "@pwragent/shared";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
 import { ThreadInfoStore } from "../app-server/thread-info-store";
+import { hasFederationErrorCode } from "./federation-rpc";
 
 export type RemoteThreadSummaryPeer = {
   target: FederationRemoteTarget;
@@ -1079,14 +1080,6 @@ function withTimeout<T>(
   });
 }
 
-function hasFederationErrorCode(error: unknown, code: string): boolean {
-  return (
-    typeof error === "object"
-    && error !== null
-    && "code" in error
-    && error.code === code
-  );
-}
 
 function rankUniqueThreadJumpMatches(
   threads: readonly NavigationThreadSummary[],


### PR DESCRIPTION
## Summary
- fall back from resolveThread to full list scans only when a peer returns method_not_found
- preserve timeout, capability, and handler failures without issuing a second unbounded RPC
- share federation error-code detection across target, messaging, generic search, and Cmd+K compatibility paths

## Tests
- 77 focused federation tests pass
- pnpm typecheck
- pnpm lint:eslint (0 errors; 45 existing warnings)
- pnpm lint:boundaries
- full pnpm test: 10,027 passed, 6 skipped; two unrelated parallel-load timeouts passed in isolation