### PR TITLE
fix(desktop): cache federation navigation selections

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -11,6 +11,7 @@ import type {
   FederationEventSubscription,
   FederationInstanceId,
   FederationProtocolEnvelope,
+  FederationThreadSelection,
   GetNavigationSnapshotTransportRequest,
   NavigationSnapshot,
   NavigationSnapshotTransportResponse,
@@ -159,6 +160,7 @@ type RuntimeHarness = {
   remoteNavigationSnapshot: (
     target: { scope: "remote"; instanceId: FederationInstanceId },
     request: { backend?: "all" | "codex"; filter?: string },
+    selectionOverride?: FederationThreadSelection,
   ) => Promise<NavigationSnapshot>;
   remoteThreadSummaries: () => {
     searchForJump: (request: { query: string }) => Promise<{ results: unknown[] }>;
@@ -286,6 +288,79 @@ function applyEventSubscription(params: {
     ...(params.hopCount === undefined ? {} : { hopCount: params.hopCount }),
     createdAt: 1_000,
   }, params.sourcePeerId ?? params.subscriberInstanceId)).toBe(true);
+}
+
+function createNavigationSnapshot(threadId: string): NavigationSnapshot {
+  return {
+    backend: "all",
+    fetchedAt: 1_000,
+    unchanged: false,
+    threads: [{
+      id: threadId,
+      title: `Remote ${threadId}`,
+      titleSource: "explicit",
+      source: "codex",
+      linkedDirectories: [],
+      inbox: { inInbox: false },
+    }],
+    inboxThreadKeys: [],
+    directories: [],
+    launchpadDefaults: {
+      backend: "codex",
+      executionMode: "default",
+    },
+  };
+}
+
+function createNavigationTransportRuntime(
+  getNavigationSnapshotTransport: (
+    request: GetNavigationSnapshotTransportRequest,
+  ) => Promise<NavigationSnapshotTransportResponse>,
+): RuntimeHarness {
+  const fallbackSnapshot = createNavigationSnapshot("fallback");
+  const runtime = new DesktopFederationRuntime() as unknown as RuntimeHarness;
+  runtime.remoteBackend = () => ({
+    getNavigationSnapshot: async () => fallbackSnapshot,
+    getNavigationSnapshotTransport,
+    listThreads: async () => ({
+      backend: "codex",
+      fetchedAt: 1_000,
+      threads: [],
+    }),
+  });
+  runtime.store = () => ({
+    getPeer: () => ({ label: "Studio Mac", status: "connected" }),
+    listPeers: () => [],
+  });
+  runtime.visiblePeers = () => [{
+    id: "client_one",
+    label: "Studio Mac",
+    role: "client",
+    status: "connected",
+    capabilities: ["thread_navigation", "navigation_snapshot_deltas"],
+  }];
+  return runtime;
+}
+
+function createRevisionAwareNavigationTransport() {
+  return vi
+    .fn<(request: GetNavigationSnapshotTransportRequest) =>
+      Promise<NavigationSnapshotTransportResponse>>()
+    .mockImplementation(async (request) => {
+      const selection = request.transport.selection ?? { kind: "all" };
+      const selectionKey = selection.kind === "all"
+        ? "all"
+        : selection.threadKeys.join(",");
+      const revision = `revision:${selectionKey}`;
+      if (request.transport.baseRevision === revision) {
+        return { kind: "unchanged", revision };
+      }
+      return {
+        kind: "full",
+        revision,
+        snapshot: createNavigationSnapshot(selectionKey),
+      };
+    });
 }
 
 describe("DesktopFederationRuntime", () => {
@@ -509,6 +584,167 @@ describe("DesktopFederationRuntime", () => {
         baseRevision: "peer-revision-2",
         protocol: 1,
         selection: { kind: "all" },
+      },
+    });
+  });
+
+  it("reuses explicit all-selection revisions without an event subscription", async () => {
+    const getNavigationSnapshotTransport =
+      createRevisionAwareNavigationTransport();
+    const runtime = createNavigationTransportRuntime(
+      getNavigationSnapshotTransport,
+    );
+    const target = { scope: "remote" as const, instanceId: "client_one" };
+
+    await runtime.remoteNavigationSnapshot(target, {}, { kind: "all" });
+    await runtime.remoteNavigationSnapshot(target, {}, { kind: "all" });
+
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(2, {
+      transport: {
+        baseRevision: "revision:all",
+        protocol: 1,
+        selection: { kind: "all" },
+      },
+    });
+  });
+
+  it("retains independent revisions for explicit sparse and all selections", async () => {
+    const getNavigationSnapshotTransport =
+      createRevisionAwareNavigationTransport();
+    const runtime = createNavigationTransportRuntime(
+      getNavigationSnapshotTransport,
+    );
+    const target = { scope: "remote" as const, instanceId: "client_one" };
+    const allSelection = { kind: "all" as const };
+    const sparseSelection = {
+      kind: "threads" as const,
+      threads: [{ backend: "codex" as const, threadId: "thread-1" }],
+    };
+
+    await runtime.remoteNavigationSnapshot(target, {}, allSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, sparseSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, allSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, sparseSelection);
+
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(3, {
+      transport: {
+        baseRevision: "revision:all",
+        protocol: 1,
+        selection: { kind: "all" },
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(4, {
+      transport: {
+        baseRevision: "revision:codex:thread-1",
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-1"],
+        },
+      },
+    });
+  });
+
+  it("bounds each peer selection cache with deterministic LRU eviction", async () => {
+    const getNavigationSnapshotTransport =
+      createRevisionAwareNavigationTransport();
+    const runtime = createNavigationTransportRuntime(
+      getNavigationSnapshotTransport,
+    );
+    const target = { scope: "remote" as const, instanceId: "client_one" };
+    const cacheLimit = 8;
+    const selections = Array.from({ length: cacheLimit + 1 }, (_, index) => ({
+      kind: "threads" as const,
+      threads: [{
+        backend: "codex" as const,
+        threadId: `thread-${index}`,
+      }],
+    }));
+
+    for (const selection of selections.slice(0, cacheLimit)) {
+      await runtime.remoteNavigationSnapshot(target, {}, selection);
+    }
+    await runtime.remoteNavigationSnapshot(target, {}, selections[0]);
+    await runtime.remoteNavigationSnapshot(target, {}, selections[cacheLimit]);
+    await runtime.remoteNavigationSnapshot(target, {}, selections[0]);
+    await runtime.remoteNavigationSnapshot(target, {}, selections[1]);
+
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(9, {
+      transport: {
+        baseRevision: "revision:codex:thread-0",
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-0"],
+        },
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(10, {
+      transport: {
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-8"],
+        },
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(11, {
+      transport: {
+        baseRevision: "revision:codex:thread-0",
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-0"],
+        },
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(12, {
+      transport: {
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-1"],
+        },
+      },
+    });
+  });
+
+  it("clears every cached selection when a peer disconnects", async () => {
+    const getNavigationSnapshotTransport =
+      createRevisionAwareNavigationTransport();
+    const runtime = createNavigationTransportRuntime(
+      getNavigationSnapshotTransport,
+    );
+    const target = { scope: "remote" as const, instanceId: "client_one" };
+    const allSelection = { kind: "all" as const };
+    const sparseSelection = {
+      kind: "threads" as const,
+      threads: [{ backend: "codex" as const, threadId: "thread-1" }],
+    };
+
+    await runtime.remoteNavigationSnapshot(target, {}, allSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, sparseSelection);
+    runtime.publishPeerStatus(
+      "client_one",
+      "disconnected",
+      "Federation peer connection closed.",
+    );
+    await runtime.remoteNavigationSnapshot(target, {}, allSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, sparseSelection);
+
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(3, {
+      transport: {
+        protocol: 1,
+        selection: { kind: "all" },
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(4, {
+      transport: {
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-1"],
+        },
       },
     });
   });

--- a/apps/desktop/src/main/__tests__/federation-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime.test.ts
@@ -749,6 +749,55 @@ describe("DesktopFederationRuntime", () => {
     });
   });
 
+  it("clears every cached selection when a connected peer session is replaced", async () => {
+    const getNavigationSnapshotTransport =
+      createRevisionAwareNavigationTransport();
+    const runtime = createNavigationTransportRuntime(
+      getNavigationSnapshotTransport,
+    );
+    runtime.router = new FederationRouter({ localInstanceId: "viewer_one" });
+    const target = { scope: "remote" as const, instanceId: "client_one" };
+    const allSelection = { kind: "all" as const };
+    const sparseSelection = {
+      kind: "threads" as const,
+      threads: [{ backend: "codex" as const, threadId: "thread-1" }],
+    };
+    const oldConnection = createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_navigation", "navigation_snapshot_deltas"],
+      sendEnvelope: () => undefined,
+    });
+    const replacementConnection = createConnection({
+      peerId: "client_one",
+      capabilities: ["thread_navigation", "navigation_snapshot_deltas"],
+      sendEnvelope: () => undefined,
+    });
+
+    runtime.registerGatewayConnection(oldConnection);
+    await runtime.remoteNavigationSnapshot(target, {}, allSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, sparseSelection);
+    runtime.registerGatewayConnection(replacementConnection);
+    runtime.unregisterGatewayConnection(oldConnection);
+    await runtime.remoteNavigationSnapshot(target, {}, allSelection);
+    await runtime.remoteNavigationSnapshot(target, {}, sparseSelection);
+
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(3, {
+      transport: {
+        protocol: 1,
+        selection: { kind: "all" },
+      },
+    });
+    expect(getNavigationSnapshotTransport).toHaveBeenNthCalledWith(4, {
+      transport: {
+        protocol: 1,
+        selection: {
+          kind: "threads",
+          threadKeys: ["codex:thread-1"],
+        },
+      },
+    });
+  });
+
   it("counts every upsert in batched navigation changes for diagnostics", () => {
     const change = (
       baseRevision: string,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -3096,6 +3096,10 @@ export class DesktopFederationRuntime {
   }
 
   private registerGatewayConnection(connection: FederationGatewayConnection): void {
+    // A live socket can be replaced without a disconnected status transition.
+    // Transport revisions are scoped to the remote process lifetime, so a
+    // replacement must not reuse any selection state from the prior session.
+    this.clearRemoteNavigationTransportForPeer(connection.peerId);
     this.router?.registerConnection({
       peerId: connection.peerId,
       capabilities: connection.capabilities,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -335,6 +335,7 @@ const FEDERATION_CELESTIAL_ICONS_METHOD = "federation.celestialIcons";
 const FEDERATION_STAR_MAP_ARRANGEMENT_METHOD = "federation.starMapArrangement";
 const FEDERATION_EVENT_SUBSCRIPTION_METHOD = "federation.eventSubscription";
 const FEDERATION_EVENT_RELAY_MAX_HOPS = 4;
+const REMOTE_NAVIGATION_SELECTION_CACHE_LIMIT = 8;
 const CELESTIAL_ICON_ASSIGNMENTS_META_KEY =
   "federation_celestial_icon_assignments";
 /**
@@ -803,11 +804,8 @@ export class DesktopFederationRuntime {
   >();
   private readonly rpcByPeer = new Map<FederationInstanceId, FederationRpcEndpoint>();
   private readonly remoteNavigationTransportByPeer = new Map<
-    string,
-    {
-      selectionKey: string;
-      state: NavigationSnapshotTransportState;
-    }
+    FederationInstanceId,
+    Map<string, NavigationSnapshotTransportState>
   >();
   private ownedNavigationSnapshotTransport?: NavigationSnapshotTransport;
   private readonly turnInputAttachmentReceiver =
@@ -1938,17 +1936,10 @@ export class DesktopFederationRuntime {
         : desiredThreadSelection ?? selectionOverride ?? { kind: "all" };
     const selection = transportSelectionFor(threadSelection);
     const selectionKey = federationThreadSelectionKey(threadSelection);
-    const cacheable =
-      desiredThreadSelection !== undefined
-        ? selectionKey === federationThreadSelectionKey(desiredThreadSelection)
-        : selectionOverride === undefined;
-    const cachedTransport = this.remoteNavigationTransportByPeer.get(
+    const previousTransportState = this.remoteNavigationTransportStateFor(
       target.instanceId,
+      selectionKey,
     );
-    const previousTransportState =
-      cacheable && cachedTransport?.selectionKey === selectionKey
-        ? cachedTransport.state
-        : undefined;
     let startedAt = Date.now();
     let transportResponse = await backend.getNavigationSnapshotTransport({
       transport: {
@@ -2008,17 +1999,47 @@ export class DesktopFederationRuntime {
         "Federation navigation snapshot transport did not provide a recoverable baseline.",
       );
     }
-    if (cacheable) {
-      this.remoteNavigationTransportByPeer.set(target.instanceId, {
-        selectionKey,
-        state: nextTransportState,
-      });
-    }
+    this.cacheRemoteNavigationTransportState(
+      target.instanceId,
+      selectionKey,
+      nextTransportState,
+    );
     const response = projectNavigationSnapshot(
       normalizeNavigationSnapshotThreadKeys(nextTransportState.snapshot),
       snapshotRequest,
     );
     return await this.stampRemoteNavigationSnapshot(target, response);
+  }
+
+  private remoteNavigationTransportStateFor(
+    peerId: FederationInstanceId,
+    selectionKey: string,
+  ): NavigationSnapshotTransportState | undefined {
+    const selections = this.remoteNavigationTransportByPeer.get(peerId);
+    const state = selections?.get(selectionKey);
+    if (!state || !selections) return undefined;
+    selections.delete(selectionKey);
+    selections.set(selectionKey, state);
+    return state;
+  }
+
+  private cacheRemoteNavigationTransportState(
+    peerId: FederationInstanceId,
+    selectionKey: string,
+    state: NavigationSnapshotTransportState,
+  ): void {
+    let selections = this.remoteNavigationTransportByPeer.get(peerId);
+    if (!selections) {
+      selections = new Map();
+      this.remoteNavigationTransportByPeer.set(peerId, selections);
+    }
+    selections.delete(selectionKey);
+    selections.set(selectionKey, state);
+    if (selections.size <= REMOTE_NAVIGATION_SELECTION_CACHE_LIMIT) return;
+    const leastRecentlyUsedSelection = selections.keys().next().value;
+    if (leastRecentlyUsedSelection !== undefined) {
+      selections.delete(leastRecentlyUsedSelection);
+    }
   }
 
   private logRemoteNavigationWireResponse(params: {
@@ -4520,6 +4541,7 @@ export class DesktopFederationRuntime {
     // leave a still-fresh cache marked degraded, and the reconnect refresh
     // has no reason to retry it until another navigation event arrives.
     this.remoteThreadSummaryCache?.invalidate(instanceId);
+    this.clearRemoteNavigationTransportForPeer(instanceId);
     if (status === "connected") {
       // Hooked to the status TRANSITION (this method already de-dupes
       // repeats) rather than to a specific enrollment call site, so every


### PR DESCRIPTION
## Summary

- cache viewer-side remote navigation transport state independently per peer and explicit selection
- bound each peer cache to eight LRU selections so repeated messaging all-selection reads receive warm deltas
- clear all cached selections on peer status invalidation while preserving legacy and mixed-version fallbacks
- cover explicit all reuse, sparse/all independence, deterministic eviction, and disconnect invalidation

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-runtime.test.ts` (72 passed)
- `pnpm test` (678 files, 10,033 passed, 6 skipped)
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 45 existing warnings)
- `pnpm lint:boundaries`
- `git diff --check`

## Stack

Depends on #1975 and targets `fix/desktop-narrow-federation-fallbacks`.