### PR TITLE
fix(desktop): harden federation search transport

### DIFF
--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -1,9 +1,16 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type {
   AppServerListThreadsResponse,
   AppServerThreadSummary,
+  FederationProtocolEnvelope,
 } from "@pwragent/shared";
+import { FederationRemoteBackendClient } from "../federation/federation-backend-bridge";
 import { FederatedSearchService } from "../federation/federated-search-service";
+import { FederationRpcEndpoint } from "../federation/federation-rpc";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 function thread(
   id: string,
@@ -297,12 +304,12 @@ describe("FederatedSearchService", () => {
       backend: "codex",
       archived: false,
       filter: "collector",
-    });
+    }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
     expect(listThreads).toHaveBeenNthCalledWith(2, {
       backend: "codex",
       archived: true,
       filter: "collector",
-    });
+    }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
   });
 
   it("reports totalCount and truncation before slicing the result page", async () => {
@@ -400,5 +407,36 @@ describe("FederatedSearchService", () => {
       ],
       searchedInstances: [],
     });
+  });
+
+  it("terminates the underlying peer RPC at the search deadline", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const sent: FederationProtocolEnvelope[] = [];
+    const endpoint = new FederationRpcEndpoint({
+      localInstanceId: "client_one",
+      remoteInstanceId: "child_hung",
+      sendEnvelope: (envelope) => sent.push(envelope),
+    });
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      peerTimeoutMs: 25,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "child_hung",
+        label: "Hung Peer",
+        backend: new FederationRemoteBackendClient(endpoint),
+      }],
+    });
+
+    const search = service.search({ query: "timeout" });
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(search).resolves.toMatchObject({
+      failures: [{ instanceId: "child_hung" }],
+    });
+    expect(sent[0]).toMatchObject({ deadlineAt: 1_025 });
+    expect(
+      (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
+    ).toBe(0);
   });
 });

--- a/apps/desktop/src/main/__tests__/federation-noise.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-noise.test.ts
@@ -139,7 +139,13 @@ describe("Noise_IK_25519_AESGCM_SHA256", () => {
     const gatewayChannel = responder.split();
 
     const message = Buffer.from("startTurn: rm -rf nothing", "utf8");
+    expect(clientChannel.encryptedByteLength(message.byteLength)).toBe(
+      message.byteLength + 16,
+    );
     const onWire = clientChannel.encrypt(message);
+    expect(onWire.byteLength).toBe(
+      clientChannel.encryptedByteLength(message.byteLength),
+    );
     expect(onWire.equals(message)).toBe(false); // ciphertext != plaintext
     expect(gatewayChannel.decrypt(onWire).toString("utf8")).toBe(
       message.toString("utf8"),

--- a/apps/desktop/src/main/__tests__/federation-rpc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-rpc.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from "vitest";
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { FederationRpcEndpoint } from "../federation/federation-rpc";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("FederationRpcEndpoint", () => {
   it("rejects and removes a request when its route fails synchronously", async () => {
@@ -15,6 +20,58 @@ describe("FederationRpcEndpoint", () => {
       method: "backend.getNavigationSnapshot",
       params: {},
     })).rejects.toThrow("Federation peer gateway_one is not connected.");
+    expect(
+      (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
+    ).toBe(0);
+  });
+
+  it("uses an absolute deadline for the wire envelope and pending timer", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const sent: FederationProtocolEnvelope[] = [];
+    const endpoint = new FederationRpcEndpoint({
+      localInstanceId: "client_one",
+      remoteInstanceId: "gateway_one",
+      sendEnvelope: (envelope) => sent.push(envelope),
+    });
+
+    const request = endpoint.request({
+      method: "backend.listThreads",
+      params: {},
+      deadlineAt: 1_025,
+    });
+    const rejection = request.catch((error: unknown) => error);
+
+    expect(sent[0]).toMatchObject({ deadlineAt: 1_025 });
+    expect(
+      (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
+    ).toBe(1);
+    await vi.advanceTimersByTimeAsync(25);
+    await expect(rejection).resolves.toMatchObject({
+      message: "Federation request timed out: backend.listThreads",
+    });
+    expect(
+      (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
+    ).toBe(0);
+  });
+
+  it("does not send a request after its shared deadline has expired", async () => {
+    const sendEnvelope = vi.fn();
+    const endpoint = new FederationRpcEndpoint({
+      localInstanceId: "client_one",
+      remoteInstanceId: "gateway_one",
+      now: () => 1_000,
+      sendEnvelope,
+    });
+
+    await expect(endpoint.request({
+      method: "backend.getNavigationSnapshot",
+      params: {},
+      deadlineAt: 1_000,
+    })).rejects.toThrow(
+      "Federation request timed out: backend.getNavigationSnapshot",
+    );
+    expect(sendEnvelope).not.toHaveBeenCalled();
     expect(
       (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
     ).toBe(0);

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -32,6 +32,7 @@ import {
   FederationGatewayWebSocketServer,
   FederationSocketKeepalive,
   waitForFederationSendCapacity,
+  type FederationGatewayConnection,
   type FederationKeepaliveSocket,
 } from "../federation/federation-transport";
 import { StateDb } from "../state/state-db";
@@ -1303,6 +1304,119 @@ describe("federation transport liveness", () => {
     client.sendEnvelope(envelope({ blob: "x".repeat(128 * 1024) }));
     await expect.poll(() => closeCount, { timeout: 5_000 }).toBe(1);
     expect(received).toHaveLength(1);
+  });
+
+  it("rejects an oversized client envelope before sending it", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-client-send-limit",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    const received: FederationProtocolEnvelope[] = [];
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      onEnvelope: (envelope) => received.push(envelope),
+    });
+    const { url } = await server.start();
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+      maxFrameBytes: 64 * 1024,
+    });
+    const envelope = (id: string, payload: unknown): FederationProtocolEnvelope => ({
+      id,
+      kind: "request",
+      method: "backend.listThreads",
+      params: payload,
+      protocolVersion: 1,
+      sourceInstanceId: "client_one",
+      targetInstanceId: "gateway_one",
+      createdAt: 1_000,
+    });
+
+    expect(() => client.sendEnvelope(
+      envelope("request-too-large", { blob: "x".repeat(128 * 1024) }),
+    )).toThrow(/exceeds.*frame.*limit/i);
+    client.sendEnvelope(envelope("request-small", { note: "small" }));
+    await expect.poll(() => received.length, { timeout: 5_000 }).toBe(1);
+    expect(received[0]?.id).toBe("request-small");
+  });
+
+  it("rejects an oversized gateway envelope before sending it", async () => {
+    const clientKeyPair = generateFederationIdentityKeyPair();
+    const invite = createFederationEnrollmentInvite({
+      store,
+      token: "invite-token-gateway-send-limit",
+      gatewayInstanceId: "gateway_one",
+      generatedAt: Date.now() - 1_000,
+      expiresAt: Date.now() + 60_000,
+    });
+    let gatewayConnection: FederationGatewayConnection | undefined;
+    const received: FederationProtocolEnvelope[] = [];
+    server = new FederationGatewayWebSocketServer({
+      gatewayInstanceId: "gateway_one",
+      gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      host: "127.0.0.1",
+      port: 0,
+      store,
+      maxFrameBytes: 64 * 1024,
+      onConnection: (connection) => {
+        gatewayConnection = connection;
+      },
+    });
+    const { url } = await server.start();
+    const client = await connectFederationClient({
+      url,
+      mode: "enroll",
+      gatewayInstanceId: "gateway_one",
+      gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      peerInstanceId: "client_one",
+      privateKeyPem: clientKeyPair.privateKeyPem,
+      publicKeyPem: clientKeyPair.publicKeyPem,
+      capabilities: ["remote_window"],
+      inviteToken: invite.token,
+      label: "Client",
+      role: "client",
+      onEnvelope: (envelope) => received.push(envelope),
+    });
+    await expect.poll(() => gatewayConnection).toBeDefined();
+    const envelope = (id: string, payload: unknown): FederationProtocolEnvelope => ({
+      id,
+      kind: "request",
+      method: "backend.listThreads",
+      params: payload,
+      protocolVersion: 1,
+      sourceInstanceId: "gateway_one",
+      targetInstanceId: "client_one",
+      createdAt: 1_000,
+    });
+
+    expect(() => gatewayConnection?.sendEnvelope(
+      envelope("request-too-large", { blob: "x".repeat(128 * 1024) }),
+    )).toThrow(/exceeds.*frame.*limit/i);
+    gatewayConnection?.sendEnvelope(
+      envelope("request-small", { note: "small" }),
+    );
+    await expect.poll(() => received.length, { timeout: 5_000 }).toBe(1);
+    expect(received[0]?.id).toBe("request-small");
   });
 
   it("terminates the client side when a gateway stops answering keepalive probes", async () => {

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -1307,6 +1307,8 @@ describe("federation transport liveness", () => {
   });
 
   it("rejects an oversized client envelope before sending it", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
     const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({
       store,
@@ -1323,6 +1325,7 @@ describe("federation transport liveness", () => {
       host: "127.0.0.1",
       port: 0,
       store,
+      noiseStatic: gatewayNoise,
       onEnvelope: (envelope) => received.push(envelope),
     });
     const { url } = await server.start();
@@ -1339,6 +1342,8 @@ describe("federation transport liveness", () => {
       label: "Client",
       role: "client",
       maxFrameBytes: 64 * 1024,
+      noiseStatic: clientNoise,
+      gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
     });
     const envelope = (id: string, payload: unknown): FederationProtocolEnvelope => ({
       id,
@@ -1360,6 +1365,8 @@ describe("federation transport liveness", () => {
   });
 
   it("rejects an oversized gateway envelope before sending it", async () => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
     const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({
       store,
@@ -1378,12 +1385,13 @@ describe("federation transport liveness", () => {
       port: 0,
       store,
       maxFrameBytes: 64 * 1024,
+      noiseStatic: gatewayNoise,
       onConnection: (connection) => {
         gatewayConnection = connection;
       },
     });
     const { url } = await server.start();
-    const client = await connectFederationClient({
+    const _client = await connectFederationClient({
       url,
       mode: "enroll",
       gatewayInstanceId: "gateway_one",
@@ -1395,6 +1403,8 @@ describe("federation transport liveness", () => {
       inviteToken: invite.token,
       label: "Client",
       role: "client",
+      noiseStatic: clientNoise,
+      gatewayNoisePublicKey: gatewayNoise.publicKeyRaw,
       onEnvelope: (envelope) => received.push(envelope),
     });
     await expect.poll(() => gatewayConnection).toBeDefined();

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -125,6 +125,7 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
     expect(searchPeer).toHaveBeenCalledWith(
       remoteTarget("peer-a"),
       { query: "match", limit: 3 },
+      { deadlineAt: expect.any(Number) },
     );
     expect(fetchSnapshot).not.toHaveBeenCalled();
   });
@@ -183,8 +184,18 @@ describe("RemoteThreadSummaryCache — searchForJump", () => {
 
     try {
       const pending = cache.searchForJump({ query: "match" });
+      const searchCall = searchPeer.mock.calls[0] as unknown as [
+        unknown,
+        unknown,
+        { deadlineAt: number },
+      ];
+      const deadlineAt = searchCall[2].deadlineAt;
       await vi.advanceTimersByTimeAsync(80);
-      expect(fetchSnapshot).toHaveBeenCalledTimes(1);
+      expect(fetchSnapshot).toHaveBeenCalledWith(
+        remoteTarget("peer-a"),
+        { kind: "all" },
+        { deadlineAt },
+      );
 
       await vi.advanceTimersByTimeAsync(20);
       await expect(pending).resolves.toEqual({ results: [] });

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -11,7 +11,10 @@ import {
   buildThreadIdentityKey,
 } from "@pwragent/shared";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
-import { hasFederationErrorCode } from "./federation-rpc";
+import {
+  hasFederationErrorCode,
+  type FederationRpcRequestOptions,
+} from "./federation-rpc";
 
 export type FederatedSearchPeer = {
   instanceId: FederationInstanceId;
@@ -60,9 +63,10 @@ export class FederatedSearchService {
         ? []
         : [this.searchLocal(query, request)]),
       ...this.options.peers().map(async (peer) => {
+        const rpcOptions = { deadlineAt: Date.now() + peerTimeoutMs };
         try {
           const peerResults = await withTimeout(
-            this.searchPeer(peer, query, request),
+            this.searchPeer(peer, query, request, rpcOptions),
             peerTimeoutMs,
             `Federated search timed out after ${Math.round(peerTimeoutMs / 1000)}s.`,
           );
@@ -143,11 +147,13 @@ export class FederatedSearchService {
     peer: FederatedSearchPeer,
     query: string,
     request: FederatedSearchRequest,
+    rpcOptions: FederationRpcRequestOptions,
   ): Promise<FederatedSearchResponse["results"]> {
     const resolved = await this.resolveExactThreadId(
       peer.backend,
       query,
       request,
+      rpcOptions,
     );
     if (resolved !== undefined) {
       return resolved
@@ -168,6 +174,7 @@ export class FederatedSearchService {
       peer.backend,
       query,
       request,
+      rpcOptions,
     );
     return threads.map((thread) => ({
       ref: buildFederatedThreadRef({
@@ -186,6 +193,7 @@ export class FederatedSearchService {
     backendOperations: FederatedSearchPeer["backend"],
     query: string,
     request: FederatedSearchRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<AppServerThreadSummary | null | undefined> {
     if (
       !backendOperations.resolveThread
@@ -194,12 +202,15 @@ export class FederatedSearchService {
       return undefined;
     }
     try {
-      const response = await backendOperations.resolveThread({
+      const resolveRequest = {
         ...(request.backend && request.backend !== "all"
           ? { backend: request.backend }
           : {}),
         threadId: query,
-      });
+      };
+      const response = rpcOptions
+        ? await backendOperations.resolveThread(resolveRequest, rpcOptions)
+        : await backendOperations.resolveThread(resolveRequest);
       if (
         response.thread
         && matchesFederatedSearchFilters(response.thread, request)
@@ -220,6 +231,7 @@ export class FederatedSearchService {
       backendOperations,
       "",
       request,
+      rpcOptions,
     );
     return threads.find((thread) => thread.id === query) ?? null;
   }
@@ -229,13 +241,18 @@ async function listFederatedSearchThreads(
   backendOperations: FederatedSearchPeer["backend"],
   query: string,
   request: FederatedSearchRequest,
+  rpcOptions?: FederationRpcRequestOptions,
 ): Promise<AppServerThreadSummary[]> {
-  const list = async (archived: boolean) =>
-    await backendOperations.listThreads({
+  const list = async (archived: boolean) => {
+    const listRequest = {
       backend: request.backend === "all" ? undefined : request.backend,
       archived,
       ...(query ? { filter: query } : {}),
-    });
+    };
+    return rpcOptions
+      ? await backendOperations.listThreads(listRequest, rpcOptions)
+      : await backendOperations.listThreads(listRequest);
+  };
   const responses: AppServerListThreadsResponse[] = [await list(false)];
   if (request.includeArchived) {
     responses.push(await list(true));

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -157,7 +157,10 @@ import {
 } from "@pwragent/shared";
 import { NavigationSnapshotTransport } from "../navigation-snapshot-transport";
 import type { FederationRouter } from "./federation-router";
-import type { FederationRpcEndpoint } from "./federation-rpc";
+import type {
+  FederationRpcEndpoint,
+  FederationRpcRequestOptions,
+} from "./federation-rpc";
 import {
   fitNormalizedReplayWithinByteBudget,
   pageNormalizedReplay,
@@ -560,6 +563,7 @@ export function additionalFederationBackendCapabilities(
 export type FederationBackendOperations = {
   getNavigationSnapshot(
     request?: GetNavigationSnapshotRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<NavigationSnapshot>;
   /**
    * Optional for test doubles and non-desktop adapters. When absent, the RPC
@@ -568,11 +572,16 @@ export type FederationBackendOperations = {
    */
   searchNavigationThreads?(
     request: FederationJumpSearchRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<FederationJumpSearchResponse>;
   listThreads(
     request?: AppServerListThreadsRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<AppServerListThreadsResponse>;
-  resolveThread(request: ResolveThreadRequest): Promise<ResolveThreadResponse>;
+  resolveThread(
+    request: ResolveThreadRequest,
+    rpcOptions?: FederationRpcRequestOptions,
+  ): Promise<ResolveThreadResponse>;
   resolveThreadAdmissionState?(request: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -1535,50 +1544,60 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
 
   async getNavigationSnapshot(
     request: GetNavigationSnapshotRequest = {},
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<NavigationSnapshot> {
     return normalizeNavigationSnapshotThreadKeys(
       await this.rpc.request<NavigationSnapshot>({
         method: FEDERATION_BACKEND_METHODS.getNavigationSnapshot,
         params: request,
+        ...rpcOptions,
       }),
     );
   }
 
   async getNavigationSnapshotTransport(
     request: GetNavigationSnapshotTransportRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<NavigationSnapshot | NavigationSnapshotTransportResponse> {
     return await this.rpc.request<
       NavigationSnapshot | NavigationSnapshotTransportResponse
     >({
       method: FEDERATION_BACKEND_METHODS.getNavigationSnapshot,
       params: request,
+      ...rpcOptions,
     });
   }
 
   async searchNavigationThreads(
     request: FederationJumpSearchRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<FederationJumpSearchResponse> {
     return await this.rpc.request<FederationJumpSearchResponse>({
       method: FEDERATION_BACKEND_METHODS.searchNavigationThreads,
       params: request,
+      ...rpcOptions,
     });
   }
 
   async listThreads(
     request: AppServerListThreadsRequest = {},
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<AppServerListThreadsResponse> {
     return await this.rpc.request<AppServerListThreadsResponse>({
       method: FEDERATION_BACKEND_METHODS.listThreads,
       params: request,
+      ...rpcOptions,
     });
   }
 
   async resolveThread(
     request: ResolveThreadRequest,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<ResolveThreadResponse> {
     return await this.rpc.request<ResolveThreadResponse>({
       method: FEDERATION_BACKEND_METHODS.resolveThread,
       params: request,
+      ...rpcOptions,
     });
   }
 

--- a/apps/desktop/src/main/federation/federation-noise.ts
+++ b/apps/desktop/src/main/federation/federation-noise.ts
@@ -50,6 +50,8 @@ export type NoiseKeyPair = {
 export type NoiseRole = "initiator" | "responder";
 
 export type NoiseTransport = {
+  /** Exact ciphertext size without consuming the outbound nonce. */
+  encryptedByteLength(plaintextByteLength: number): number;
   /** Encrypt an outbound transport frame (AEAD, monotonic nonce). */
   encrypt(plaintext: Buffer): Buffer;
   /** Decrypt an inbound transport frame; throws on tamper/replay. */
@@ -366,6 +368,7 @@ export class NoiseIKHandshake {
     const handshakeHash = Buffer.from(this.sym.hash);
     return {
       handshakeHash,
+      encryptedByteLength: (plaintextByteLength) => plaintextByteLength + TAGLEN,
       encrypt: (plaintext) => send.encryptWithAd(Buffer.alloc(0), plaintext),
       decrypt: (ciphertext) => recv.decryptWithAd(Buffer.alloc(0), ciphertext),
     };

--- a/apps/desktop/src/main/federation/federation-rpc.ts
+++ b/apps/desktop/src/main/federation/federation-rpc.ts
@@ -14,6 +14,15 @@ type PendingRequest = {
   timer: ReturnType<typeof setTimeout>;
 };
 
+export type FederationRpcRequestOptions = {
+  /**
+   * Absolute wall-clock deadline shared by every RPC attempt in one logical
+   * operation. This prevents compatibility fallbacks from restarting a full
+   * timeout after the first request consumes most of the caller's budget.
+   */
+  deadlineAt?: number;
+};
+
 export function hasFederationErrorCode(
   error: unknown,
   code: string,
@@ -43,9 +52,19 @@ export class FederationRpcEndpoint {
     method: string;
     params: unknown;
     timeoutMs?: number;
+    deadlineAt?: number;
   }): Promise<Result> {
     const id = `federation-request:${randomUUID()}`;
-    const timeoutMs = params.timeoutMs ?? this.options.defaultTimeoutMs ?? 30_000;
+    const now = this.now();
+    const deadlineAt =
+      params.deadlineAt
+      ?? now + (params.timeoutMs ?? this.options.defaultTimeoutMs ?? 30_000);
+    const timeoutMs = deadlineAt - now;
+    if (timeoutMs <= 0) {
+      return Promise.reject(
+        new Error(`Federation request timed out: ${params.method}`),
+      );
+    }
     const envelope: FederationRequestEnvelope = {
       id,
       kind: "request",
@@ -54,8 +73,8 @@ export class FederationRpcEndpoint {
       protocolVersion: FEDERATION_PROTOCOL_VERSION,
       sourceInstanceId: this.options.localInstanceId,
       targetInstanceId: this.options.remoteInstanceId,
-      createdAt: this.now(),
-      deadlineAt: this.now() + timeoutMs,
+      createdAt: now,
+      deadlineAt,
     };
 
     const promise = new Promise<Result>((resolve, reject) => {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -125,6 +125,7 @@ import {
   type DesktopFederationMode,
   type HandoffThreadWorkspaceRequest,
   type GetNavigationSnapshotRequest,
+  type GetNavigationSnapshotTransportRequest,
   type GetWorktreeUnpublishedCommitDiffRequest,
   type GetWorktreeUnpublishedCommitDiffResponse,
   type InterruptTurnRequest,
@@ -271,7 +272,10 @@ import {
   type FederationRemotePtyOperations,
 } from "./federation-pty-service";
 import { FederationRouter } from "./federation-router";
-import { FederationRpcEndpoint } from "./federation-rpc";
+import {
+  FederationRpcEndpoint,
+  type FederationRpcRequestOptions,
+} from "./federation-rpc";
 import {
   FederationPeerUnavailableError,
 } from "./federation-peer-unavailable-error";
@@ -1891,6 +1895,7 @@ export class DesktopFederationRuntime {
     target: FederationRemoteTarget,
     request: Pick<GetNavigationSnapshotRequest, "backend" | "filter">,
     selectionOverride?: FederationThreadSelection,
+    rpcOptions?: FederationRpcRequestOptions,
   ): Promise<NavigationSnapshot> {
     const backend = this.remoteBackend(target);
     const snapshotRequest = {
@@ -1905,9 +1910,9 @@ export class DesktopFederationRuntime {
       )
     ) {
       const startedAt = Date.now();
-      const legacyResponse = await backend.getNavigationSnapshot(
-        snapshotRequest,
-      );
+      const legacyResponse = rpcOptions
+        ? await backend.getNavigationSnapshot(snapshotRequest, rpcOptions)
+        : await backend.getNavigationSnapshot(snapshotRequest);
       this.logRemoteNavigationWireResponse({
         target,
         startedAt,
@@ -1943,7 +1948,7 @@ export class DesktopFederationRuntime {
       selectionKey,
     );
     let startedAt = Date.now();
-    let transportResponse = await backend.getNavigationSnapshotTransport({
+    const transportRequest: GetNavigationSnapshotTransportRequest = {
       transport: {
         protocol: 1,
         selection,
@@ -1951,7 +1956,13 @@ export class DesktopFederationRuntime {
           ? { baseRevision: previousTransportState.revision }
           : {}),
       },
-    });
+    };
+    let transportResponse = rpcOptions
+      ? await backend.getNavigationSnapshotTransport(
+          transportRequest,
+          rpcOptions,
+        )
+      : await backend.getNavigationSnapshotTransport(transportRequest);
     this.logRemoteNavigationWireResponse({
       target,
       startedAt,
@@ -1973,9 +1984,15 @@ export class DesktopFederationRuntime {
     );
     if (!nextTransportState) {
       startedAt = Date.now();
-      transportResponse = await backend.getNavigationSnapshotTransport({
+      const baselineRequest: GetNavigationSnapshotTransportRequest = {
         transport: { protocol: 1, selection },
-      });
+      };
+      transportResponse = rpcOptions
+        ? await backend.getNavigationSnapshotTransport(
+            baselineRequest,
+            rpcOptions,
+          )
+        : await backend.getNavigationSnapshotTransport(baselineRequest);
       this.logRemoteNavigationWireResponse({
         target,
         startedAt,
@@ -2232,9 +2249,9 @@ export class DesktopFederationRuntime {
   remoteThreadSummaries(): RemoteThreadSummaryCache {
     this.remoteThreadSummaryCache ??= new RemoteThreadSummaryCache({
       peers: () => this.connectedPeerTargets(),
-      fetchSnapshot: (target, selection) =>
-        this.remoteNavigationSnapshot(target, {}, selection),
-      searchPeer: async (target, request) => {
+      fetchSnapshot: (target, selection, rpcOptions) =>
+        this.remoteNavigationSnapshot(target, {}, selection, rpcOptions),
+      searchPeer: async (target, request, rpcOptions) => {
         const startedAt = Date.now();
         const backend = this.remoteBackend(target);
         if (!backend.searchNavigationThreads) {
@@ -2245,7 +2262,9 @@ export class DesktopFederationRuntime {
           throw unavailable;
         }
         try {
-          const response = await backend.searchNavigationThreads(request);
+          const response = rpcOptions
+            ? await backend.searchNavigationThreads(request, rpcOptions)
+            : await backend.searchNavigationThreads(request);
           const durationMs = Date.now() - startedAt;
           if (durationMs >= 1_000) {
             const responseBytes = Buffer.byteLength(

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -74,6 +74,22 @@ export const FEDERATION_KEEPALIVE_INTERVAL_MS = 15_000;
  * peer can force that allocation per frame.
  */
 export const FEDERATION_MAX_FRAME_BYTES = 16 * 1024 * 1024;
+const FEDERATION_LARGE_FRAME_LOG_BYTES = 512 * 1024;
+
+export class FederationFrameTooLargeError extends Error {
+  readonly code = "frame_too_large";
+
+  constructor(
+    readonly byteCount: number,
+    readonly maxFrameBytes: number,
+  ) {
+    super(
+      `Federation envelope exceeds configured frame send limit (${byteCount} > ${maxFrameBytes} bytes).`,
+    );
+    this.name = "FederationFrameTooLargeError";
+  }
+}
+
 const FEDERATION_BLOB_FRAME_MAGIC = Buffer.from("PWRBLOB1", "ascii");
 const FEDERATION_BLOB_FRAME_PREFIX_BYTES =
   FEDERATION_BLOB_FRAME_MAGIC.byteLength + 4;
@@ -265,7 +281,7 @@ export type FederationGatewayWebSocketServerOptions = {
   noiseStatic?: NoiseKeyPair;
   /** Ping cadence; a peer missing one interval's pong is terminated. */
   keepaliveIntervalMs?: number;
-  /** Per-frame receive ceiling (ws maxPayload). */
+  /** Per-frame send and receive ceiling. */
   maxFrameBytes?: number;
   /** Deadline for a connected socket to finish Noise + identity auth. */
   authTimeoutMs?: number;
@@ -574,6 +590,7 @@ export class FederationGatewayWebSocketServer {
           socket,
           { kind: "envelope", envelope },
           transport,
+          this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
         );
         if (byteCount > 0) {
           this.options.onEnvelopeTransfer?.({
@@ -588,6 +605,7 @@ export class FederationGatewayWebSocketServer {
           socket,
           { kind: "envelope", envelope },
           transport,
+          this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
         );
         if (byteCount > 0) {
           this.options.onEnvelopeTransfer?.({
@@ -835,7 +853,7 @@ export async function connectFederationClient(params: {
   connectTimeoutMs?: number;
   /** Ping cadence; a gateway missing one interval's pong is terminated. */
   keepaliveIntervalMs?: number;
-  /** Per-frame receive ceiling (ws maxPayload). */
+  /** Per-frame send and receive ceiling. */
   maxFrameBytes?: number;
   /** Client's Noise static keypair. Enables encryption (initiator role). */
   noiseStatic?: NoiseKeyPair;
@@ -921,6 +939,7 @@ async function establishFederationClient(
   socket: WebSocket,
   reader: FederationFrameReader,
 ): Promise<FederationClientWebSocketClient> {
+  const maxFrameBytes = params.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES;
   await waitForOpen(socket);
 
   // Phase 1: Noise_IK handshake (initiator). Skipped in tunnel mode.
@@ -1128,7 +1147,12 @@ async function establishFederationClient(
     // granting a capability we predate is ignored, not fatal.
     capabilities: knownCapabilities(accepted.capabilities),
     sendEnvelope: (envelope) => {
-      const byteCount = sendFrame(socket, { kind: "envelope", envelope }, transport);
+      const byteCount = sendFrame(
+        socket,
+        { kind: "envelope", envelope },
+        transport,
+        maxFrameBytes,
+      );
       if (byteCount > 0) {
         params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
       }
@@ -1138,6 +1162,7 @@ async function establishFederationClient(
         socket,
         { kind: "envelope", envelope },
         transport,
+        maxFrameBytes,
       );
       if (byteCount > 0) {
         params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
@@ -1242,10 +1267,39 @@ function sendFrame(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
+  maxFrameBytes = FEDERATION_MAX_FRAME_BYTES,
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
   const payload = encodeFederationSocketPayload(message);
   const wire = transport ? transport.encrypt(payload) : payload;
+  if (wire.byteLength > maxFrameBytes) {
+    const envelope = message.kind === "envelope" ? message.envelope : undefined;
+    log.error("federation frame exceeds configured send limit", {
+      byteCount: wire.byteLength,
+      envelopeKind: envelope?.kind,
+      maxFrameBytes,
+      messageKind: message.kind,
+      method: envelope?.kind === "request" ? envelope.method : undefined,
+      sourceInstanceId: envelope?.sourceInstanceId,
+      targetInstanceId: envelope?.targetInstanceId,
+    });
+    throw new FederationFrameTooLargeError(wire.byteLength, maxFrameBytes);
+  }
+  const envelope = message.kind === "envelope" ? message.envelope : undefined;
+  if (
+    wire.byteLength >= FEDERATION_LARGE_FRAME_LOG_BYTES
+    && envelope?.kind !== "blob_chunk"
+  ) {
+    log.info("large federation frame queued for send", {
+      byteCount: wire.byteLength,
+      envelopeKind: envelope?.kind,
+      maxFrameBytes,
+      messageKind: message.kind,
+      method: envelope?.kind === "request" ? envelope.method : undefined,
+      sourceInstanceId: envelope?.sourceInstanceId,
+      targetInstanceId: envelope?.targetInstanceId,
+    });
+  }
   socket.send(wire);
   return wire.byteLength;
 }
@@ -1254,12 +1308,13 @@ async function sendFrameWithBackpressure(
   socket: WebSocket,
   message: FederationSocketMessage,
   transport?: NoiseTransport,
+  maxFrameBytes = FEDERATION_MAX_FRAME_BYTES,
 ): Promise<number> {
   await waitForFederationSendCapacity(socket);
   if (socket.readyState !== WebSocket.OPEN) {
     throw new Error("Federation connection closed while sending an attachment.");
   }
-  return sendFrame(socket, message, transport);
+  return sendFrame(socket, message, transport, maxFrameBytes);
 }
 
 export async function waitForFederationSendCapacity(

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -1271,11 +1271,13 @@ function sendFrame(
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
   const payload = encodeFederationSocketPayload(message);
-  const wire = transport ? transport.encrypt(payload) : payload;
-  if (wire.byteLength > maxFrameBytes) {
+  const wireByteLength = transport
+    ? transport.encryptedByteLength(payload.byteLength)
+    : payload.byteLength;
+  if (wireByteLength > maxFrameBytes) {
     const envelope = message.kind === "envelope" ? message.envelope : undefined;
     log.error("federation frame exceeds configured send limit", {
-      byteCount: wire.byteLength,
+      byteCount: wireByteLength,
       envelopeKind: envelope?.kind,
       maxFrameBytes,
       messageKind: message.kind,
@@ -1283,15 +1285,15 @@ function sendFrame(
       sourceInstanceId: envelope?.sourceInstanceId,
       targetInstanceId: envelope?.targetInstanceId,
     });
-    throw new FederationFrameTooLargeError(wire.byteLength, maxFrameBytes);
+    throw new FederationFrameTooLargeError(wireByteLength, maxFrameBytes);
   }
   const envelope = message.kind === "envelope" ? message.envelope : undefined;
   if (
-    wire.byteLength >= FEDERATION_LARGE_FRAME_LOG_BYTES
+    wireByteLength >= FEDERATION_LARGE_FRAME_LOG_BYTES
     && envelope?.kind !== "blob_chunk"
   ) {
     log.info("large federation frame queued for send", {
-      byteCount: wire.byteLength,
+      byteCount: wireByteLength,
       envelopeKind: envelope?.kind,
       maxFrameBytes,
       messageKind: message.kind,
@@ -1300,6 +1302,7 @@ function sendFrame(
       targetInstanceId: envelope?.targetInstanceId,
     });
   }
+  const wire = transport ? transport.encrypt(payload) : payload;
   socket.send(wire);
   return wire.byteLength;
 }

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -18,7 +18,10 @@ import {
 } from "@pwragent/shared";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
 import { ThreadInfoStore } from "../app-server/thread-info-store";
-import { hasFederationErrorCode } from "./federation-rpc";
+import {
+  hasFederationErrorCode,
+  type FederationRpcRequestOptions,
+} from "./federation-rpc";
 
 export type RemoteThreadSummaryPeer = {
   target: FederationRemoteTarget;
@@ -181,6 +184,7 @@ export class RemoteThreadSummaryCache {
       fetchSnapshot: (
         target: FederationRemoteTarget,
         selection: FederationThreadSelection,
+        rpcOptions?: FederationRpcRequestOptions,
       ) => Promise<NavigationSnapshot>;
       /**
        * Bounded owner-side Cmd+K search. Older peers reject the new method;
@@ -189,6 +193,7 @@ export class RemoteThreadSummaryCache {
       searchPeer?: (
         target: FederationRemoteTarget,
         request: FederationJumpSearchRequest,
+        rpcOptions?: FederationRpcRequestOptions,
       ) => Promise<NavigationThreadSummary[]>;
       /** Archived threads for one backend on a connected peer. */
       fetchArchivedThreads: (
@@ -834,7 +839,7 @@ export class RemoteThreadSummaryCache {
     if (this.options.searchPeer) {
       try {
         return await withTimeout(
-          this.options.searchPeer(target, request),
+          this.options.searchPeer(target, request, { deadlineAt }),
           timeoutMs,
           `Remote thread search timed out after ${Math.round(timeoutMs / 1000)}s.`,
         );
@@ -904,8 +909,11 @@ export class RemoteThreadSummaryCache {
     // recorded.
     const nameObservationSequence = this.reserveThreadNameObservation();
     const promise = (async () => {
+      const rpcOptions = deadlineAt !== undefined ? { deadlineAt } : undefined;
       const snapshot = await this.awaitPeerSnapshot(
-        this.options.fetchSnapshot(target, selection),
+        rpcOptions
+          ? this.options.fetchSnapshot(target, selection, rpcOptions)
+          : this.options.fetchSnapshot(target, selection),
         deadlineAt,
       );
       if (this.generationFor(target.instanceId) !== generation) {


### PR DESCRIPTION
## Summary

- propagate one absolute peer deadline through generic federation search, Cmd+K bounded search, and legacy snapshot fallbacks so timed-out RPCs are removed instead of lingering on the 30-second default
- reject oversized federation envelopes before WebSocket send on both gateway and client paths, and log non-attachment frames at 512 KiB for generic response-size visibility
- cover expired deadlines, underlying pending-RPC cleanup, shared legacy-fallback budgets, and both send directions

Stacked on #1978.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/federation-rpc.test.ts apps/desktop/src/main/__tests__/federated-search-service.test.ts apps/desktop/src/main/__tests__/federation-transport.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts apps/desktop/src/main/__tests__/federation-runtime.test.ts`
- `pnpm typecheck`
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint`
- targeted ESLint on all changed files
- `pnpm lint:boundaries`
- `git diff --check`