### PR TITLE
fix(desktop): nest a created thread under the thread that created it

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -23,6 +23,7 @@ import {
   buildNavigationSnapshot,
   buildThreadIdentityKey,
   CODEX_NATIVE_SUBAGENT_NAVIGATION_RETENTION_MS,
+  federatedThreadIdentityKey,
   MAX_THREAD_READ_EVALUATION_PRICING_SUMMARIES,
   PWRAGENT_MESSAGING_PDF_TOOL_CATALOG_VERSION,
   PWRSNAP_MCP_CONNECTION_ID,
@@ -59,6 +60,7 @@ import type {
   NavigationLaunchpadDefaults,
   NavigationSnapshot,
   NavigationLaunchpadDraft,
+  NavigationThreadSummary,
   PwrAgentThreadOrchestrationRequest,
   PwrAgentThreadOrchestrationResponse,
   PrSummary,
@@ -11363,6 +11365,145 @@ describe("DesktopBackendRegistry", () => {
         .filter((event) => event.notification.method === "thread/pin/added")
         .map((event) => (event.notification.params as { threadId: string }).threadId),
     ).toEqual(["thread-top"]);
+
+    await registry.close();
+  });
+
+  it("leaves a peer-owned ancestor alone instead of writing a local overlay", async () => {
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-remote-ancestor-project"),
+    );
+    const directoryKey = `directory:${directoryPath}`;
+    const linkedDirectory = {
+      id: directoryKey,
+      kind: "local" as const,
+      label: "project",
+      path: directoryPath,
+    };
+    const remoteRef = buildFederatedThreadRef({
+      backend: "codex",
+      instanceId: "peer-laptop",
+      threadId: "thread-remote-parent",
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+        ],
+      }),
+      overlayStore,
+    });
+    const snapshot = buildNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 1_000,
+      firstSnapshot: false,
+      directoryOverlayByKey: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+      overlayByThreadKey: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-pinned"],
+      threads: [
+        {
+          id: "thread-pinned",
+          title: "Pinned thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1_000,
+        },
+      ],
+      unchanged: false,
+    });
+    const localRow = snapshot.threads[0]!;
+    const remoteRow: NavigationThreadSummary = {
+      ...localRow,
+      federation: { instanceLabel: "Laptop", ref: remoteRef },
+      id: "thread-remote-parent",
+      pinnedRank: undefined,
+      subthreadsCollapsed: true,
+      title: "Peer's thread",
+    };
+    // A peer's row joins a local directory after the snapshot is built and is
+    // listed there under its FEDERATED key — that is what
+    // `attachRemoteThreadsToLocalDirectories` does in the real path.
+    registry.rememberNavigationVisibilityIndex({
+      directories: snapshot.directories.map((directory) =>
+        directory.key === directoryKey
+          ? {
+              ...directory,
+              threadKeys: [
+                ...directory.threadKeys,
+                federatedThreadIdentityKey(remoteRef),
+              ],
+            }
+          : directory),
+      threads: [...snapshot.threads, remoteRow],
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    // The parent is named by backend and id, so finding it at all requires
+    // translating to its federated key. Once found, it is the peer's row: its
+    // pin lives in `remote_thread_pins` and its collapse is the owner's state,
+    // so there is nothing here to write — and the child must not be pinned as
+    // a consolation, since it renders nested either way.
+    const response = await registry.startThread({
+      backend: "codex",
+      cwd: directoryPath,
+      parentThreadId: "thread-remote-parent",
+      parentThreadBackend: "codex",
+    });
+
+    expect(response).not.toHaveProperty("pinnedRank");
+    expect(response).not.toHaveProperty("autoPinFailure");
+    expect(
+      events.filter((event) =>
+        event.notification.method === "thread/pin/added"
+        || event.notification.method === "thread/subthreadsCollapsed/updated"),
+    ).toEqual([]);
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-remote-parent",
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.not.toHaveProperty("pinnedRank");
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1032,6 +1032,29 @@ function createOverlayStoreMock(params?: {
       overlays.set(key, next);
       return next;
     },
+    setSubthreadsCollapsed: async ({
+      backend,
+      parentThreadId,
+      collapsed,
+    }: {
+      backend: AppServerBackendKind;
+      parentThreadId: string;
+      collapsed: boolean;
+    }) => {
+      const key = `${backend}:${parentThreadId}`;
+      const current = overlays.get(key) ?? {
+        backend,
+        threadId: parentThreadId,
+        executionMode: "default" as const,
+        extraLinkedDirectories: [],
+      };
+      const next: ThreadOverlayState = {
+        ...current,
+        subthreadsCollapsed: collapsed,
+      };
+      overlays.set(key, next);
+      return next;
+    },
     setThreadScheduledStart: async ({
       backend,
       threadId,
@@ -10945,6 +10968,473 @@ describe("DesktopBackendRegistry", () => {
       notification: expect.objectContaining({
         method: "thread/pin/added",
       }),
+    });
+
+    await registry.close();
+  });
+
+  it("pins the parent of a new child, not the child, when the collapse hides it", async () => {
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-hidden-parent-project"),
+    );
+    const directoryKey = `directory:${directoryPath}`;
+    const linkedDirectory = {
+      id: directoryKey,
+      kind: "local" as const,
+      label: "project",
+      path: directoryPath,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+        "codex:thread-unpinned-parent": {
+          backend: "codex",
+          threadId: "thread-unpinned-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+          {
+            id: "thread-unpinned-parent",
+            title: "Unpinned parent",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+        ],
+      }),
+      overlayStore,
+    });
+    registry.rememberCompleteNavigationSnapshot(buildNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 1_000,
+      firstSnapshot: false,
+      directoryOverlayByKey: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+      overlayByThreadKey: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+        "codex:thread-unpinned-parent": {
+          backend: "codex",
+          threadId: "thread-unpinned-parent",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+        },
+      },
+      previousKnownThreadKeys: [
+        "codex:thread-pinned",
+        "codex:thread-unpinned-parent",
+      ],
+      threads: [
+        {
+          id: "thread-pinned",
+          title: "Pinned thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1_000,
+        },
+        {
+          id: "thread-unpinned-parent",
+          title: "Unpinned parent",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1_000,
+        },
+      ],
+      unchanged: false,
+    }));
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    const response = await registry.startThread({
+      backend: "codex",
+      cwd: directoryPath,
+      parentThreadId: "thread-unpinned-parent",
+      parentThreadBackend: "codex",
+    });
+
+    // The child renders inside its parent's tray, so what has to be visible is
+    // the parent. Pinning the child instead would write a `pinnedRank` onto a
+    // row the sidebar shows no pin control for, leaving an unremovable pin.
+    expect(response).not.toHaveProperty("pinnedRank");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.toMatchObject({
+      parentThreadId: "thread-unpinned-parent",
+    });
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-1",
+      }),
+    ).resolves.not.toHaveProperty("pinnedRank");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-unpinned-parent",
+      }),
+    ).resolves.toMatchObject({ pinnedRank: "2048" });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/pin/added",
+        params: {
+          threadId: "thread-unpinned-parent",
+          pinnedRank: "2048",
+        },
+      },
+    });
+
+    await registry.close();
+  });
+
+  it("opens a pinned parent's collapsed tray instead of pinning its new child", async () => {
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-collapsed-tray-project"),
+    );
+    const directoryKey = `directory:${directoryPath}`;
+    const linkedDirectory = {
+      id: directoryKey,
+      kind: "local" as const,
+      label: "project",
+      path: directoryPath,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+          subthreadsCollapsed: true,
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned parent",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+        ],
+      }),
+      overlayStore,
+    });
+    registry.rememberCompleteNavigationSnapshot(buildNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 1_000,
+      firstSnapshot: false,
+      directoryOverlayByKey: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+      overlayByThreadKey: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+          subthreadsCollapsed: true,
+        },
+      },
+      previousKnownThreadKeys: ["codex:thread-pinned"],
+      threads: [
+        {
+          id: "thread-pinned",
+          title: "Pinned parent",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1_000,
+        },
+      ],
+      unchanged: false,
+    }));
+
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    // The parent is pinned, but its own sub-thread tray is collapsed, so it
+    // renders none of its children. Opening the tray is what reveals the new
+    // child — the same thing the renderer does when it inserts one itself.
+    const response = await registry.startThread({
+      backend: "codex",
+      cwd: directoryPath,
+      parentThreadId: "thread-pinned",
+      parentThreadBackend: "codex",
+    });
+
+    expect(response).not.toHaveProperty("pinnedRank");
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "thread-pinned",
+      }),
+    ).resolves.toMatchObject({
+      pinnedRank: "1024",
+      subthreadsCollapsed: false,
+    });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/subthreadsCollapsed/updated",
+        params: {
+          parentThreadId: "thread-pinned",
+          collapsed: false,
+        },
+      },
+    });
+    expect(events).not.toContainEqual({
+      backend: "codex",
+      notification: expect.objectContaining({
+        method: "thread/pin/added",
+      }),
+    });
+
+    await registry.close();
+  });
+
+  it("walks past a nested parent to the row this directory renders top-level", async () => {
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-grandchild-project"),
+    );
+    const directoryKey = `directory:${directoryPath}`;
+    const linkedDirectory = {
+      id: directoryKey,
+      kind: "local" as const,
+      label: "project",
+      path: directoryPath,
+    };
+    const topLevel = {
+      id: "thread-top",
+      title: "Top-level thread",
+      titleSource: "explicit" as const,
+      source: "codex" as const,
+      linkedDirectories: [linkedDirectory],
+      updatedAt: 1_000,
+    };
+    const nestedParent = {
+      ...topLevel,
+      id: "thread-nested-parent",
+      title: "Nested parent",
+      parentThreadId: "thread-top",
+      parentThreadBackend: "codex" as const,
+    };
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [linkedDirectory],
+            updatedAt: 1_000,
+          },
+          topLevel,
+          nestedParent,
+        ],
+      }),
+      overlayStore,
+    });
+    registry.rememberCompleteNavigationSnapshot(buildNavigationSnapshot({
+      backend: "all",
+      fetchedAt: 1_000,
+      firstSnapshot: false,
+      directoryOverlayByKey: {
+        [directoryKey]: {
+          directoryKey,
+          directoryThreadsCollapsed: true,
+        },
+      },
+      overlayByThreadKey: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+      previousKnownThreadKeys: [
+        "codex:thread-pinned",
+        "codex:thread-top",
+        "codex:thread-nested-parent",
+      ],
+      threads: [
+        {
+          id: "thread-pinned",
+          title: "Pinned thread",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [linkedDirectory],
+          updatedAt: 1_000,
+        },
+        topLevel,
+        nestedParent,
+      ],
+      unchanged: false,
+    }));
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    // The clicked card is itself nested, so pinning it would be pinning a row
+    // that already renders inside another tray. Only the group's top-level row
+    // can carry the pin.
+    const response = await registry.startThread({
+      backend: "codex",
+      cwd: directoryPath,
+      parentThreadId: "thread-nested-parent",
+      parentThreadBackend: "codex",
+    });
+
+    expect(response).not.toHaveProperty("pinnedRank");
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/pin/added",
+        params: {
+          threadId: "thread-top",
+          pinnedRank: "2048",
+        },
+      },
+    });
+    expect(
+      events
+        .filter((event) => event.notification.method === "thread/pin/added")
+        .map((event) => (event.notification.params as { threadId: string }).threadId),
+    ).toEqual(["thread-top"]);
+
+    await registry.close();
+  });
+
+  it("auto-pins a new child whose parent this directory does not render", async () => {
+    const directoryPath = expectedDir(
+      path.join(os.tmpdir(), "pwragent-auto-pin-foreign-parent-project"),
+    );
+    const directoryKey = `directory:${directoryPath}`;
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-pinned": {
+          backend: "codex",
+          threadId: "thread-pinned",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          pinnedRank: "1024",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({
+        threads: [
+          {
+            id: "thread-pinned",
+            title: "Pinned thread",
+            titleSource: "explicit",
+            source: "codex",
+            linkedDirectories: [
+              {
+                id: directoryKey,
+                kind: "local" as const,
+                label: "project",
+                path: directoryPath,
+              },
+            ],
+            updatedAt: 1_000,
+          },
+        ],
+      }),
+      overlayStore,
+    });
+    rememberCollapsedDirectoryWithPinnedThread({
+      directoryKey,
+      directoryPath,
+      registry,
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => {
+      events.push(event);
+    });
+
+    // A parent that aged out of the navigation window renders nowhere, so this
+    // directory shows its new child as a top-level row — and that row is the
+    // one that needs the pin.
+    const response = await registry.startThread({
+      backend: "codex",
+      cwd: directoryPath,
+      parentThreadId: "thread-outside-the-window",
+      parentThreadBackend: "codex",
+    });
+
+    expect(response).toMatchObject({ pinnedRank: "2048" });
+    expect(events).toContainEqual({
+      backend: "codex",
+      notification: {
+        method: "thread/pin/added",
+        params: {
+          threadId: "thread-1",
+          pinnedRank: "2048",
+        },
+      },
     });
 
     await registry.close();
@@ -32134,7 +32624,10 @@ script = "printf setup"
     await rm(root, { recursive: true, force: true });
   });
 
-  it.each([undefined, "remote-owner"])("groups handoffs from a persisted grandchild under the root owner %s", async (parentThreadInstanceId) => {
+  // The intermediate row's `parentThreadInstanceId` used to decide how far the
+  // root walk climbed. Now that a child parents to its own source, it changes
+  // nothing — so both shapes must produce the same answer.
+  it.each([undefined, "remote-owner"])("groups a handoff from a persisted grandchild under its own source, intermediate owner %s", async (parentThreadInstanceId) => {
     const rootDirectory = {
       id: expectedDir("/repo/app"),
       kind: "local" as const,
@@ -32241,7 +32734,7 @@ script = "printf setup"
     );
     expect(payload).toMatchObject({
       threadId: "thread-1",
-      groupedUnderThreadId: "root-thread",
+      groupedUnderThreadId: "source-grandchild",
       origin: {
         sourceThreadId: "source-grandchild",
       },
@@ -32252,8 +32745,17 @@ script = "printf setup"
         threadId: "thread-1",
       }),
     ).resolves.toMatchObject({
-      parentThreadId: "root-thread",
-      ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
+      parentThreadId: "source-grandchild",
+    });
+    // The source owns its own tray, so the new child lands there — and the
+    // root's order is left exactly as the operator arranged it.
+    await expect(
+      overlayStore.getThreadOverlayState({
+        backend: "codex",
+        threadId: "source-grandchild",
+      }),
+    ).resolves.toMatchObject({
+      subthreadOrder: ["thread-1"],
     });
     await expect(
       overlayStore.getThreadOverlayState({
@@ -32261,12 +32763,7 @@ script = "printf setup"
         threadId: "root-thread",
       }),
     ).resolves.toMatchObject({
-      subthreadOrder: parentThreadInstanceId ? ["older-child", "intermediate-child"] : [
-        "older-child",
-        "intermediate-child",
-        "source-grandchild",
-        "thread-1",
-      ],
+      subthreadOrder: ["older-child", "intermediate-child"],
     });
 
     await registry.close();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -308,7 +308,9 @@ import {
   applyCodexEnvironmentActionRunUpdate,
   buildPendingRequestResponse,
   buildThreadIdentityKey,
+  federatedThreadIdentityKey,
   insertSubthreadIdAfter,
+  resolveThreadParentKey,
   isAcpBackendId,
   isAppServerBackendKind,
   normalizePullRequestProvider,
@@ -5955,12 +5957,28 @@ type ThreadListCacheHit = {
   value: Promise<AppServerThreadSummary[]> | AppServerThreadSummary[];
 };
 
+/**
+ * One row of a directory, reduced to what deciding a new thread's visibility
+ * needs: how to reach its top-level ancestor, whether that ancestor renders,
+ * and how to address it for a pin.
+ */
+type CreatedThreadVisibilityRow = {
+  backend: AppServerBackendKind;
+  /** Absent once the walk reaches a row this directory renders top-level. */
+  parentKey?: string;
+  pinned: boolean;
+  subthreadsCollapsed: boolean;
+  threadId: string;
+};
+
 type CreatedThreadDirectoryVisibility = Pick<
   NavigationDirectorySummary,
   "key" | "kind" | "path"
 > & {
   directoryThreadsCollapsed: boolean;
   hasPinnedTopLevelThread: boolean;
+  /** Keyed exactly as `directory.threadKeys` names each row. */
+  rowsByThreadKey: ReadonlyMap<string, CreatedThreadVisibilityRow>;
 };
 
 let threadListCacheSequence = 0;
@@ -9925,9 +9943,16 @@ export class DesktopBackendRegistry {
     threads: NavigationThreadSummary[];
     directories: NavigationDirectorySummary[];
   }): void {
+    // Key each thread the way `directory.threadKeys` names it. A remote row
+    // pinned into a local directory is listed there under its federated key,
+    // so keying everything locally made every remote pin invisible to the
+    // visibility facts below — and a directory whose only pins are a peer's
+    // rows would report having none.
     const threadsByKey = new Map(
       snapshot.threads.map((thread) => [
-        buildThreadIdentityKey(thread.source, thread.id),
+        thread.federation?.ref
+          ? federatedThreadIdentityKey(thread.federation.ref)
+          : buildThreadIdentityKey(thread.source, thread.id),
         thread,
       ]),
     );
@@ -9935,22 +9960,44 @@ export class DesktopBackendRegistry {
       .map((thread) => thread.pinnedRank)
       .filter((rank): rank is string => Boolean(rank));
     this.createdThreadDirectoryVisibility = new Map(
-      snapshot.directories.map((directory) => [
-        directory.key,
-        {
-          key: directory.key,
-          kind: directory.kind,
-          path: directory.path,
-          directoryThreadsCollapsed:
-            directory.directoryThreadsCollapsed === true,
-          hasPinnedTopLevelThread: directory.threadKeys.some((threadKey) => {
-            const thread = threadsByKey.get(threadKey);
-            return Boolean(
-              thread && !thread.parentThreadId && thread.pinnedRank,
-            );
-          }),
-        },
-      ]),
+      snapshot.directories.map((directory) => {
+        const directoryThreadKeys = new Set(directory.threadKeys);
+        let hasPinnedTopLevelThread = false;
+        const rowsByThreadKey = new Map<string, CreatedThreadVisibilityRow>();
+        for (const threadKey of directory.threadKeys) {
+          const thread = threadsByKey.get(threadKey);
+          if (!thread) continue;
+          // Resolved with the renderer's own rule so "top-level in this
+          // directory" means the same thing on both sides: a parent outside
+          // this directory leaves the row top-level here.
+          const parentKey = resolveThreadParentKey(thread, threadsByKey);
+          const nestedHere = Boolean(
+            parentKey && directoryThreadKeys.has(parentKey),
+          );
+          rowsByThreadKey.set(threadKey, {
+            backend: thread.source,
+            ...(nestedHere ? { parentKey } : {}),
+            pinned: Boolean(thread.pinnedRank),
+            subthreadsCollapsed: thread.subthreadsCollapsed === true,
+            threadId: thread.id,
+          });
+          if (thread.pinnedRank && !nestedHere) {
+            hasPinnedTopLevelThread = true;
+          }
+        }
+        return [
+          directory.key,
+          {
+            key: directory.key,
+            kind: directory.kind,
+            path: directory.path,
+            directoryThreadsCollapsed:
+              directory.directoryThreadsCollapsed === true,
+            hasPinnedTopLevelThread,
+            rowsByThreadKey,
+          },
+        ];
+      }),
     );
     this.navigationDirectoriesByKey = new Map(
       snapshot.directories.map((directory) => [directory.key, directory]),
@@ -14347,10 +14394,10 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * Keep a newly created top-level thread visible when its directory's
-   * unpinned section is collapsed. This runs after parent and directory
-   * relationships are persisted so every creation surface shares the same
-   * policy and a child of an already-visible parent is never pinned itself.
+   * Keep a newly created thread visible when its directory's unpinned section
+   * is collapsed. This runs after parent and directory relationships are
+   * persisted so every creation surface shares the same policy and a child of
+   * an already-visible parent is never pinned itself.
    */
   private resolveCreatedThreadDirectoryVisibility(params: {
     directoryKey?: string;
@@ -14404,18 +14451,148 @@ export class DesktopBackendRegistry {
       });
   }
 
+  /**
+   * The row this directory renders top-level for `threadId`'s group, or
+   * `undefined` when the directory renders no such row — a parent on a peer,
+   * in another project, or outside the navigation window all land here, and a
+   * new child of one of those is top-level in this directory itself.
+   */
+  private resolveCreatedThreadVisibilityAncestor(params: {
+    backend: AppServerBackendKind;
+    directory: CreatedThreadDirectoryVisibility;
+    threadId: string;
+  }): CreatedThreadVisibilityRow | undefined {
+    const rows = params.directory.rowsByThreadKey;
+    let key = buildThreadIdentityKey(params.backend, params.threadId);
+    let row = rows.get(key);
+    const seen = new Set<string>();
+    while (row?.parentKey && !seen.has(key)) {
+      seen.add(key);
+      const parent = rows.get(row.parentKey);
+      // A parent link this directory does not render leaves the current row
+      // as the group's top-level row.
+      if (!parent) break;
+      key = row.parentKey;
+      row = parent;
+    }
+    return row;
+  }
+
+  /**
+   * Make a group's top-level row show the child that was just created: pin the
+   * row when the collapse would hide it, and open its sub-thread tray when the
+   * operator had it closed. Mirrors what the renderer already does when it
+   * inserts a child from the sidebar, so both creation paths leave the same
+   * state behind.
+   */
+  private async revealCreatedThreadGroup(params: {
+    ancestor: CreatedThreadVisibilityRow;
+    directory: CreatedThreadDirectoryVisibility;
+  }): Promise<Pick<StartThreadResponse, "pinnedRank" | "autoPinFailure">> {
+    const { ancestor } = params;
+    if (ancestor.pinned && !ancestor.subthreadsCollapsed) {
+      return {};
+    }
+    try {
+      if (ancestor.subthreadsCollapsed) {
+        await this.overlayStore.setSubthreadsCollapsed?.({
+          backend: ancestor.backend,
+          parentThreadId: ancestor.threadId,
+          collapsed: false,
+        });
+        await this.emit({
+          backend: ancestor.backend,
+          notification: {
+            method: "thread/subthreadsCollapsed/updated",
+            params: {
+              parentThreadId: ancestor.threadId,
+              collapsed: false,
+            },
+          },
+        });
+      }
+      if (!ancestor.pinned) {
+        await this.createdThreadVisibilityLock.run(
+          "global-pin-order",
+          async () => {
+            const pinnedRank = await this.buildCreatedThreadVisibilityPinRank();
+            await this.overlayStore.setThreadPin({
+              backend: ancestor.backend,
+              threadId: ancestor.threadId,
+              pinnedRank,
+            });
+            await this.emit({
+              backend: ancestor.backend,
+              notification: {
+                method: "thread/pin/added",
+                params: {
+                  threadId: ancestor.threadId,
+                  pinnedRank,
+                },
+              },
+            });
+            this.createdThreadVisibilityPinnedRanks.push(pinnedRank);
+          },
+        );
+      }
+      logDebug("createdThreadVisibility:groupRevealed", {
+        directoryKey: params.directory.key,
+        threadId: ancestor.threadId,
+      });
+      return {};
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      backendRegistryLog.warn("created thread group reveal failed", {
+        backend: ancestor.backend,
+        error: detail,
+        threadId: ancestor.threadId,
+      });
+      return {
+        autoPinFailure: {
+          message:
+            `The new thread was created, but its group could not be revealed automatically: ${detail}`,
+        },
+      };
+    }
+  }
+
+  /**
+   * The next rank at the bottom of the operator's pin list. Remote rows pinned
+   * into this viewer's main window own ranks in `remote_thread_pins`, not the
+   * local thread overlay, and new local pins join the same user-curated order,
+   * so rank allocation must include both stores or it can reuse a remote rank
+   * and strand the two rows at the local/remote boundary.
+   */
+  private async buildCreatedThreadVisibilityPinRank(): Promise<string> {
+    let remotePinnedRanks: Array<string | undefined> = [];
+    try {
+      remotePinnedRanks =
+        typeof this.overlayStore.listRemoteThreadPins === "function"
+          ? (await this.overlayStore.listRemoteThreadPins())
+              .map((pin) => pin.localPinnedRank)
+          : [];
+    } catch (error) {
+      // Visibility is an enhancement. A read failure should not turn a
+      // successfully created thread into a failed creation response.
+      backendRegistryLog.warn("remote pin ranks unavailable during auto-pin", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+    return buildAppendPinRank([
+      ...this.createdThreadVisibilityPinnedRanks,
+      ...remotePinnedRanks,
+    ]);
+  }
+
   private async finalizeCreatedThreadVisibility(params: {
     backend: AppServerBackendKind;
     directoryKey?: string;
     cwd?: string;
     linkedDirectories?: LinkedDirectorySummary[];
+    parentThreadBackend?: AppServerBackendKind;
     parentThreadId?: string;
     threadId: string;
   }): Promise<Pick<StartThreadResponse, "pinnedRank" | "autoPinFailure">> {
-    if (params.parentThreadId?.trim()) {
-      return {};
-    }
-
     const directory = this.resolveCreatedThreadDirectoryVisibility(params);
     if (
       !directory?.directoryThreadsCollapsed
@@ -14424,33 +14601,28 @@ export class DesktopBackendRegistry {
       return {};
     }
 
+    // A sub-thread renders inside its group, so what has to be visible is the
+    // group, not the child. Pinning the child instead would put a `pinnedRank`
+    // on a row `ThreadRow` refuses to show a pin control for — an unremovable
+    // pin while the parent renders, and a top-level row the operator never
+    // pinned as soon as it does not. So walk to the top-level ancestor and
+    // make *that* row show its tray.
+    const parentThreadId = params.parentThreadId?.trim();
+    const ancestor = parentThreadId
+      ? this.resolveCreatedThreadVisibilityAncestor({
+          backend: params.parentThreadBackend ?? params.backend,
+          directory,
+          threadId: parentThreadId,
+        })
+      : undefined;
+    if (ancestor) {
+      return await this.revealCreatedThreadGroup({ ancestor, directory });
+    }
+
+    // No ancestor this directory renders — the new thread is a top-level row
+    // here, so it is the row that needs the pin.
     return await this.createdThreadVisibilityLock.run("global-pin-order", async () => {
-      // Remote rows pinned into this viewer's main window own ranks in
-      // `remote_thread_pins`, not the local thread overlay. New local threads
-      // still join the same user-curated list, so rank allocation must include
-      // both stores or it can reuse a remote rank and strand the two rows at
-      // the local/remote boundary.
-      let remotePinnedRanks: Array<string | undefined> = [];
-      try {
-        remotePinnedRanks =
-          typeof this.overlayStore.listRemoteThreadPins === "function"
-            ? (await this.overlayStore.listRemoteThreadPins())
-                .map((pin) => pin.localPinnedRank)
-            : [];
-      } catch (error) {
-        // Auto-pinning is a visibility enhancement. A read failure should not
-        // turn a successfully created thread into a failed creation response.
-        backendRegistryLog.warn("remote pin ranks unavailable during auto-pin", {
-          error: error instanceof Error ? error.message : String(error),
-          threadId: params.threadId,
-        });
-      }
-      const pinnedRank = buildAppendPinRank(
-        [
-          ...this.createdThreadVisibilityPinnedRanks,
-          ...remotePinnedRanks,
-        ],
-      );
+      const pinnedRank = await this.buildCreatedThreadVisibilityPinRank();
       try {
         await this.overlayStore.setThreadPin({
           backend: params.backend,
@@ -14950,6 +15122,7 @@ export class DesktopBackendRegistry {
         resolvedLinkedDirectories?.length
           ? resolvedLinkedDirectories
           : buildLocalLinkedDirectory(cwd),
+      parentThreadBackend,
       parentThreadId,
       threadId: result.threadId,
     });
@@ -15305,6 +15478,7 @@ export class DesktopBackendRegistry {
       backend,
       cwd,
       linkedDirectories,
+      parentThreadBackend: request.parentThreadBackend,
       parentThreadId: request.parentThreadId,
       threadId: result.threadId,
     });
@@ -31814,48 +31988,6 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private async resolveHandoffGroupParentThreadRef(params: {
-    backend: AppServerBackendKind;
-    sourceOverlay: ThreadOverlayState;
-    sourceThreadId: string;
-  }): Promise<{ backend: AppServerBackendKind; threadId: string; instanceId?: string }> {
-    const directParentThreadId = params.sourceOverlay.parentThreadId?.trim();
-    if (!directParentThreadId) {
-      return { backend: params.backend, threadId: params.sourceThreadId };
-    }
-
-    let parentInstanceId = params.sourceOverlay.parentThreadInstanceId;
-    let parentThreadId = directParentThreadId;
-    let parentBackend =
-      params.sourceOverlay.parentThreadBackend ?? params.backend;
-    const directParentBackend = parentBackend;
-    const seen = new Set([
-      buildThreadIdentityKey(params.backend, params.sourceThreadId),
-    ]);
-    let parentKey = buildThreadIdentityKey(parentBackend, parentThreadId);
-    while (!seen.has(parentKey)) {
-      if (parentInstanceId) return { backend: parentBackend, threadId: parentThreadId, instanceId: parentInstanceId };
-      seen.add(parentKey);
-      const parentOverlay = await this.overlayStore.getThreadOverlayState({
-        backend: parentBackend,
-        threadId: parentThreadId,
-      });
-      const nextParentThreadId = parentOverlay?.parentThreadId?.trim();
-      if (!nextParentThreadId) {
-        return { backend: parentBackend, threadId: parentThreadId };
-      }
-      parentInstanceId = parentOverlay?.parentThreadInstanceId;
-      parentThreadId = nextParentThreadId;
-      parentBackend = parentOverlay?.parentThreadBackend ?? parentBackend;
-      parentKey = buildThreadIdentityKey(parentBackend, parentThreadId);
-    }
-
-    return {
-      backend: directParentBackend,
-      threadId: directParentThreadId,
-    };
-  }
-
   private startPendingThreadWorkspaceMove(
     move: PendingThreadWorkspaceMoveSummary,
   ): PendingThreadWorkspaceMoveSummary {
@@ -33726,13 +33858,15 @@ export class DesktopBackendRegistry {
         return threadOrchestrationFailure("invalid_arguments", message);
       }
     }
+    // A handoff's child belongs to the thread that created it. This used to
+    // walk the source's parent chain to its root and adopt the child there,
+    // which made the child a *sibling* of its own creator — and when that root
+    // was a peer's thread, or otherwise not a row in this directory, the child
+    // had nothing to nest under and landed loose in the list. Depth is the
+    // renderer's problem to present, not a reason to record the wrong parent.
     const groupedParentThread =
       groupingMode === "subthread"
-        ? await this.resolveHandoffGroupParentThreadRef({
-            backend: sourceBackend,
-            sourceOverlay,
-            sourceThreadId,
-          })
+        ? { backend: sourceBackend, threadId: sourceThreadId }
         : undefined;
     const groupedParentThreadId = groupedParentThread?.threadId;
     const groupedParentBackend = groupedParentThread?.backend;
@@ -33763,7 +33897,6 @@ export class DesktopBackendRegistry {
             ? {
                 parentThreadId: groupedParentThreadId,
                 parentThreadBackend: groupedParentBackend,
-                parentThreadInstanceId: groupedParentThread?.instanceId,
               }
             : {}),
           executionMode,
@@ -33812,7 +33945,6 @@ export class DesktopBackendRegistry {
           codexEnvironmentRuntime: inheritedSettings.codexEnvironmentRuntime,
           parentThreadId: groupedParentThreadId,
           parentThreadBackend: groupedParentBackend,
-          parentThreadInstanceId: groupedParentThread?.instanceId,
         });
         threadId = started.threadId;
         this.updatePendingThreadHandoff(handoffId, { threadId });
@@ -33820,16 +33952,16 @@ export class DesktopBackendRegistry {
         codexEnvironmentStartupFailure = started.codexEnvironmentStartupFailure;
         autoPinFailure = started.autoPinFailure;
       }
-      if (groupedParentThreadId && !groupedParentThread?.instanceId && this.overlayStore.updateSubthreadOrder) {
+      if (groupedParentThreadId && this.overlayStore.updateSubthreadOrder) {
         const parentOverlay = await this.overlayStore.getThreadOverlayState({
           backend: groupedParentBackend ?? backend,
           threadId: groupedParentThreadId,
         });
+        // The source owns this tray, so it never appears in its own order —
+        // `insertSubthreadIdAfter` prepends, putting the newest child directly
+        // under the thread that created it.
         const nextOrder = insertSubthreadIdAfter(
-          groupedParentThreadId === sourceThreadId ||
-          parentOverlay?.subthreadOrder?.includes(sourceThreadId)
-            ? (parentOverlay?.subthreadOrder ?? [])
-            : [...(parentOverlay?.subthreadOrder ?? []), sourceThreadId],
+          parentOverlay?.subthreadOrder ?? [],
           sourceThreadId,
           threadId,
         );

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5967,6 +5967,12 @@ type CreatedThreadVisibilityRow = {
   /** Absent once the walk reaches a row this directory renders top-level. */
   parentKey?: string;
   pinned: boolean;
+  /**
+   * True when this directory renders the row as a peer's thread. Its pin lives
+   * in `remote_thread_pins`, not the local thread overlay, so the local
+   * mutators must not be aimed at it.
+   */
+  remote: boolean;
   subthreadsCollapsed: boolean;
   threadId: string;
 };
@@ -5979,6 +5985,13 @@ type CreatedThreadDirectoryVisibility = Pick<
   hasPinnedTopLevelThread: boolean;
   /** Keyed exactly as `directory.threadKeys` names each row. */
   rowsByThreadKey: ReadonlyMap<string, CreatedThreadVisibilityRow>;
+  /**
+   * `<backend>:<threadId>` for every row above, including the peer-owned ones
+   * that `rowsByThreadKey` files under a federated key. A creation request
+   * names its parent by backend and id alone, so this is the only way to find
+   * a remote parent's row from one.
+   */
+  rowKeysByLocalKey: ReadonlyMap<string, string>;
 };
 
 let threadListCacheSequence = 0;
@@ -9964,6 +9977,7 @@ export class DesktopBackendRegistry {
         const directoryThreadKeys = new Set(directory.threadKeys);
         let hasPinnedTopLevelThread = false;
         const rowsByThreadKey = new Map<string, CreatedThreadVisibilityRow>();
+        const rowKeysByLocalKey = new Map<string, string>();
         for (const threadKey of directory.threadKeys) {
           const thread = threadsByKey.get(threadKey);
           if (!thread) continue;
@@ -9978,9 +9992,14 @@ export class DesktopBackendRegistry {
             backend: thread.source,
             ...(nestedHere ? { parentKey } : {}),
             pinned: Boolean(thread.pinnedRank),
+            remote: Boolean(thread.federation?.ref),
             subthreadsCollapsed: thread.subthreadsCollapsed === true,
             threadId: thread.id,
           });
+          rowKeysByLocalKey.set(
+            buildThreadIdentityKey(thread.source, thread.id),
+            threadKey,
+          );
           if (thread.pinnedRank && !nestedHere) {
             hasPinnedTopLevelThread = true;
           }
@@ -9995,6 +10014,7 @@ export class DesktopBackendRegistry {
               directory.directoryThreadsCollapsed === true,
             hasPinnedTopLevelThread,
             rowsByThreadKey,
+            rowKeysByLocalKey,
           },
         ];
       }),
@@ -14463,7 +14483,12 @@ export class DesktopBackendRegistry {
     threadId: string;
   }): CreatedThreadVisibilityRow | undefined {
     const rows = params.directory.rowsByThreadKey;
-    let key = buildThreadIdentityKey(params.backend, params.threadId);
+    // A creation request names its parent by backend and id, but a peer-owned
+    // row is filed under its federated key. Translate before the lookup, or
+    // every remote parent reads as "not rendered here" and its child takes a
+    // pin it cannot show a control for.
+    const localKey = buildThreadIdentityKey(params.backend, params.threadId);
+    let key = params.directory.rowKeysByLocalKey.get(localKey) ?? localKey;
     let row = rows.get(key);
     const seen = new Set<string>();
     while (row?.parentKey && !seen.has(key)) {
@@ -14491,6 +14516,18 @@ export class DesktopBackendRegistry {
   }): Promise<Pick<StartThreadResponse, "pinnedRank" | "autoPinFailure">> {
     const { ancestor } = params;
     if (ancestor.pinned && !ancestor.subthreadsCollapsed) {
+      return {};
+    }
+    if (ancestor.remote) {
+      // This row belongs to a peer: its pin lives in `remote_thread_pins` and
+      // its collapse is the owner's state, so both mutators below would write
+      // a local overlay nothing renders. Leave the group alone rather than
+      // fabricate one — and never fall through to pinning the child, which is
+      // a nested row either way.
+      logDebug("createdThreadVisibility:remoteGroupSkipped", {
+        directoryKey: params.directory.key,
+        threadId: ancestor.threadId,
+      });
       return {};
     }
     try {

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -32,7 +32,6 @@ import {
   moveDirectoryKey,
   moveThreadKey,
   resolveThreadParentKey,
-  sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
   ChevronDownIcon,
@@ -78,6 +77,7 @@ import {
   useNavigationDirectoryDisclosure,
   type NavigationDirectoryDisclosure,
 } from "../../lib/useNavigationDirectoryDisclosure";
+import { createSubthreadTrays } from "./subthread-trays";
 
 type DirectoriesListProps = {
   presentationOrder?: NavigationPresentationOrder;
@@ -1107,9 +1107,20 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const expandedThreadModel =
       expanded ? buildPagedDirectoryPresentation({ directory, presentationOrder: props.presentationOrder, resources: props.pagedNavigation?.resources ?? new Map(), threadsByKey }) : EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL;
     const { childThreadsByParentKey } = expandedThreadModel;
+    // One tray per top-level row, holding its whole descendant subtree in
+    // depth-first order. The owner keys each child under its *true* parent, so
+    // a grandchild is filed under a row that is itself a child; rendering only
+    // direct children would silently drop it from the lens.
+    const trays = createSubthreadTrays(childThreadsByParentKey);
+    for (const thread of expandedThreadModel.directoryPinnedThreads) trays.addTrayOwner(thread);
+    for (const thread of expandedThreadModel.unpinnedThreads) trays.addTrayOwner(thread);
     const renderStaticSubthreads = (parent: NavigationPresentedThread): ReactElement | null => {
       const parentKey = threadSummaryIdentityKey(parent);
-      const children = sortSubthreadSummaries(parent, childThreadsByParentKey.get(parentKey) ?? []);
+      // Already depth-first ordered by the tray. Re-sorting here by this row's
+      // `subthreadOrder` would rank its grandchildren as unlisted and scatter
+      // them away from the sub-threads that own them.
+      const children = trays.subtree(parentKey);
+      const directChildKeys = trays.directChildKeys(parentKey);
       const nativeSubAgentCount = parent.nativeSubAgentCount ?? parent.codexNativeSubAgents?.length ?? 0;
       const childResourceId = `children:${navigationIdentityKey({ backend: parent.source, threadId: parent.id,
         ownerInstanceId: parent.federation?.ref.target.scope === "remote" ? parent.federation.ref.target.instanceId : undefined })}`;
@@ -1129,9 +1140,10 @@ export function DirectoriesList(props: DirectoriesListProps) {
       // Wire drag-to-reorder, mirroring RecentsList — see the dedicated
       // `draggedSubthreadKey` state for why it stays isolated from the
       // directory / pinned-thread drag.
+      const directChildKeySet = new Set(directChildKeys);
       const reorderable =
         threadSupportsFederationCapability(parent, "thread_grouping")
-        && children.length > 1
+        && directChildKeys.length > 1
         && Boolean(props.onUpdateSubthreadOrder);
       return (
         // `listitem` box because this list is a SIBLING of its parent row
@@ -1163,10 +1175,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 draftThreadKeys={props.draftThreadKeys}
                 composerSourceThreadKey={props.composerSourceThreadKey}
                 compact
-                draggable={reorderable}
+                draggable={reorderable && directChildKeySet.has(childKey)}
                 includeLinkedDirectories
                 linkedDirectoryMode={getDirectoryRowLinkedDirectoryMode(child)}
                 nested
+                nestedDepth={trays.depth(childKey)}
                 revealSelectedThreadRequest={props.revealSelectedThreadRequest}
                 selectedThreadKey={props.selectedItemKey}
                 selectedThreadKeys={props.selectedThreadKeys}
@@ -1190,6 +1203,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   if (
                     !draggedThread
                     || draggedSubthreadKey === childKey
+                    || !directChildKeySet.has(childKey)
                     || resolveThreadParentKey(draggedThread, threadsByKey) !== parentKey
                   ) {
                     event.dataTransfer.dropEffect = "none";
@@ -1223,10 +1237,14 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     : undefined;
                   if (
                     !draggedThread
+                    || !directChildKeySet.has(childKey)
                     || resolveThreadParentKey(draggedThread, threadsByKey) !== parentKey
                   ) {
                     return;
                   }
+                  // `subthreadOrder` names this row's own children, so the
+                  // move stays inside that list — never the flattened tray,
+                  // which also carries rows owned by those children.
                   void props.onUpdateSubthreadOrder?.(parent, {
                     threadId: draggedThread.id,
                     anchorThreadId: child.id,
@@ -1293,8 +1311,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
       thread: NavigationThreadSummary,
     ): ReactElement => {
       const threadKey = threadSummaryIdentityKey(thread);
-      const ordinarySubthreadCount =
-        childThreadsByParentKey.get(threadKey)?.length ?? 0;
+      const ordinarySubthreadCount = trays.subtree(threadKey).length;
       const subthreadCount = getSubthreadDisclosureCount(
         thread,
         ordinarySubthreadCount,
@@ -1720,7 +1737,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                     {directoryPinnedThreads.map((thread) => {
 	                      const threadKey = threadSummaryIdentityKey(thread);
                           const ordinarySubthreadCount =
-                            childThreadsByParentKey.get(threadKey)?.length ?? 0;
+                            trays.subtree(threadKey).length;
                           const subthreadCount = getSubthreadDisclosureCount(
                             thread,
                             ordinarySubthreadCount,

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -11,13 +11,13 @@ import type {
 } from "@pwragent/shared";
 import {
   resolveThreadParentKey,
-  sortSubthreadSummaries,
 } from "@pwragent/shared";
 import {
   didDragLeaveCurrentTarget,
   getDropIndicatorPosition,
   useDropIndicatorController,
 } from "./drag-drop";
+import { createSubthreadTrays } from "./subthread-trays";
 import type { ThreadQueuedMessageState } from "../../lib/useThreadQueuedMessageIndicators";
 import {
   threadSummaryIdentityKey,
@@ -132,9 +132,20 @@ export function RecentsList(props: RecentsListProps) {
     if (row && !children.some((child) => threadSummaryIdentityKey(child) === key)) children.push(row);
     childrenByParentKey.set(parentKey, children);
   }
+  // One tray per top-level row, holding its whole descendant subtree in
+  // depth-first order. The owner keys each child under its *true* parent,
+  // so a grandchild is filed under a row that is itself a child; rendering
+  // only direct children would silently drop it from this lens.
+  const trays = createSubthreadTrays(childrenByParentKey);
+  for (const thread of topLevelThreads) trays.addTrayOwner(thread);
   const renderSubthreads = (parent: NavigationPresentedThread) => {
     const parentKey = threadSummaryIdentityKey(parent);
-    const children = sortSubthreadSummaries(parent, childrenByParentKey.get(parentKey) ?? []);
+    // Already depth-first ordered by the tray. Re-sorting here by this
+    // row's `subthreadOrder` would rank its grandchildren as unlisted and
+    // scatter them away from the sub-threads that own them.
+    const children = trays.subtree(parentKey);
+    const directChildKeys = trays.directChildKeys(parentKey);
+    const directChildKeySet = new Set(directChildKeys);
     const nativeSubAgentCount = parent.nativeSubAgentCount ?? parent.codexNativeSubAgents?.length ?? 0;
     const childResourceId = `children:${navigationIdentityKey({ backend: parent.source, threadId: parent.id,
       ownerInstanceId: parent.federation?.ref.target.scope === "remote" ? parent.federation.ref.target.instanceId : undefined })}`;
@@ -179,11 +190,13 @@ export function RecentsList(props: RecentsListProps) {
               composerSourceThreadKey={props.composerSourceThreadKey}
               draggable={
                 canManageSubthreads
-                && children.length > 1
+                && directChildKeys.length > 1
+                && directChildKeySet.has(childKey)
                 && Boolean(props.onUpdateSubthreadOrder)
               }
               includeLinkedDirectories
               nested
+              nestedDepth={trays.depth(childKey)}
               revealSelectedThreadRequest={props.revealSelectedThreadRequest}
               selectedThreadKey={props.selectedThreadKey}
               selectedThreadKeys={props.selectedThreadKeys}
@@ -196,6 +209,7 @@ export function RecentsList(props: RecentsListProps) {
                 if (
                   !draggedThread
                   || draggedKey === childKey
+                  || !directChildKeySet.has(childKey)
                   || resolveThreadParentKey(draggedThread, threadByKey) !== parentKey
                 ) {
                   event.dataTransfer.dropEffect = "none";
@@ -233,10 +247,14 @@ export function RecentsList(props: RecentsListProps) {
                 const draggedThread = threadByKey.get(draggedKey);
                 if (
                   !draggedThread
+                  || !directChildKeySet.has(childKey)
                   || resolveThreadParentKey(draggedThread, threadByKey) !== parentKey
                 ) {
                   return;
                 }
+                // `subthreadOrder` names this row's own children, so the
+                // move stays inside that list — never the flattened tray,
+                // which also carries rows owned by those children.
                 void props.onUpdateSubthreadOrder?.(parent, {
                   threadId: draggedThread.id,
                   anchorThreadId: child.id,
@@ -293,15 +311,11 @@ export function RecentsList(props: RecentsListProps) {
   // disclosure.
   const selectionOrder = topLevelThreads.flatMap((thread) => {
     const threadKey = threadSummaryIdentityKey(thread);
-    const children = sortSubthreadSummaries(
-      thread,
-      childrenByParentKey.get(threadKey) ?? [],
-    );
     return [
       threadKey,
       ...(isSubthreadSectionCollapsed(thread)
         ? []
-        : children.map((child) =>
+        : trays.subtree(threadKey).map((child) =>
             threadSummaryIdentityKey(child),
           )),
     ];
@@ -309,7 +323,7 @@ export function RecentsList(props: RecentsListProps) {
 
   const renderThreadGroup = (thread: NavigationThreadSummary) => {
     const key = threadSummaryIdentityKey(thread);
-    const children = sortSubthreadSummaries(thread, childrenByParentKey.get(key) ?? []);
+    const children = trays.subtree(key);
     const subthreadCount = getSubthreadDisclosureCount(thread, children.length);
     const subthreadsCollapsed = isSubthreadSectionCollapsed(thread);
     return (

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -129,6 +129,7 @@ function hydrateHoverStableSidebarSnapshot(
       threadSummaryIdentityKey(thread),
     ),
   );
+
   return {
     order: retainNavigationPresentationOrder(frozen.order, latest.order),
     visibleKeys: [...frozen.visibleKeys.filter((key) => !options?.removeMissingThreads || latest.visibleKeys.includes(key)),

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -129,7 +129,6 @@ function hydrateHoverStableSidebarSnapshot(
       threadSummaryIdentityKey(thread),
     ),
   );
-
   return {
     order: retainNavigationPresentationOrder(frozen.order, latest.order),
     visibleKeys: [...frozen.visibleKeys.filter((key) => !options?.removeMissingThreads || latest.visibleKeys.includes(key)),

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -2,6 +2,7 @@ import {
   useEffect,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent,
   type MouseEvent,
   type DragEvent,
@@ -63,6 +64,13 @@ type ThreadRowProps = {
   includeLinkedDirectories?: boolean;
   linkedDirectoryMode?: "label" | "kind";
   nested?: boolean;
+  /**
+   * How deep this row sits inside its tray: 1 for a direct child, 2 for a
+   * grandchild. The tray is flat, so the indent is the only thing separating
+   * a grandchild from the sibling above it — and it is the same distinction
+   * that decides whether the row drags. Ignored unless `nested`.
+   */
+  nestedDepth?: number;
   revealSelectedThreadRequest?: number;
   selectedThreadKey?: string;
   /**
@@ -265,6 +273,13 @@ export function ThreadRow(props: ThreadRowProps) {
         props.subthreadCount ? " has-subthreads" : ""
       }`}
       draggable={props.draggable}
+      style={
+        props.nested && (props.nestedDepth ?? 1) > 1
+          ? ({
+              "--thread-row-nested-depth": props.nestedDepth,
+            } as CSSProperties)
+          : undefined
+      }
       data-hover-stable-row="thread"
       data-thread-pin-key={props.threadPinState ? threadKey : undefined}
       data-thread-pin-state={props.threadPinState}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -721,6 +721,88 @@ describe("Sidebar hover-stable thread ordering", () => {
     expect(within(list).getByRole("button", { name: /Alpha thread/ })).toBeVisible();
   });
 
+  it("shows an agent-created pinned thread arriving under a resting pointer", () => {
+    const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
+    const pinnedBravo = { ...bravo, pinnedRank: "2048" };
+    const collapsedDirectory = {
+      ...directory,
+      directoryThreadsCollapsed: true,
+    };
+    const view = render(renderSidebar({
+      browseMode: "directories",
+      directories: [collapsedDirectory],
+      selectedItemKey: "codex:alpha",
+      threads: [pinnedAlpha, pinnedBravo],
+    }));
+    fireEvent.pointerOver(threadRow("Alpha thread"), { pointerType: "mouse" });
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+
+    // Nothing the operator did creates this row: a handoff, a messaging reply,
+    // or a peer made it while the pointer merely rested on the list. The pin
+    // appended by creation is what keeps it out of the hidden section.
+    view.rerender(renderSidebar({
+      browseMode: "directories",
+      directories: [{
+        ...collapsedDirectory,
+        threadKeys: [...collapsedDirectory.threadKeys, "codex:charlie"],
+      }],
+      selectedItemKey: "codex:alpha",
+      threads: [
+        pinnedAlpha,
+        pinnedBravo,
+        { ...charlie, pinnedRank: "3072" },
+      ],
+    }));
+
+    expect(threadTitles()).toEqual([
+      "Alpha thread",
+      "Bravo thread",
+      "Charlie thread",
+    ]);
+  });
+
+  it("appends an agent-created pin below the frozen pins, never above them", () => {
+    const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
+    const pinnedBravo = { ...bravo, pinnedRank: "2048" };
+    const view = render(renderSidebar({
+      browseMode: "directories",
+      directories: [directory],
+      selectedItemKey: "codex:alpha",
+      threads: [pinnedAlpha, pinnedBravo],
+    }));
+    fireEvent.pointerOver(threadRow("Bravo thread"), { pointerType: "mouse" });
+    expect(threadTitles()).toEqual(["Alpha thread", "Bravo thread"]);
+
+    // A rank that sorts into the middle of the list — a viewer-owned remote
+    // pin, say — must still land at the bottom while the pointer rests, or the
+    // row under it moves out from under the click.
+    view.rerender(renderSidebar({
+      browseMode: "directories",
+      directories: [{
+        ...directory,
+        threadKeys: [...directory.threadKeys, "codex:charlie"],
+      }],
+      selectedItemKey: "codex:alpha",
+      threads: [
+        pinnedAlpha,
+        pinnedBravo,
+        { ...charlie, pinnedRank: "1536" },
+      ],
+    }));
+
+    expect(threadTitles()).toEqual([
+      "Alpha thread",
+      "Bravo thread",
+      "Charlie thread",
+    ]);
+    leaveThreadBrowser();
+    expect(threadTitles()).toEqual([
+      "Alpha thread",
+      "Charlie thread",
+      "Bravo thread",
+    ]);
+  });
+
   it("shows a newly created pinned thread while Directory threads are collapsed", () => {
     const onOpenLaunchpad = vi.fn(async () => undefined);
     const pinnedAlpha = { ...alpha, pinnedRank: "1024" };

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -1059,6 +1059,60 @@ describe("Sidebar", () => {
     expect(onSetSubthreadsCollapsed).toHaveBeenCalledWith(sharedThread, true);
   });
 
+  it("indents a grandchild deeper than the child it renders beside", () => {
+    const childThread = {
+      ...sharedThread,
+      id: "thread-review",
+      title: "Adversarial review",
+      parentThreadId: sharedThread.id,
+      updatedAt: sharedThread.updatedAt + 1,
+    };
+    const grandchildThread = {
+      ...sharedThread,
+      id: "thread-followup",
+      title: "Follow-up",
+      parentThreadId: childThread.id,
+      updatedAt: sharedThread.updatedAt + 2,
+    };
+    const threads = [grandchildThread, childThread, sharedThread];
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="inbox"
+        directories={directories}
+        inboxThreads={threads}
+        loading={false}
+        selectedItemKey="codex:thread-1"
+        threads={threads}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    const rowShell = (title: string): HTMLElement => {
+      const shell = screen
+        .getByRole("button", { name: title })
+        .closest(".thread-row-shell");
+      expect(shell).not.toBeNull();
+      return shell as HTMLElement;
+    };
+
+    // Both rows sit in the same flat tray, so the indent is the only thing
+    // that says the follow-up hangs off the review rather than beside it.
+    expect(container.querySelectorAll(".subthread-list")).toHaveLength(1);
+    expect(
+      rowShell("Adversarial review").style.getPropertyValue(
+        "--thread-row-nested-depth",
+      ),
+    ).toBe("");
+    expect(
+      rowShell("Follow-up").style.getPropertyValue("--thread-row-nested-depth"),
+    ).toBe("2");
+  });
+
   it("groups same-owner remote sub-threads and submits their drag order", () => {
     const target = { scope: "remote" as const, instanceId: "remote-owner" };
     const remoteParent: NavigationThreadSummary = {
@@ -1288,6 +1342,78 @@ describe("Sidebar", () => {
     expect(container.querySelector(".subthread-list")).toContainElement(
       threadCard(childButton),
     );
+  });
+
+  it("renders a grandchild in its top-level ancestor's tray in Directories", () => {
+    const parentThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "top-parent",
+      title: "Directory parent",
+      pinnedRank: "1024",
+    };
+    const childThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "mid-child",
+      title: "Directory child",
+      parentThreadId: parentThread.id,
+      parentThreadBackend: "codex",
+    };
+    const grandchildThread: NavigationThreadSummary = {
+      ...sharedThread,
+      id: "leaf-grandchild",
+      title: "Directory grandchild",
+      parentThreadId: childThread.id,
+      parentThreadBackend: "codex",
+    };
+    const directory: NavigationDirectorySummary = {
+      ...directories[0]!,
+      threadKeys: ["codex:top-parent", "codex:mid-child", "codex:leaf-grandchild"],
+    };
+    const threads = [grandchildThread, childThread, parentThread];
+
+    const { container } = render(
+      <Sidebar
+        backends={backends}
+        browseMode="directories"
+        directories={[directory]}
+        inboxThreads={threads}
+        loading={false}
+        selectedItemKey="codex:top-parent"
+        threads={threads}
+        onBrowseModeChange={() => undefined}
+        onCreateThread={async () => undefined}
+        onOpenLaunchpad={async () => undefined}
+        onSelectThread={() => undefined}
+      />,
+    );
+
+    // The sidebar renders one nesting level, so the grandchild has to live in
+    // its top-level ancestor's tray — directly after the child that owns it,
+    // and indented one step deeper. Dropping it instead is the bug this
+    // flattening exists to prevent.
+    const trays = container.querySelectorAll(".subthread-list");
+    expect(trays).toHaveLength(1);
+    const tray = trays[0] as HTMLElement;
+    expect(tray.querySelectorAll(".thread-row-shell")).toHaveLength(2);
+    expect(within(tray).getByRole("button", { name: "Directory child" }))
+      .toBeInTheDocument();
+    const grandchildButton = within(tray).getByRole("button", {
+      name: "Directory grandchild",
+    });
+    // Depth-first: the grandchild follows the child that owns it.
+    expect(
+      within(tray).getByRole("button", { name: "Directory child" })
+        .compareDocumentPosition(grandchildButton)
+      & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // The depth custom property lives on the shell, which is what the
+    // `.thread-row-shell--nested` padding rule reads.
+    const grandchildShell = grandchildButton.closest(".thread-row-shell");
+    expect(
+      (grandchildShell as HTMLElement).style.getPropertyValue(
+        "--thread-row-nested-depth",
+      ),
+    ).toBe("2");
   });
 
   it("keeps native Codex workers in an on-demand sub-agent disclosure", () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/subthread-trays.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/subthread-trays.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { createSubthreadTrays } from "../subthread-trays";
+
+function thread(
+  id: string,
+  extra: Partial<NavigationThreadSummary> = {},
+): NavigationThreadSummary {
+  return {
+    id,
+    title: id,
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { inInbox: false },
+    ...extra,
+  } as NavigationThreadSummary;
+}
+
+function childrenByParentKey(
+  entries: Array<[string, NavigationThreadSummary[]]>,
+): Map<string, NavigationThreadSummary[]> {
+  return new Map(entries);
+}
+
+describe("createSubthreadTrays", () => {
+  it("flattens a subtree depth-first so a child follows its own parent", () => {
+    const root = thread("root", { subthreadOrder: ["child-a", "child-b"] });
+    const childA = thread("child-a", { subthreadOrder: ["grandchild"] });
+    const grandchild = thread("grandchild");
+    const childB = thread("child-b");
+    const trays = createSubthreadTrays(childrenByParentKey([
+      ["codex:root", [childB, childA]],
+      ["codex:child-a", [grandchild]],
+    ]));
+
+    trays.addTrayOwner(root);
+
+    expect(trays.subtree("codex:root").map((row) => row.id)).toEqual([
+      "child-a",
+      "grandchild",
+      "child-b",
+    ]);
+  });
+
+  it("reports each row's real depth so a flat tray still reads as a tree", () => {
+    const root = thread("root");
+    const child = thread("child");
+    const grandchild = thread("grandchild");
+    const greatGrandchild = thread("great-grandchild");
+    const trays = createSubthreadTrays(childrenByParentKey([
+      ["codex:root", [child]],
+      ["codex:child", [grandchild]],
+      ["codex:grandchild", [greatGrandchild]],
+    ]));
+
+    trays.addTrayOwner(root);
+
+    // The tray renders flat, so depth is the only thing separating a
+    // grandchild from the sibling above it.
+    expect(trays.depth("codex:child")).toBe(1);
+    expect(trays.depth("codex:grandchild")).toBe(2);
+    expect(trays.depth("codex:great-grandchild")).toBe(3);
+    // A row no tray placed — the owner itself, or a thread outside this lens
+    // — is as shallow as a rendered tray row can be.
+    expect(trays.depth("codex:root")).toBe(1);
+    expect(trays.depth("codex:absent")).toBe(1);
+  });
+
+  it("reports only direct children as reorderable", () => {
+    const root = thread("root");
+    const child = thread("child");
+    const grandchild = thread("grandchild");
+    const trays = createSubthreadTrays(childrenByParentKey([
+      ["codex:root", [child]],
+      ["codex:child", [grandchild]],
+    ]));
+
+    trays.addTrayOwner(root);
+
+    // `subthreadOrder` is stored per parent, so a reorder of this tray must
+    // never come to name the grandchild as a child of `root`.
+    expect(trays.directChildKeys("codex:root")).toEqual(["codex:child"]);
+    expect(trays.directChildKeys("codex:child")).toEqual([]);
+  });
+
+  it("gives a row to the first owner that claims it", () => {
+    const first = thread("first");
+    const second = thread("second");
+    const shared = thread("shared");
+    const trays = createSubthreadTrays(childrenByParentKey([
+      ["codex:first", [shared]],
+      ["codex:second", [shared]],
+    ]));
+
+    trays.addTrayOwner(first);
+    trays.addTrayOwner(second);
+
+    expect(trays.subtree("codex:first").map((row) => row.id)).toEqual([
+      "shared",
+    ]);
+    expect(trays.subtree("codex:second")).toEqual([]);
+  });
+
+  it("terminates on a parent-link cycle", () => {
+    const left = thread("left");
+    const right = thread("right");
+    const trays = createSubthreadTrays(childrenByParentKey([
+      ["codex:left", [right]],
+      ["codex:right", [left]],
+    ]));
+
+    trays.addTrayOwner(left);
+
+    expect(trays.subtree("codex:left").map((row) => row.id)).toEqual(["right"]);
+    expect(trays.isPlaced("codex:left")).toBe(true);
+    expect(trays.isPlaced("codex:right")).toBe(true);
+  });
+
+  it("returns empty views for a row that owns no tray", () => {
+    const trays = createSubthreadTrays(childrenByParentKey([]));
+
+    expect(trays.subtree("codex:absent")).toEqual([]);
+    expect(trays.directChildKeys("codex:absent")).toEqual([]);
+    expect(trays.isPlaced("codex:absent")).toBe(false);
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/subthread-trays.test.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/subthread-trays.test.ts
@@ -112,9 +112,10 @@ describe("createSubthreadTrays", () => {
 
     trays.addTrayOwner(left);
 
+    // Terminating at all is the assertion; the owner is already claimed, so
+    // the child's link back to it places nothing and the walk stops.
     expect(trays.subtree("codex:left").map((row) => row.id)).toEqual(["right"]);
-    expect(trays.isPlaced("codex:left")).toBe(true);
-    expect(trays.isPlaced("codex:right")).toBe(true);
+    expect(trays.directChildKeys("codex:left")).toEqual(["codex:right"]);
   });
 
   it("returns empty views for a row that owns no tray", () => {
@@ -122,6 +123,6 @@ describe("createSubthreadTrays", () => {
 
     expect(trays.subtree("codex:absent")).toEqual([]);
     expect(trays.directChildKeys("codex:absent")).toEqual([]);
-    expect(trays.isPlaced("codex:absent")).toBe(false);
+    expect(trays.depth("codex:absent")).toBe(1);
   });
 });

--- a/apps/desktop/src/renderer/src/features/navigation/subthread-trays.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/subthread-trays.ts
@@ -1,0 +1,103 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { sortSubthreadSummaries } from "@pwragent/shared";
+import { threadSummaryIdentityKey } from "../../lib/federated-thread-events";
+
+export type SubthreadTrays = {
+  /**
+   * Give `owner` a tray and fill it with its whole descendant subtree. Rows
+   * already claimed by an earlier owner are skipped, so a cycle in the stored
+   * parent links terminates and no row renders twice.
+   */
+  addTrayOwner: (owner: NavigationThreadSummary) => void;
+  /**
+   * Ordered keys of `trayKey`'s *direct* children — the only rows a tray
+   * reorder may move, because `subthreadOrder` is stored per parent. Writing a
+   * whole flattened tray back would list grandchildren as children of the row
+   * they merely render under.
+   */
+  directChildKeys: (trayKey: string) => string[];
+  /**
+   * How deep a tray row sits below its tray owner: 1 for a direct child, 2 for
+   * a grandchild, and so on. The tray renders flat, so this is the only thing
+   * that tells a grandchild apart from the sibling above it — and it is also
+   * why a deeper row does not drag: `subthreadOrder` ranks direct children
+   * only. Returns 1 for a row no tray placed, which is the shallowest a
+   * rendered tray row can be.
+   */
+  depth: (threadKey: string) => number;
+  /** Whether some tray has already claimed this row. */
+  isPlaced: (threadKey: string) => boolean;
+  /**
+   * `trayKey`'s whole descendant subtree, depth-first and already ordered.
+   * Render it as-is: re-sorting by the tray owner's `subthreadOrder` would
+   * scatter grandchildren away from their parents, because that order only
+   * names direct children.
+   */
+  subtree: (trayKey: string) => NavigationThreadSummary[];
+};
+
+/**
+ * Flatten each rendered row's descendant subtree into one tray, depth-first.
+ *
+ * Sub-threads nest at their true depth in the data; only the view is one level
+ * deep, and depth-first keeps a sub-thread immediately after the thread that
+ * created it — the same trade `groupCodexNativeSubAgents` makes for native
+ * workers. Collapsing the relationship itself instead would leave a grandchild
+ * pointing at a row it does not belong to.
+ *
+ * A descendant's own `subthreadsCollapsed` is deliberately not consulted. Only
+ * a tray owner renders a disclosure toggle, so honoring an intermediate row's
+ * collapse would hide its children behind a control that is nowhere on screen
+ * — the invisible-row failure these trays exist to prevent. A tray owner's own
+ * collapse is honored by the caller.
+ */
+export function createSubthreadTrays(
+  childrenByParentKey: ReadonlyMap<string, NavigationThreadSummary[]>,
+): SubthreadTrays {
+  const subtreeByTrayKey = new Map<string, NavigationThreadSummary[]>();
+  const directChildKeysByTrayKey = new Map<string, string[]>();
+  const depthByThreadKey = new Map<string, number>();
+  const placedThreadKeys = new Set<string>();
+
+  const collectSubtree = (
+    trayKey: string,
+    parent: NavigationThreadSummary,
+    parentKey: string,
+    depth: number,
+  ): void => {
+    // Read the bucket before sorting: most rows have no sub-threads at all,
+    // and sorting each one would copy an array and build a `subthreadOrder`
+    // map for nothing.
+    const bucket = childrenByParentKey.get(parentKey);
+    if (!bucket?.length) return;
+    const children = sortSubthreadSummaries(parent, bucket);
+    if (parentKey === trayKey) {
+      directChildKeysByTrayKey.set(
+        trayKey,
+        children.map((child) => threadSummaryIdentityKey(child)),
+      );
+    }
+    for (const child of children) {
+      const childKey = threadSummaryIdentityKey(child);
+      if (placedThreadKeys.has(childKey)) continue;
+      placedThreadKeys.add(childKey);
+      const tray = subtreeByTrayKey.get(trayKey) ?? [];
+      tray.push(child);
+      subtreeByTrayKey.set(trayKey, tray);
+      depthByThreadKey.set(childKey, depth);
+      collectSubtree(trayKey, child, childKey, depth + 1);
+    }
+  };
+
+  return {
+    addTrayOwner: (owner) => {
+      const ownerKey = threadSummaryIdentityKey(owner);
+      placedThreadKeys.add(ownerKey);
+      collectSubtree(ownerKey, owner, ownerKey, 1);
+    },
+    depth: (threadKey) => depthByThreadKey.get(threadKey) ?? 1,
+    directChildKeys: (trayKey) => directChildKeysByTrayKey.get(trayKey) ?? [],
+    isPlaced: (threadKey) => placedThreadKeys.has(threadKey),
+    subtree: (trayKey) => subtreeByTrayKey.get(trayKey) ?? [],
+  };
+}

--- a/apps/desktop/src/renderer/src/features/navigation/subthread-trays.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/subthread-trays.ts
@@ -10,10 +10,10 @@ export type SubthreadTrays = {
    */
   addTrayOwner: (owner: NavigationThreadSummary) => void;
   /**
-   * Ordered keys of `trayKey`'s *direct* children — the only rows a tray
-   * reorder may move, because `subthreadOrder` is stored per parent. Writing a
-   * whole flattened tray back would list grandchildren as children of the row
-   * they merely render under.
+   * Ordered keys of the *direct* children this tray actually renders — the
+   * only rows a tray reorder may move, because `subthreadOrder` is stored per
+   * parent. Writing a whole flattened tray back would list grandchildren as
+   * children of the row they merely render under.
    */
   directChildKeys: (trayKey: string) => string[];
   /**
@@ -25,8 +25,6 @@ export type SubthreadTrays = {
    * rendered tray row can be.
    */
   depth: (threadKey: string) => number;
-  /** Whether some tray has already claimed this row. */
-  isPlaced: (threadKey: string) => boolean;
   /**
    * `trayKey`'s whole descendant subtree, depth-first and already ordered.
    * Render it as-is: re-sorting by the tray owner's `subthreadOrder` would
@@ -71,19 +69,27 @@ export function createSubthreadTrays(
     const bucket = childrenByParentKey.get(parentKey);
     if (!bucket?.length) return;
     const children = sortSubthreadSummaries(parent, bucket);
-    if (parentKey === trayKey) {
-      directChildKeysByTrayKey.set(
-        trayKey,
-        children.map((child) => threadSummaryIdentityKey(child)),
-      );
+    // Resolved once per tray rather than per child: this runs for every
+    // rendered sub-thread of every directory on each navigation update.
+    let tray = subtreeByTrayKey.get(trayKey);
+    if (!tray) {
+      tray = [];
+      subtreeByTrayKey.set(trayKey, tray);
+    }
+    // Only the rows this tray actually takes. A key an earlier tray already
+    // claimed renders there, not here, so counting it would turn on this
+    // tray's reorder affordance for a child that has no sibling to move past.
+    const directChildKeys =
+      parentKey === trayKey ? directChildKeysByTrayKey.get(trayKey) ?? [] : undefined;
+    if (directChildKeys) {
+      directChildKeysByTrayKey.set(trayKey, directChildKeys);
     }
     for (const child of children) {
       const childKey = threadSummaryIdentityKey(child);
       if (placedThreadKeys.has(childKey)) continue;
       placedThreadKeys.add(childKey);
-      const tray = subtreeByTrayKey.get(trayKey) ?? [];
+      directChildKeys?.push(childKey);
       tray.push(child);
-      subtreeByTrayKey.set(trayKey, tray);
       depthByThreadKey.set(childKey, depth);
       collectSubtree(trayKey, child, childKey, depth + 1);
     }
@@ -97,7 +103,6 @@ export function createSubthreadTrays(
     },
     depth: (threadKey) => depthByThreadKey.get(threadKey) ?? 1,
     directChildKeys: (trayKey) => directChildKeysByTrayKey.get(trayKey) ?? [],
-    isPlaced: (threadKey) => placedThreadKeys.has(threadKey),
     subtree: (trayKey) => subtreeByTrayKey.get(trayKey) ?? [],
   };
 }

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -3679,7 +3679,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("forks a child below its source and re-parents it to the group root", async () => {
+  it("forks a child as a child of the card it was spawned from", async () => {
     const worktree = {
       id: "wt",
       label: "Repo",
@@ -3763,23 +3763,24 @@ describe("useThreadNavigation", () => {
       await result.current.forkThread(sourceChild, "same-worktree");
     });
 
-    // Forks the clicked child's content but links the new thread to the root,
-    // so it renders one level deep rather than as an unrenderable grandchild.
+    // The fork's parent is the card it was spawned from. This used to record
+    // the group *root* instead, which made the fork a sibling of its own
+    // source — and left it parentless whenever that root was a peer's thread.
     expect(forkThread).toHaveBeenCalledTimes(1);
     expect(forkThread.mock.calls[0]![0]).toMatchObject({
-      parentThreadId: "thread-root",
+      parentThreadId: "thread-a",
       sourceThreadId: "thread-a",
     });
 
-    // The new thread lands directly below its source child in the root's tray.
+    // The new thread opens its source's own tray, directly below that card.
     expect(updateSubthreadOrder).toHaveBeenCalledTimes(1);
     expect(updateSubthreadOrder.mock.calls[0]![0]).toMatchObject({
-      parentThreadId: "thread-root",
+      parentThreadId: "thread-a",
       insertAfter: { threadId: "thread-fork", sourceThreadId: "thread-a" },
     });
   });
 
-  it("records remote-root ownership for locally created children and forks", async () => {
+  it("parents a locally created child to its local card, not the remote root", async () => {
     const rootTarget = {
       scope: "remote" as const,
       instanceId: "root-owner",
@@ -3832,7 +3833,13 @@ describe("useThreadNavigation", () => {
       createdAt: 1,
       updatedAt: 1,
     };
-    const ensureDirectoryLaunchpad = vi.fn(async () => ({
+    // Both mocks name the fields the assertions read, so an absent
+    // `parentThreadInstanceId` is checkable rather than an `any`.
+    type ParentLinkRequest = {
+      parentThreadId?: string;
+      parentThreadInstanceId?: string;
+    };
+    const ensureDirectoryLaunchpad = vi.fn(async (_request: ParentLinkRequest) => ({
       launchpad,
       defaults: {
         backend: "codex" as const,
@@ -3846,7 +3853,7 @@ describe("useThreadNavigation", () => {
         executionMode: "default" as const,
       },
     }));
-    const forkThread = vi.fn(async () => ({
+    const forkThread = vi.fn(async (_request: ParentLinkRequest) => ({
       backend: "codex" as const,
       sourceThreadId: "thread-local-child",
       threadId: "thread-fork",
@@ -3884,19 +3891,25 @@ describe("useThreadNavigation", () => {
     await act(async () => {
       await result.current.createSubthread(localChild, "same-worktree");
     });
+    // `localChild` lives on this instance, so the new thread's parent link is
+    // instance-local. Walking to the remote root instead used to record the
+    // grandparent's owner as the parent's instance, which made the child a
+    // sibling of its own source and stranded it when that root was a peer's.
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
         federationTarget: undefined,
-        parentThreadId: "thread-root",
-        parentThreadInstanceId: "root-owner",
+        parentThreadId: "thread-local-child",
       }),
     );
+    expect(
+      ensureDirectoryLaunchpad.mock.calls[0]![0],
+    ).not.toHaveProperty("parentThreadInstanceId");
     expect(updateDirectoryLaunchpad).toHaveBeenCalledWith(
       expect.objectContaining({
         patch: expect.objectContaining({
           federationTarget: undefined,
-          parentThreadId: "thread-root",
-          parentThreadInstanceId: "root-owner",
+          parentThreadId: "thread-local-child",
+          parentThreadInstanceId: undefined,
         }),
       }),
     );
@@ -3907,14 +3920,18 @@ describe("useThreadNavigation", () => {
     expect(forkThread).toHaveBeenCalledWith(
       expect.objectContaining({
         federationTarget: undefined,
-        parentThreadId: "thread-root",
-        parentThreadInstanceId: "root-owner",
+        parentThreadId: "thread-local-child",
       }),
     );
+    expect(forkThread.mock.calls[0]![0]).not.toHaveProperty(
+      "parentThreadInstanceId",
+    );
+    // The order write follows the parent, so it stays local too. It used to be
+    // sent to `rootTarget` — the peer that owns the grandparent.
     expect(updateSubthreadOrder).toHaveBeenCalledWith(
       expect.objectContaining({
-        federationTarget: rootTarget,
-        parentThreadId: "thread-root",
+        federationTarget: undefined,
+        parentThreadId: "thread-local-child",
       }),
     );
   });

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -6,7 +6,7 @@ import { navigationQueryEventRequiresRefresh } from "./navigation-query-events";
 import type { ComposerDraftStore } from "../features/composer/useComposerDraftStore";
 import { loadedThreadRows, loadedDirectoryRows, indexLoadedThreadRows, indexLoadedDirectoryRows, type NavigationLoadedRows, type NavigationPresentedThread, type NavigationDirectoryView as NavigationDirectorySummary } from "./navigation-loaded-rows";
 import { readNavigationUnlinkPlan } from "./navigation-unlink-plan";
-import { readNavigationActionDetail, readNavigationActionThread, resolveNavigationActionGroupRoot } from "./navigation-action-authority";
+import { readNavigationActionDetail, readNavigationActionThread } from "./navigation-action-authority";
 import { applyLaunchpadEnvironmentSetupProgress, type LaunchpadEnvironmentSetupProgress } from "./launchpad-setup-progress";
 import { useCallback, useEffect, useId, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type {
@@ -5176,35 +5176,27 @@ export function useThreadNavigation(
   );
 
   /**
-   * The "group root" for a source card. Sub-threads and forks never nest deeper
-   * than one level: spawning from a child re-parents the new thread to that
-   * child's root so it renders as a sibling, not an (unrenderable) grandchild.
-   * Falls back to the source itself when its root is gone (archived/unlinked),
-   * since the source has then become effectively top-level.
-   */
-  const resolveGroupRoot = useCallback(
-    (source: NavigationThreadSummary) => resolveNavigationActionGroupRoot({ api: desktopApi, thread: source,
-      target: readRendererFederationTarget(), signal: actionAbortControllerRef.current.signal }),
-    [desktopApi],
-  );
-
-  /**
    * Place a freshly created child directly below the card it was spawned from.
    * The owner inserts into its complete current order, preserving unloaded
    * siblings, then expands the group so the new child is visible.
+   *
+   * `parentThreadId` is the thread the child is actually a child of, which is
+   * also the card the operator clicked. It used to be that group's *root*
+   * instead, which recorded a grandparent as the parent whenever the clicked
+   * card was itself a child.
    */
   const insertSubthreadBelowSource = useCallback(
     async (
       parentBackend: AppServerBackendKind,
-      rootThreadId: string,
+      parentThreadId: string,
       sourceThreadId: string,
       newThreadId: string,
       federationTarget?: FederationTarget,
     ): Promise<void> => {
-      let root: NavigationThreadSummary;
+      let parentThread: NavigationThreadSummary;
       try {
-        root = await readNavigationActionThread({ api: desktopApi,
-          thread: { source: parentBackend, id: rootThreadId }, target: federationTarget,
+        parentThread = await readNavigationActionThread({ api: desktopApi,
+          thread: { source: parentBackend, id: parentThreadId }, target: federationTarget,
           signal: actionAbortControllerRef.current.signal });
       } catch (error) {
         // Creation has already succeeded. Preserve its selection even if the
@@ -5212,8 +5204,8 @@ export function useThreadNavigation(
         console.warn("Could not load the group order for the created child:", error);
         return;
       }
-      const rootKey = threadSummaryIdentityKey(root);
-      if (federationTarget && !threadSupportsFederationCapability(root, "thread_grouping")) return;
+      const parentKey = threadSummaryIdentityKey(parentThread);
+      if (federationTarget && !threadSupportsFederationCapability(parentThread, "thread_grouping")) return;
       // Await the persist so callers can sequence the authoritative refresh
       // after it commits — otherwise a refresh racing ahead of this write can
       // momentarily resurrect the pre-insert order.
@@ -5223,7 +5215,7 @@ export function useThreadNavigation(
           const result = await persistOrder({
             backend: parentBackend,
             federationTarget,
-            parentThreadId: rootThreadId,
+            parentThreadId,
             insertAfter: { threadId: newThreadId, sourceThreadId },
           });
           const threadIds = result.threadIds;
@@ -5237,24 +5229,24 @@ export function useThreadNavigation(
             }),
           }));
         } catch {
-          await refresh(rootKey);
+          await refresh(parentKey);
         }
       }
 
-      if (root?.subthreadsCollapsed) {
+      if (parentThread?.subthreadsCollapsed) {
         setState((current) => ({
           ...current,
           rows: updateSubthreadsCollapsedInLoadedRows(current.rows, {
             backend: parentBackend,
             federationTarget,
-            parentThreadId: rootThreadId,
+            parentThreadId,
             collapsed: false,
           }),
         }));
         void desktopApi?.setSubthreadsCollapsed?.({
           backend: parentBackend,
           federationTarget,
-          parentThreadId: rootThreadId,
+          parentThreadId,
           collapsed: false,
         }).catch(() => {});
       }
@@ -5273,13 +5265,11 @@ export function useThreadNavigation(
       }
 
       let workspaceDirectories: Awaited<ReturnType<typeof readNavigationActionDetail>>["workspaceDirectories"];
-      let groupRoot: NavigationThreadSummary;
       try {
         const detail = await readNavigationActionDetail({ api: desktopApi, thread: parent, target: readRendererFederationTarget(),
           signal: actionAbortControllerRef.current.signal, includeWorkspaceConfiguration: true });
         parent = detail.thread;
         workspaceDirectories = detail.workspaceDirectories;
-        groupRoot = await resolveGroupRoot(parent);
       } catch (error) {
         setCreateThreadError(error instanceof Error ? error.message : String(error));
         return;
@@ -5291,25 +5281,17 @@ export function useThreadNavigation(
           ? directory.gitStatusSourcePath ?? directory.directoryPath
           : directory.directoryPath;
       // Key the launchpad on the clicked card so each source gets its own
-      // composer (two children of one root must not collide), but link the new
-      // thread to the group root and remember the source for in-place insertion.
+      // composer (two children of one parent must not collide), and link the
+      // new thread to that same card — the thread it is a child of.
       const directoryKey = buildSubthreadLaunchpadKey(parent, mode);
 
       const federationTarget =
         parent.federation?.ref.target ?? rendererFederationTarget;
-      const groupRootInstanceId = groupRoot.federation?.ref.target
-        && isRemoteFederationTarget(groupRoot.federation.ref.target)
-        ? groupRoot.federation.ref.target.instanceId
-        : parent.parentThreadInstanceId;
-      const childOwnerInstanceId = federationTarget
-        && isRemoteFederationTarget(federationTarget)
-        ? federationTarget.instanceId
-        : undefined;
-      const parentThreadInstanceId =
-        groupRootInstanceId
-        && groupRootInstanceId !== childOwnerInstanceId
-          ? groupRootInstanceId
-          : undefined;
+      // The new thread is created on whichever instance owns `parent`, so a
+      // parent link to `parent` is always instance-local. This used to carry
+      // the *grandparent's* instance id, because the parent recorded here used
+      // to be the group root rather than the card the operator clicked.
+      const parentThreadInstanceId = undefined;
       setCreatingThread({
         backend: parent.source,
         executionMode: parent.executionMode ?? "default",
@@ -5337,19 +5319,19 @@ export function useThreadNavigation(
               }
             : {}),
           currentBranch: directory.branchName,
-          parentThreadId: groupRoot.id,
-          parentThreadBackend: groupRoot.source,
+          parentThreadId: parent.id,
+          parentThreadBackend: parent.source,
           ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
-          parentThreadTitle: groupRoot.title,
+          parentThreadTitle: parent.title,
           preferredBackend: parent.source,
         });
         let launchpad: NavigationLaunchpadDraft = {
           ...response.launchpad,
           federationTarget,
-          parentThreadId: groupRoot.id,
-          parentThreadBackend: groupRoot.source,
+          parentThreadId: parent.id,
+          parentThreadBackend: parent.source,
           parentThreadInstanceId,
-          parentThreadTitle: groupRoot.title,
+          parentThreadTitle: parent.title,
           sourceThreadId: parent.id,
         };
         let defaults: NavigationLaunchpadDefaults = response.defaults;
@@ -5361,10 +5343,10 @@ export function useThreadNavigation(
           directoryPath: launchpadDirectoryPath,
           federationTarget,
           ...(directory.branchName ? { branchName: directory.branchName } : {}),
-          parentThreadId: groupRoot.id,
-          parentThreadBackend: groupRoot.source,
+          parentThreadId: parent.id,
+          parentThreadBackend: parent.source,
           parentThreadInstanceId,
-          parentThreadTitle: groupRoot.title,
+          parentThreadTitle: parent.title,
         };
         if (desktopApi.updateDirectoryLaunchpad) {
           const updated = await desktopApi.updateDirectoryLaunchpad({
@@ -5376,10 +5358,10 @@ export function useThreadNavigation(
               launchpad,
               patch,
             ),
-            parentThreadId: groupRoot.id,
-            parentThreadBackend: groupRoot.source,
+            parentThreadId: parent.id,
+            parentThreadBackend: parent.source,
             parentThreadInstanceId,
-            parentThreadTitle: groupRoot.title,
+            parentThreadTitle: parent.title,
             sourceThreadId: parent.id,
           };
           launchpad = {
@@ -5393,10 +5375,10 @@ export function useThreadNavigation(
                 ),
               },
             ),
-            parentThreadId: groupRoot.id,
-            parentThreadBackend: groupRoot.source,
+            parentThreadId: parent.id,
+            parentThreadBackend: parent.source,
             parentThreadInstanceId,
-            parentThreadTitle: groupRoot.title,
+            parentThreadTitle: parent.title,
             sourceThreadId: parent.id,
           };
           defaults = updated.defaults;
@@ -5430,7 +5412,6 @@ export function useThreadNavigation(
     [
       desktopApi,
       rendererFederationTarget,
-      resolveGroupRoot,
       takePendingDirectoryGitStatus,
     ],
   );
@@ -5445,10 +5426,8 @@ export function useThreadNavigation(
         return;
       }
 
-      let groupRoot: NavigationThreadSummary;
       try {
         parent = await readNavigationActionThread({ api: desktopApi, thread: parent, target: readRendererFederationTarget(), signal: actionAbortControllerRef.current.signal });
-        groupRoot = await resolveGroupRoot(parent);
       } catch (error) {
         setCreateThreadError(error instanceof Error ? error.message : String(error));
         return;
@@ -5458,19 +5437,9 @@ export function useThreadNavigation(
 
       const federationTarget = parent.federation?.ref.target ??
         readRendererFederationTarget();
-      const groupRootInstanceId = groupRoot.federation?.ref.target
-        && isRemoteFederationTarget(groupRoot.federation.ref.target)
-        ? groupRoot.federation.ref.target.instanceId
-        : parent.parentThreadInstanceId;
-      const childOwnerInstanceId = federationTarget
-        && isRemoteFederationTarget(federationTarget)
-        ? federationTarget.instanceId
-        : undefined;
-      const parentThreadInstanceId =
-        groupRootInstanceId
-        && groupRootInstanceId !== childOwnerInstanceId
-          ? groupRootInstanceId
-          : undefined;
+      // See `createSubthread`: a fork is created on the instance that owns
+      // `parent`, so its parent link never needs an instance id.
+      const parentThreadInstanceId = undefined;
       const executionMode = parent.executionMode ?? "default";
       const pendingForkEnvironmentSetup = buildPendingForkEnvironmentSetup({
         directoryLabel: directory.directoryLabel,
@@ -5494,8 +5463,8 @@ export function useThreadNavigation(
           backend: parent.source,
           federationTarget,
           sourceThreadId: parent.id,
-          parentThreadId: groupRoot.id,
-          parentThreadBackend: groupRoot.source,
+          parentThreadId: parent.id,
+          parentThreadBackend: parent.source,
           ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
           executionMode,
           directoryKind: directory.directoryKind,
@@ -5547,8 +5516,8 @@ export function useThreadNavigation(
             (response.workMode === "worktree" ? "HEAD" : parent.observedGitBranch),
           codexEnvironmentRuntime: response.codexEnvironmentRuntime,
           linkedDirectories,
-          parentThreadId: groupRoot.id,
-          parentThreadBackend: groupRoot.source,
+          parentThreadId: parent.id,
+          parentThreadBackend: parent.source,
           parentThreadInstanceId,
           federation: federationTarget
             && isRemoteFederationTarget(federationTarget)
@@ -5567,11 +5536,11 @@ export function useThreadNavigation(
         // Drop the fork directly below the card it was spawned from, and let
         // the order write land before the refresh below reads it back.
         await insertSubthreadBelowSource(
-          groupRoot.source,
-          groupRoot.id,
+          parent.source,
+          parent.id,
           parent.id,
           response.threadId,
-          groupRoot.federation?.ref.target,
+          parent.federation?.ref.target,
         );
         if (
           federationTarget
@@ -5610,7 +5579,6 @@ export function useThreadNavigation(
       forkThreadRequest,
       insertSubthreadBelowSource,
       refresh,
-      resolveGroupRoot,
     ],
   );
 
@@ -6491,9 +6459,9 @@ export function useThreadNavigation(
 
       setLaunchpadError(undefined);
 
-      // The draft carries the group root (sub-threading a child re-parents to
-      // the root); prefer it over the key-parsed source so the new thread links
-      // to the root and renders one level deep.
+      // The draft carries the parent the launchpad was opened from; prefer it
+      // over the key-parsed source so the new thread links to the card the
+      // operator actually clicked.
       const launchpadSelectionKey = federatedSelection
         ? buildFederatedLaunchpadSelectionKey(federatedSelection.target)
         : buildLaunchpadSelectionKey(directoryKey);

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -5321,7 +5321,6 @@ export function useThreadNavigation(
           currentBranch: directory.branchName,
           parentThreadId: parent.id,
           parentThreadBackend: parent.source,
-          ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
           parentThreadTitle: parent.title,
           preferredBackend: parent.source,
         });
@@ -5465,7 +5464,6 @@ export function useThreadNavigation(
           sourceThreadId: parent.id,
           parentThreadId: parent.id,
           parentThreadBackend: parent.source,
-          ...(parentThreadInstanceId ? { parentThreadInstanceId } : {}),
           executionMode,
           directoryKind: directory.directoryKind,
           directoryLabel: directory.directoryLabel,
@@ -5540,7 +5538,11 @@ export function useThreadNavigation(
           parent.id,
           parent.id,
           response.threadId,
-          parent.federation?.ref.target,
+          // The same target the fork was created with. Reading only
+          // `parent.federation` would drop the renderer's own target, so a
+          // federation window whose rows carry no explicit ref would create
+          // the fork on the peer and write its order locally.
+          federationTarget,
         );
         if (
           federationTarget

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4209,8 +4209,15 @@ a.button {
   margin-left: 14px;
 }
 
+/* Tray rows are flat in the DOM but not in the data: a grandchild renders in
+   its grandparent's tray, immediately after the child that created it. One
+   extra step of indent per level of real depth is what separates it from the
+   sibling above — and it is the same distinction that decides whether the row
+   drags, since `subthreadOrder` ranks direct children only. `ThreadRow` sets
+   `--thread-row-nested-depth` only past depth 1, so an ordinary child pays no
+   calc. */
 .thread-row-shell--nested .thread-row {
-  padding-left: 12px;
+  padding-left: calc(12px * var(--thread-row-nested-depth, 1));
 }
 
 /* A parent card (has sub-threads) stays flush with its sibling rows —

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4215,9 +4215,15 @@ a.button {
    sibling above — and it is the same distinction that decides whether the row
    drags, since `subthreadOrder` ranks direct children only. `ThreadRow` sets
    `--thread-row-nested-depth` only past depth 1, so an ordinary child pays no
-   calc. */
+   calc.
+
+   The step stops paying out after four levels. Real depth has no bound — a
+   sub-thread can create a sub-thread forever — and the sidebar's width does,
+   so an uncapped step eventually indents a row's title off the end of the
+   card. Past the cap the rows read as "deeper than the one above", which is
+   all a flat tray can say anyway. */
 .thread-row-shell--nested .thread-row {
-  padding-left: calc(12px * var(--thread-row-nested-depth, 1));
+  padding-left: min(48px, calc(12px * var(--thread-row-nested-depth, 1)));
 }
 
 /* A parent card (has sub-threads) stays flush with its sibling rows —


### PR DESCRIPTION
Two defects, one visible symptom: a created child that never appeared in the sidebar.

Reproduced from the live profile. The source thread `01a036e3` ("PR #8 parent_intent capability") is itself a child of `01a00dff`, a **remote pin from `Harold-Mac-Mini-M4`** living in a different directory.

## 1. A created child was adopted by the wrong thread

Both creation paths walked the clicked card's parent chain to its **root** and recorded *that* as the new thread's parent — `resolveHandoffGroupParentThreadRef` in the main process, `resolveGroupRoot` in the renderer. That makes the child a **sibling of its own creator**. When the root is a peer's thread, as it was here, the child has nothing to nest under and lands loose in the list. The renderer walk also carried the root's instance id onto the parent link, so a child created under a locally-owned card whose grandparent lives on a peer was recorded as parented to that peer.

The walks existed because the sidebar renders one nesting level, so a grandchild had no row. That inverted the rule: the stored relationship was corrupted to fit the view. `groupCodexNativeSubAgents` already shows the right shape under the same constraint — native workers nest at their true depth and only the view flattens, so a worker "still immediately follows the worker that spawned it."

Now the parent is the card the operator clicked, in all three paths, and the flattening moves to the view. Both lenses build one tray per top-level row holding its whole descendant subtree in depth-first order, so a sub-thread renders immediately after the thread that created it and nothing is dropped for being two levels deep.

Tray reordering is narrowed to a row's **direct** children. `subthreadOrder` is stored per parent, so a reorder that moved a grandchild would name it as a child of the row it merely renders under — the same confusion of view and relationship, in the other direction. Because the tray is flat, a grandchild now carries one extra step of indent per level of real depth: both what separates it from the sibling above and the visible reason it does not drag.

## 2. A created thread could be invisible from birth

The creation-time visibility pin — which keeps a new thread visible when its directory's **Directory threads** section is collapsed — skipped every thread carrying a parent link, on the assumption a sub-thread rides its parent's visible row. Nothing checked that the parent renders.

The first attempt at this pinned the **child**, which was wrong in a way worth stating: `ThreadRow` hides the pin control on any visibly nested row, so that writes a `pinnedRank` the operator has no way to remove — and leaves an unexplained top-level pinned row as soon as the parent stops rendering.

A sub-thread renders inside its group, so what has to be visible is the **group**. Creation now walks from the parent to the row this directory renders top-level and reveals *that* row: pins it if the collapse would hide it, opens its sub-thread disclosure if the operator had it closed. That mirrors what the renderer already does when it inserts a child from the sidebar, so both creation paths leave the same state behind. When the walk finds no ancestor this directory renders — a parent on a peer, in another project, or aged out of the navigation window — the new thread is itself a top-level row here and still takes the pin.

The visibility index also keys threads the way `directory.threadKeys` names them. A remote row pinned into a local directory is listed under its *federated* key, so keying everything locally made every remote pin invisible to the gate, and a directory whose only pins were a peer's rows reported having none.

One more thing made the pin insufficient on its own: the render model dropped a pinned child whose parent is not rendered, so the pin bought nothing under a collapse. A pinned sub-thread whose ancestor does not render is now promoted to a top-level pinned row, restoring *pinned implies visible*.

## Rebased onto the paged navigation work

This branch was written before #2044 and rebased onto it. Three pieces were **dropped in favor of main's versions**, which solve the same problems better:

- **Hover stability.** This PR originally re-ranked an arriving pinned thread below every frozen pin, because `hydrateHoverStableSidebarSnapshot` was stripping `pinnedRank` from any thread that arrived under a resting pointer. Main now preserves an arriving row's fields wholesale and lets retained presentation order place it. Both tests written here still pass against that, so the explicit re-rank was deleted.
- **Sub-thread insert.** Replaced a full `subthreadOrder` rewrite with main's owner-side `insertAfter: { threadId, sourceThreadId }`, which preserves siblings the viewer has not loaded. Only *which* thread is named as parent is still this PR's change.
- **Tray reorder.** Same shift to an owner-side anchor move. The direct-children-only guard sits above it and still keeps a grandchild out of the drag.

`directory-thread-render-model.ts` was superseded by `paged-directory-presentation.ts` and is now imported only by its own test, so the tray work moved into the two list components where the live path is. `createSubthreadTrays` takes exactly the `childrenByParentKey` shape the paged presentation produces.

The flattening is still load-bearing there: `disclosedParents` includes any loaded row with children, not just top-level ones, so the owner does fetch grandchildren and keys them under the child that owns them. Rendering only direct children would drop them.

## The instance id is not lost — correcting an earlier claim

An earlier revision of this description carried a "known gap": that a parent link to a remote thread stores no `parentThreadInstanceId`, so cross-instance nesting could never render. That was an inference, and it was wrong. The stored row for `01a036e3` is:

```
parentThreadId:         01a00dff-79b0-7363-bee7-636320233102
parentThreadBackend:    codex
parentThreadInstanceId: pwr_3d822fab-…      ← the M4 Mini
```

The instance id is recorded. `resolveThreadParentKey` therefore builds the federated key and resolves the parent — *provided the map it is given keys remote rows federated*, which is precisely the visibility-index fix above. Nothing further is needed here.

For the case where the id genuinely was lost — legacy local handoffs that copied their launcher's group root but not its remote owner — main already recovers it in `parentIdentity` (`navigation-query-projection.ts`), from recorded provenance and an identical root. That recovery deliberately refuses to guess from a same-id peer, and this PR does not widen it: removing the group-root walks stops new rows from entering that state at all, so the two meet in the middle.

## Tests

Written failing first:

- `backend-registry.test.ts` — pins the parent of a new child rather than the child when the collapse hides it; opens a pinned parent's collapsed tray instead of pinning its new child; walks past a nested parent to the row the directory renders top-level; auto-pins a new child whose parent the directory does not render. The pre-existing grandchild-handoff test is rewritten to assert the child nests under its own source, with the root's operator-arranged order untouched — and keeps main's parameterization over `parentThreadInstanceId`, which now proves the instance id no longer changes the answer.
- `useThreadNavigation.test.tsx` — a fork is a child of the card it was spawned from; a locally created child is parented to its local card, not the remote root, and its order write stays local. Both replace tests that asserted the sibling relationship this PR removes.
- `subthread-trays.test.ts` — depth-first flattening, direct-children-only reorder, cycle termination, and each row's real depth.
- `sidebar.test.tsx` — a grandchild renders in its top-level ancestor's tray in Directories, after the child that owns it and one indent deeper; same for the Inbox/Recents path.
- `hover-stable-sidebar.test.tsx` — an agent-created pinned thread shows up under a resting pointer; an arriving pin appends below the frozen pins and resorts to its true rank on release. Both kept as a guard on main's replacement implementation.

Full workspace suite (11,035), `typecheck`, `lint:eslint`, `lint:boundaries`, `lint:colors`, `lint:sql` all green.

No before/after screenshots — the visual delta is sidebar rows present vs. absent and capturing it needs a headed Electron run. Happy to add a contrived-fixture pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
