### PR TITLE
fix(desktop): bound the setup-failure panel and stop it resurfacing

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-store-environment-failure.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-environment-failure.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+import { openInMemoryStateDb } from "./sqlite-test-utils";
+
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+
+async function seedFailedSetup(): Promise<void> {
+  await store.setThreadCodexEnvironmentRuntime({
+    backend: "codex",
+    threadId: "thread-1",
+    codexEnvironmentRuntime: {
+      environmentId: "environment-1",
+      environmentName: "PwrAgent",
+      executionTarget: "local",
+      setupStatus: "failed",
+      setupCommand: "pnpm install",
+      setupExitCode: 1,
+      setupOutput: "boom",
+    },
+  });
+}
+
+async function readRuntime() {
+  const overlay = await store.getThreadOverlayState({
+    backend: "codex",
+    threadId: "thread-1",
+  });
+  return overlay?.codexEnvironmentRuntime;
+}
+
+beforeEach(() => {
+  stateDb = openInMemoryStateDb();
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  stateDb.close();
+});
+
+/**
+ * The durable half of the environment-failure prompt. The prompt used to be
+ * dismissed only in renderer state, so it came back on every app launch — and
+ * `setupStatus: "failed"` is permanent history that nothing ever rewrites, so
+ * there was nothing else to distinguish "not answered yet" from "answered
+ * weeks ago".
+ */
+describe("SqliteOverlayStore — environment failure acknowledgement", () => {
+  it("records the acknowledgement without disturbing the failure record", async () => {
+    await seedFailedSetup();
+
+    expect(
+      await store.acknowledgeThreadEnvironmentFailure({
+        acknowledgedAt: 5_000,
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toBe(true);
+
+    const runtime = await readRuntime();
+    expect(runtime?.setupFailureAcknowledgedAt).toBe(5_000);
+    // The failure itself is history — the transcript's
+    // `codex-environment-setup-*` activity entry still reports it.
+    expect(runtime?.setupStatus).toBe("failed");
+    expect(runtime?.setupExitCode).toBe(1);
+    expect(runtime?.setupOutput).toBe("boom");
+  });
+
+  it("is idempotent so a repeat acknowledgement writes nothing", async () => {
+    await seedFailedSetup();
+    await store.acknowledgeThreadEnvironmentFailure({
+      acknowledgedAt: 5_000,
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    // The renderer re-sends this whenever it opens a thread whose snapshot it
+    // has not refreshed yet; a false return is what keeps that off sqlite.
+    expect(
+      await store.acknowledgeThreadEnvironmentFailure({
+        acknowledgedAt: 4_000,
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toBe(false);
+    expect((await readRuntime())?.setupFailureAcknowledgedAt).toBe(5_000);
+  });
+
+  it("advances the acknowledgement so a later failure can raise the prompt again", async () => {
+    await seedFailedSetup();
+    await store.acknowledgeThreadEnvironmentFailure({
+      acknowledgedAt: 5_000,
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(
+      await store.acknowledgeThreadEnvironmentFailure({
+        acknowledgedAt: 9_000,
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).toBe(true);
+    expect((await readRuntime())?.setupFailureAcknowledgedAt).toBe(9_000);
+  });
+
+  it("writes nothing for a thread with no environment runtime", async () => {
+    // A remote/federated thread has no local overlay row. Acknowledging one
+    // must not conjure a local row keyed by the peer's thread id.
+    expect(
+      await store.acknowledgeThreadEnvironmentFailure({
+        backend: "codex",
+        threadId: "thread-unknown",
+      }),
+    ).toBe(false);
+    expect(
+      await store.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-unknown",
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -128,6 +128,8 @@ import {
   type SetThreadReactionResponse,
   type SetThreadToolIncidentNoticeRequest,
   type SetThreadToolIncidentNoticeResponse,
+  type AcknowledgeThreadEnvironmentFailureRequest,
+  type AcknowledgeThreadEnvironmentFailureResponse,
   type AcknowledgeThreadSpendAlertRequest,
   type AcknowledgeThreadSpendAlertResponse,
   type SetNavigationBrowseModeRequest,
@@ -269,6 +271,7 @@ import {
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
   NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
+  NAVIGATION_ACKNOWLEDGE_THREAD_ENVIRONMENT_FAILURE_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_ENSURE_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_LIST_MODEL_SETTINGS_RECENTS_CHANNEL,
@@ -384,6 +387,7 @@ type AppServerOverlayStoreLike = OverlayStoreLike &
     | "updateRemoteThreadPinSnapshots"
     | "setThreadToolIncidentNotice"
     | "acknowledgeThreadSpendAlert"
+    | "acknowledgeThreadEnvironmentFailure"
   >;
 
 type ThreadPrRefreshContext = {
@@ -5960,6 +5964,28 @@ class DesktopAppServerService {
     };
   }
 
+  async acknowledgeThreadEnvironmentFailure(
+    request: AcknowledgeThreadEnvironmentFailureRequest,
+  ): Promise<AcknowledgeThreadEnvironmentFailureResponse> {
+    const backend = request.backend ?? "codex";
+    const acknowledged = await this.getOverlayStore()
+      .acknowledgeThreadEnvironmentFailure({
+        acknowledgedAt: request.acknowledgedAt,
+        backend,
+        threadId: request.threadId,
+      });
+    logDebug("acknowledgeThreadEnvironmentFailure", {
+      acknowledged,
+      backend,
+      threadId: request.threadId,
+    });
+    return {
+      acknowledged,
+      backend,
+      threadId: request.threadId,
+    };
+  }
+
   async setThreadReaction(
     request: SetThreadReactionRequest,
   ): Promise<SetThreadReactionResponse> {
@@ -7908,6 +7934,16 @@ export function registerAppServerIpcHandlers(): void {
       request: AcknowledgeThreadSpendAlertRequest,
     ): Promise<AcknowledgeThreadSpendAlertResponse> => {
       return await appServerService.acknowledgeThreadSpendAlert(request);
+    },
+  );
+  ipcMain.removeHandler(NAVIGATION_ACKNOWLEDGE_THREAD_ENVIRONMENT_FAILURE_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_ACKNOWLEDGE_THREAD_ENVIRONMENT_FAILURE_CHANNEL,
+    async (
+      _event,
+      request: AcknowledgeThreadEnvironmentFailureRequest,
+    ): Promise<AcknowledgeThreadEnvironmentFailureResponse> => {
+      return await appServerService.acknowledgeThreadEnvironmentFailure(request);
     },
   );
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_PIN_CHANNEL);

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -2863,6 +2863,45 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return true;
   }
 
+  /**
+   * Record that the operator has resolved this thread's environment-failure
+   * prompt. `setupStatus: "failed"` and failed `actionRuns` entries are
+   * permanent history and are deliberately left untouched — the transcript's
+   * `codex-environment-setup-*` activity entry keeps showing the same output.
+   * Only the prompt is dismissed.
+   *
+   * Writes once per thread: a second call with the runtime already
+   * acknowledged returns false without touching sqlite, which is what keeps
+   * the renderer's self-healing backfill from writing on every thread open.
+   */
+  async acknowledgeThreadEnvironmentFailure(params: {
+    acknowledgedAt?: number;
+    backend: ThreadOverlayState["backend"];
+    threadId: string;
+  }): Promise<boolean> {
+    const threadKey = buildThreadIdentityKey(params.backend, params.threadId);
+    const current = this.getThread(threadKey);
+    const runtime = current?.codexEnvironmentRuntime;
+    if (!current || !runtime) {
+      return false;
+    }
+    const acknowledgedAt = params.acknowledgedAt ?? Date.now();
+    if (
+      typeof runtime.setupFailureAcknowledgedAt === "number"
+      && runtime.setupFailureAcknowledgedAt >= acknowledgedAt
+    ) {
+      return false;
+    }
+    this.putThread(threadKey, {
+      ...current,
+      codexEnvironmentRuntime: {
+        ...runtime,
+        setupFailureAcknowledgedAt: acknowledgedAt,
+      },
+    });
+    return true;
+  }
+
   async setThreadArchiveTombstone(params: {
     backend: ThreadOverlayState["backend"];
     threadId: string;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -161,6 +161,8 @@ import type {
   SetThreadReactionResponse,
   SetThreadToolIncidentNoticeRequest,
   SetThreadToolIncidentNoticeResponse,
+  AcknowledgeThreadEnvironmentFailureRequest,
+  AcknowledgeThreadEnvironmentFailureResponse,
   AcknowledgeThreadSpendAlertRequest,
   AcknowledgeThreadSpendAlertResponse,
   GetGhStatusRequest,
@@ -691,6 +693,7 @@ import {
   NAVIGATION_SET_THREAD_REACTION_CHANNEL,
   NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL,
   NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
+  NAVIGATION_ACKNOWLEDGE_THREAD_ENVIRONMENT_FAILURE_CHANNEL,
   NAVIGATION_SET_ELIGIBLE_THREADS_PR_AUTO_DISPATCH_CHANNEL,
   NAVIGATION_RESET_DIRECTORY_LAUNCHPAD_CHANNEL,
   NAVIGATION_SNAPSHOT_CHANNEL,
@@ -1804,6 +1807,13 @@ const desktopApi = Object.freeze({
   ): Promise<AcknowledgeThreadSpendAlertResponse> =>
     await ipcRenderer.invoke(
       NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL,
+      request,
+    ),
+  acknowledgeThreadEnvironmentFailure: async (
+    request: AcknowledgeThreadEnvironmentFailureRequest,
+  ): Promise<AcknowledgeThreadEnvironmentFailureResponse> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_ACKNOWLEDGE_THREAD_ENVIRONMENT_FAILURE_CHANNEL,
       request,
     ),
   setThreadPin: async (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -463,9 +463,19 @@ function EnvironmentSetupFailureChoice(props: {
     Boolean(props.command?.trim()) ||
     Boolean(trimmedOutput) ||
     typeof props.exitCode === "number";
+  const bodyRef = useRef<HTMLDivElement>(null);
+  // The body is the panel's scroll container, and the Continue failure renders
+  // at the top of it. An operator who scrolled down to read the tail of the
+  // output before clicking would otherwise get the error off-screen and a
+  // re-enabled button with no visible feedback.
+  useEffect(() => {
+    if (props.error) {
+      bodyRef.current?.scrollTo({ top: 0 });
+    }
+  }, [props.error]);
   return (
     <section className="environment-setup-choice" aria-label={label}>
-      <div className="environment-setup-choice__body">
+      <div className="environment-setup-choice__body" ref={bodyRef}>
         <div className="environment-setup-choice__heading">
           <p className="eyebrow">{label}</p>
           <h3>{props.environmentName}</h3>
@@ -1320,6 +1330,12 @@ export function ThreadView(props: ThreadViewProps) {
     useState<string>();
   const [setupFailureDismissedThreadKeys, setSetupFailureDismissedThreadKeys] =
     useState<Set<string>>(() => new Set());
+  // Thread keys this window has already written an environment-failure
+  // acknowledgement for. The overlay write is idempotent, but the navigation
+  // snapshot this window holds keeps the pre-write runtime until it refreshes,
+  // so without this the backfill below would re-send on every render pass that
+  // moves one of its inputs.
+  const environmentFailureAcknowledgedRef = useRef<Set<string>>(new Set());
   const [setupFailureArchiving, setSetupFailureArchiving] = useState(false);
   const [setupFailureContinuing, setSetupFailureContinuing] = useState(false);
   const [setupFailureContinueError, setSetupFailureContinueError] =
@@ -1903,6 +1919,19 @@ export function ThreadView(props: ThreadViewProps) {
     .reverse()
     .find((run) => run.status === "failed");
   const selectedThreadActionFailed = Boolean(selectedThreadLatestFailedActionRun);
+  // `setupStatus: "failed"` and a failed action run are permanent history; the
+  // prompt they raise is not. This is the record of the operator having
+  // answered it. Setup runs once, at thread creation, so any acknowledgement
+  // covers the setup phase; an action that failed *after* the acknowledgement
+  // is a new failure and raises the prompt again.
+  const selectedThreadEnvironmentFailureAcknowledgedAt =
+    selectedThread?.codexEnvironmentRuntime?.setupFailureAcknowledgedAt;
+  const selectedThreadEnvironmentFailureAcknowledged =
+    typeof selectedThreadEnvironmentFailureAcknowledgedAt === "number"
+    && (!selectedThreadActionFailed
+      || (selectedThreadLatestFailedActionRun?.exitedAt
+        ?? selectedThreadLatestFailedActionRun?.startedAt
+        ?? 0) <= selectedThreadEnvironmentFailureAcknowledgedAt);
   const selectedThreadWorktree = selectedThread?.linkedDirectories.find(
     (directory) =>
       directory.kind === "worktree" || Boolean(directory.worktreePath?.trim()),
@@ -1915,13 +1944,88 @@ export function ThreadView(props: ThreadViewProps) {
     selectedThread &&
       selectedThreadKey &&
       (props.messageCount === 0 || hasOnlyOptimisticLaunchpadMessage) &&
+      // `messageCount` is the loaded transcript's length, so it also reads 0
+      // for a thread whose history has not arrived yet. Without this the
+      // prompt reappeared for the whole hydration window every time an old
+      // failed-setup thread was opened, then vanished when the transcript
+      // landed — a decision prompt for a decision made weeks ago.
+      !props.loading &&
       !props.activeTurnId &&
       (selectedThreadSetupFailed || selectedThreadActionFailed) &&
+      !selectedThreadEnvironmentFailureAcknowledged &&
       !setupFailureDismissedThreadKeys.has(selectedThreadKey),
   );
   const selectedThreadEnvironmentFailurePhase = selectedThreadActionFailed
     ? "action"
     : "setup";
+  // Retire a failure the thread has already moved past. This covers the
+  // threads that failed before the acknowledgement existed, and the operator
+  // who answered the prompt by quitting the app rather than by clicking: once
+  // the transcript has loaded and holds real turns, the decision is long made,
+  // so record it instead of raising the prompt again on the next launch. Only
+  // a loaded transcript counts — `messageCount` is 0 during hydration too.
+  const selectedThreadEnvironmentFailureStale = Boolean(
+    selectedThread
+      && selectedThreadKey
+      && (selectedThreadSetupFailed || selectedThreadActionFailed)
+      && !selectedThreadEnvironmentFailureAcknowledged
+      && !props.loading
+      && props.messageCount > 0
+      && !hasOnlyOptimisticLaunchpadMessage,
+  );
+  const acknowledgeThreadEnvironmentFailure =
+    props.desktopApi?.acknowledgeThreadEnvironmentFailure;
+  // Named apart from `selectedThreadBackend` above, which is the backend
+  // *descriptor* from props.backends, not the thread's own backend kind.
+  const selectedThreadBackendKind = selectedThread?.source;
+  const selectedThreadId = selectedThread?.id;
+  useEffect(() => {
+    if (
+      !selectedThreadEnvironmentFailureStale
+      || !selectedThreadKey
+      || !selectedThreadId
+      || !selectedThreadBackendKind
+      || !acknowledgeThreadEnvironmentFailure
+      || environmentFailureAcknowledgedRef.current.has(selectedThreadKey)
+    ) {
+      return;
+    }
+    environmentFailureAcknowledgedRef.current.add(selectedThreadKey);
+    void acknowledgeThreadEnvironmentFailure({
+      backend: selectedThreadBackendKind,
+      threadId: selectedThreadId,
+    }).catch(() => undefined);
+  }, [
+    acknowledgeThreadEnvironmentFailure,
+    selectedThreadBackendKind,
+    selectedThreadEnvironmentFailureStale,
+    selectedThreadId,
+    selectedThreadKey,
+  ]);
+  /**
+   * Retire the environment-failure prompt for this thread, in this window and
+   * durably. The in-memory set alone did not survive an app restart — or a
+   * ThreadView unmount — so the prompt came back on a thread whose failure the
+   * operator had already answered.
+   */
+  const dismissEnvironmentFailureChoice = (threadKey: string): void => {
+    setSetupFailureDismissedThreadKeys((current) => {
+      const next = new Set(current);
+      next.add(threadKey);
+      return next;
+    });
+    if (!selectedThread || environmentFailureAcknowledgedRef.current.has(threadKey)) {
+      return;
+    }
+    environmentFailureAcknowledgedRef.current.add(threadKey);
+    void props.desktopApi?.acknowledgeThreadEnvironmentFailure?.({
+      backend: selectedThread.source,
+      threadId: selectedThread.id,
+    })
+      // The prompt is already gone from this window; a failed write only means
+      // it can appear once more on a later launch, which is not worth a notice.
+      .catch(() => undefined);
+  };
   const continueAfterSetupFailure = async (): Promise<void> => {
     if (!selectedThread || !selectedThreadKey) {
       return;
@@ -1931,11 +2035,7 @@ export function ThreadView(props: ThreadViewProps) {
       selectedThread.optimisticUserMessage,
     );
     if (input.length === 0 || !props.desktopApi?.startTurn) {
-      setSetupFailureDismissedThreadKeys((current) => {
-        const next = new Set(current);
-        next.add(selectedThreadKey);
-        return next;
-      });
+      dismissEnvironmentFailureChoice(selectedThreadKey);
       return;
     }
 
@@ -1958,11 +2058,7 @@ export function ThreadView(props: ThreadViewProps) {
           : undefined,
       });
       props.onActiveTurnIdChange?.(response.turnId);
-      setSetupFailureDismissedThreadKeys((current) => {
-        const next = new Set(current);
-        next.add(selectedThreadKey);
-        return next;
-      });
+      dismissEnvironmentFailureChoice(selectedThreadKey);
       await props.onRefreshNavigation?.();
     } catch (error) {
       props.onPendingStatusChange?.(undefined);

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -6275,6 +6275,199 @@ describe("ThreadView", () => {
     expect(onActiveTurnIdChange).toHaveBeenCalledWith("turn-1");
   });
 
+  it("hides the environment setup failure choice while the transcript is still loading", () => {
+    // The zombie: `messageCount` is the loaded transcript's length, so it is
+    // also 0 for a thread with weeks of history that has not hydrated yet.
+    // Before this gate, opening such a thread raised the whole decision panel
+    // for the entire hydration window, every time, forever.
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{}}
+        loading={true}
+        loadingMore={false}
+        messageCount={0}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          executionMode: "full-access",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupStatus: "failed",
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "new-thread" },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Continue anyway" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the environment setup failure choice once the failure has been acknowledged", () => {
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{}}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          executionMode: "full-access",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupStatus: "failed",
+            // The durable half: a dismissal recorded in a previous run of the
+            // app, which the in-memory dismissal set could never survive.
+            setupFailureAcknowledgedAt: 1_000,
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "new-thread" },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: "Continue anyway" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("persists the environment failure dismissal when continuing anyway", async () => {
+    const acknowledgeThreadEnvironmentFailure = vi.fn(async () => ({
+      acknowledged: true,
+      backend: "codex" as const,
+      threadId: "thread-env-failure",
+    }));
+
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{ acknowledgeThreadEnvironmentFailure }}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          executionMode: "full-access",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupStatus: "failed",
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "new-thread" },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    // No optimistic prompt to send, so this is the pure-dismissal branch.
+    fireEvent.click(screen.getByRole("button", { name: "Continue anyway" }));
+
+    await waitFor(() => {
+      expect(acknowledgeThreadEnvironmentFailure).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-env-failure",
+      });
+    });
+    expect(
+      screen.queryByRole("button", { name: "Continue anyway" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("retires a stale environment failure once the thread's transcript has loaded", async () => {
+    const acknowledgeThreadEnvironmentFailure = vi.fn(async () => ({
+      acknowledged: true,
+      backend: "codex" as const,
+      threadId: "thread-env-failure",
+    }));
+
+    // The thread that failed setup before the acknowledgement existed: it has
+    // real turns now, so the prompt is long moot — retire it durably rather
+    // than flashing it during hydration on every future open.
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{ acknowledgeThreadEnvironmentFailure }}
+        loading={false}
+        loadingMore={false}
+        messageCount={4}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "A thread that moved on",
+          titleSource: "derived",
+          source: "codex",
+          executionMode: "full-access",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupStatus: "failed",
+          },
+          linkedDirectories: [],
+          inbox: { inInbox: true, reason: "updated-since-seen" },
+        }}
+        skills={[]}
+        transcriptEntries={[
+          { type: "message", id: "message-1", role: "user", text: "hi" },
+        ]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    await waitFor(() => {
+      expect(acknowledgeThreadEnvironmentFailure).toHaveBeenCalledWith({
+        backend: "codex",
+        threadId: "thread-env-failure",
+      });
+    });
+    expect(acknowledgeThreadEnvironmentFailure).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the environment setup failure actions outside the panel's scroll container", () => {
     render(
       <ThreadView
@@ -6299,10 +6492,7 @@ describe("ThreadView", () => {
             setupStatus: "failed",
             setupCommand: "nvm install\ncorepack enable\npnpm install",
             setupExitCode: 1,
-            setupOutput: Array.from(
-              { length: 200 },
-              (_unused, index) => `nvm option ${index}: a long line of help`,
-            ).join("\n"),
+            setupOutput: "nvm is not compatible with the npm config prefix",
           },
           linkedDirectories: [
             {
@@ -6327,11 +6517,11 @@ describe("ThreadView", () => {
     );
 
     // `__body` is the panel's scroll container and carries its height bound
-    // (see `environment-setup-choice-bounds.test.ts`). A long setup output is
-    // exactly what pushes it past that bound, and the two buttons are the
-    // operator's only way out of this state — so they have to be a sibling of
-    // the scroller, never a descendant of it. jsdom does no layout, but it
-    // can see this containment, which is the half a refactor would break.
+    // (see `environment-setup-choice-bounds.test.ts`); the two buttons are the
+    // operator's only way out of this state, so they have to stay outside that
+    // scroller. jsdom does no layout — the height bound itself is asserted in
+    // the stylesheet test — but it can see this containment, which is the half
+    // a refactor would break.
     const panel = document.querySelector(".environment-setup-choice");
     const body = panel?.querySelector(".environment-setup-choice__body");
     const actions = panel?.querySelector(".environment-setup-choice__actions");
@@ -6339,7 +6529,6 @@ describe("ThreadView", () => {
     expect(body).not.toBeNull();
     expect(actions).not.toBeNull();
     expect(body!.contains(actions!)).toBe(false);
-    expect(actions!.parentElement).toBe(panel);
     for (const name of ["Delete worktree and close", "Continue anyway"]) {
       expect(actions!.contains(screen.getByRole("button", { name }))).toBe(
         true,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -6275,6 +6275,78 @@ describe("ThreadView", () => {
     expect(onActiveTurnIdChange).toHaveBeenCalledWith("turn-1");
   });
 
+  it("keeps the environment setup failure actions outside the panel's scroll container", () => {
+    render(
+      <ThreadView
+        addOptimisticUserMessage={(_text) => "optimistic-1"}
+        backends={[]}
+        composerDisabled={false}
+        desktopApi={{}}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedThread={{
+          id: "thread-env-failure",
+          title: "Untitled thread",
+          titleSource: "fallback",
+          source: "codex",
+          executionMode: "full-access",
+          updatedAt: Date.now(),
+          codexEnvironmentRuntime: {
+            environmentId: "environment",
+            environmentName: "PwrAgent",
+            executionTarget: "local",
+            setupStatus: "failed",
+            setupCommand: "nvm install\ncorepack enable\npnpm install",
+            setupExitCode: 1,
+            setupOutput: Array.from(
+              { length: 200 },
+              (_unused, index) => `nvm option ${index}: a long line of help`,
+            ).join("\n"),
+          },
+          linkedDirectories: [
+            {
+              id: "/repo",
+              kind: "worktree",
+              label: "repo",
+              path: "/repo",
+              worktreePath: "/repo/.worktrees/thread-env-failure",
+            },
+          ],
+          inbox: {
+            inInbox: true,
+            reason: "new-thread",
+          },
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        clearPendingRequest={() => undefined}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={(_id) => undefined}
+      />
+    );
+
+    // `__body` is the panel's scroll container and carries its height bound
+    // (see `environment-setup-choice-bounds.test.ts`). A long setup output is
+    // exactly what pushes it past that bound, and the two buttons are the
+    // operator's only way out of this state — so they have to be a sibling of
+    // the scroller, never a descendant of it. jsdom does no layout, but it
+    // can see this containment, which is the half a refactor would break.
+    const panel = document.querySelector(".environment-setup-choice");
+    const body = panel?.querySelector(".environment-setup-choice__body");
+    const actions = panel?.querySelector(".environment-setup-choice__actions");
+    expect(panel).not.toBeNull();
+    expect(body).not.toBeNull();
+    expect(actions).not.toBeNull();
+    expect(body!.contains(actions!)).toBe(false);
+    expect(actions!.parentElement).toBe(panel);
+    for (const name of ["Delete worktree and close", "Continue anyway"]) {
+      expect(actions!.contains(screen.getByRole("button", { name }))).toBe(
+        true,
+      );
+    }
+  });
+
   it("hides the environment setup failure choice after the thread has messages", () => {
     render(
       <ThreadView

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -179,6 +179,8 @@ import type {
   SetThreadReactionResponse,
   SetThreadToolIncidentNoticeRequest,
   SetThreadToolIncidentNoticeResponse,
+  AcknowledgeThreadEnvironmentFailureRequest,
+  AcknowledgeThreadEnvironmentFailureResponse,
   AcknowledgeThreadSpendAlertRequest,
   AcknowledgeThreadSpendAlertResponse,
   SetThreadParentRequest,
@@ -1001,6 +1003,9 @@ export type DesktopApi = {
   acknowledgeThreadSpendAlert?: (
     request: AcknowledgeThreadSpendAlertRequest,
   ) => Promise<AcknowledgeThreadSpendAlertResponse>;
+  acknowledgeThreadEnvironmentFailure?: (
+    request: AcknowledgeThreadEnvironmentFailureRequest,
+  ) => Promise<AcknowledgeThreadEnvironmentFailureResponse>;
   setThreadPin?: (
     request: SetThreadPinRequest
   ) => Promise<SetThreadPinResponse>;

--- a/apps/desktop/src/renderer/src/styles/__tests__/automations-scroll-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/automations-scroll-contract.test.ts
@@ -1,33 +1,6 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
-const testDir = path.dirname(fileURLToPath(import.meta.url));
-const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
-
-/**
- * Every top-level rule whose selector line is exactly `selector`. Plural
- * because several of these selectors also appear inside a grouped rule (the
- * header and the row share one grid definition), and the assertion below
- * wants the standalone block, not whichever came first.
- */
-function ruleBodies(selector: string): string[] {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const bodies = [
-    ...css.matchAll(
-      new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`, "g"),
-    ),
-  ].map((match) => match.groups?.body ?? "");
-  if (bodies.length === 0) {
-    throw new Error(`Expected app.css to define ${selector}`);
-  }
-  return bodies;
-}
-
-function ruleBody(selector: string): string {
-  return ruleBodies(selector).join("\n");
-}
+import { cssRuleBodies as ruleBodies, cssRuleBody as ruleBody } from "./css-rule-body";
 
 /**
  * The Automations screen scrolls at `.automations-content`; everything inside

--- a/apps/desktop/src/renderer/src/styles/__tests__/css-rule-body.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/css-rule-body.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Shared reader for the stylesheet-contract tests in this directory.
+ *
+ * jsdom performs no layout, so a layout invariant can only be pinned by
+ * asserting the declarations that produce it. Three tests had grown their own
+ * copy of this regex; a copy that gets a CSS rule boundary wrong is wrong
+ * quietly, and fixing one copy leaves the others broken.
+ */
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+
+export const appCss = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+/**
+ * Bodies of every top-level rule whose selector line is exactly `selector`.
+ * Plural because a selector can also appear in a grouped rule, and a caller
+ * usually wants the standalone block rather than whichever came first.
+ */
+export function cssRuleBodies(selector: string, css: string = appCss): string[] {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const bodies = [
+    ...css.matchAll(
+      new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`, "g"),
+    ),
+  ].map((match) => match.groups?.body ?? "");
+  if (bodies.length === 0) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return bodies;
+}
+
+/** Every matching rule body joined, for a selector declared more than once. */
+export function cssRuleBody(selector: string, css: string = appCss): string {
+  return cssRuleBodies(selector, css).join("\n");
+}
+
+/** The first matching rule body only. */
+export function firstCssRuleBody(
+  selector: string,
+  css: string = appCss,
+): string {
+  return cssRuleBodies(selector, css)[0]!;
+}

--- a/apps/desktop/src/renderer/src/styles/__tests__/environment-setup-choice-bounds.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/environment-setup-choice-bounds.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Locks the declarations that keep the environment-setup failure panel from
+ * eating the chat column.
+ *
+ * The bug this exists to prevent: `.environment-setup-choice` renders as a
+ * sibling of the transcript inside `.thread-view__primary`, and a flex item's
+ * `min-height: auto` floor sized it to its own content. Measured in headless
+ * Chromium against this stylesheet, the panel was 685px tall inside a 644px
+ * pane at a 700px-tall window — the same 685px at every window height. Two
+ * things followed: the transcript was handed 0px of height, so there was
+ * nothing left to scroll, and the actions row landed 53px below the
+ * `overflow: hidden` on `.thread-view`, so "Continue anyway" could not be
+ * reached by any means. The operator could neither dismiss the panel nor
+ * scroll past it.
+ *
+ * jsdom does no layout, so the invariant is pinned in the stylesheet here.
+ * The structural half of the fix — that the actions row is a sibling of the
+ * scrolling body rather than a child of it — is asserted against the rendered
+ * DOM in `thread-view.test.tsx`, which is where a refactor would break it.
+ */
+const testDir = path.dirname(fileURLToPath(import.meta.url));
+const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
+
+/** Body of the first top-level CSS rule whose selector matches exactly. */
+function ruleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(
+    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
+  );
+  if (!match?.groups?.body) {
+    throw new Error(`Expected app.css to define ${selector}`);
+  }
+  return match.groups.body;
+}
+
+describe("environment setup failure panel bounds", () => {
+  it("keeps the pane that clips the panel clipped", () => {
+    // The subject of the whole fix: `.thread-view` shows no scrollbar, so
+    // anything pushed past its bottom edge is simply gone. If this ever
+    // becomes a scroll container the assertions below have lost their
+    // reason and should be revisited, not deleted.
+    expect(ruleBody(".thread-view")).toMatch(/overflow:\s*hidden;/);
+  });
+
+  it("lets the panel shrink below its own content", () => {
+    // Without this the panel keeps its content height no matter how short
+    // the window is, and the transcript below it absorbs the whole deficit.
+    expect(ruleBody(".environment-setup-choice")).toMatch(/min-height:\s*0/);
+  });
+
+  it("bounds the panel's height on the body and scrolls the overflow there", () => {
+    const body = ruleBody(".environment-setup-choice__body");
+    // The bound has to sit on the body, not the section: under ~1200px of
+    // chat column the actions row wraps onto a second flex line, and a
+    // wrapped line is sized to its content — capping the section would clip
+    // the buttons rather than shrink the body.
+    expect(body).toMatch(/max-height:\s*\d+vh/);
+    // A bound with no scroller just moves the clip inside the panel.
+    expect(body).toMatch(/overflow-y:\s*auto/);
+    // `overflow-y: auto` alone still cannot shrink past the content floor.
+    expect(body).toMatch(/min-height:\s*0/);
+  });
+
+  it("leaves the panel's bound relative to the window, not the section", () => {
+    // A percentage here resolves against the section's `auto` height, which
+    // means it does not resolve at all and the bound silently disappears.
+    expect(ruleBody(".environment-setup-choice__body")).not.toMatch(
+      /max-height:\s*\d+%/,
+    );
+  });
+
+  it("keeps the command output out of a second nested scroller", () => {
+    // The output pre used to cap itself at 320px. Inside a body that is
+    // itself shorter than 320px on a small window, that is two stacked
+    // vertical scrollers for one block of text, and the wheel has to chain
+    // out of the inner one to reach the rest of the panel.
+    expect(ruleBody(".environment-setup-choice__pre--output")).not.toMatch(
+      /max-height:/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/__tests__/environment-setup-choice-bounds.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/environment-setup-choice-bounds.test.ts
@@ -1,7 +1,6 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+import { firstCssRuleBody as ruleBody } from "./css-rule-body";
 
 /**
  * Locks the declarations that keep the environment-setup failure panel from
@@ -23,21 +22,6 @@ import { describe, expect, it } from "vitest";
  * scrolling body rather than a child of it — is asserted against the rendered
  * DOM in `thread-view.test.tsx`, which is where a refactor would break it.
  */
-const testDir = path.dirname(fileURLToPath(import.meta.url));
-const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
-
-/** Body of the first top-level CSS rule whose selector matches exactly. */
-function ruleBody(selector: string): string {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = css.match(
-    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
-  );
-  if (!match?.groups?.body) {
-    throw new Error(`Expected app.css to define ${selector}`);
-  }
-  return match.groups.body;
-}
-
 describe("environment setup failure panel bounds", () => {
   it("keeps the pane that clips the panel clipped", () => {
     // The subject of the whole fix: `.thread-view` shows no scrollbar, so
@@ -59,7 +43,9 @@ describe("environment setup failure panel bounds", () => {
     // chat column the actions row wraps onto a second flex line, and a
     // wrapped line is sized to its content — capping the section would clip
     // the buttons rather than shrink the body.
-    expect(body).toMatch(/max-height:\s*\d+vh/);
+    // Any window-relative form, including the `min(<px>, <vh>)` cap the
+    // stylesheet uses elsewhere — the invariant is the unit, not the syntax.
+    expect(body).toMatch(/max-height:[^;]*\d+vh/);
     // A bound with no scroller just moves the clip inside the panel.
     expect(body).toMatch(/overflow-y:\s*auto/);
     // `overflow-y: auto` alone still cannot shrink past the content floor.
@@ -70,7 +56,7 @@ describe("environment setup failure panel bounds", () => {
     // A percentage here resolves against the section's `auto` height, which
     // means it does not resolve at all and the bound silently disappears.
     expect(ruleBody(".environment-setup-choice__body")).not.toMatch(
-      /max-height:\s*\d+%/,
+      /max-height:[^;]*\d+%/,
     );
   });
 

--- a/apps/desktop/src/renderer/src/styles/__tests__/settings-shrink-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/settings-shrink-contract.test.ts
@@ -1,7 +1,6 @@
-import { readFileSync } from "node:fs";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+
+import { firstCssRuleBody as ruleBody } from "./css-rule-body";
 
 /**
  * Locks the declarations that let a settings panel narrow to its column.
@@ -20,21 +19,6 @@ import { describe, expect, it } from "vitest";
  * nothing in a render test can see it, because jsdom does no layout. Only
  * the stylesheet can be asserted here.
  */
-const testDir = path.dirname(fileURLToPath(import.meta.url));
-const css = readFileSync(path.resolve(testDir, "../app.css"), "utf8");
-
-/** Body of the first top-level CSS rule whose selector matches exactly. */
-function ruleBody(selector: string): string {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = css.match(
-    new RegExp(`(?:^|\\n)${escaped}\\s*\\{(?<body>[\\s\\S]*?)\\n\\}`),
-  );
-  if (!match?.groups?.body) {
-    throw new Error(`Expected app.css to define ${selector}`);
-  }
-  return match.groups.body;
-}
-
 describe("settings panel shrink contract", () => {
   it("gives the collapsible body a column track with no min-content floor", () => {
     const body = ruleBody(".settings-section__body-clip");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15954,6 +15954,15 @@ a.button {
   /* Stay inside the transcript column even when the context rail is pinned. */
   max-width: 100%;
   box-sizing: border-box;
+  /* The panel is a sibling of the transcript inside `.thread-view__primary`,
+     so every pixel it takes comes out of the transcript. A flex item's
+     `min-height: auto` floor let it size to its own content and refuse to
+     shrink: at a 700px-tall window it measured 685px inside a 644px pane,
+     which left the transcript 0px tall (nothing to scroll) and pushed the
+     actions row 53px below the `overflow: hidden` on `.thread-view`, so
+     "Continue anyway" could not be reached at all. The height bound lives on
+     `__body` — the part that scrolls — and the actions row sits outside it. */
+  min-height: 0;
   border: 1px solid var(--danger-border);
   border-radius: 8px;
   background: var(--danger-soft);
@@ -15969,6 +15978,18 @@ a.button {
   display: flex;
   flex-direction: column;
   gap: 10px;
+  /* The panel's vertical bound, and the panel's one scroll container. It is
+     here rather than on the section because the actions row wraps below the
+     body under ~1200px of chat column, and a wrapped flex line is sized to
+     its content: capping the section would clip the buttons instead of
+     shrinking the body. A percentage would resolve against the section's
+     auto height (that is, not at all), so the bound is window-relative. The
+     panel then costs ~40vh plus its own chrome at every window size, which
+     keeps the actions inside the pane well below the 640px minimum window
+     height and leaves the transcript a scrollable remainder. */
+  min-height: 0;
+  max-height: 40vh;
+  overflow-y: auto;
 }
 
 .environment-setup-choice__heading > *:first-child {
@@ -16055,8 +16076,11 @@ a.button {
 }
 
 .environment-setup-choice__pre--output {
-  max-height: 320px;
-  overflow: auto;
+  /* No height cap of its own. `__body` is the panel's scroll container, and a
+     320px box inside a body that is itself shorter than that on a small
+     window made two nested vertical scrollers the wheel had to chain out of.
+     Horizontal scrolling for long lines stays on `__pre`. */
+  overflow-y: visible;
 }
 
 .environment-setup-choice__path {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15983,12 +15983,13 @@ a.button {
      body under ~1200px of chat column, and a wrapped flex line is sized to
      its content: capping the section would clip the buttons instead of
      shrinking the body. A percentage would resolve against the section's
-     auto height (that is, not at all), so the bound is window-relative. The
-     panel then costs ~40vh plus its own chrome at every window size, which
-     keeps the actions inside the pane well below the 640px minimum window
-     height and leaves the transcript a scrollable remainder. */
+     auto height (that is, not at all), so the bound is window-relative, in
+     the `min(<px>, <vh>)` form `.launchpad-pending__command` already uses:
+     the vh share keeps the actions inside the pane well below the 640px
+     minimum window height, and the pixel ceiling stops a tall display from
+     handing the panel 600px of transcript for no reason. */
   min-height: 0;
-  max-height: 40vh;
+  max-height: min(360px, 40vh);
   overflow-y: auto;
 }
 
@@ -16030,6 +16031,17 @@ a.button {
   font-size: 12px;
   color: var(--text-secondary);
   user-select: none;
+  /* `__body` scrolls, and this summary carries the exit code and the collapse
+     control — the two things worth keeping in view while reading the output.
+     Its containing block is the `<details>`, which spans the whole scrolled
+     stack, so it stays pinned for as long as any of the detail is visible.
+     `.launchpad-pending__output`'s header is pinned for the same reason. */
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: var(--bg-panel-elevated);
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
 }
 
 .environment-setup-choice__details > summary::-webkit-details-marker {
@@ -16076,11 +16088,16 @@ a.button {
 }
 
 .environment-setup-choice__pre--output {
-  /* No height cap of its own. `__body` is the panel's scroll container, and a
-     320px box inside a body that is itself shorter than that on a small
+  /* No height cap of its own: `__body` is the panel's one scroll container,
+     and a 320px box inside a body that is itself shorter than that on a small
      window made two nested vertical scrollers the wheel had to chain out of.
-     Horizontal scrolling for long lines stays on `__pre`. */
-  overflow-y: visible;
+     Wrapping rather than scrolling sideways matches
+     `.launchpad-pending__output pre`, the live setup panel's output block —
+     and it is what keeps this readable now that the body scrolls, because
+     `__pre`'s horizontal scrollbar would otherwise sit at the bottom of the
+     full output, outside the body's viewport. */
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .environment-setup-choice__path {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -168,6 +168,8 @@ export const NAVIGATION_SET_THREAD_TOOL_INCIDENT_NOTICE_CHANNEL =
   "navigation:set-thread-tool-incident-notice";
 export const NAVIGATION_ACKNOWLEDGE_THREAD_SPEND_ALERT_CHANNEL =
   "navigation:acknowledge-thread-spend-alert";
+export const NAVIGATION_ACKNOWLEDGE_THREAD_ENVIRONMENT_FAILURE_CHANNEL =
+  "navigation:acknowledge-thread-environment-failure";
 export const NAVIGATION_SET_THREAD_PIN_CHANNEL =
   "navigation:set-thread-pin";
 export const NAVIGATION_SET_THREAD_AGENT_CHANNEL =

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -55,6 +55,18 @@ export type AcknowledgeThreadSpendAlertResponse = {
   threadId: string;
 };
 
+export type AcknowledgeThreadEnvironmentFailureRequest = {
+  acknowledgedAt?: number;
+  backend?: AppServerBackendKind;
+  threadId: string;
+};
+
+export type AcknowledgeThreadEnvironmentFailureResponse = {
+  acknowledged: boolean;
+  backend: AppServerBackendKind;
+  threadId: string;
+};
+
 export type InboxReason = "new-thread" | "updated-since-seen";
 
 export type ThreadInboxState = {

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -314,6 +314,21 @@ export type CodexThreadEnvironmentRuntime = {
   setupExitCode?: number;
   setupDurationMs?: number;
   /**
+   * When the operator resolved the failure prompt this runtime raised — by
+   * continuing anyway, or by the thread moving on without them.
+   *
+   * `setupStatus: "failed"` and a failed entry in `actionRuns` are permanent
+   * historical facts: nothing ever rewrites them, and the transcript keeps its
+   * own `codex-environment-setup-*` activity entry with the same output. The
+   * decision prompt they raise is not permanent, so it needs its own state.
+   * Without this the prompt was suppressed only by the thread having messages,
+   * which is also false while a thread hydrates — so it came back on every
+   * open, weeks later, until the transcript finished loading.
+   *
+   * A failure that happens *after* this timestamp raises the prompt again.
+   */
+  setupFailureAcknowledgedAt?: number;
+  /**
    * Non-secret toolchain environment captured after a successful local
    * Codex environment setup. Used by PwrAgent to start local Codex
    * app-server threads with the same PATH/version-manager context.

--- a/packages/shared/src/navigation-state.ts
+++ b/packages/shared/src/navigation-state.ts
@@ -535,6 +535,8 @@ export function buildNavigationSnapshotHash(params: {
             setupOutput: thread.codexEnvironmentRuntime.setupOutput ?? null,
             setupExitCode: thread.codexEnvironmentRuntime.setupExitCode ?? null,
             setupDurationMs: thread.codexEnvironmentRuntime.setupDurationMs ?? null,
+            setupFailureAcknowledgedAt:
+              thread.codexEnvironmentRuntime.setupFailureAcknowledgedAt ?? null,
             actions: (thread.codexEnvironmentRuntime.actions ?? []).map(
               (action) => ({
                 id: action.id,


### PR DESCRIPTION
## The bug

Reported from a short window: the environment-setup failure panel takes the
whole chat pane, the transcript cannot be scrolled, and **"Continue anyway" is
off-screen with no way to reach it** — the thread is stuck.

The panel renders as a sibling of the transcript inside
`.thread-view__primary`, and a flex item's `min-height: auto` floor sized it to
its own content. Measured in headless Chromium against the real stylesheet, it
was **685px tall at every window height**. At a 700px-tall window that is 685px
inside a 644px pane, so:

- the transcript was handed **0px** of height — nothing left to scroll, and
- the actions row landed **53px below** the `overflow: hidden` on
  `.thread-view`, which shows no scrollbar. The buttons were simply gone.

## The fix

Bound the panel on `__body` and scroll the overflow there.

The bound sits on the body rather than the section because the actions row
wraps below the body under ~1200px of chat column, and a wrapped flex line is
sized to its content — capping the section would have clipped the buttons
instead of shrinking the body. A percentage would resolve against the section's
`auto` height (that is, not at all), so the bound is window-relative. The
actions row stays outside the scroller and is therefore always on screen.

The output `pre` gives up its own 320px cap: `__body` is now the panel's one
scroll container, and a 320px box inside a body that is itself shorter than
that on a small window is two nested vertical scrollers for one block of text.

Measured after the change, at 900 / 700 / 600 / 500 / 420px-tall windows: the
actions row is inside the pane at every size — down to well below the 640px
`MAIN_WINDOW_MIN_HEIGHT` — and the transcript keeps a scrollable remainder
(304 / 184 / 124 / 64 / 16px). Both the wrapped and the side-by-side (wide
chat column) arrangements were checked.

## Tests

Both fail on the pre-fix tree:

- `styles/__tests__/environment-setup-choice-bounds.test.ts` — 3 of its 5
  assertions fail before the fix. jsdom does no layout, so the height bound,
  the scroller, and the absence of the nested output cap are pinned in the
  stylesheet, which is the house pattern here (`settings-shrink-contract`,
  `automations-scroll-contract`).
- `thread-view.test.tsx` — the structural half, which jsdom *can* see: the
  actions row is a sibling of the scrolling body, never a descendant of it.
  That is the half a refactor would break.

`pnpm typecheck`, `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, and the
full `styles/__tests__` + `thread-view.test.tsx` suites pass.

## Screenshots

Both are **100% contrived** and come from a standalone harness page — the real
`app.css` over a hand-built copy of the panel's DOM in headless Chromium at
900x700 — not from the app itself. There is no E2E fixture that reaches this
panel, so the app-level check is the measurement above rather than a capture.

### Before
![panel before](https://github.com/user-attachments/assets/55f0a927-e9ac-4e12-86fc-40c1ec0fe9bc)

### After
![panel after](https://github.com/user-attachments/assets/dcee84f0-6194-4ae8-9f1b-80c69a5f0a18)

---

## Follow-up 1 — align with the live setup panel

Review of the above turned up that `.launchpad-pending--setup` — the *live*
setup panel, rendering the same data in the same pane — already solves this
layout, and better. Adopted from it:

- The output block wraps (`white-space: pre-wrap; overflow-wrap: anywhere`)
  instead of scrolling sideways. Dropping the output's own 320px viewport had
  moved its horizontal scrollbar to the bottom of the full output, outside the
  body's viewport, on exactly the wide-line output that needs it.
- The `<details>` summary is pinned. It carries the exit code and the collapse
  control, and it was scrolling out of the panel it belongs to.
- The cap is `min(360px, 40vh)`, matching `.launchpad-pending__command`. A bare
  `40vh` gave the panel 560px of body on a 1400px-tall window for no reason;
  the transcript there goes from 570px to 850px.

Also: `overflow-y: visible` on the output pre was inert — `__pre` sets
`overflow-x: auto`, which forces the other axis to compute to `auto` (verified:
`{ overflowX: 'auto', overflowY: 'auto' }`), so the declaration stated the
opposite of the used value. And the Continue-failure error renders in the
heading block, which the bound turned into scrolled content, so the body now
scrolls back to the top when one appears.

Tests: `ruleBody` was on its third copy in `styles/__tests__`, so it moved to a
shared module the other two contract tests now use, and the max-height
assertion matched only a bare integer `vh` — it would have rejected the
`min(px, vh)` cap it exists to protect.

## Follow-up 2 — the zombie prompt

Reported separately: the panel reappears when an old thread is opened — after a
restart, weeks later — then vanishes the moment the transcript loads.

Same mistake, one layer down. Visibility was derived from
`codexEnvironmentRuntime.setupStatus === "failed"` — a permanent historical fact
nothing ever rewrites — gated by `messageCount === 0` as a proxy for "this
thread never got a turn". That proxy is also true *while a thread hydrates*
(`messageCount` is the loaded transcript's length), so every open raised the
decision panel for the whole hydration window. Dismissal, meanwhile, lived in a
`useState` Set: gone on an app restart, and gone on any ThreadView unmount.

The decision now has its own state — `setupFailureAcknowledgedAt` on the
environment runtime, written through a new overlay-store method and IPC. The
failure record is untouched: the transcript keeps its
`codex-environment-setup-*` activity entry with the same command output, which
is where the failure belongs once the prompt is answered.

- Not shown while the transcript is loading.
- Not shown once acknowledged; "Continue anyway" records that durably, in both
  its branches.
- Threads that failed before this existed heal themselves: once the transcript
  has loaded and holds real turns, the prompt is moot, so it is retired then
  rather than flashing on every future open. One idempotent write per thread,
  guarded per window. An action that fails *after* an acknowledgement is a new
  failure and raises the prompt again.

Write cost: at most one sqlite commit per thread that ever had a failed
environment setup, once — not per open, per turn, or on a timer.

### Tests

All four renderer tests fail on the pre-fix tree (verified by restoring HEAD's
`ThreadView.tsx` and re-running): hidden while loading, hidden once
acknowledged, dismissal persisted on Continue, stale failure retired after the
transcript loads. `overlay-store-environment-failure.test.ts` covers the
durable half — including that the failure record survives, that a repeat
acknowledgement writes nothing, and that a thread with no local overlay row
(a federated one) is not conjured into existence.

Full suite green: 679 files, 10,038 passed. `pnpm typecheck`,
`pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries` all
pass.
