### PR TITLE
fix(desktop): bound federated thread search on owners

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -7835,6 +7835,34 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it.each([false, true])("isolates unavailable Codex in aggregate search candidates (archived: %s)", async (archived) => {
+    const failure = new Error("Codex unavailable");
+    const codexClient = new MockBackendClient({ listThreadsError: failure });
+    const { registry } = createKimiAcpRegistry({
+      codexClient,
+      sessions: [{
+        backendId: "acp:kimi", sessionId: "healthy-acp", title: "Healthy ACP",
+        createdAt: 1000, updatedAt: 2000, executionMode: "default", status: "idle",
+        ...(archived ? { archivedAt: 3000 } : {}),
+      }],
+    });
+    onTestFinished(() => registry.close());
+
+    await expect(registry.listThreadSearchCandidates({ archived })).resolves.toEqual([
+      expect.objectContaining({ id: "healthy-acp", source: "acp:kimi" }),
+    ]);
+    // An aggregate partial result must not mask an explicitly requested error.
+    await expect(registry.listThreadSearchCandidates({ backend: "codex", archived })).rejects.toBe(failure);
+    // Nor should caching a partial aggregate hide a recovered provider.
+    vi.spyOn(codexClient, "listThreads").mockResolvedValue([{
+      id: "recovered-codex", source: "codex", title: "Recovered", titleSource: "explicit", linkedDirectories: [],
+    }]);
+    await expect(registry.listThreadSearchCandidates({ archived })).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "recovered-codex" }),
+      expect.objectContaining({ id: "healthy-acp" }),
+    ]));
+  });
+
   it("serves durable startup threads before provider refresh completes", async () => {
     const providerRefresh = createDeferred<void>();
     const codexClient = new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2919,6 +2919,28 @@ describe("CodexAppServerClient", () => {
     }
   });
 
+  it("stops owner search pagination at its absolute deadline", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const send = MockTransport.prototype.send;
+    const spy = vi.spyOn(MockTransport.prototype, "send").mockImplementation(function (this: MockTransport, message) {
+      send.call(this, message);
+      if (JSON.parse(message).method === "thread/list") now.mockReturnValue(1_101);
+    });
+    try {
+      await expect(client.listThreads({ archived: true, filter: "paginated-archive", deadlineAt: 1_100 }))
+        .rejects.toThrow("deadline expired");
+      const requests = MockTransport.instances.at(-1)!.sentMessages
+        .map((message) => JSON.parse(message)).filter((message) => message.method === "thread/list");
+      expect(requests).toHaveLength(1);
+    } finally {
+      spy.mockRestore();
+      now.mockRestore();
+      await client.close();
+    }
+  });
+
   it("follows thread/list pagination for archived codex threads", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -307,6 +307,89 @@ describe("DesktopMessagingBackendBridge", () => {
     });
   });
 
+  it("filters and bounds generic search on the owner without reconciliation", async () => {
+    const listThreads = vi.fn(async (request?: { archived?: boolean }) =>
+      request?.archived
+        ? [
+            {
+              id: "archived-newer",
+              title: "Collector result",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              projectKey: "PwrSuiteLab",
+              archivedAt: 6_000,
+              updatedAt: 5_500,
+            },
+            {
+              id: "archived-older",
+              title: "Collector result",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              projectKey: "PwrSuiteLab",
+              archivedAt: 5_000,
+              updatedAt: 4_500,
+            },
+          ]
+        : [
+            ...Array.from({ length: 1_200 }, (_, index) => ({
+              id: `active-match-${index}`,
+              title: "Collector result",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              projectKey: "PwrSuiteLab",
+              updatedAt: 5_000,
+            })),
+            {
+              id: "wrong-project",
+              title: "Collector result",
+              titleSource: "explicit" as const,
+              source: "codex" as const,
+              linkedDirectories: [],
+              projectKey: "OtherProject",
+              updatedAt: 5_000,
+            },
+          ]);
+    const registry = { listThreads } as unknown as DesktopBackendRegistry;
+    const bridge = new DesktopMessagingBackendBridge(registry);
+    const reconcileCallsBefore = reconcileNavigationSnapshot.mock.calls.length;
+
+    await expect(bridge.searchFederatedThreads({
+      query: "collector",
+      backend: "codex",
+      includeArchived: true,
+      projectKeys: ["PwrSuiteLab"],
+      updatedAfter: 4_000,
+      updatedBefore: 6_000,
+      limit: 1,
+    })).resolves.toMatchObject({
+      threads: [{ id: "archived-newer" }],
+      totalCount: 1_202,
+      truncated: true,
+    });
+    expect(listThreads).toHaveBeenNthCalledWith(1, {
+      backend: "codex",
+      archived: false,
+      callerReason: "federation-thread-search",
+      enrichDirectories: false,
+      filter: "collector",
+      skipArchivedMetadataRefresh: true,
+    });
+    expect(listThreads).toHaveBeenNthCalledWith(2, {
+      backend: "codex",
+      archived: true,
+      callerReason: "federation-thread-search",
+      enrichDirectories: false,
+      filter: "collector",
+      skipArchivedMetadataRefresh: true,
+    });
+    expect(reconcileNavigationSnapshot).toHaveBeenCalledTimes(
+      reconcileCallsBefore,
+    );
+  });
+
   it("returns a broad snapshot before its stale directory batch finishes", async () => {
     reconcileNavigationSnapshot.mockResolvedValueOnce({
       backend: "all",

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -352,7 +352,7 @@ describe("DesktopMessagingBackendBridge", () => {
               updatedAt: 5_000,
             },
           ]);
-    const registry = { listThreads } as unknown as DesktopBackendRegistry;
+    const registry = { listThreadSearchCandidates: listThreads } as unknown as DesktopBackendRegistry;
     const bridge = new DesktopMessagingBackendBridge(registry);
     const reconcileCallsBefore = reconcileNavigationSnapshot.mock.calls.length;
 
@@ -372,18 +372,12 @@ describe("DesktopMessagingBackendBridge", () => {
     expect(listThreads).toHaveBeenNthCalledWith(1, {
       backend: "codex",
       archived: false,
-      callerReason: "federation-thread-search",
-      enrichDirectories: false,
-      filter: "collector",
-      skipArchivedMetadataRefresh: true,
+      deadlineAt: undefined,
     });
     expect(listThreads).toHaveBeenNthCalledWith(2, {
       backend: "codex",
       archived: true,
-      callerReason: "federation-thread-search",
-      enrichDirectories: false,
-      filter: "collector",
-      skipArchivedMetadataRefresh: true,
+      deadlineAt: undefined,
     });
     expect(reconcileNavigationSnapshot).toHaveBeenCalledTimes(
       reconcileCallsBefore,

--- a/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-messaging-backend-bridge.test.ts
@@ -266,6 +266,7 @@ describe("DesktopMessagingBackendBridge", () => {
       {
         id: "thread-alpha",
         title: "Alpha federation work",
+        summary: "large provider preview".repeat(100_000),
         titleSource: "explicit",
         source: "codex",
         linkedDirectories: [],
@@ -295,6 +296,9 @@ describe("DesktopMessagingBackendBridge", () => {
       .resolves.toMatchObject({ results: [{ id: "thread-alpha" }] });
     await expect(bridge.searchNavigationThreads({ query: "beta" }))
       .resolves.toMatchObject({ results: [{ id: "thread-beta" }] });
+    const wireResponse = await bridge.searchNavigationThreads({ query: "alpha" });
+    expect(Buffer.byteLength(JSON.stringify(wireResponse))).toBeLessThan(8 * 1024);
+    expect(wireResponse.results[0]).not.toHaveProperty("summary");
 
     expect(registry.listThreads).toHaveBeenCalledTimes(1);
     expect(reconcileNavigationSnapshot).toHaveBeenCalledTimes(

--- a/apps/desktop/src/main/__tests__/federated-search-integration.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-integration.test.ts
@@ -1,0 +1,226 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppServerThreadSummary } from "@pwragent/shared";
+import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { DesktopMessagingBackendBridge } from "../messaging/desktop-backend-bridge";
+import { StateDb } from "../state/state-db";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { measureSqliteWrites, SQLITE_WRITE_METRICS_ENV } from "../state/sqlite-write-metrics";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
+import { AcpSessionStore } from "../acp/acp-session-store";
+import { FederatedSearchService } from "../federation/federated-search-service";
+import { FederationRpcEndpoint } from "../federation/federation-rpc";
+import { FederationRouter } from "../federation/federation-router";
+import {
+  FEDERATION_BACKEND_METHOD_CAPABILITIES,
+  FederationRemoteBackendClient,
+  registerFederationBackendHandlers,
+  type FederationBackendOperations,
+} from "../federation/federation-backend-bridge";
+
+const exactId = "019fd821-1450-7952-85ca-3bb8e5d150da";
+function row(
+  id: string,
+  title: string,
+  extra: Partial<AppServerThreadSummary> = {},
+): AppServerThreadSummary {
+  return {
+    id,
+    title,
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    updatedAt: 100,
+    ...extra,
+  };
+}
+
+describe("generic search through the owner adapter, registry and real SQLite", () => {
+  let root: string;
+  let db: StateDb;
+  let store: SqliteOverlayStore;
+  let registry: DesktopBackendRegistry;
+  let bridge: DesktopMessagingBackendBridge;
+  let rows: AppServerThreadSummary[];
+  let sessions: AcpSessionStore;
+  const listThreads = vi.fn(async (request: { archived?: boolean; filter?: string } = {}) =>
+    rows.filter((thread) => Boolean(thread.archivedAt) === Boolean(request.archived)
+      && (!request.filter || thread.title.toLowerCase().includes(request.filter.toLowerCase()))));
+
+  beforeEach(() => {
+    vi.stubEnv(SQLITE_WRITE_METRICS_ENV, "1");
+    root = mkdtempSync(path.join(os.tmpdir(), "pwragent-search-integration-"));
+    db = StateDb.open(path.join(root, "state.db"));
+    store = new SqliteOverlayStore(db);
+    sessions = new AcpSessionStore(db);
+    rows = [];
+    listThreads.mockClear();
+    registry = new DesktopBackendRegistry({
+      overlayStore: store as never,
+      acpSessionStore: sessions,
+      codexClient: {
+        listThreads,
+        close: async () => {},
+        getInitializeResult: async () => ({ methods: ["thread/list"] }),
+        onNotification: () => () => {},
+        onPendingRequest: () => () => {},
+      } as never,
+    });
+    bridge = new DesktopMessagingBackendBridge(registry);
+  });
+  afterEach(async () => {
+    await registry.close();
+    db.close();
+    rmSync(root, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+  });
+
+  it("selects an archived exact ID before text filtering and top K", async () => {
+    rows = [row(exactId, "Archived work", { archivedAt: 200 }), row("decoy", exactId)];
+    expect(await bridge.searchFederatedThreads({ query: exactId, backend: "codex", includeArchived: true, limit: 1 }))
+      .toMatchObject({ threads: [{ id: exactId }], totalCount: 1, truncated: false });
+  });
+
+  it("matches summary and project path independently of provider text filtering", async () => {
+    rows = [
+      row("summary", "Unrelated title", { summary: "needle" }),
+      row("path", "Another title", { projectKey: "/repos/needle" }),
+      row("miss", "Other"),
+    ];
+    expect(await bridge.searchFederatedThreads({ query: "needle", backend: "codex", limit: 10 }))
+      .toMatchObject({ threads: [{ id: "summary" }, { id: "path" }], totalCount: 2 });
+  });
+
+  it("does not repair directories or write SQLite on first or repeated search", async () => {
+    rows = [row("worktree", "Needle", {
+      projectKey: "/repos/project/wt",
+      linkedDirectories: [{
+        id: "worktree:/repos/project/wt",
+        kind: "worktree",
+        label: "project",
+        path: "/repos/project",
+        worktreePath: "/repos/project/wt",
+      }],
+    })];
+    const { writes } = await measureSqliteWrites(async () => {
+      for (const query of ["needle", "", "Needle"]) {
+        await bridge.searchFederatedThreads({ query, backend: "codex", includeArchived: true, limit: 1 });
+      }
+    });
+    expect(writes.commits).toBe(0);
+    expect(listThreads).toHaveBeenCalledTimes(2);
+    expectSqliteWriteBudget({
+      scenario: "federated-owner-search",
+      note: "first and repeated generic owner searches, including archives",
+      writes,
+    });
+  });
+
+  it("propagates provider failures instead of reporting a successful empty search", async () => {
+    listThreads.mockRejectedValueOnce(new Error("Provider unavailable"));
+    await expect(bridge.searchFederatedThreads({ query: "needle", backend: "codex", limit: 1 }))
+      .rejects.toThrow("Provider unavailable");
+    rows = [row("recovered", "Needle")];
+    expect(await bridge.searchFederatedThreads({ query: "needle", backend: "codex", limit: 1 }))
+      .toMatchObject({ threads: [{ id: "recovered" }], totalCount: 1 });
+  });
+
+  it("refreshes the read-only candidate cache after its short reuse window", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    try {
+      rows = [row("old", "Needle")];
+      await bridge.searchFederatedThreads({ query: "needle", backend: "codex", limit: 1 });
+      rows = [row("new", "Needle")];
+      now.mockReturnValue(3_001);
+      expect(await bridge.searchFederatedThreads({ query: "needle", backend: "codex", limit: 1 }))
+        .toMatchObject({ threads: [{ id: "new" }], totalCount: 1 });
+      expect(listThreads).toHaveBeenCalledTimes(2);
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it("does not start archived discovery after the active read exhausts the deadline", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    listThreads.mockImplementationOnce(async () => { now.mockReturnValue(1_101); return []; });
+    try {
+      await expect(bridge.searchFederatedThreads({ query: "needle", backend: "codex", includeArchived: true, limit: 1 },
+        { deadlineAt: 1_100 })).rejects.toThrow("deadline expired");
+      expect(listThreads).toHaveBeenCalledTimes(1);
+      expect(listThreads).toHaveBeenCalledWith(expect.objectContaining({ deadlineAt: 1_100 }), expect.anything());
+    } finally {
+      now.mockRestore();
+    }
+  });
+
+  it("searches ACP worktree paths with zero writes and preserves archive filters", async () => {
+    sessions.upsertSession({
+      backendId: "acp:test",
+      sessionId: "session_1234567890",
+      title: "Unrelated",
+      cwd: "/repos/.worktrees/needle",
+      createdAt: 1,
+      updatedAt: 2,
+      executionMode: "default",
+      status: "idle",
+      archivedAt: 3,
+    });
+    const { writes } = await measureSqliteWrites(async () => {
+      expect(await bridge.searchFederatedThreads({ query: "needle", backend: "acp:test", limit: 1 }))
+        .toMatchObject({ totalCount: 0 });
+      expect(await bridge.searchFederatedThreads({ query: "needle", backend: "acp:test", includeArchived: true, limit: 1 }))
+        .toMatchObject({ threads: [{ id: "session_1234567890" }], totalCount: 1 });
+    });
+    expect(writes.commits).toBe(0);
+  });
+
+  it("bounds the actual RPC response after filtering a large owner inventory", async () => {
+    rows = Array.from({ length: 1_200 }, (_, index) => row(`match-${index}`, "Needle", {
+      projectKey: "project", updatedAt: index,
+    }));
+    rows.push(row("wrong-project", "Needle", { projectKey: "other", updatedAt: 10_000 }));
+    const router = new FederationRouter({
+      localInstanceId: "owner",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    const replies: unknown[] = [];
+    const rpc = new FederationRpcEndpoint({
+      localInstanceId: "viewer",
+      remoteInstanceId: "owner",
+      sendEnvelope: (envelope) => { void router.routeEnvelope({ sourcePeerId: "viewer", envelope }); },
+    });
+    router.registerConnection({
+      peerId: "viewer",
+      capabilities: ["federated_search"],
+      sendEnvelope: (envelope) => {
+        replies.push(envelope);
+        rpc.receiveEnvelope(envelope);
+      },
+    });
+    registerFederationBackendHandlers({
+      router,
+      backend: {
+        searchFederatedThreads: bridge.searchFederatedThreads.bind(bridge),
+      } as FederationBackendOperations,
+    });
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{ instanceId: "owner", label: "Owner", backend: new FederationRemoteBackendClient(rpc) }],
+    });
+    const result = await service.search({
+      query: "needle",
+      backend: "codex",
+      projectKeys: ["project"],
+      updatedAfter: 100,
+      updatedBefore: 1_000,
+      limit: 1,
+    });
+    expect(result).toMatchObject({ results: [{ thread: { id: "match-1000" } }], totalCount: 901, truncated: true, failures: [] });
+    expect(replies).toEqual([expect.objectContaining({ kind: "response", result: {
+      threads: [expect.objectContaining({ id: "match-1000" })], totalCount: 901, truncated: true,
+    } })]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -3,8 +3,12 @@ import type {
   AppServerListThreadsResponse,
   AppServerThreadSummary,
   FederationProtocolEnvelope,
+  FederationThreadSearchResponse,
 } from "@pwragent/shared";
-import { FederationRemoteBackendClient } from "../federation/federation-backend-bridge";
+import {
+  FEDERATION_BACKEND_METHODS,
+  FederationRemoteBackendClient,
+} from "../federation/federation-backend-bridge";
 import { FederatedSearchService } from "../federation/federated-search-service";
 import { FederationRpcEndpoint } from "../federation/federation-rpc";
 
@@ -43,6 +47,7 @@ describe("FederatedSearchService", () => {
           label: "Harold-Mac-Mini-M4",
           backend: {
             listThreads: remoteListThreads,
+            searchFederatedThreads: vi.fn(),
             resolveThread: vi.fn(async () => ({
               thread: thread(
                 threadId,
@@ -70,7 +75,7 @@ describe("FederatedSearchService", () => {
     expect(remoteListThreads).not.toHaveBeenCalled();
   });
 
-  it("falls back to exact list scanning when a peer lacks resolution RPC", async () => {
+  it("falls back to exact list scanning only when both search RPCs are missing", async () => {
     const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
     const service = new FederatedSearchService({
       includeLocal: false,
@@ -80,6 +85,11 @@ describe("FederatedSearchService", () => {
           instanceId: "pwr_older",
           label: "Older Mac",
           backend: {
+            searchFederatedThreads: vi.fn(async () => {
+              throw Object.assign(new Error("Unsupported federation method"), {
+                code: "method_not_found",
+              });
+            }),
             resolveThread: vi.fn(async () => {
               throw Object.assign(new Error("Unsupported federation method"), {
                 code: "method_not_found",
@@ -110,6 +120,49 @@ describe("FederatedSearchService", () => {
     });
   });
 
+  it("uses bounded owner search for an archived exact-id resolve miss", async () => {
+    const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
+    const listThreads = vi.fn();
+    const searchFederatedThreads = vi.fn(async () => ({
+      threads: [{
+        ...thread(threadId, "Archived reconnect fix", 3_000),
+        archivedAt: 4_000,
+      }],
+      totalCount: 1,
+      truncated: false,
+    }));
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_current",
+        label: "Current Mac",
+        backend: {
+          listThreads,
+          resolveThread: vi.fn(async () => ({})),
+          searchFederatedThreads,
+        },
+      }],
+    });
+
+    await expect(service.search({
+      query: threadId,
+      backend: "codex",
+      includeArchived: true,
+      limit: 5,
+    })).resolves.toMatchObject({
+      results: [{ thread: { id: threadId, archivedAt: 4_000 } }],
+      failures: [],
+    });
+    expect(searchFederatedThreads).toHaveBeenCalledWith({
+      query: threadId,
+      backend: "codex",
+      includeArchived: true,
+      limit: 5,
+    }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
+    expect(listThreads).not.toHaveBeenCalled();
+  });
+
   it("does not amplify a resolve failure into full active and archive scans", async () => {
     const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
     const listThreads = vi.fn();
@@ -120,6 +173,7 @@ describe("FederatedSearchService", () => {
         instanceId: "pwr_broken",
         label: "Broken Mac",
         backend: {
+          searchFederatedThreads: vi.fn(),
           resolveThread: vi.fn(async () => {
             throw Object.assign(new Error("Remote handler failed"), {
               code: "handler_failed",
@@ -164,6 +218,11 @@ describe("FederatedSearchService", () => {
               backend: "codex" as const,
               fetchedAt: 1_000,
               threads: [thread("remote-1", "Remote control design", 2_000)],
+            })),
+            searchFederatedThreads: vi.fn(async () => ({
+              threads: [thread("remote-1", "Remote control design", 2_000)],
+              totalCount: 1,
+              truncated: false,
             })),
           },
         },
@@ -212,7 +271,8 @@ describe("FederatedSearchService", () => {
           instanceId: "child_one",
           label: "Laptop",
           backend: {
-            listThreads: vi.fn(async () => {
+            listThreads: vi.fn(),
+            searchFederatedThreads: vi.fn(async () => {
               throw new Error("offline");
             }),
           },
@@ -221,10 +281,11 @@ describe("FederatedSearchService", () => {
           instanceId: "child_two",
           label: "Desktop",
           backend: {
-            listThreads: vi.fn(async () => ({
-              backend: "codex" as const,
-              fetchedAt: 1_000,
+            listThreads: vi.fn(),
+            searchFederatedThreads: vi.fn(async () => ({
               threads: [thread("remote-2", "Search survives failure", 3_000)],
+              totalCount: 1,
+              truncated: false,
             })),
           },
         },
@@ -258,7 +319,7 @@ describe("FederatedSearchService", () => {
     });
   });
 
-  it("applies backend, project, archive, and date filters before limiting", async () => {
+  it("uses full-list compatibility only for a method_not_found old peer", async () => {
     const listThreads = vi.fn(async (request?: {
       archived?: boolean;
       backend?: string;
@@ -283,7 +344,14 @@ describe("FederatedSearchService", () => {
       peers: () => [{
         instanceId: "pwr_remote",
         label: "Remote Mac",
-        backend: { listThreads },
+        backend: {
+          listThreads,
+          searchFederatedThreads: vi.fn(async () => {
+            throw Object.assign(new Error("Older peer"), {
+              code: "method_not_found",
+            });
+          }),
+        },
       }],
     });
 
@@ -312,6 +380,153 @@ describe("FederatedSearchService", () => {
     }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
   });
 
+  it("keeps one absolute deadline through the old-peer list fallback", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const searchFederatedThreads = vi.fn(
+      (
+        _request: unknown,
+        _rpcOptions?: { deadlineAt?: number },
+      ) => new Promise<FederationThreadSearchResponse>((_resolve, reject) => {
+        setTimeout(() => reject(Object.assign(new Error("Older peer"), {
+          code: "method_not_found",
+        })), 40);
+      }),
+    );
+    const listThreads = vi.fn((
+      request?: { archived?: boolean },
+      _rpcOptions?: { deadlineAt?: number },
+    ) =>
+      request?.archived
+        ? new Promise<AppServerListThreadsResponse>(() => {})
+        : new Promise<AppServerListThreadsResponse>((resolve) => {
+            setTimeout(() => resolve({
+              backend: "codex",
+              fetchedAt: 1_000,
+              threads: [],
+            }), 40);
+          }));
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      peerTimeoutMs: 100,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_older",
+        label: "Older Mac",
+        backend: { listThreads, searchFederatedThreads },
+      }],
+    });
+
+    const search = service.search({
+      query: "collector",
+      includeArchived: true,
+    });
+    await vi.advanceTimersByTimeAsync(100);
+    await expect(search).resolves.toMatchObject({
+      failures: [{
+        instanceId: "pwr_older",
+        error: "Federated search timed out after 0s.",
+      }],
+    });
+    expect(searchFederatedThreads.mock.calls[0]?.[1]).toEqual({
+      deadlineAt: 1_100,
+    });
+    expect(listThreads.mock.calls[0]?.[1]).toEqual({ deadlineAt: 1_100 });
+    expect(listThreads.mock.calls[1]?.[1]).toEqual({ deadlineAt: 1_100 });
+  });
+
+  it("forwards filters and the global limit to bounded owner-side search", async () => {
+    const listThreads = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: 1_000,
+      threads: [thread("legacy-full-list", "Collector result", 4_500)],
+    }));
+    const searchFederatedThreads = vi.fn(async () => ({
+      threads: [{
+        ...thread("bounded-match", "Collector result", 5_000),
+        archivedAt: 6_000,
+        projectKey: "PwrSuiteLab",
+      }],
+      totalCount: 37,
+      truncated: true,
+    }));
+    const remoteBackend = {
+      listThreads,
+      searchFederatedThreads,
+    };
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_remote",
+        label: "Remote Mac",
+        backend: remoteBackend,
+      }],
+    });
+
+    await expect(service.search({
+      query: "  collector  ",
+      backend: "codex",
+      includeArchived: true,
+      projectKeys: ["PwrSuiteLab"],
+      updatedAfter: 4_000,
+      updatedBefore: 6_000,
+      limit: 1,
+    })).resolves.toMatchObject({
+      results: [{ thread: { id: "bounded-match" } }],
+      totalCount: 37,
+      truncated: true,
+      searchedInstances: [{
+        instanceId: "pwr_remote",
+        resultCount: 37,
+      }],
+    });
+    expect(searchFederatedThreads).toHaveBeenCalledWith({
+      query: "collector",
+      backend: "codex",
+      includeArchived: true,
+      projectKeys: ["PwrSuiteLab"],
+      updatedAfter: 4_000,
+      updatedBefore: 6_000,
+      limit: 1,
+    }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
+    expect(listThreads).not.toHaveBeenCalled();
+  });
+
+  it("does not fall back to full lists after bounded owner search fails", async () => {
+    const listThreads = vi.fn(async () => ({
+      backend: "codex" as const,
+      fetchedAt: 1_000,
+      threads: [thread("should-not-load", "Collector result", 5_000)],
+    }));
+    const remoteBackend = {
+      listThreads,
+      searchFederatedThreads: vi.fn(async () => {
+        throw Object.assign(new Error("Remote handler failed"), {
+          code: "handler_failed",
+        });
+      }),
+    };
+    const service = new FederatedSearchService({
+      includeLocal: false,
+      local: { listThreads: vi.fn() },
+      peers: () => [{
+        instanceId: "pwr_broken",
+        label: "Broken Mac",
+        backend: remoteBackend,
+      }],
+    });
+
+    await expect(service.search({ query: "collector" })).resolves.toMatchObject({
+      results: [],
+      failures: [{
+        instanceId: "pwr_broken",
+        error: "Remote handler failed",
+      }],
+    });
+    expect(listThreads).not.toHaveBeenCalled();
+  });
+
   it("reports totalCount and truncation before slicing the result page", async () => {
     const service = new FederatedSearchService({
       includeLocal: false,
@@ -320,11 +535,12 @@ describe("FederatedSearchService", () => {
         instanceId: "pwr_remote",
         label: "Remote Mac",
         backend: {
-          listThreads: vi.fn(async () => ({
-            backend: "codex" as const,
-            fetchedAt: 1_000,
-            threads: Array.from({ length: 11 }, (_, index) =>
+          listThreads: vi.fn(),
+          searchFederatedThreads: vi.fn(async () => ({
+            threads: Array.from({ length: 10 }, (_, index) =>
               thread(`remote-${index}`, "Collector result", index)),
+            totalCount: 11,
+            truncated: true,
           })),
         },
       }],
@@ -350,13 +566,14 @@ describe("FederatedSearchService", () => {
         instanceId: "pwr_remote",
         label: "Remote Mac",
         backend: {
-          listThreads: vi.fn(async () => ({
-            backend: "codex" as const,
-            fetchedAt: 1_000,
+          listThreads: vi.fn(),
+          searchFederatedThreads: vi.fn(async () => ({
             threads: [
               thread("older", "Older", 1_000),
               thread("newer", "Newer", 2_000),
             ],
+            totalCount: 2,
+            truncated: false,
           })),
         },
       }],
@@ -388,8 +605,9 @@ describe("FederatedSearchService", () => {
           backend: {
             // Never resolves — simulates a peer that accepted the RPC
             // but will not answer within the interactive window.
-            listThreads: vi.fn(
-              () => new Promise<AppServerListThreadsResponse>(() => {}),
+            listThreads: vi.fn(),
+            searchFederatedThreads: vi.fn(
+              () => new Promise<FederationThreadSearchResponse>(() => {}),
             ),
           },
         },
@@ -434,7 +652,10 @@ describe("FederatedSearchService", () => {
     await expect(search).resolves.toMatchObject({
       failures: [{ instanceId: "child_hung" }],
     });
-    expect(sent[0]).toMatchObject({ deadlineAt: 1_025 });
+    expect(sent[0]).toMatchObject({
+      deadlineAt: 1_025,
+      method: FEDERATION_BACKEND_METHODS.searchFederatedThreads,
+    });
     expect(
       (endpoint as unknown as { pending: Map<string, unknown> }).pending.size,
     ).toBe(0);

--- a/apps/desktop/src/main/__tests__/federated-search-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federated-search-service.test.ts
@@ -32,13 +32,40 @@ function thread(
 }
 
 describe("FederatedSearchService", () => {
-  it("uses exact resolution for a pasted thread UUID", async () => {
+  it("returns a healthy peer when local search fails", async () => {
+    const service = new FederatedSearchService({
+      local: { listThreads: vi.fn(), searchFederatedThreads: vi.fn(async () => { throw new Error("local unavailable"); }) },
+      peers: () => [{ instanceId: "healthy", label: "Healthy", backend: {
+        listThreads: vi.fn(), searchFederatedThreads: vi.fn(async () => ({
+          threads: [thread("peer-result", "Needle", 1)], totalCount: 1, truncated: false,
+        })),
+      } }],
+    });
+    expect(await service.search({ query: "needle" })).toMatchObject({
+      results: [{ thread: { id: "peer-result" } }],
+      localSearch: { error: "local unavailable", totalCount: 0 },
+    });
+  });
+
+  it("bounds a hung local owner by the same search budget", async () => {
+    vi.useFakeTimers();
+    const service = new FederatedSearchService({ peerTimeoutMs: 25,
+      local: { listThreads: vi.fn(), searchFederatedThreads: vi.fn(() => new Promise<never>(() => {})) },
+      peers: () => [],
+    });
+    const pending = service.search({ query: "needle" });
+    await vi.advanceTimersByTimeAsync(25);
+    expect(await pending).toMatchObject({ localSearch: { error: "Local federated search timed out." } });
+  });
+
+  it("uses the read-only bounded owner path for a pasted thread UUID", async () => {
     const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
     const localListThreads = vi.fn();
     const remoteListThreads = vi.fn();
     const service = new FederatedSearchService({
       local: {
         listThreads: localListThreads,
+        searchFederatedThreads: vi.fn(async () => ({ threads: [], totalCount: 0, truncated: false })),
         resolveThread: vi.fn(async () => ({})),
       },
       peers: () => [
@@ -47,7 +74,11 @@ describe("FederatedSearchService", () => {
           label: "Harold-Mac-Mini-M4",
           backend: {
             listThreads: remoteListThreads,
-            searchFederatedThreads: vi.fn(),
+            searchFederatedThreads: vi.fn(async () => ({
+              threads: [thread(threadId, "Thread list stays disabled after reconnect", 3_000)],
+              totalCount: 1,
+              truncated: false,
+            })),
             resolveThread: vi.fn(async () => ({
               thread: thread(
                 threadId,
@@ -75,7 +106,7 @@ describe("FederatedSearchService", () => {
     expect(remoteListThreads).not.toHaveBeenCalled();
   });
 
-  it("falls back to exact list scanning only when both search RPCs are missing", async () => {
+  it("falls back to exact list scanning only when bounded search is missing", async () => {
     const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
     const service = new FederatedSearchService({
       includeLocal: false,
@@ -163,7 +194,7 @@ describe("FederatedSearchService", () => {
     expect(listThreads).not.toHaveBeenCalled();
   });
 
-  it("does not amplify a resolve failure into full active and archive scans", async () => {
+  it("does not amplify an exact owner search failure into full active and archive scans", async () => {
     const threadId = "019fd821-1450-7952-85ca-3bb8e5d150da";
     const listThreads = vi.fn();
     const service = new FederatedSearchService({
@@ -173,8 +204,7 @@ describe("FederatedSearchService", () => {
         instanceId: "pwr_broken",
         label: "Broken Mac",
         backend: {
-          searchFederatedThreads: vi.fn(),
-          resolveThread: vi.fn(async () => {
+          searchFederatedThreads: vi.fn(async () => {
             throw Object.assign(new Error("Remote handler failed"), {
               code: "handler_failed",
             });
@@ -371,12 +401,10 @@ describe("FederatedSearchService", () => {
     expect(listThreads).toHaveBeenNthCalledWith(1, {
       backend: "codex",
       archived: false,
-      filter: "collector",
     }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
     expect(listThreads).toHaveBeenNthCalledWith(2, {
       backend: "codex",
       archived: true,
-      filter: "collector",
     }, expect.objectContaining({ deadlineAt: expect.any(Number) }));
   });
 

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -1180,10 +1180,11 @@ describe("federation agent tools service", () => {
           },
         ],
         remoteBackend: (() => ({
-          listThreads: async () => ({
-            backend: "all",
-            fetchedAt: 10,
+          listThreads: vi.fn(),
+          searchFederatedThreads: async () => ({
             threads: [remoteThread],
+            totalCount: 1,
+            truncated: false,
           }),
         })) as never,
       }),
@@ -1255,6 +1256,20 @@ describe("federation agent tools service", () => {
         },
       ],
     }));
+    const remoteSearchThreads = vi.fn(async () => ({
+      threads: [
+        {
+          id: "thread-remote",
+          title: "Recorder crash investigation",
+          source: "codex" as const,
+          linkedDirectories: [],
+          createdAt: 1,
+          updatedAt: 3,
+        },
+      ],
+      totalCount: 1,
+      truncated: false,
+    }));
     const handler = createFederationAgentToolsHandler({
       // Never let unit tests mint a machine-id in the real PwrAgent root.
       collectHostInfo: async () => localHostInfo,
@@ -1268,7 +1283,10 @@ describe("federation agent tools service", () => {
             capabilities: ["federated_search"],
           },
         ],
-        remoteBackend: (() => ({ listThreads: remoteListThreads })) as never,
+        remoteBackend: (() => ({
+          listThreads: remoteListThreads,
+          searchFederatedThreads: remoteSearchThreads,
+        })) as never,
       }),
     });
 
@@ -1296,7 +1314,8 @@ describe("federation agent tools service", () => {
     const localData = (
       localOnly as { ok: true; data: SearchFederationThreadsResult }
     ).data;
-    expect(remoteListThreads).toHaveBeenCalledTimes(1);
+    expect(remoteSearchThreads).toHaveBeenCalledTimes(1);
+    expect(remoteListThreads).not.toHaveBeenCalled();
     expect(localData.results.map((entry) => entry.threadId)).toEqual([
       "thread-local",
     ]);
@@ -1332,10 +1351,11 @@ describe("federation agent tools service", () => {
           },
         ],
         remoteBackend: (() => ({
-          listThreads: async () => ({
-            backend: "all",
-            fetchedAt: 10,
+          listThreads: vi.fn(),
+          searchFederatedThreads: async () => ({
             threads: [],
+            totalCount: 0,
+            truncated: false,
           }),
         })) as never,
       }),

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -1169,7 +1169,7 @@ describe("federation agent tools service", () => {
           listThreads: async () => ({
             backend: "all",
             fetchedAt: 10,
-            threads: [localThread],
+            threads: Array.from({ length: 100 }, (_, index) => ({ ...localThread, id: `local-${index}` })),
           }),
         })) as never,
         connectedPeerTargets: () => [
@@ -1193,20 +1193,13 @@ describe("federation agent tools service", () => {
     const response = await handler({
       operation: "search_federation_threads",
       context,
-      args: { query: "recorder crash" },
+      args: { query: "recorder crash", limit: 1 },
     });
 
     const data = (response as { ok: true; data: SearchFederationThreadsResult })
       .data;
-    expect(data.results).toHaveLength(2);
-    const local = data.results.find((entry) => entry.isLocal);
+    expect(data.results).toHaveLength(1);
     const remote = data.results.find((entry) => !entry.isLocal);
-    expect(local).toMatchObject({
-      instanceId: "pwr_local",
-      instanceLabel: "Local Mac",
-      threadId: "thread-local",
-    });
-    expect(local?.threadLink).toContain("pwragent://thread/thread-local");
     expect(remote).toMatchObject({
       instanceId: "pwr_studio",
       instanceLabel: "Studio Mac",
@@ -1215,14 +1208,9 @@ describe("federation agent tools service", () => {
     expect(remote?.threadLink).toContain(
       "instanceId=pwr_studio",
     );
-    expect(rememberRemoteThreadTarget).toHaveBeenCalledWith({
-      instanceId: "pwr_studio",
-      instanceLabel: "Studio Mac",
-      backend: "codex",
-      threadId: "thread-remote",
-    });
+    expect(rememberRemoteThreadTarget).not.toHaveBeenCalled();
     expect(data.searchedInstances).toEqual([
-      { instanceId: "pwr_local", instanceLabel: "Local Mac", resultCount: 1 },
+      { instanceId: "pwr_local", instanceLabel: "Local Mac", resultCount: 100, truncated: true },
       { instanceId: "pwr_studio", instanceLabel: "Studio Mac", resultCount: 1 },
     ]);
   });

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -687,6 +687,74 @@ describe("federation backend bridge", () => {
     expect(backend.getNavigationSnapshot).not.toHaveBeenCalled();
   });
 
+  it("routes generic search filters to a bounded owner response", async () => {
+    const match = {
+      id: "thread-553",
+      title: "Collector result",
+      titleSource: "explicit" as const,
+      linkedDirectories: [],
+      source: "codex" as const,
+      projectKey: "PwrSuiteLab",
+      updatedAt: 5_000,
+    };
+    const listThreads = vi.fn();
+    const searchFederatedThreads = vi.fn(async () => ({
+      threads: [match],
+      totalCount: 1_200,
+      truncated: true,
+    }));
+    const backend = {
+      getNavigationSnapshot: vi.fn(),
+      listThreads,
+      searchFederatedThreads,
+    } as unknown as FederationBackendOperations;
+    const replies: FederationProtocolEnvelope[] = [];
+    const router = new FederationRouter({
+      localInstanceId: "owner_one",
+      methodCapabilities: FEDERATION_BACKEND_METHOD_CAPABILITIES,
+    });
+    router.registerConnection({
+      peerId: "viewer_one",
+      capabilities: ["federated_search"],
+      sendEnvelope: (envelope) => replies.push(envelope),
+    });
+    registerFederationBackendHandlers({ router, backend });
+    const request = {
+      query: "collector",
+      backend: "codex" as const,
+      includeArchived: true,
+      projectKeys: ["PwrSuiteLab"],
+      updatedAfter: 4_000,
+      updatedBefore: 6_000,
+      limit: 10,
+    };
+
+    await router.routeEnvelope({
+      sourcePeerId: "viewer_one",
+      envelope: {
+        id: "generic-search",
+        kind: "request",
+        method: FEDERATION_BACKEND_METHODS.searchFederatedThreads,
+        params: request,
+        protocolVersion: 1,
+        sourceInstanceId: "viewer_one",
+        targetInstanceId: "owner_one",
+        createdAt: 1_000,
+      },
+    });
+
+    expect(replies[0]).toMatchObject({
+      kind: "response",
+      result: {
+        threads: [{ id: "thread-553" }],
+        totalCount: 1_200,
+        truncated: true,
+      },
+    });
+    expect(searchFederatedThreads).toHaveBeenCalledWith(request);
+    expect(listThreads).not.toHaveBeenCalled();
+  });
+
   it("sends unchanged and sparse navigation responses instead of full Federation payloads", async () => {
     const buildThread = (index: number): NavigationThreadSummary => ({
       id: `thread-${index}`,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -733,6 +733,7 @@ describe("federation backend bridge", () => {
       sourcePeerId: "viewer_one",
       envelope: {
         id: "generic-search",
+        deadlineAt: Date.now() + 10_000,
         kind: "request",
         method: FEDERATION_BACKEND_METHODS.searchFederatedThreads,
         params: request,
@@ -751,7 +752,9 @@ describe("federation backend bridge", () => {
         truncated: true,
       },
     });
-    expect(searchFederatedThreads).toHaveBeenCalledWith(request);
+    expect(searchFederatedThreads).toHaveBeenCalledWith(request, {
+      deadlineAt: expect.any(Number),
+    });
     expect(listThreads).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/main/__tests__/federation-envelope-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-envelope-diagnostics.test.ts
@@ -14,6 +14,17 @@ const response = {
 } satisfies FederationProtocolEnvelope;
 
 describe("federation envelope diagnostics", () => {
+  it("correlates search query fingerprints without logging query text", () => {
+    const diagnostics = new FederationEnvelopeDiagnostics();
+    const search = { ...request, method: "backend.searchNavigationThreads", params: { query: "private search phrase" } };
+    diagnostics.observe(search);
+    const fields = diagnostics.describe(search);
+    expect(fields.queryFingerprint).toMatch(/^[a-f0-9]{12}$/);
+    expect(diagnostics.describe(response).queryFingerprint).toBe(fields.queryFingerprint);
+    expect(diagnostics.describe({ ...search, params: { query: "other phrase" } }).queryFingerprint).not.toBe(fields.queryFingerprint);
+    expect(JSON.stringify(fields)).not.toContain("private search phrase");
+  });
+
   it("correlates both relay legs without retaining or logging payloads", () => {
     const diagnostics = new FederationEnvelopeDiagnostics();
     diagnostics.observe(request);

--- a/apps/desktop/src/main/__tests__/federation-envelope-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-envelope-diagnostics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import { FederationEnvelopeDiagnostics } from "../federation/federation-envelope-diagnostics";
+
+const request = {
+  kind: "request", id: "req", sourceInstanceId: "viewer", targetInstanceId: "owner",
+  protocolVersion: 1, createdAt: 0,
+  method: "backend.getNavigationSnapshot", params: { secret: "do not log" },
+} satisfies FederationProtocolEnvelope;
+const response = {
+  kind: "response", id: "res", requestId: "req",
+  sourceInstanceId: "owner", targetInstanceId: "viewer", result: { secret: "do not log" },
+  protocolVersion: 1, createdAt: 0,
+} satisfies FederationProtocolEnvelope;
+
+describe("federation envelope diagnostics", () => {
+  it("correlates both relay legs without retaining or logging payloads", () => {
+    const diagnostics = new FederationEnvelopeDiagnostics();
+    diagnostics.observe(request);
+    diagnostics.observe(request);
+    diagnostics.observe(response);
+    const fields = diagnostics.describe(response, (id) => `Friendly ${id}`);
+    expect(fields).toMatchObject({
+      method: "backend.getNavigationSnapshot", requestId: "req",
+      sourceInstanceLabel: "Friendly owner", targetInstanceLabel: "Friendly viewer",
+    });
+    expect(diagnostics.describe(response)).toMatchObject({ method: request.method });
+    expect(JSON.stringify(fields)).not.toContain("secret");
+  });
+
+  it("bounds correlation retention and does not confuse reversed owners", () => {
+    let now = 0;
+    const diagnostics = new FederationEnvelopeDiagnostics(() => now, 1, 100);
+    diagnostics.observe(request);
+    expect(diagnostics.describe({ ...response, sourceInstanceId: "other" } as FederationProtocolEnvelope).method).toBe("unknown");
+    now = 101;
+    expect(diagnostics.describe(response).method).toBe("unknown");
+    diagnostics.observe(request);
+    diagnostics.observe({ ...request, id: "second" });
+    expect(diagnostics.describe(response).method).toBe("unknown");
+  });
+
+  it("identifies wrapped notifications and uncorrelated responses", () => {
+    const diagnostics = new FederationEnvelopeDiagnostics();
+    expect(diagnostics.describe({
+      ...request, kind: "notification", method: "backend.event",
+      params: { notification: { method: "thread/updated", params: { secret: true } } },
+    } as FederationProtocolEnvelope)).toMatchObject({ method: "backend.event", notificationMethod: "thread/updated" });
+    expect(diagnostics.describe(response)).toMatchObject({ method: "unknown", requestId: "req" });
+  });
+
+  it("correlates error responses and retains their error code", () => {
+    const diagnostics = new FederationEnvelopeDiagnostics();
+    diagnostics.observe(request);
+    expect(diagnostics.describe({
+      ...response, kind: "error", error: { code: "method_not_found", message: "private detail" },
+    })).toMatchObject({
+      method: request.method, requestId: "req", errorCode: "method_not_found",
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -37,6 +37,9 @@ import {
 } from "../federation/federation-transport";
 import { StateDb } from "../state/state-db";
 
+const transportLog = vi.hoisted(() => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }));
+vi.mock("../log", () => ({ getMainLogger: () => transportLog }));
+
 let stateDb: StateDb;
 let store: FederationStore;
 let tempDir: string;
@@ -45,6 +48,7 @@ let rawServer: WebSocketServer | undefined;
 let gatewayKeyPair: ReturnType<typeof generateFederationIdentityKeyPair>;
 
 beforeEach(() => {
+  vi.clearAllMocks();
   tempDir = mkdtempSync(path.join(os.tmpdir(), "pwragent-federation-transport-"));
   stateDb = StateDb.open(path.join(tempDir, "state.db"));
   store = new FederationStore(stateDb);
@@ -276,7 +280,7 @@ describe("federation transport", () => {
     client.close();
   });
 
-  it.each([false, true])("reports exact data and encoded bytes at both ends (Noise: %s)", async (encrypted) => {
+  it.each([false, true])("reports exact bytes and correlated large responses at both ends (Noise: %s)", async (encrypted) => {
     const gatewayNoise = generateNoiseStaticKeyPair();
     const clientNoise = generateNoiseStaticKeyPair();
     const clientKeyPair = generateFederationIdentityKeyPair();
@@ -305,6 +309,7 @@ describe("federation transport", () => {
       gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
       gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
       noiseStatic: encrypted ? gatewayNoise : undefined,
+      instanceLabel: (id) => id === "gateway_one" ? "Gateway" : "Client",
       host: "127.0.0.1",
       port: 0,
       store,
@@ -317,7 +322,7 @@ describe("federation transport", () => {
           sourceInstanceId: "gateway_one",
           targetInstanceId: connection.peerId,
           createdAt: 2_000,
-          result: { ok: true },
+          result: { privatePayload: "x".repeat(600_000) },
         });
       },
       onEnvelopeTransfer: (info) => gatewayTransfers.push(info),
@@ -328,6 +333,7 @@ describe("federation transport", () => {
       void connectFederationClient({
         url,
         noiseStatic: encrypted ? clientNoise : undefined,
+        instanceLabel: (id) => id === "gateway_one" ? "Gateway" : "Client",
         gatewayNoisePublicKey: encrypted ? gatewayNoise.publicKeyRaw : undefined,
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
@@ -365,6 +371,23 @@ describe("federation transport", () => {
     expect(clientTransfers).toHaveLength(2);
     const [gatewayReceived, gatewaySent] = gatewayTransfers;
     const [clientSent, clientReceived] = clientTransfers;
+    for (const message of ["large federation frame queued for send", "large federation frame received"]) {
+      expect(transportLog.info).toHaveBeenCalledWith(message, expect.objectContaining({
+        envelopeKind: "response",
+        requestId: "request-transfer",
+        method: "thread.list",
+        sourceInstanceId: "gateway_one",
+        sourceInstanceLabel: "Gateway",
+        targetInstanceId: "client_one",
+        targetInstanceLabel: "Client",
+      }));
+    }
+    const largeLogs = transportLog.info.mock.calls.filter(([message]) => message.startsWith("large federation frame"));
+    expect(largeLogs).toHaveLength(2);
+    expect(largeLogs[0][1]).toMatchObject({ peerId: "client_one", peerLabel: "Client" });
+    expect(largeLogs[1][1]).toMatchObject({ peerId: "gateway_one", peerLabel: "Gateway" });
+    expect(JSON.stringify(largeLogs)).not.toContain("privatePayload");
+    expect(JSON.stringify(largeLogs)).not.toContain("maxFrameBytes");
     expect(gatewayReceived).toMatchObject({
       peerId: "client_one",
       direction: "received",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -97,6 +97,13 @@
     "rowsChanged": 0,
     "statements": 0
   },
+  "federated-owner-search": {
+    "commits": 0,
+    "note": "first and repeated generic owner searches, including archives",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "federation-activity-monitor": {
     "commits": 0,
     "note": "10,000 transfers, local snapshots and reset: in-memory only; 0 MB/day added WAL",

--- a/apps/desktop/src/main/__tests__/navigation-search-result.test.ts
+++ b/apps/desktop/src/main/__tests__/navigation-search-result.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { rankThreadJumpMatches, type NavigationThreadSummary } from "@pwragent/shared";
+import { compactNavigationSearchResult } from "../federation/navigation-search-result";
+import { federationTransportCodecForTest } from "../federation/federation-transport";
+
+describe("compact navigation search results", () => {
+  it("keeps eight bloated matches below 64 KiB without shipping thread state", () => {
+    const huge = "x".repeat(1_000_000);
+    const thread: NavigationThreadSummary = {
+      id: "thread", source: "codex", title: "PR 1968", titleSource: "explicit",
+      linkedDirectories: [{ id: "dir", label: "repo", path: "/repo", kind: "local" }],
+      inbox: { inInbox: true }, summary: huge,
+      optimisticUserMessage: { text: huge },
+      agent: { name: "Agent", instructions: huge, instructionLineCount: 1, instructionsTooLong: true, updatedAt: 0 },
+      prs: [{ provider: "github.com", org: "org", repo: "repo", number: 1968,
+        url: "https://github.com/org/repo/pull/1968", state: "passing", commitShas: Array(10000).fill(huge.slice(0, 40)) }],
+    };
+    const results = Array.from({ length: 8 }, (_, index) => compactNavigationSearchResult({ ...thread, id: `thread-${index}` }, "1968"));
+    const wire = federationTransportCodecForTest.encodeEnvelope({
+      kind: "response", id: "response", requestId: "search", protocolVersion: 1,
+      sourceInstanceId: "owner", targetInstanceId: "viewer", createdAt: 0,
+      result: { results },
+    });
+    expect(wire.byteLength).toBeLessThan(64 * 1024);
+    expect(results[0]).toMatchObject({ id: "thread-0", linkedDirectories: [{ path: "/repo" }], prs: [{ number: 1968, url: thread.prs![0].url }] });
+    expect(results[0]).not.toHaveProperty("optimisticUserMessage");
+    expect(results[0]).not.toHaveProperty("summary");
+    expect(results[0].prs![0]).not.toHaveProperty("commitShas");
+    expect(thread.optimisticUserMessage!.text).toHaveLength(1_000_000);
+  });
+
+  it("preserves matches for old viewers even when evidence is deep in large fields", () => {
+    const thread: NavigationThreadSummary = {
+      id: "thread", source: "codex", title: "Agent", titleSource: "explicit",
+      linkedDirectories: [], inbox: { inInbox: false },
+      agent: { name: "Agent", instructions: `${"x".repeat(10000)} needle ${"y".repeat(10000)} haystack`, instructionLineCount: 1, instructionsTooLong: true, updatedAt: 0 },
+    };
+    const result = compactNavigationSearchResult(thread, "needle haystack");
+    expect(rankThreadJumpMatches([result], "needle haystack")).toHaveLength(1);
+    expect(result.agent!.instructions!.length).toBeLessThan(2048);
+  });
+});

--- a/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/remote-thread-summary-cache.test.ts
@@ -102,6 +102,22 @@ function pin(params: {
 }
 
 describe("RemoteThreadSummaryCache — searchForJump", () => {
+  it("keeps owner-matched rows whose large matching fields were omitted and compacts older responses", async () => {
+    const thread = stampedThread({ instanceId: "peer-a", threadId: "t1", title: "Agent" });
+    const cache = new RemoteThreadSummaryCache({
+      peers: () => [peer("peer-a")],
+      fetchSnapshot: async () => snapshotOf([]),
+      searchPeer: async () => [{ ...thread, optimisticUserMessage: { text: "private".repeat(100000) } }],
+      fetchArchivedThreads: noArchivedThreads,
+      peerStatus: () => ({}),
+    });
+    const response = await cache.searchForJump({ query: "matches omitted agent instructions", limit: 8 });
+    expect(response.results.map((result) => result.id)).toEqual(["t1"]);
+    expect(response.results[0].federation?.ref).toEqual(thread.federation?.ref);
+    expect(response.results[0]).not.toHaveProperty("optimisticUserMessage");
+    expect(Buffer.byteLength(JSON.stringify(response))).toBeLessThan(8 * 1024);
+  });
+
   it("asks each peer for bounded matches instead of fetching its full snapshot", async () => {
     const fetchSnapshot = vi.fn(async () => snapshotOf([]));
     const searchPeer = vi.fn(async () => [

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -648,6 +648,7 @@ const REPLAY_THREAD_TITLE_ENV = "PWRAGENT_REPLAY_THREAD_TITLE";
 // background polling catches external Codex changes on a slower cadence.
 const THREAD_LIST_REUSE_WINDOW_MS = 5 * 60_000;
 const CODEX_RATE_LIMIT_BROADCAST_WINDOW_MS = 20_000;
+const THREAD_SEARCH_REUSE_WINDOW_MS = 2_000;
 const ACTIVE_TURN_HANDOFF_ERROR =
   "Worktree/local migration is not available while a turn is in progress. Resubmit when the turn completes.";
 const CODEX_WORKSPACE_CWD_SYNC_PENDING_WARNING =
@@ -745,6 +746,7 @@ type BackendClient = {
       limit?: number;
       maxPages?: number;
       skipArchivedMetadataRefresh?: boolean;
+      deadlineAt?: number;
     },
     diagnostics?: { callerReason?: string; ownerId?: string },
   ): Promise<AppServerThreadSummary[]>;
@@ -10343,6 +10345,99 @@ export class DesktopBackendRegistry {
         `backend-registry.${method} is forbidden in bootstrap mode`,
       );
     }
+  }
+
+  /** Read-only candidates for generic search. Never run navigation/list maintenance. */
+  async listThreadSearchCandidates(params: {
+    backend?: AppServerBackendKind;
+    archived?: boolean;
+    deadlineAt?: number;
+  }): Promise<AppServerThreadSummary[]> {
+    const checkDeadline = () => {
+      if (params.deadlineAt !== undefined && Date.now() >= params.deadlineAt) {
+        throw new Error("Federated search deadline expired.");
+      }
+    };
+    checkDeadline();
+    if (this.isBootstrapModeFn()) return [];
+    // Share a completed inventory across query prefixes, not one full provider
+    // walk per keystroke. Use the existing event invalidation, but keep this
+    // read-only projection separate from maintenance-bearing list cache entries.
+    const cacheKey = JSON.stringify({
+      backend: params.backend ?? "all",
+      archived: params.archived === true,
+      readOnlySearch: true,
+    });
+    const cached = this.threadListCache.get(cacheKey);
+    if (cached?.threads && (cached.expiresAt ?? 0) > Date.now()) {
+      return cached.threads;
+    }
+    // An event during the read must prevent publishing the old projection.
+    // Do not share an in-flight request whose deadline belongs to another caller.
+    const pending: ThreadListCacheState = {};
+    this.threadListCache.set(cacheKey, pending);
+    const threads: AppServerThreadSummary[] = [];
+    if (
+      (!params.backend || params.backend === "codex")
+      && !this.isCodexBootstrapDeferredFn()
+    ) {
+      // Provider text filters do not cover IDs, overlay names or project paths.
+      // Match the complete metadata projection on the owner, after this read.
+      const codexThreads = await this.codexClient.listThreads({
+        archived: params.archived,
+        enrichDirectories: false,
+        skipArchivedMetadataRefresh: true,
+        deadlineAt: params.deadlineAt,
+      }, {
+        callerReason: "federation-thread-search",
+        ownerId: this.threadListCacheOwnerId,
+      });
+      threads.push(...this.withPendingStartedThreads("codex", codexThreads, params));
+    }
+    checkDeadline();
+    const acpBackends = params.backend
+      ? (isAcpBackendId(params.backend) ? [params.backend] : [])
+      : (await this.acpBackend.listAvailableAgents()).map((agent) => agent.backendId);
+    for (const backend of acpBackends) {
+      checkDeadline();
+      threads.push(...this.acpBackend.listSessions(backend, { archived: params.archived })
+        .map((session) => this.acpBackend.sessionToThreadSummary(session)));
+    }
+    const result: AppServerThreadSummary[] = [];
+    for (const thread of threads) {
+      checkDeadline();
+      const overlay = await this.overlayStore.getThreadOverlayState({
+        backend: thread.source,
+        threadId: thread.id,
+      });
+      if (overlay?.archiveTombstonedAt !== undefined) continue;
+      const cwd = resolveThreadWorkspaceCwd(thread, overlay?.extraLinkedDirectories ?? []);
+      const cachedDirectory = overlay?.acpWorktreeDirectory && overlay.acpWorktreeDirectory.cwd === cwd
+        ? overlay.acpWorktreeDirectory.directory
+        : undefined;
+      const projected = this.withObservedThreadName({
+        ...thread,
+        executionMode: overlay?.executionMode ?? thread.executionMode,
+        model: overlay?.model ?? thread.model,
+        reasoningEffort: overlay?.reasoningEffort ?? thread.reasoningEffort,
+        serviceTier: overlay?.serviceTier ?? thread.serviceTier,
+        fastMode: overlay?.fastMode ?? thread.fastMode,
+        linkedDirectories: dedupeLinkedDirectoriesByNormalizedIdentity([
+          ...thread.linkedDirectories,
+          ...(overlay?.extraLinkedDirectories ?? []),
+          ...(cachedDirectory ? [cachedDirectory] : []),
+        ]),
+      });
+      result.push(projected);
+    }
+    checkDeadline();
+    if (this.threadListCache.get(cacheKey) === pending) {
+      this.threadListCache.set(cacheKey, {
+        threads: result,
+        expiresAt: Date.now() + THREAD_SEARCH_REUSE_WINDOW_MS,
+      });
+    }
+    return result;
   }
 
   async listThreads(params: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -10377,6 +10377,7 @@ export class DesktopBackendRegistry {
     const pending: ThreadListCacheState = {};
     this.threadListCache.set(cacheKey, pending);
     const threads: AppServerThreadSummary[] = [];
+    let providerFailed = false;
     if (
       (!params.backend || params.backend === "codex")
       && !this.isCodexBootstrapDeferredFn()
@@ -10391,6 +10392,16 @@ export class DesktopBackendRegistry {
       }, {
         callerReason: "federation-thread-search",
         ownerId: this.threadListCacheOwnerId,
+      }).catch((error) => {
+        // Aggregate discovery must still reach healthy ACP providers. Explicit
+        // Codex requests retain the provider error, and the deadline check below
+        // still applies to the entire search rather than restarting its budget.
+        if (params.backend === "codex") throw error;
+        providerFailed = true;
+        backendRegistryLog.warn("Codex search discovery failed; continuing aggregate search", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return [];
       });
       threads.push(...this.withPendingStartedThreads("codex", codexThreads, params));
     }
@@ -10432,10 +10443,15 @@ export class DesktopBackendRegistry {
     }
     checkDeadline();
     if (this.threadListCache.get(cacheKey) === pending) {
-      this.threadListCache.set(cacheKey, {
-        threads: result,
-        expiresAt: Date.now() + THREAD_SEARCH_REUSE_WINDOW_MS,
-      });
+      if (providerFailed) {
+        // Do not hide a recovered provider behind a cached partial inventory.
+        this.threadListCache.delete(cacheKey);
+      } else {
+        this.threadListCache.set(cacheKey, {
+          threads: result,
+          expiresAt: Date.now() + THREAD_SEARCH_REUSE_WINDOW_MS,
+        });
+      }
     }
     return result;
   }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7220,16 +7220,21 @@ async function requestWithFallbacks(params: {
   methods: Array<CodexClientRequestMethod | (string & {})>;
   payloads: unknown[];
   timeoutMs: number;
+  deadlineAt?: number;
 }): Promise<unknown> {
   let lastError: unknown;
 
   for (const method of params.methods) {
     for (const payload of params.payloads) {
+      const timeoutMs = params.deadlineAt === undefined
+        ? params.timeoutMs
+        : Math.min(params.timeoutMs, params.deadlineAt - Date.now());
+      if (timeoutMs <= 0) throw new Error("Thread search deadline expired.");
       try {
         return await params.client.request(
           method,
           payload,
-          params.timeoutMs,
+          timeoutMs,
           params.diagnostics,
         );
       } catch (error) {
@@ -7252,6 +7257,7 @@ async function requestThreadListPages(params: {
   limit?: number;
   maxPages?: number;
   requestTimeoutMs: number;
+  deadlineAt?: number;
   sourceKinds?: CodexThreadListParams["sourceKinds"];
 }): Promise<RawCodexThreadSummary[]> {
   const pages: RawCodexThreadSummary[] = [];
@@ -7283,6 +7289,7 @@ async function requestThreadListPages(params: {
         params.sourceKinds,
       ),
       timeoutMs: params.requestTimeoutMs,
+      deadlineAt: params.deadlineAt,
     });
     const page = extractThreadListPage(result);
     pages.push(...page.threads);
@@ -8070,6 +8077,7 @@ export class CodexAppServerClient {
     limit?: number;
     maxPages?: number;
     skipArchivedMetadataRefresh?: boolean;
+    deadlineAt?: number;
   }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
@@ -8088,6 +8096,7 @@ export class CodexAppServerClient {
         limit: params?.limit,
         maxPages: params?.maxPages,
         requestTimeoutMs: requestParams.timeoutMs,
+        deadlineAt: params?.deadlineAt,
       });
       return await this.enrichThreads(filterVisibleCodexThreads(archivedThreads), {
         enrichDirectories: params?.enrichDirectories ?? true,
@@ -8103,6 +8112,7 @@ export class CodexAppServerClient {
         limit: params?.limit,
         maxPages: params?.maxPages,
         requestTimeoutMs: requestParams.timeoutMs,
+        deadlineAt: params?.deadlineAt,
       }),
     );
     const threads = params?.skipArchivedMetadataRefresh

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -5,6 +5,8 @@ import type {
   FederatedSearchResponse,
   FederationInstanceId,
   FederationPeerSummary,
+  FederationThreadSearchRequest,
+  FederationThreadSearchResponse,
 } from "@pwragent/shared";
 import {
   buildFederatedThreadRef,
@@ -20,14 +22,31 @@ export type FederatedSearchPeer = {
   instanceId: FederationInstanceId;
   label: string;
   status?: FederationPeerSummary["status"];
-  backend: Pick<FederationBackendOperations, "listThreads">
+  backend: Pick<
+    Required<FederationBackendOperations>,
+    "listThreads" | "searchFederatedThreads"
+  >
     & Partial<Pick<FederationBackendOperations, "resolveThread">>;
 };
 
 export type FederatedSearchLocalBackend = Pick<
   FederationBackendOperations,
   "listThreads"
+> & Partial<Pick<
+  FederationBackendOperations,
+  "resolveThread" | "searchFederatedThreads"
+>>;
+
+type FederatedSearchResolvableBackend = Pick<
+  FederationBackendOperations,
+  "listThreads"
 > & Partial<Pick<FederationBackendOperations, "resolveThread">>;
+
+type FederatedSearchResultPage = {
+  results: FederatedSearchResponse["results"];
+  totalCount: number;
+  truncated: boolean;
+};
 
 /**
  * Per-peer deadline for a search fan-out. Much tighter than the 30s RPC
@@ -73,7 +92,8 @@ export class FederatedSearchService {
           searchedInstances.push({
             instanceId: peer.instanceId,
             instanceLabel: peer.label,
-            resultCount: peerResults.length,
+            resultCount: peerResults.totalCount,
+            ...(peerResults.truncated ? { truncated: true } : {}),
           });
           return peerResults;
         } catch (error) {
@@ -82,24 +102,37 @@ export class FederatedSearchService {
             instanceLabel: peer.label,
             error: error instanceof Error ? error.message : String(error),
           });
-          return [];
+          return {
+            results: [],
+            totalCount: 0,
+            truncated: false,
+          };
         }
       }),
     ]);
     const matches = resultGroups
-      .flat()
+      .flatMap((group) => group.results)
       .sort((left, right) => {
         if (right.score !== left.score) return right.score - left.score;
-        return (right.thread.updatedAt ?? 0) - (left.thread.updatedAt ?? 0);
+        return (
+          (right.thread.updatedAt ?? right.thread.createdAt ?? 0)
+          - (left.thread.updatedAt ?? left.thread.createdAt ?? 0)
+        );
       });
     const results = matches.slice(0, limit);
+    const totalCount = resultGroups.reduce(
+      (count, group) => count + group.totalCount,
+      0,
+    );
 
     return {
       query,
       searchedAt,
       results,
-      totalCount: matches.length,
-      truncated: matches.length > limit,
+      totalCount,
+      truncated:
+        totalCount > limit
+        || resultGroups.some((group) => group.truncated),
       failures,
       searchedInstances,
     };
@@ -108,14 +141,14 @@ export class FederatedSearchService {
   private async searchLocal(
     query: string,
     request: FederatedSearchRequest,
-  ): Promise<FederatedSearchResponse["results"]> {
+  ): Promise<FederatedSearchResultPage> {
     const resolved = await this.resolveExactThreadId(
       this.options.local,
       query,
       request,
     );
     if (resolved !== undefined) {
-      return resolved
+      const results = resolved
         ? [{
             ref: buildFederatedThreadRef({
               backend: resolved.source,
@@ -126,21 +159,34 @@ export class FederatedSearchService {
             score: scoreThread(resolved, query),
           }]
         : [];
+      return {
+        results,
+        totalCount: results.length,
+        truncated: false,
+      };
     }
-    const threads = await listFederatedSearchThreads(
-      this.options.local,
-      query,
-      request,
-    );
-    return threads.map((thread) => ({
-      ref: buildFederatedThreadRef({
-        backend: thread.source,
-        threadId: thread.id,
-      }),
-      thread,
-      instanceLabel: "This Mac",
-      score: scoreThread(thread, query),
-    }));
+    const ownerResult = this.options.local.searchFederatedThreads
+      ? await this.options.local.searchFederatedThreads(
+          buildOwnerSearchRequest(query, request),
+        )
+      : await searchFederatedThreadsOnOwner(
+          this.options.local,
+          buildOwnerSearchRequest(query, request),
+        );
+    const ownerResponse = normalizeExactOwnerSearchResponse(ownerResult, query);
+    return {
+      results: ownerResponse.threads.map((thread) => ({
+        ref: buildFederatedThreadRef({
+          backend: thread.source,
+          threadId: thread.id,
+        }),
+        thread,
+        instanceLabel: "This Mac",
+        score: scoreThread(thread, query),
+      })),
+      totalCount: ownerResponse.totalCount,
+      truncated: ownerResponse.truncated,
+    };
   }
 
   private async searchPeer(
@@ -148,7 +194,7 @@ export class FederatedSearchService {
     query: string,
     request: FederatedSearchRequest,
     rpcOptions: FederationRpcRequestOptions,
-  ): Promise<FederatedSearchResponse["results"]> {
+  ): Promise<FederatedSearchResultPage> {
     const resolved = await this.resolveExactThreadId(
       peer.backend,
       query,
@@ -156,7 +202,7 @@ export class FederatedSearchService {
       rpcOptions,
     );
     if (resolved !== undefined) {
-      return resolved
+      const results = resolved
         ? [{
             ref: buildFederatedThreadRef({
               backend: resolved.source,
@@ -169,28 +215,63 @@ export class FederatedSearchService {
             score: scoreThread(resolved, query),
           }]
         : [];
+      return {
+        results,
+        totalCount: results.length,
+        truncated: false,
+      };
     }
-    const threads = await listFederatedSearchThreads(
-      peer.backend,
-      query,
-      request,
-      rpcOptions,
-    );
-    return threads.map((thread) => ({
-      ref: buildFederatedThreadRef({
-        backend: thread.source,
-        instanceId: peer.instanceId,
-        threadId: thread.id,
-      }),
-      thread,
-      instanceLabel: peer.label,
-      peerStatus: peer.status,
-      score: scoreThread(thread, query),
-    }));
+    let ownerResponse: FederationThreadSearchResponse;
+    try {
+      ownerResponse = await peer.backend.searchFederatedThreads(
+        buildOwnerSearchRequest(query, request),
+        rpcOptions,
+      );
+    } catch (error) {
+      if (!hasFederationErrorCode(error, "method_not_found")) {
+        throw error;
+      }
+      if (looksLikeExactThreadId(query)) {
+        const legacyThreads = await listFederatedSearchThreads(
+          peer.backend,
+          "",
+          request,
+          rpcOptions,
+        );
+        const exact = legacyThreads.find((thread) => thread.id === query);
+        ownerResponse = {
+          threads: exact ? [exact] : [],
+          totalCount: exact ? 1 : 0,
+          truncated: false,
+        };
+      } else {
+        ownerResponse = await searchFederatedThreadsOnOwner(
+          peer.backend,
+          buildOwnerSearchRequest(query, request),
+          rpcOptions,
+        );
+      }
+    }
+    ownerResponse = normalizeExactOwnerSearchResponse(ownerResponse, query);
+    return {
+      results: ownerResponse.threads.map((thread) => ({
+        ref: buildFederatedThreadRef({
+          backend: thread.source,
+          instanceId: peer.instanceId,
+          threadId: thread.id,
+        }),
+        thread,
+        instanceLabel: peer.label,
+        peerStatus: peer.status,
+        score: scoreThread(thread, query),
+      })),
+      totalCount: ownerResponse.totalCount,
+      truncated: ownerResponse.truncated,
+    };
   }
 
   private async resolveExactThreadId(
-    backendOperations: FederatedSearchPeer["backend"],
+    backendOperations: FederatedSearchResolvableBackend,
     query: string,
     request: FederatedSearchRequest,
     rpcOptions?: FederationRpcRequestOptions,
@@ -224,21 +305,73 @@ export class FederatedSearchService {
       if (!hasFederationErrorCode(error, "method_not_found")) {
         throw error;
       }
-      // Mixed-version peers may not expose the exact lookup RPC yet. Fall
-      // through to exact list scans rather than using fuzzy UUID filtering.
+      // Continue through bounded owner search. Only method_not_found from that
+      // newer RPC may select the raw-list compatibility path.
     }
-    const threads = await listFederatedSearchThreads(
-      backendOperations,
-      "",
-      request,
-      rpcOptions,
-    );
-    return threads.find((thread) => thread.id === query) ?? null;
+    return undefined;
   }
 }
 
+function buildOwnerSearchRequest(
+  query: string,
+  request: FederatedSearchRequest,
+): FederationThreadSearchRequest {
+  return {
+    query,
+    limit: Math.max(1, Math.min(request.limit ?? 50, 200)),
+    ...(request.backend !== undefined ? { backend: request.backend } : {}),
+    ...(request.includeArchived !== undefined
+      ? { includeArchived: request.includeArchived }
+      : {}),
+    ...(request.projectKeys !== undefined
+      ? { projectKeys: request.projectKeys }
+      : {}),
+    ...(request.updatedAfter !== undefined
+      ? { updatedAfter: request.updatedAfter }
+      : {}),
+    ...(request.updatedBefore !== undefined
+      ? { updatedBefore: request.updatedBefore }
+      : {}),
+  };
+}
+
+function normalizeExactOwnerSearchResponse(
+  response: FederationThreadSearchResponse,
+  query: string,
+): FederationThreadSearchResponse {
+  if (!looksLikeExactThreadId(query)) {
+    return response;
+  }
+  const exact = response.threads.find((thread) => thread.id === query);
+  return {
+    threads: exact ? [exact] : [],
+    totalCount: exact ? 1 : 0,
+    truncated: false,
+  };
+}
+
+export async function searchFederatedThreadsOnOwner(
+  backendOperations: Pick<FederationBackendOperations, "listThreads">,
+  request: FederationThreadSearchRequest,
+  rpcOptions?: FederationRpcRequestOptions,
+): Promise<FederationThreadSearchResponse> {
+  const limit = Math.max(1, Math.min(request.limit, 200));
+  const threads = await listFederatedSearchThreads(
+    backendOperations,
+    request.query,
+    request,
+    rpcOptions,
+  );
+  threads.sort(compareFederatedSearchThreads(request.query));
+  return {
+    threads: threads.slice(0, limit),
+    totalCount: threads.length,
+    truncated: threads.length > limit,
+  };
+}
+
 async function listFederatedSearchThreads(
-  backendOperations: FederatedSearchPeer["backend"],
+  backendOperations: Pick<FederationBackendOperations, "listThreads">,
   query: string,
   request: FederatedSearchRequest,
   rpcOptions?: FederationRpcRequestOptions,
@@ -337,4 +470,18 @@ function scoreThread(thread: AppServerThreadSummary, query: string): number {
   if (summary.includes(normalized)) score += 100;
   if (directories.includes(normalized)) score += 50;
   return score;
+}
+
+function compareFederatedSearchThreads(query: string) {
+  return (
+    left: AppServerThreadSummary,
+    right: AppServerThreadSummary,
+  ): number => {
+    const scoreDifference = scoreThread(right, query) - scoreThread(left, query);
+    if (scoreDifference !== 0) return scoreDifference;
+    return (
+      (right.updatedAt ?? right.createdAt ?? 0)
+      - (left.updatedAt ?? left.createdAt ?? 0)
+    );
+  };
 }

--- a/apps/desktop/src/main/federation/federated-search-service.ts
+++ b/apps/desktop/src/main/federation/federated-search-service.ts
@@ -37,11 +37,6 @@ export type FederatedSearchLocalBackend = Pick<
   "resolveThread" | "searchFederatedThreads"
 >>;
 
-type FederatedSearchResolvableBackend = Pick<
-  FederationBackendOperations,
-  "listThreads"
-> & Partial<Pick<FederationBackendOperations, "resolveThread">>;
-
 type FederatedSearchResultPage = {
   results: FederatedSearchResponse["results"];
   totalCount: number;
@@ -69,9 +64,10 @@ export class FederatedSearchService {
 
   async search(request: FederatedSearchRequest): Promise<FederatedSearchResponse> {
     const query = request.query.trim();
-    const limit = Math.max(1, Math.min(request.limit ?? 50, 200));
+    const limit = searchLimit(request.limit);
     const searchedAt = this.options.now?.() ?? Date.now();
     const failures: FederatedSearchResponse["failures"] = [];
+    let localSearch: FederatedSearchResponse["localSearch"];
     const searchedInstances: NonNullable<
       FederatedSearchResponse["searchedInstances"]
     > = [];
@@ -80,7 +76,29 @@ export class FederatedSearchService {
     const resultGroups = await Promise.all([
       ...(this.options.includeLocal === false
         ? []
-        : [this.searchLocal(query, request)]),
+        : [(async () => {
+            try {
+              const page = await withTimeout(
+                this.searchLocal(query, request, {
+                  deadlineAt: Date.now() + peerTimeoutMs,
+                }),
+                peerTimeoutMs,
+                "Local federated search timed out.",
+              );
+              localSearch = {
+                totalCount: page.totalCount,
+                truncated: page.truncated,
+              };
+              return page;
+            } catch (error) {
+              localSearch = {
+                totalCount: 0,
+                truncated: false,
+                error: error instanceof Error ? error.message : String(error),
+              };
+              return { results: [], totalCount: 0, truncated: false };
+            }
+          })()]),
       ...this.options.peers().map(async (peer) => {
         const rpcOptions = { deadlineAt: Date.now() + peerTimeoutMs };
         try {
@@ -134,6 +152,7 @@ export class FederatedSearchService {
         totalCount > limit
         || resultGroups.some((group) => group.truncated),
       failures,
+      ...(localSearch ? { localSearch } : {}),
       searchedInstances,
     };
   }
@@ -141,39 +160,18 @@ export class FederatedSearchService {
   private async searchLocal(
     query: string,
     request: FederatedSearchRequest,
+    rpcOptions: FederationRpcRequestOptions,
   ): Promise<FederatedSearchResultPage> {
-    const resolved = await this.resolveExactThreadId(
-      this.options.local,
-      query,
-      request,
-    );
-    if (resolved !== undefined) {
-      const results = resolved
-        ? [{
-            ref: buildFederatedThreadRef({
-              backend: resolved.source,
-              threadId: resolved.id,
-            }),
-            thread: resolved,
-            instanceLabel: "This Mac",
-            score: scoreThread(resolved, query),
-          }]
-        : [];
-      return {
-        results,
-        totalCount: results.length,
-        truncated: false,
-      };
-    }
-    const ownerResult = this.options.local.searchFederatedThreads
+    const ownerResponse = this.options.local.searchFederatedThreads
       ? await this.options.local.searchFederatedThreads(
           buildOwnerSearchRequest(query, request),
+          rpcOptions,
         )
       : await searchFederatedThreadsOnOwner(
           this.options.local,
           buildOwnerSearchRequest(query, request),
+          rpcOptions,
         );
-    const ownerResponse = normalizeExactOwnerSearchResponse(ownerResult, query);
     return {
       results: ownerResponse.threads.map((thread) => ({
         ref: buildFederatedThreadRef({
@@ -195,32 +193,6 @@ export class FederatedSearchService {
     request: FederatedSearchRequest,
     rpcOptions: FederationRpcRequestOptions,
   ): Promise<FederatedSearchResultPage> {
-    const resolved = await this.resolveExactThreadId(
-      peer.backend,
-      query,
-      request,
-      rpcOptions,
-    );
-    if (resolved !== undefined) {
-      const results = resolved
-        ? [{
-            ref: buildFederatedThreadRef({
-              backend: resolved.source,
-              instanceId: peer.instanceId,
-              threadId: resolved.id,
-            }),
-            thread: resolved,
-            instanceLabel: peer.label,
-            peerStatus: peer.status,
-            score: scoreThread(resolved, query),
-          }]
-        : [];
-      return {
-        results,
-        totalCount: results.length,
-        truncated: false,
-      };
-    }
     let ownerResponse: FederationThreadSearchResponse;
     try {
       ownerResponse = await peer.backend.searchFederatedThreads(
@@ -231,28 +203,12 @@ export class FederatedSearchService {
       if (!hasFederationErrorCode(error, "method_not_found")) {
         throw error;
       }
-      if (looksLikeExactThreadId(query)) {
-        const legacyThreads = await listFederatedSearchThreads(
-          peer.backend,
-          "",
-          request,
-          rpcOptions,
-        );
-        const exact = legacyThreads.find((thread) => thread.id === query);
-        ownerResponse = {
-          threads: exact ? [exact] : [],
-          totalCount: exact ? 1 : 0,
-          truncated: false,
-        };
-      } else {
-        ownerResponse = await searchFederatedThreadsOnOwner(
-          peer.backend,
-          buildOwnerSearchRequest(query, request),
-          rpcOptions,
-        );
-      }
+      ownerResponse = await searchFederatedThreadsOnOwner(
+        peer.backend,
+        buildOwnerSearchRequest(query, request),
+        rpcOptions,
+      );
     }
-    ownerResponse = normalizeExactOwnerSearchResponse(ownerResponse, query);
     return {
       results: ownerResponse.threads.map((thread) => ({
         ref: buildFederatedThreadRef({
@@ -269,47 +225,12 @@ export class FederatedSearchService {
       truncated: ownerResponse.truncated,
     };
   }
+}
 
-  private async resolveExactThreadId(
-    backendOperations: FederatedSearchResolvableBackend,
-    query: string,
-    request: FederatedSearchRequest,
-    rpcOptions?: FederationRpcRequestOptions,
-  ): Promise<AppServerThreadSummary | null | undefined> {
-    if (
-      !backendOperations.resolveThread
-      || !looksLikeExactThreadId(query)
-    ) {
-      return undefined;
-    }
-    try {
-      const resolveRequest = {
-        ...(request.backend && request.backend !== "all"
-          ? { backend: request.backend }
-          : {}),
-        threadId: query,
-      };
-      const response = rpcOptions
-        ? await backendOperations.resolveThread(resolveRequest, rpcOptions)
-        : await backendOperations.resolveThread(resolveRequest);
-      if (
-        response.thread
-        && matchesFederatedSearchFilters(response.thread, request)
-      ) {
-        return response.thread;
-      }
-      if (!request.includeArchived) {
-        return null;
-      }
-    } catch (error) {
-      if (!hasFederationErrorCode(error, "method_not_found")) {
-        throw error;
-      }
-      // Continue through bounded owner search. Only method_not_found from that
-      // newer RPC may select the raw-list compatibility path.
-    }
-    return undefined;
-  }
+function searchLimit(limit: number | undefined): number {
+  return Number.isFinite(limit)
+    ? Math.max(1, Math.min(Math.floor(limit!), 200))
+    : 50;
 }
 
 function buildOwnerSearchRequest(
@@ -318,7 +239,7 @@ function buildOwnerSearchRequest(
 ): FederationThreadSearchRequest {
   return {
     query,
-    limit: Math.max(1, Math.min(request.limit ?? 50, 200)),
+    limit: searchLimit(request.limit),
     ...(request.backend !== undefined ? { backend: request.backend } : {}),
     ...(request.includeArchived !== undefined
       ? { includeArchived: request.includeArchived }
@@ -335,52 +256,42 @@ function buildOwnerSearchRequest(
   };
 }
 
-function normalizeExactOwnerSearchResponse(
-  response: FederationThreadSearchResponse,
-  query: string,
-): FederationThreadSearchResponse {
-  if (!looksLikeExactThreadId(query)) {
-    return response;
-  }
-  const exact = response.threads.find((thread) => thread.id === query);
-  return {
-    threads: exact ? [exact] : [],
-    totalCount: exact ? 1 : 0,
-    truncated: false,
-  };
-}
-
 export async function searchFederatedThreadsOnOwner(
   backendOperations: Pick<FederationBackendOperations, "listThreads">,
   request: FederationThreadSearchRequest,
   rpcOptions?: FederationRpcRequestOptions,
 ): Promise<FederationThreadSearchResponse> {
-  const limit = Math.max(1, Math.min(request.limit, 200));
+  const limit = searchLimit(request.limit);
+  const query = request.query.trim();
   const threads = await listFederatedSearchThreads(
     backendOperations,
-    request.query,
     request,
     rpcOptions,
   );
-  threads.sort(compareFederatedSearchThreads(request.query));
+  const exact = looksLikeExactThreadId(query);
+  const normalized = query.toLowerCase();
+  const matches = threads.filter((thread) => exact
+    ? thread.id.toLowerCase() === normalized
+    : !query || scoreThread(thread, query) > 0 || thread.id.toLowerCase().includes(normalized));
+  matches.sort(compareFederatedSearchThreads(query));
+  checkSearchDeadline(rpcOptions);
   return {
-    threads: threads.slice(0, limit),
-    totalCount: threads.length,
-    truncated: threads.length > limit,
+    threads: matches.slice(0, limit),
+    totalCount: matches.length,
+    truncated: matches.length > limit,
   };
 }
 
 async function listFederatedSearchThreads(
   backendOperations: Pick<FederationBackendOperations, "listThreads">,
-  query: string,
   request: FederatedSearchRequest,
   rpcOptions?: FederationRpcRequestOptions,
 ): Promise<AppServerThreadSummary[]> {
   const list = async (archived: boolean) => {
+    checkSearchDeadline(rpcOptions);
     const listRequest = {
       backend: request.backend === "all" ? undefined : request.backend,
       archived,
-      ...(query ? { filter: query } : {}),
     };
     return rpcOptions
       ? await backendOperations.listThreads(listRequest, rpcOptions)
@@ -391,12 +302,17 @@ async function listFederatedSearchThreads(
     responses.push(await list(true));
   }
   const byIdentity = new Map<string, AppServerThreadSummary>();
-  for (const thread of responses.flatMap((response) => response.threads)) {
-    if (matchesFederatedSearchFilters(thread, request)) {
-      byIdentity.set(buildThreadIdentityKey(thread.source, thread.id), thread);
-    }
+  // Active membership wins if an old provider reports the same row in both lists.
+  for (const thread of responses.slice().reverse().flatMap((response) => response.threads)) {
+    byIdentity.set(buildThreadIdentityKey(thread.source, thread.id), thread);
   }
-  return [...byIdentity.values()];
+  return [...byIdentity.values()].filter((thread) => matchesFederatedSearchFilters(thread, request));
+}
+
+function checkSearchDeadline(options?: FederationRpcRequestOptions): void {
+  if (options?.deadlineAt !== undefined && Date.now() >= options.deadlineAt) {
+    throw new Error("Federated search deadline expired.");
+  }
 }
 
 function matchesFederatedSearchFilters(
@@ -469,6 +385,7 @@ function scoreThread(thread: AppServerThreadSummary, query: string): number {
   if (title.includes(normalized)) score += 250;
   if (summary.includes(normalized)) score += 100;
   if (directories.includes(normalized)) score += 50;
+  if (thread.projectKey?.toLowerCase().includes(normalized)) score += 50;
   return score;
 }
 

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -151,7 +151,6 @@ export function createFederationAgentToolsHandler(
         runtime(),
         request.args,
         collectHostInfo,
-        options.targetStore,
       );
     } catch (error) {
       return failure(
@@ -532,7 +531,6 @@ async function searchFederationThreads(
   runtime: DesktopFederationRuntime,
   args: SearchFederationThreadsToolArgs,
   collectHostInfo: () => Promise<FederationHostInfo>,
-  targetStore: RemoteThreadTargetStore | undefined,
 ): Promise<PwrAgentFederationResponse> {
   const scope = args.scope ?? "all";
   const health = await runtime.health();
@@ -603,35 +601,34 @@ async function searchFederationThreads(
       };
     },
   );
-  await Promise.all(
-    results
-      .filter((entry) => !entry.isLocal)
-      .map(async (entry) => await rememberTarget(targetStore, {
-        instanceId: entry.instanceId,
-        instanceLabel: entry.instanceLabel,
-        backend: entry.backend,
-        threadId: entry.threadId,
-      })),
-  );
-  const localResultCount = results.filter((entry) => entry.isLocal).length;
+  // Search links carry the owner identity. Persist routing knowledge when a
+  // thread is acted on, not once per result on every search.
   const result: SearchFederationThreadsResult = {
     query: response.query,
     results,
     totalCount: response.totalCount,
     truncated: response.truncated,
     searchedInstances: [
-      ...(includeLocal && localId
+      ...(includeLocal && localId && !response.localSearch?.error
         ? [
             {
               instanceId: localId,
               instanceLabel: local.label,
-              resultCount: localResultCount,
+              resultCount: response.localSearch?.totalCount ?? 0,
+              ...(response.localSearch?.truncated ? { truncated: true } : {}),
             },
           ]
         : []),
       ...response.searchedInstances ?? [],
     ],
-    failures: response.failures,
+    failures: [
+      ...response.failures,
+      ...(response.localSearch?.error ? [{
+        instanceId: localId ?? "local",
+        instanceLabel: local.label,
+        error: response.localSearch.error,
+      }] : []),
+    ],
   };
   return ok(result);
 }

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -37,6 +37,8 @@ import type {
   FederationCapability,
   FederationJumpSearchRequest,
   FederationJumpSearchResponse,
+  FederationThreadSearchRequest,
+  FederationThreadSearchResponse,
   FederationInstanceId,
   FederatedThreadRef,
   FederationLoadStatus,
@@ -362,6 +364,7 @@ function authenticateScheduledTurnOrigin<
 export const FEDERATION_BACKEND_METHODS = {
   getNavigationSnapshot: "backend.getNavigationSnapshot",
   searchNavigationThreads: "backend.searchNavigationThreads",
+  searchFederatedThreads: "backend.searchFederatedThreads",
   listThreads: "backend.listThreads",
   resolveThread: "backend.resolveThread",
   resolveThreadAdmissionState: "backend.resolveThreadAdmissionState",
@@ -461,6 +464,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
 > = {
   [FEDERATION_BACKEND_METHODS.getNavigationSnapshot]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.searchNavigationThreads]: "thread_navigation",
+  [FEDERATION_BACKEND_METHODS.searchFederatedThreads]: "federated_search",
   [FEDERATION_BACKEND_METHODS.listThreads]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThread]: "thread_navigation",
   [FEDERATION_BACKEND_METHODS.resolveThreadAdmissionState]: "messaging_route",
@@ -579,6 +583,14 @@ export type FederationBackendOperations = {
     request: FederationJumpSearchRequest,
     rpcOptions?: FederationRpcRequestOptions,
   ): Promise<FederationJumpSearchResponse>;
+  /**
+   * Optional on owner adapters so mixed-version peers return method_not_found
+   * and callers can select the explicit legacy list fallback.
+   */
+  searchFederatedThreads?(
+    request: FederationThreadSearchRequest,
+    rpcOptions?: FederationRpcRequestOptions,
+  ): Promise<FederationThreadSearchResponse>;
   listThreads(
     request?: AppServerListThreadsRequest,
     rpcOptions?: FederationRpcRequestOptions,
@@ -853,6 +865,19 @@ export function registerFederationBackendHandlers(params: {
         }
         return await params.backend.searchNavigationThreads(
           envelope.params as FederationJumpSearchRequest,
+        );
+      },
+    );
+  }
+  if (params.backend.searchFederatedThreads) {
+    params.router.registerHandler(
+      FEDERATION_BACKEND_METHODS.searchFederatedThreads,
+      async (envelope) => {
+        if (!params.backend.searchFederatedThreads) {
+          throw new Error("Bounded federated search became unavailable.");
+        }
+        return await params.backend.searchFederatedThreads(
+          envelope.params as FederationThreadSearchRequest,
         );
       },
     );
@@ -1589,6 +1614,17 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   ): Promise<FederationJumpSearchResponse> {
     return await this.rpc.request<FederationJumpSearchResponse>({
       method: FEDERATION_BACKEND_METHODS.searchNavigationThreads,
+      params: request,
+      ...rpcOptions,
+    });
+  }
+
+  async searchFederatedThreads(
+    request: FederationThreadSearchRequest,
+    rpcOptions?: FederationRpcRequestOptions,
+  ): Promise<FederationThreadSearchResponse> {
+    return await this.rpc.request<FederationThreadSearchResponse>({
+      method: FEDERATION_BACKEND_METHODS.searchFederatedThreads,
       params: request,
       ...rpcOptions,
     });

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -878,6 +878,7 @@ export function registerFederationBackendHandlers(params: {
         }
         return await params.backend.searchFederatedThreads(
           envelope.params as FederationThreadSearchRequest,
+          { deadlineAt: envelope.deadlineAt },
         );
       },
     );

--- a/apps/desktop/src/main/federation/federation-envelope-diagnostics.ts
+++ b/apps/desktop/src/main/federation/federation-envelope-diagnostics.ts
@@ -1,4 +1,5 @@
 import type { FederationProtocolEnvelope } from "@pwragent/shared";
+import { createHash } from "node:crypto";
 
 export type FederationEnvelopeLogFields = Record<string, string | undefined>;
 
@@ -6,7 +7,7 @@ export type FederationEnvelopeLogFields = Record<string, string | undefined>;
  * Keep completed entries briefly: receiving a response precedes forwarding it.
  */
 export class FederationEnvelopeDiagnostics {
-  private readonly requests = new Map<string, { method: string; expiresAt: number }>();
+  private readonly requests = new Map<string, { method: string; queryFingerprint?: string; expiresAt: number }>();
 
   constructor(
     private readonly now = Date.now,
@@ -23,7 +24,11 @@ export class FederationEnvelopeDiagnostics {
     while (this.requests.size >= Math.max(1, this.capacity)) {
       this.requests.delete(this.requests.keys().next().value!);
     }
-    this.requests.set(key, { method: envelope.method, expiresAt: this.now() + this.ttlMs });
+    this.requests.set(key, {
+      method: envelope.method,
+      queryFingerprint: searchQueryFingerprint(envelope),
+      expiresAt: this.now() + this.ttlMs,
+    });
   }
 
   describe(
@@ -46,6 +51,8 @@ export class FederationEnvelopeDiagnostics {
       envelopeId: envelope.id,
       requestId,
       method,
+      queryFingerprint: envelope.kind === "request" ? searchQueryFingerprint(envelope)
+        : request && request.expiresAt > this.now() ? request.queryFingerprint : undefined,
       errorCode: envelope.kind === "error" ? envelope.error.code : undefined,
       notificationMethod: notification && typeof notification === "object"
         && "method" in notification && typeof notification.method === "string"
@@ -56,4 +63,12 @@ export class FederationEnvelopeDiagnostics {
       targetInstanceLabel: envelope.targetInstanceId ? label(envelope.targetInstanceId) : undefined,
     };
   }
+}
+
+function searchQueryFingerprint(envelope: FederationProtocolEnvelope): string | undefined {
+  if (envelope.kind !== "request"
+    || (envelope.method !== "backend.searchNavigationThreads" && envelope.method !== "backend.searchFederatedThreads")) return undefined;
+  const params = envelope.params;
+  if (!params || typeof params !== "object" || !("query" in params) || typeof params.query !== "string") return undefined;
+  return createHash("sha256").update(params.query.trim()).digest("hex").slice(0, 12);
 }

--- a/apps/desktop/src/main/federation/federation-envelope-diagnostics.ts
+++ b/apps/desktop/src/main/federation/federation-envelope-diagnostics.ts
@@ -1,0 +1,59 @@
+import type { FederationProtocolEnvelope } from "@pwragent/shared";
+
+export type FederationEnvelopeLogFields = Record<string, string | undefined>;
+
+/** Volatile metadata only. Shared across gateway sockets to correlate relay hops.
+ * Keep completed entries briefly: receiving a response precedes forwarding it.
+ */
+export class FederationEnvelopeDiagnostics {
+  private readonly requests = new Map<string, { method: string; expiresAt: number }>();
+
+  constructor(
+    private readonly now = Date.now,
+    private readonly capacity = 4096,
+    private readonly ttlMs = 5 * 60_000,
+  ) {}
+
+  observe(envelope: FederationProtocolEnvelope): void {
+    if (envelope.kind !== "request") return;
+    const key = JSON.stringify([envelope.id, envelope.sourceInstanceId, envelope.targetInstanceId]);
+    const existing = this.requests.get(key);
+    if (existing && existing.expiresAt > this.now()) return;
+    this.requests.delete(key);
+    while (this.requests.size >= Math.max(1, this.capacity)) {
+      this.requests.delete(this.requests.keys().next().value!);
+    }
+    this.requests.set(key, { method: envelope.method, expiresAt: this.now() + this.ttlMs });
+  }
+
+  describe(
+    envelope: FederationProtocolEnvelope,
+    label: (id: string) => string | undefined = () => undefined,
+  ): FederationEnvelopeLogFields {
+    const requestId = envelope.kind === "request" ? envelope.id
+      : envelope.kind === "response" || envelope.kind === "error" ? envelope.requestId : undefined;
+    const key = JSON.stringify([requestId, envelope.targetInstanceId, envelope.sourceInstanceId]);
+    const request = this.requests.get(key);
+    if (request && request.expiresAt <= this.now()) this.requests.delete(key);
+    const method = envelope.kind === "request" || envelope.kind === "notification"
+      ? envelope.method
+      : request && request.expiresAt > this.now() ? request.method : "unknown";
+    const params = envelope.kind === "notification" ? envelope.params : undefined;
+    const notification = params && typeof params === "object" && "notification" in params
+      ? params.notification : undefined;
+    return {
+      envelopeKind: envelope.kind,
+      envelopeId: envelope.id,
+      requestId,
+      method,
+      errorCode: envelope.kind === "error" ? envelope.error.code : undefined,
+      notificationMethod: notification && typeof notification === "object"
+        && "method" in notification && typeof notification.method === "string"
+        ? notification.method : undefined,
+      sourceInstanceId: envelope.sourceInstanceId,
+      sourceInstanceLabel: label(envelope.sourceInstanceId),
+      targetInstanceId: envelope.targetInstanceId,
+      targetInstanceLabel: envelope.targetInstanceId ? label(envelope.targetInstanceId) : undefined,
+    };
+  }
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4979,8 +4979,8 @@ function localBackendOperations(): FederationBackendOperations {
     async searchNavigationThreads(request) {
       return await messagingBridge.searchNavigationThreads(request);
     },
-    async searchFederatedThreads(request) {
-      return await messagingBridge.searchFederatedThreads(request);
+    async searchFederatedThreads(request, rpcOptions) {
+      return await messagingBridge.searchFederatedThreads(request, rpcOptions);
     },
     async listThreads(
       request: AppServerListThreadsRequest = {},

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2107,11 +2107,29 @@ export class DesktopFederationRuntime {
     log.info("remote navigation wire response was slow or large", {
       durationMs,
       instanceId: params.target.instanceId,
+      instanceLabel: this.diagnosticInstanceLabel(params.target.instanceId),
+      method: "backend.getNavigationSnapshot",
       responseBytes,
       responseKind,
       selection: params.selection,
       threadCount,
     });
+  }
+
+  private diagnosticInstanceLabel(instanceId: string): string {
+    // Diagnostics must not disrupt transport during startup/teardown.
+    try {
+      if (instanceId === this.ensureLocalInstanceId()) {
+        return this.instanceLabel || defaultInstanceLabel();
+      }
+      const visible = this.visiblePeers();
+      const peer = visible.find((candidate) => candidate.id === instanceId)
+        ?? this.remotePeerDirectory.get(instanceId as FederationInstanceId)
+        ?? this.store().getPeer(instanceId as FederationInstanceId);
+      return peer ? formatFederationPeerDisplayLabel(peer, visible) : instanceId;
+    } catch {
+      return instanceId;
+    }
   }
 
   private remotePeerAdvertisesCapability(
@@ -2293,6 +2311,8 @@ export class DesktopFederationRuntime {
             log.info("remote bounded navigation search was slow", {
               durationMs,
               instanceId: target.instanceId,
+              instanceLabel: this.diagnosticInstanceLabel(target.instanceId),
+              method: "backend.searchNavigationThreads",
               queryLength: request.query.length,
               responseBytes,
               resultCount: response.results.length,
@@ -2311,12 +2331,21 @@ export class DesktopFederationRuntime {
             && typeof error.code === "string"
               ? error.code
               : undefined;
-          if (code !== "method_not_found" || durationMs >= 1_000) {
+          if (code === "method_not_found") {
+            log.info("remote navigation search using legacy snapshot fallback", {
+              instanceId: target.instanceId,
+              instanceLabel: this.diagnosticInstanceLabel(target.instanceId),
+              method: "backend.searchNavigationThreads",
+              code,
+            });
+          } else {
             log.warn("remote bounded navigation search failed", {
               code,
               durationMs,
               error: error instanceof Error ? error.message : String(error),
               instanceId: target.instanceId,
+              instanceLabel: this.diagnosticInstanceLabel(target.instanceId),
+              method: "backend.searchNavigationThreads",
               queryLength: request.query.length,
             });
           }
@@ -2645,6 +2674,7 @@ export class DesktopFederationRuntime {
         .getOrCreateFederationIdentityKeyPair();
       if (startupAborted()) return;
       const server = new FederationGatewayWebSocketServer({
+        instanceLabel: (id) => this.diagnosticInstanceLabel(id),
         gatewayInstanceId: localInstanceId,
         gatewayPrivateKeyPem: gatewayIdentity.privateKeyPem,
         gatewayPublicKeyPem: gatewayIdentity.publicKeyPem,
@@ -2903,6 +2933,7 @@ export class DesktopFederationRuntime {
           localInstanceId: this.ensureLocalInstanceId(),
         });
       },
+      instanceLabel: (id) => this.diagnosticInstanceLabel(id),
       role: "client",
       headers: cloudflareAccessEnabled
         ? {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -4979,6 +4979,9 @@ function localBackendOperations(): FederationBackendOperations {
     async searchNavigationThreads(request) {
       return await messagingBridge.searchNavigationThreads(request);
     },
+    async searchFederatedThreads(request) {
+      return await messagingBridge.searchFederatedThreads(request);
+    },
     async listThreads(
       request: AppServerListThreadsRequest = {},
     ): Promise<AppServerListThreadsResponse> {

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -39,6 +39,31 @@ import {
 } from "./federation-redaction";
 import { FederationSessionRegistry } from "./federation-session-state";
 import type { FederationStore } from "./federation-store";
+import { FederationEnvelopeDiagnostics } from "./federation-envelope-diagnostics";
+
+type EnvelopeDiagnosticsContext = {
+  diagnostics: FederationEnvelopeDiagnostics;
+  peerId: string;
+  instanceLabel?: (id: string) => string | undefined;
+};
+
+function envelopeLogFields(envelope: FederationProtocolEnvelope, context?: EnvelopeDiagnosticsContext) {
+  return {
+    ...(context?.diagnostics ?? new FederationEnvelopeDiagnostics()).describe(envelope, context?.instanceLabel),
+    peerId: context?.peerId,
+    peerLabel: context?.instanceLabel?.(context.peerId),
+  };
+}
+
+function observeReceivedEnvelope(envelope: FederationProtocolEnvelope, byteCount: number, context: EnvelopeDiagnosticsContext) {
+  context.diagnostics.observe(envelope);
+  if (byteCount >= FEDERATION_LARGE_FRAME_LOG_BYTES && envelope.kind !== "blob_chunk") {
+    log.info("large federation frame received", {
+      byteCount,
+      ...envelopeLogFields(envelope, context),
+    });
+  }
+}
 
 const log = getMainLogger("pwragent:federation-transport");
 const FEDERATION_NOISE_TRANSPORT = "noise_ik_25519_aesgcm_sha256";
@@ -265,6 +290,7 @@ export type FederationGatewayConnection = {
 };
 
 export type FederationGatewayWebSocketServerOptions = {
+  instanceLabel?: (id: string) => string | undefined;
   gatewayInstanceId: FederationInstanceId;
   gatewayPrivateKeyPem: string;
   gatewayPublicKeyPem: string;
@@ -317,6 +343,7 @@ export type FederationGatewayWebSocketServerOptions = {
 };
 
 export class FederationGatewayWebSocketServer {
+  private readonly envelopeDiagnostics = new FederationEnvelopeDiagnostics();
   private httpServer?: http.Server;
   private wsServer?: WebSocketServer;
   private sweepTimer?: ReturnType<typeof setInterval>;
@@ -584,6 +611,11 @@ export class FederationGatewayWebSocketServer {
       connectedAt: Date.now(),
       capabilities: decision.capabilities,
     });
+    const diagnosticsContext: EnvelopeDiagnosticsContext = {
+      diagnostics: this.envelopeDiagnostics,
+      peerId: decision.peer.id,
+      instanceLabel: this.options.instanceLabel,
+    };
     const connection: FederationGatewayConnection = {
       peerId: decision.peer.id,
       sessionId,
@@ -594,6 +626,7 @@ export class FederationGatewayWebSocketServer {
           { kind: "envelope", envelope },
           transport,
           this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+          diagnosticsContext,
         );
         if (byteCount > 0) {
           this.options.onEnvelopeTransfer?.({
@@ -611,6 +644,7 @@ export class FederationGatewayWebSocketServer {
           { kind: "envelope", envelope },
           transport,
           this.options.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES,
+          diagnosticsContext,
         );
         if (byteCount > 0) {
           this.options.onEnvelopeTransfer?.({
@@ -750,6 +784,7 @@ export class FederationGatewayWebSocketServer {
         return;
       }
       if (!next || next.kind !== "envelope") continue;
+      observeReceivedEnvelope(next.envelope, frame.byteLength, diagnosticsContext);
       this.sessions.heartbeat(sessionId, Date.now());
       this.options.onEnvelopeTransfer?.({
         peerId: connection.peerId,
@@ -827,6 +862,7 @@ export type FederationClientWebSocketClient = {
 };
 
 export async function connectFederationClient(params: {
+  instanceLabel?: (id: string) => string | undefined;
   url: string;
   mode: "enroll" | "reconnect";
   gatewayInstanceId: FederationInstanceId;
@@ -951,6 +987,11 @@ async function establishFederationClient(
   reader: FederationFrameReader,
 ): Promise<FederationClientWebSocketClient> {
   const maxFrameBytes = params.maxFrameBytes ?? FEDERATION_MAX_FRAME_BYTES;
+  const diagnosticsContext: EnvelopeDiagnosticsContext = {
+    diagnostics: new FederationEnvelopeDiagnostics(),
+    peerId: params.gatewayInstanceId,
+    instanceLabel: params.instanceLabel,
+  };
   await waitForOpen(socket);
 
   // Phase 1: Noise_IK handshake (initiator). Skipped in tunnel mode.
@@ -1142,6 +1183,7 @@ async function establishFederationClient(
         return;
       }
       if (message?.kind === "envelope") {
+        observeReceivedEnvelope(message.envelope, frame.byteLength, diagnosticsContext);
         params.onEnvelopeTransfer?.({
           direction: "received",
           byteCount: frame.byteLength,
@@ -1165,6 +1207,7 @@ async function establishFederationClient(
         { kind: "envelope", envelope },
         transport,
         maxFrameBytes,
+        diagnosticsContext,
       );
       if (byteCount > 0) {
         params.onEnvelopeTransfer?.({
@@ -1179,6 +1222,7 @@ async function establishFederationClient(
         { kind: "envelope", envelope },
         transport,
         maxFrameBytes,
+        diagnosticsContext,
       );
       if (byteCount > 0) {
         params.onEnvelopeTransfer?.({
@@ -1287,8 +1331,10 @@ function sendFrame(
   message: FederationSocketMessage,
   transport?: NoiseTransport,
   maxFrameBytes = FEDERATION_MAX_FRAME_BYTES,
+  context?: EnvelopeDiagnosticsContext,
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
+  if (message.kind === "envelope") context?.diagnostics.observe(message.envelope);
   const payload = encodeFederationSocketPayload(message);
   const wireByteLength = transport
     ? transport.encryptedByteLength(payload.byteLength)
@@ -1297,12 +1343,9 @@ function sendFrame(
     const envelope = message.kind === "envelope" ? message.envelope : undefined;
     log.error("federation frame exceeds configured send limit", {
       byteCount: wireByteLength,
-      envelopeKind: envelope?.kind,
       maxFrameBytes,
       messageKind: message.kind,
-      method: envelope?.kind === "request" ? envelope.method : undefined,
-      sourceInstanceId: envelope?.sourceInstanceId,
-      targetInstanceId: envelope?.targetInstanceId,
+      ...(envelope ? envelopeLogFields(envelope, context) : {}),
     });
     throw new FederationFrameTooLargeError(wireByteLength, maxFrameBytes);
   }
@@ -1313,12 +1356,8 @@ function sendFrame(
   ) {
     log.info("large federation frame queued for send", {
       byteCount: wireByteLength,
-      envelopeKind: envelope?.kind,
-      maxFrameBytes,
       messageKind: message.kind,
-      method: envelope?.kind === "request" ? envelope.method : undefined,
-      sourceInstanceId: envelope?.sourceInstanceId,
-      targetInstanceId: envelope?.targetInstanceId,
+      ...(envelope ? envelopeLogFields(envelope, context) : {}),
     });
   }
   const wire = transport ? transport.encrypt(payload) : payload;
@@ -1331,12 +1370,13 @@ async function sendFrameWithBackpressure(
   message: FederationSocketMessage,
   transport?: NoiseTransport,
   maxFrameBytes = FEDERATION_MAX_FRAME_BYTES,
+  context?: EnvelopeDiagnosticsContext,
 ): Promise<number> {
   await waitForFederationSendCapacity(socket);
   if (socket.readyState !== WebSocket.OPEN) {
     throw new Error("Federation connection closed while sending an attachment.");
   }
-  return sendFrame(socket, message, transport, maxFrameBytes);
+  return sendFrame(socket, message, transport, maxFrameBytes, context);
 }
 
 export async function waitForFederationSendCapacity(

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -1335,6 +1335,11 @@ function sendFrame(
 ): number {
   if (socket.readyState !== WebSocket.OPEN) return 0;
   if (message.kind === "envelope") context?.diagnostics.observe(message.envelope);
+  if (message.kind === "envelope" && message.envelope.kind === "request"
+    && (message.envelope.method === "backend.searchNavigationThreads"
+      || message.envelope.method === "backend.searchFederatedThreads")) {
+    log.info("federation search request queued for send", envelopeLogFields(message.envelope, context));
+  }
   const payload = encodeFederationSocketPayload(message);
   const wireByteLength = transport
     ? transport.encryptedByteLength(payload.byteLength)

--- a/apps/desktop/src/main/federation/navigation-search-result.ts
+++ b/apps/desktop/src/main/federation/navigation-search-result.ts
@@ -1,0 +1,68 @@
+import type { NavigationThreadSummary } from "@pwragent/shared";
+
+/** Search rows are navigation-compatible placeholders, not hydrated thread state.
+ * Use an allowlist so new overlay fields never silently become search payloads.
+ * Selecting a row pins its owner/id and refreshes navigation before opening it.
+ */
+export function compactNavigationSearchResult(
+  thread: NavigationThreadSummary,
+  query: string,
+): NavigationThreadSummary {
+  const needle = query.trim().toLowerCase();
+  const excerpt = (value: string | undefined, length = 512): string | undefined => {
+    if (value === undefined || value.length <= length) return value;
+    const at = value.toLowerCase().indexOf(needle);
+    const start = Math.max(0, at - 80);
+    return value.slice(start, start + length);
+  };
+  // Older viewers re-run matching. Retain small genuine instruction excerpts
+  // around each matching token instead of shipping the complete persona text.
+  const instructions = thread.agent?.instructions;
+  const lowerInstructions = instructions?.toLowerCase();
+  const tokens = needle.split(/\s+/).filter(Boolean);
+  const instructionExcerpts = instructions
+    ? tokens.map((token) => {
+        const at = lowerInstructions!.indexOf(token);
+        return at < 0 ? "" : instructions.slice(Math.max(0, at - 24), at + token.length + 24);
+      }).filter(Boolean).join(" … ").slice(0, 2048)
+    : undefined;
+  const prNumber = Number(needle.replace(/^#/, ""));
+  return {
+    id: thread.id,
+    source: thread.source,
+    title: excerpt(thread.title)!,
+    titleSource: thread.titleSource,
+    createdAt: thread.createdAt,
+    updatedAt: thread.updatedAt,
+    projectKey: thread.projectKey,
+    gitBranch: excerpt(thread.gitBranch),
+    linkedDirectories: [...thread.linkedDirectories]
+      .sort((a, b) => Number(b.label.toLowerCase().includes(needle)) - Number(a.label.toLowerCase().includes(needle)))
+      .slice(0, 3)
+      .map(({ id, label, path, worktreePath, kind, gitBranch }) => ({
+        id, label: excerpt(label)!, path, worktreePath, kind, gitBranch: excerpt(gitBranch),
+      })),
+    inbox: { inInbox: thread.inbox.inInbox },
+    federation: thread.federation,
+    agent: thread.agent ? {
+      name: excerpt(thread.agent.name)!,
+      instructions: instructionExcerpts,
+      instructionLineCount: thread.agent.instructionLineCount,
+      instructionsTooLong: thread.agent.instructionsTooLong,
+      updatedAt: thread.agent.updatedAt,
+    } : undefined,
+    prs: [...(thread.prs ?? [])]
+      .sort((a, b) =>
+        Number(b.number === prNumber) - Number(a.number === prNumber)
+        || Number(String(b.number).includes(needle.replace(/^#/, "")))
+          - Number(String(a.number).includes(needle.replace(/^#/, ""))),
+      )
+      .slice(0, 8)
+      .map((pr) => ({
+        provider: pr.provider, org: pr.org, repo: pr.repo, number: pr.number,
+        url: pr.url, title: excerpt(pr.title), state: pr.state,
+        checkState: pr.checkState, lifecycleState: pr.lifecycleState,
+        reviewState: pr.reviewState, mergeState: pr.mergeState,
+      })),
+  };
+}

--- a/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
+++ b/apps/desktop/src/main/federation/remote-thread-summary-cache.ts
@@ -15,8 +15,10 @@ import {
   buildThreadIdentityKey,
   federatedThreadIdentityKey,
   rankThreadJumpMatches,
+  sortThreadJumpMatches,
 } from "@pwragent/shared";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
+import { compactNavigationSearchResult } from "./navigation-search-result";
 import { ThreadInfoStore } from "../app-server/thread-info-store";
 import {
   hasFederationErrorCode,
@@ -849,12 +851,13 @@ export class RemoteThreadSummaryCache {
         }
       }
     }
-    return await this.threadsForPeer(
+    const legacyThreads = await this.threadsForPeer(
       target,
       { kind: "all" },
       "jump-search",
       deadlineAt,
     );
+    return rankThreadJumpMatches(legacyThreads, request.query);
   }
 
   private async threadsForPeer(
@@ -1095,7 +1098,7 @@ function rankUniqueThreadJumpMatches(
   limit: number,
 ): NavigationThreadSummary[] {
   const seen = new Set<string>();
-  return rankThreadJumpMatches(threads, query)
+  return sortThreadJumpMatches(threads, query)
     .filter((thread) => {
       const key = thread.federation?.ref
         ? federatedThreadIdentityKey(thread.federation.ref)
@@ -1106,5 +1109,6 @@ function rankUniqueThreadJumpMatches(
       seen.add(key);
       return true;
     })
-    .slice(0, limit);
+    .slice(0, limit)
+    .map((thread) => compactNavigationSearchResult(thread, query));
 }

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -466,17 +466,15 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
    */
   async searchFederatedThreads(
     request: FederationThreadSearchRequest,
+    rpcOptions?: { deadlineAt?: number },
   ): Promise<FederationThreadSearchResponse> {
     return await searchFederatedThreadsOnOwner(
       {
         listThreads: async (listRequest = {}) => {
-          const threads = await this.registry.listThreads({
+          const threads = await this.registry.listThreadSearchCandidates({
             backend: listRequest.backend,
             archived: listRequest.archived,
-            callerReason: "federation-thread-search",
-            enrichDirectories: false,
-            filter: listRequest.filter,
-            skipArchivedMetadataRefresh: true,
+            deadlineAt: rpcOptions?.deadlineAt,
           });
           return {
             backend: listRequest.backend ?? "all",
@@ -486,6 +484,7 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
         },
       },
       request,
+      rpcOptions,
     );
   }
 

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { compactNavigationSearchResult } from "../federation/navigation-search-result";
 import type {
   AgentEvent,
   AppServerBackendKind,
@@ -455,7 +456,8 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     const limit = Math.max(1, Math.min(request.limit ?? 8, 50));
     const threads = await this.navigationThreadsForSearch();
     return {
-      results: rankThreadJumpMatches(threads, query).slice(0, limit),
+      results: rankThreadJumpMatches(threads, query).slice(0, limit)
+        .map((thread) => compactNavigationSearchResult(thread, query)),
     };
   }
 

--- a/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
+++ b/apps/desktop/src/main/messaging/desktop-backend-bridge.ts
@@ -21,6 +21,8 @@ import type {
   FederationInstanceId,
   FederationJumpSearchRequest,
   FederationJumpSearchResponse,
+  FederationThreadSearchRequest,
+  FederationThreadSearchResponse,
   FederationRemoteTarget,
   FederationTarget,
   FederationThreadSelection,
@@ -83,6 +85,7 @@ import { buildMessagingBindingsByThreadKey } from "./messaging-bindings-snapshot
 import { hydrateLaunchpadCodexEnvironmentOptions } from "../app-server/codex-environment-config";
 import { materializeTranscriptMessageImagesForMessaging } from "../transcript-image-protocol";
 import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
+import { searchFederatedThreadsOnOwner } from "../federation/federated-search-service";
 import {
   FederatedThreadTargetError,
   resolveFederatedThreadTarget,
@@ -454,6 +457,36 @@ export class DesktopMessagingBackendBridge implements MessagingBackendBridge {
     return {
       results: rankThreadJumpMatches(threads, query).slice(0, limit),
     };
+  }
+
+  /**
+   * Generic Federation search stays on the owner and returns only its top K.
+   * This path deliberately skips navigation reconciliation and archive-state
+   * maintenance: a debounced read must not turn into SQLite writes.
+   */
+  async searchFederatedThreads(
+    request: FederationThreadSearchRequest,
+  ): Promise<FederationThreadSearchResponse> {
+    return await searchFederatedThreadsOnOwner(
+      {
+        listThreads: async (listRequest = {}) => {
+          const threads = await this.registry.listThreads({
+            backend: listRequest.backend,
+            archived: listRequest.archived,
+            callerReason: "federation-thread-search",
+            enrichDirectories: false,
+            filter: listRequest.filter,
+            skipArchivedMetadataRefresh: true,
+          });
+          return {
+            backend: listRequest.backend ?? "all",
+            fetchedAt: Date.now(),
+            threads,
+          };
+        },
+      },
+      request,
+    );
   }
 
   private async navigationThreadsForSearch(): Promise<NavigationThreadSummary[]> {

--- a/apps/desktop/src/renderer/src/lib/__tests__/useFederatedThreadSearch.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useFederatedThreadSearch.test.tsx
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FederationJumpSearchRequest, FederationJumpSearchResponse } from "@pwragent/shared";
+import { FEDERATED_THREAD_SEARCH_DEBOUNCE_MS, useFederatedThreadSearch } from "../useFederatedThreadSearch";
+
+vi.mock("../federation-window", () => ({ readRendererFederationTarget: () => undefined }));
+vi.mock("../desktop-api", () => ({ getDesktopApi: () => undefined }));
+afterEach(() => vi.useRealTimers());
+
+describe("federated search scheduling", () => {
+  it("debounces typing and coalesces in-flight changes to only the latest query", async () => {
+    vi.useFakeTimers();
+    let finish!: (value: FederationJumpSearchResponse) => void;
+    const search = vi.fn((_request: FederationJumpSearchRequest) => new Promise<FederationJumpSearchResponse>((resolve) => { finish = resolve; }));
+    const hook = renderHook(({ query }) => useFederatedThreadSearch({ query, search }), { initialProps: { query: "19" } });
+    hook.rerender({ query: "196" });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FEDERATED_THREAD_SEARCH_DEBOUNCE_MS); });
+    expect(search).toHaveBeenCalledTimes(1);
+    hook.rerender({ query: "1967" });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FEDERATED_THREAD_SEARCH_DEBOUNCE_MS); });
+    hook.rerender({ query: "1968" });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FEDERATED_THREAD_SEARCH_DEBOUNCE_MS); });
+    expect(search).toHaveBeenCalledTimes(1);
+    await act(async () => { finish({ results: [] }); });
+    expect(search).toHaveBeenCalledTimes(2);
+    expect(search.mock.calls.at(-1)?.[0]).toMatchObject({ query: "1968" });
+    hook.unmount();
+  });
+
+  it("does not dispatch a queued query after the palette unmounts", async () => {
+    vi.useFakeTimers();
+    let finish!: (value: FederationJumpSearchResponse) => void;
+    const search = vi.fn((_request: FederationJumpSearchRequest) => new Promise<FederationJumpSearchResponse>((resolve) => { finish = resolve; }));
+    const hook = renderHook(({ query }) => useFederatedThreadSearch({ query, search }), { initialProps: { query: "196" } });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FEDERATED_THREAD_SEARCH_DEBOUNCE_MS); });
+    hook.rerender({ query: "1968" });
+    await act(async () => { await vi.advanceTimersByTimeAsync(FEDERATED_THREAD_SEARCH_DEBOUNCE_MS); });
+    hook.unmount();
+    await act(async () => { finish({ results: [] }); });
+    expect(search).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederatedThreadSearch.ts
@@ -36,6 +36,10 @@ export function useFederatedThreadSearch(params: {
   const [completedPeerCount, setCompletedPeerCount] = useState(0);
   const [totalPeerCount, setTotalPeerCount] = useState(0);
   const generationRef = useRef(0);
+  // One fan-out at a time per mounted search surface. New input replaces the
+  // pending generation, not the request already on the wire. Peer deadlines
+  // still bound that request; stale progress never updates the current query.
+  const inFlightRef = useRef<Promise<void> | undefined>(undefined);
   const query = params.query.trim();
   const search = params.search ?? getDesktopApi()?.jumpSearchRemoteThreads;
   // A remote-viewer window already scopes to one peer; only the main window
@@ -61,40 +65,48 @@ export function useFederatedThreadSearch(params: {
     setCompletedPeerCount(0);
     setTotalPeerCount(0);
     const timer = setTimeout(() => {
-      search(
-        {
-          query,
-          limit: params.limit ?? FEDERATED_THREAD_SEARCH_LIMIT,
-        },
-        (progress) => {
-          if (generationRef.current !== generation) {
-            return;
-          }
-          setResults(progress.results);
-          setCompletedPeerCount(progress.completedPeerCount);
-          setTotalPeerCount(progress.totalPeerCount);
-          if (progress.complete) {
+      const dispatch = async (): Promise<void> => {
+        await inFlightRef.current;
+        if (generationRef.current !== generation) return;
+        const pending = search(
+          {
+            query,
+            limit: params.limit ?? FEDERATED_THREAD_SEARCH_LIMIT,
+          },
+          (progress) => {
+            if (generationRef.current !== generation) {
+              return;
+            }
+            setResults(progress.results);
+            setCompletedPeerCount(progress.completedPeerCount);
+            setTotalPeerCount(progress.totalPeerCount);
+            if (progress.complete) {
+              setLoading(false);
+              setSettledQuery(query);
+            }
+          },
+        )
+          .then((response) => {
+            if (generationRef.current !== generation) {
+              return;
+            }
+            setResults(response.results);
             setLoading(false);
             setSettledQuery(query);
-          }
-        },
-      )
-        .then((response) => {
-          if (generationRef.current !== generation) {
-            return;
-          }
-          setResults(response.results);
-          setLoading(false);
-          setSettledQuery(query);
-        })
-        .catch(() => {
-          if (generationRef.current !== generation) {
-            return;
-          }
-          setResults([]);
-          setLoading(false);
-          setSettledQuery(query);
-        });
+          })
+          .catch(() => {
+            if (generationRef.current !== generation) {
+              return;
+            }
+            setResults([]);
+            setLoading(false);
+            setSettledQuery(query);
+          });
+        inFlightRef.current = pending;
+        await pending;
+        if (inFlightRef.current === pending) inFlightRef.current = undefined;
+      };
+      void dispatch();
     }, FEDERATED_THREAD_SEARCH_DEBOUNCE_MS);
     return () => {
       clearTimeout(timer);

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -648,6 +648,8 @@ export type FederatedSearchResponse = {
   totalCount: number;
   truncated: boolean;
   failures: FederatedSearchPeerFailure[];
+  /** Local owner metadata before the global page is sliced. */
+  localSearch?: { totalCount: number; truncated: boolean; error?: string };
   /** Peers that were queried successfully, so the UI can disclose scope. */
   searchedInstances?: FederatedSearchInstanceSummary[];
 };

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -606,6 +606,20 @@ export type FederatedSearchRequest = {
   updatedBefore?: number;
 };
 
+/** Owner-executed generic thread search used by Federation fan-out. */
+export type FederationThreadSearchRequest = FederatedSearchRequest & {
+  /** Maximum rows that may cross the Federation transport. */
+  limit: number;
+};
+
+export type FederationThreadSearchResponse = {
+  /** Owner-ranked matches, bounded by the request limit. */
+  threads: AppServerThreadSummary[];
+  /** Matches on the owner before applying the transport limit. */
+  totalCount: number;
+  truncated: boolean;
+};
+
 export type FederatedSearchResult = {
   ref: FederatedThreadRef;
   thread: AppServerThreadSummary;
@@ -624,6 +638,7 @@ export type FederatedSearchInstanceSummary = {
   instanceId: FederationInstanceId;
   instanceLabel: string;
   resultCount: number;
+  truncated?: boolean;
 };
 
 export type FederatedSearchResponse = {

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1588,7 +1588,10 @@ export type FederationJumpSearchRequest = {
 };
 
 export type FederationJumpSearchResponse = {
-  /** Stamped remote rows (`federation` set), ordered by updatedAt desc. */
+  /** Compact navigation-compatible search placeholders, not hydrated thread
+   * state. Owner matching precedes projection. Viewers stamp `federation`;
+   * selecting a result fetches authoritative navigation/thread state.
+   */
   results: NavigationThreadSummary[];
 };
 

--- a/packages/shared/src/thread-jump-match.ts
+++ b/packages/shared/src/thread-jump-match.ts
@@ -118,18 +118,24 @@ export function rankThreadJumpMatches(
   threads: readonly NavigationThreadSummary[],
   query: string,
 ): NavigationThreadSummary[] {
-  return threads
-    .filter((thread) => threadMatchesQuery(thread, query))
-    .sort((left, right) => {
-      const exactPrPriority =
-        Number(threadHasExactPrNumberMatch(right, query))
-        - Number(threadHasExactPrNumberMatch(left, query));
-      if (exactPrPriority !== 0) {
-        return exactPrPriority;
-      }
-      return (
-        (right.updatedAt ?? right.createdAt ?? 0)
-        - (left.updatedAt ?? left.createdAt ?? 0)
-      );
-    });
+  return sortThreadJumpMatches(threads.filter((thread) => threadMatchesQuery(thread, query)), query);
+}
+
+/** Merge owner-matched results without re-filtering their compact display data. */
+export function sortThreadJumpMatches(
+  threads: readonly NavigationThreadSummary[],
+  query: string,
+): NavigationThreadSummary[] {
+  return [...threads].sort((left, right) => {
+    const exactPrPriority =
+      Number(threadHasExactPrNumberMatch(right, query))
+      - Number(threadHasExactPrNumberMatch(left, query));
+    if (exactPrPriority !== 0) {
+      return exactPrPriority;
+    }
+    return (
+      (right.updatedAt ?? right.createdAt ?? 0)
+      - (left.updatedAt ?? left.createdAt ?? 0)
+    );
+  });
 }


### PR DESCRIPTION
## Problem and result

Generic federated search previously fetched full thread lists from peers. Current owners now receive the query, backend/archive/project/date filters and global K, perform matching and ranking locally, and return at most K rows with the pre-limit total and truncation metadata.

The owner uses a dedicated read-only registry projection. Exact IDs are selected before limiting; text matches cover titles, summaries, project paths and linked directories consistently across providers. For example, an archived UUID still resolves at limit 1 even when another thread has that UUID as its title. With 100 local matches and a higher-ranked remote result at limit 1, the local instance still reports 100 matches.

## Design

- Search bypasses directory reconciliation, archive maintenance and native-worker reconciliation. Returned links carry owner identity, so listing results no longer writes routing metadata per result.
- A separate two-second in-memory candidate cache reuses completed reads across query prefixes, with existing event invalidation. There is no per-query persisted index or reconciliation.
- Each peer returns its top K; the viewer merges those pages using the same ranking. Only an explicit `method_not_found` selects the legacy full-list fallback.
- One absolute deadline covers owner search, provider pagination and compatibility calls. Local search is also time-bounded. Provider/local failures are reported rather than converted into successful empty searches; healthy peer results survive.
- Cold searches still enumerate provider candidates to compute complete matching and exact totals. The response row count is bounded; this is not a provider-side indexed search or a byte/chunk transport redesign. Old-peer compatibility retains the old listing behavior.

## Validation

- Added regressions first: archived ID and metadata misses, swallowed provider errors, an actual SQLite maintenance commit, per-result routing writes, and repeated provider scans reproduced before their fixes.
- Integration coverage uses the real owner adapter, registry and SQLite store. A real Federation RPC endpoint/router round trip reduces a 1,201-row inventory to one wire result with the correct filtered total of 901.
- Checked-in owner search budget: zero SQLite commits/statements/rows, projected 0 MB/day. ACP archive/path searches also assert zero commits.
- 907 tests passed across search, owner bridge, Federation RPC, agent tools, Codex client and registry suites. Tests cover deadline expiry between provider pages and before archive discovery, local failure/timeout, legacy compatibility, counts, cache reuse and expiry.
- Workspace typecheck, ESLint (no errors), dependency boundaries, SQL lint, Codex-storage lint and diff checks passed.

Project-specific RPCs, messaging navigation, Star Map, peer-directory deltas and chunked relay are outside this change. This PR now targets main after #1980 was squash-merged.
