### PR TITLE
feat(desktop): support GPT-6 Astra

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6212,6 +6212,12 @@ describe("DesktopBackendRegistry", () => {
         launchpadOptions: {
           models: [
             {
+              id: "gpt-6-astra",
+              label: "GPT-6-Astra",
+              supportsReasoning: true,
+              supportsFast: true,
+            },
+            {
               id: "gpt-5.6-sol",
               label: "GPT-5.6-Sol",
               supportsReasoning: true,
@@ -15011,8 +15017,8 @@ script = "echo setup"
 
     expect(codexClient.listModelsCallCount).toBe(2);
     expect(response.backends[0]?.launchpadOptions?.models?.[0]).toMatchObject({
-      id: "gpt-5.6-sol",
-      label: "GPT-5.6-Sol",
+      id: "gpt-6-astra",
+      label: "GPT-6-Astra",
     });
     expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25909,7 +25909,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("leaves multi-request Astra turn aggregates above 272K unpriced", async () => {
+  it("prices each Astra request before aggregating a multi-request turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },
     });
@@ -25928,25 +25928,101 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
 
     for (const cumulativeInputTokens of [200_000, 400_000]) {
+      for (let emission = 0; emission < 2; emission += 1) {
+        await codexClient.emit({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 200_000,
+                cache_write_input_tokens: 10_000,
+                cached_input_tokens: 100_000,
+                output_tokens: 10_000,
+                reasoning_output_tokens: 0,
+                total_tokens: 210_000,
+              },
+              total_token_usage: {
+                input_tokens: cumulativeInputTokens,
+                cache_write_input_tokens: cumulativeInputTokens / 20,
+                cached_input_tokens: cumulativeInputTokens / 2,
+                output_tokens: cumulativeInputTokens / 20,
+                reasoning_output_tokens: 0,
+                total_tokens: cumulativeInputTokens * 1.05,
+              },
+            },
+          },
+        });
+      }
+    }
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cacheWriteInputCostMicros: 250_000,
+      cacheWriteInputTokens: 20_000,
+      cachedInputTokens: 200_000,
+      cachedInputCostMicros: 200_000,
+      inputTokens: 400_000,
+      outputCostMicros: 1_000_000,
+      priceStatus: "priced",
+      pricingBasis: "request-components",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      totalCostMicros: 3_250_000,
+      uncachedInputCostMicros: 1_800_000,
+      uncachedInputTokens: 200_000,
+    });
+
+    await registry.close();
+  });
+
+  it("sums mixed Astra short- and long-context request rates exactly", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-6-astra",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+    const requests = [
+      { cached: 100_000, input: 200_000, totalInput: 200_000 },
+      { cached: 100_000, input: 300_000, totalInput: 500_000 },
+    ];
+
+    for (const request of requests) {
       await codexClient.emit({
         method: "thread/tokenUsage/updated",
         params: {
           threadId: "thread-1",
           turnId: "turn-1",
           tokenUsage: {
-            last_token_usage: {
-              input_tokens: 200_000,
-              cached_input_tokens: 100_000,
-              output_tokens: 10_000,
-              reasoning_output_tokens: 0,
-              total_tokens: 210_000,
+            last: {
+              cachedInputTokens: request.cached,
+              inputTokens: request.input,
+              outputTokens: 10_000,
+              reasoningOutputTokens: 0,
+              totalTokens: request.input + 10_000,
             },
-            total_token_usage: {
-              input_tokens: cumulativeInputTokens,
-              cached_input_tokens: cumulativeInputTokens / 2,
-              output_tokens: cumulativeInputTokens / 20,
-              reasoning_output_tokens: 0,
-              total_tokens: cumulativeInputTokens * 1.05,
+            total: {
+              cachedInputTokens: request.totalInput === 200_000 ? 100_000 : 200_000,
+              inputTokens: request.totalInput,
+              outputTokens: request.totalInput === 200_000 ? 10_000 : 20_000,
+              reasoningOutputTokens: 0,
+              totalTokens: request.totalInput === 200_000 ? 210_000 : 520_000,
             },
           },
         },
@@ -25960,12 +26036,17 @@ command = "pnpm dev"
 
     expect(pricing.lines).toHaveLength(1);
     expect(pricing.lines[0]).toMatchObject({
-      cachedInputTokens: 200_000,
-      inputTokens: 400_000,
-      priceStatus: "unpriced",
-      totalCostMicros: 0,
-      uncachedInputTokens: 200_000,
+      cachedInputCostMicros: 300_000,
+      inputTokens: 500_000,
+      outputCostMicros: 1_250_000,
+      priceStatus: "priced",
+      pricingBasis: "request-components",
+      pricingCatalogId: "openai-api",
+      pricingCatalogVersion: "2026-09-04",
+      totalCostMicros: 6_550_000,
+      uncachedInputCostMicros: 5_000_000,
     });
+    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -25909,6 +25909,67 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("leaves multi-request Astra turn aggregates above 272K unpriced", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-6-astra",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    for (const cumulativeInputTokens of [200_000, 400_000]) {
+      await codexClient.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          tokenUsage: {
+            last_token_usage: {
+              input_tokens: 200_000,
+              cached_input_tokens: 100_000,
+              output_tokens: 10_000,
+              reasoning_output_tokens: 0,
+              total_tokens: 210_000,
+            },
+            total_token_usage: {
+              input_tokens: cumulativeInputTokens,
+              cached_input_tokens: cumulativeInputTokens / 2,
+              output_tokens: cumulativeInputTokens / 20,
+              reasoning_output_tokens: 0,
+              total_tokens: cumulativeInputTokens * 1.05,
+            },
+          },
+        },
+      });
+    }
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cachedInputTokens: 200_000,
+      inputTokens: 400_000,
+      priceStatus: "unpriced",
+      totalCostMicros: 0,
+      uncachedInputTokens: 200_000,
+    });
+
+    await registry.close();
+  });
+
   it("attributes turnless usage emitted after completion to the completed turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2350,6 +2350,11 @@ describe("CodexAppServerClient", () => {
     MockTransport.modelListResult = {
       data: [
         {
+          id: "gpt-6-astra",
+          displayName: "GPT-6 Astra",
+          supportsReasoning: true,
+        },
+        {
           id: "gpt-5.6-terra",
           displayName: "GPT-5.6-Terra",
           defaultReasoningEffort: "medium",
@@ -2424,6 +2429,12 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(client.listModels()).resolves.toEqual([
+      {
+        id: "gpt-6-astra",
+        label: "GPT-6-Astra",
+        current: undefined,
+        supportsReasoning: true,
+      },
       {
         id: "gpt-5.6-sol",
         label: "GPT-5.6-Sol",
@@ -2506,6 +2517,16 @@ describe("CodexAppServerClient", () => {
   it("derives Fast support from Codex model service tiers", async () => {
     MockTransport.modelListResult = createModelListResponse([
       createCodexModel({
+        id: "gpt-6-astra",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low", description: "Fast responses" },
+          { reasoningEffort: "medium", description: "Balanced" },
+          { reasoningEffort: "high", description: "Deep reasoning" },
+          { reasoningEffort: "xhigh", description: "Extra high" },
+          { reasoningEffort: "max", description: "Maximum reasoning" },
+        ],
+      }),
+      createCodexModel({
         id: "gpt-5.6-sol",
         serviceTiers: [
           {
@@ -2561,6 +2582,7 @@ describe("CodexAppServerClient", () => {
         supportsFast: model.supportsFast,
       })),
     ).toEqual([
+      { id: "gpt-6-astra", supportsFast: false },
       { id: "gpt-5.6-sol", supportsFast: true },
       { id: "gpt-5.6-terra", supportsFast: true },
       { id: "gpt-5.6-luna", supportsFast: true },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5516,6 +5516,60 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("prices a single Astra request above 272K at the long-context rate", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-astra-long-request", {
+      events: [
+        {
+          type: "turn_context",
+          timestamp: "2026-09-04T12:00:00.000Z",
+          payload: {
+            turn_id: "turn-1",
+            model: "gpt-6-astra",
+          },
+        },
+        {
+          type: "event_msg",
+          timestamp: "2026-09-04T12:00:10.000Z",
+          payload: {
+            type: "token_count",
+            info: {
+              last_token_usage: {
+                input_tokens: 272_001,
+                cached_input_tokens: 72_001,
+                output_tokens: 100_000,
+                reasoning_output_tokens: 0,
+                total_tokens: 372_001,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-astra-long-request",
+    });
+    const usage = replay.entries.find(
+      (entry) => entry.type === "activity" && entry.usageLine,
+    );
+
+    expect(usage?.type === "activity" ? usage.usageLine : undefined).toMatchObject({
+      cachedInputCostMicros: 144_002,
+      priceStatus: "priced",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-gt-272k",
+      totalCostMicros: 11_644_002,
+      uncachedInputCostMicros: 4_000_000,
+    });
+
+    await client.close();
+  });
+
   it("prices token_count entries with each turn's own model metadata", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-token-count-model-switch", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -5536,6 +5536,7 @@ describe("CodexAppServerClient", () => {
             info: {
               last_token_usage: {
                 input_tokens: 272_001,
+                cache_write_input_tokens: 20_000,
                 cached_input_tokens: 72_001,
                 output_tokens: 100_000,
                 reasoning_output_tokens: 0,
@@ -5560,12 +5561,22 @@ describe("CodexAppServerClient", () => {
     );
 
     expect(usage?.type === "activity" ? usage.usageLine : undefined).toMatchObject({
+      cacheWriteInputCostMicros: 500_000,
+      cacheWriteInputTokens: 20_000,
       cachedInputCostMicros: 144_002,
       priceStatus: "priced",
       pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-gt-272k",
-      totalCostMicros: 11_644_002,
-      uncachedInputCostMicros: 4_000_000,
+      totalCostMicros: 11_744_002,
+      uncachedInputCostMicros: 3_600_000,
     });
+    expect(usage?.type === "activity" ? usage.summary : undefined).toContain(
+      "20,000 cache writes",
+    );
+    expect(
+      usage?.type === "activity"
+        ? usage.details.map((detail) => detail.label)
+        : [],
+    ).toContain("Cache write cost: 20,000 tokens at $25.00/M = $0.50");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -52,6 +52,50 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     ]);
   });
 
+  it("round-trips request-component pricing for a mixed-band Astra turn", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cacheWriteInputCostMicros: 375_000,
+        cacheWriteInputTokens: 20_000,
+        cachedInputCostMicros: 300_000,
+        cachedInputTokens: 200_000,
+        createdAt: Date.UTC(2026, 8, 5),
+        inputTokens: 500_000,
+        model: "gpt-6-astra",
+        outputCostMicros: 1_250_000,
+        outputTokens: 20_000,
+        pricingBasis: "request-components",
+        pricingCatalogVersion: "2026-09-04",
+        pricingRateId: undefined,
+        reasoningOutputTokens: 0,
+        totalCostMicros: 6_625_000,
+        totalTokens: 520_000,
+        uncachedInputCostMicros: 4_700_000,
+        uncachedInputTokens: 300_000,
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      cacheWriteInputCostMicros: 375_000,
+      cacheWriteInputTokens: 20_000,
+      cachedInputCostMicros: 300_000,
+      priceStatus: "priced",
+      pricingBasis: "request-components",
+      totalCostMicros: 6_625_000,
+      uncachedInputCostMicros: 4_700_000,
+    });
+    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
+    expect(pricing.summaries[0]).toMatchObject({
+      totalCostMicros: 6_625_000,
+      unpricedUsageLineCount: 0,
+    });
+  });
+
   it("does not rewrite a finalized usage line model when thread settings change later", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
@@ -782,6 +826,40 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       totalCostMicros: 0,
       unpricedUsageLineCount: 1,
       usageLineCount: 1,
+    });
+  });
+
+  it("labels aggregate Astra usage as missing a request breakdown", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cachedInputCostMicros: 0,
+        cachedInputTokens: 100_000,
+        createdAt: Date.UTC(2026, 8, 5),
+        inputTokens: 300_000,
+        model: "gpt-6-astra",
+        outputCostMicros: 0,
+        outputTokens: 10_000,
+        priceStatus: "unpriced",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        reasoningOutputTokens: 0,
+        scope: "turn",
+        totalCostMicros: 0,
+        totalTokens: 310_000,
+        uncachedInputCostMicros: 0,
+        uncachedInputTokens: 200_000,
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "unpriced",
+      priceUnavailableReason: "insufficient-token-breakdown",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -446,6 +446,17 @@ describe("StateDb", () => {
       "thread_usage_lines",
       "thread_usage_turns",
     ]);
+    const usageLineColumns = stateDb.raw
+      .prepare("PRAGMA table_info(thread_usage_lines)")
+      .all() as Array<{ name: string }>;
+    expect(usageLineColumns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "cache_write_input_cost_micros",
+        "cache_write_input_tokens",
+        "cumulative_cache_write_input_tokens",
+        "pricing_basis",
+      ]),
+    );
   });
 
   it("creates thread tool accounting tables", () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -77,7 +77,7 @@ import {
   isCodexNativeSubAgentVisibleInNavigation,
   isToolManagedWorktreePath,
   normalizeRenamedTitleSource,
-  resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
   shortenDerivedThreadTitle,
   type AgentEvent,
   type ArchiveWorktreeRequest,
@@ -3577,6 +3577,7 @@ function buildTaskMonitorRecoveryPrompt(params: {
 }
 
 type TaskMonitorTokenUsageBreakdown = {
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   uncachedInputTokens?: number;
@@ -3907,6 +3908,10 @@ function buildTaskMonitorUsageSnapshot(params: {
   const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
   const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cacheWriteInputTokens = Math.min(
+    uncachedInputTokens,
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const totalTokens = Math.max(
@@ -3914,6 +3919,7 @@ function buildTaskMonitorUsageSnapshot(params: {
     tokens.totalTokens ?? inputTokens + outputTokens + reasoningOutputTokens,
   );
   const cost = estimateTaskMonitorUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,
@@ -3943,6 +3949,9 @@ function buildTaskMonitorUsageSnapshot(params: {
     ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
     summary,
     tokenUsage: {
+      ...(tokens.cacheWriteInputTokens !== undefined
+        ? { cacheWriteInputTokens }
+        : {}),
       cachedInputTokens,
       inputTokens,
       outputTokens,
@@ -4146,6 +4155,50 @@ function readTaskMonitorTokenUsageRecords(
   return undefined;
 }
 
+function foldLiveThreadRequestUsage(params: {
+  current: LiveThreadRequestUsage | undefined;
+  tokenUsage: unknown;
+}): LiveThreadRequestUsage | undefined {
+  const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
+  const latestUsage = records?.latestUsage;
+  const cumulativeInputTokens = records?.totalUsage?.inputTokens;
+  if (
+    !latestUsage
+    || typeof cumulativeInputTokens !== "number"
+    || !Number.isFinite(cumulativeInputTokens)
+  ) {
+    return params.current;
+  }
+
+  const normalizedCumulativeInputTokens = Math.max(0, cumulativeInputTokens);
+  if (
+    params.current
+    && normalizedCumulativeInputTokens < params.current.cumulativeInputTokens
+  ) {
+    return params.current;
+  }
+  if (
+    params.current
+    && normalizedCumulativeInputTokens === params.current.cumulativeInputTokens
+  ) {
+    const priorRequest = params.current.requests.at(-1);
+    if (taskMonitorTokenUsageEqual(priorRequest, latestUsage)) {
+      return params.current;
+    }
+    return {
+      cumulativeInputTokens: normalizedCumulativeInputTokens,
+      requests: [
+        ...params.current.requests.slice(0, -1),
+        latestUsage,
+      ],
+    };
+  }
+  return {
+    cumulativeInputTokens: normalizedCumulativeInputTokens,
+    requests: [...(params.current?.requests ?? []), latestUsage],
+  };
+}
+
 function readTaskMonitorTokenBreakdownFromUnknown(
   value: unknown,
 ): TaskMonitorTokenUsageBreakdown | undefined {
@@ -4158,6 +4211,12 @@ function readTaskMonitorTokenBreakdown(
 ): TaskMonitorTokenUsageBreakdown | undefined {
   const explicitTotal = readTaskMonitorNumber(record, "totalTokens", "total_tokens");
   const inputTokens = readTaskMonitorNumber(record, "inputTokens", "input_tokens");
+  const cacheWriteInputTokens = readTaskMonitorNumber(
+    record,
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cache_write_tokens",
+  );
   const cachedInputTokens = readTaskMonitorNumber(
     record,
     "cachedInputTokens",
@@ -4175,6 +4234,7 @@ function readTaskMonitorTokenBreakdown(
   if (
     totalTokens === undefined &&
     inputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     cachedInputTokens === undefined &&
     outputTokens === undefined &&
     reasoningOutputTokens === undefined
@@ -4182,6 +4242,7 @@ function readTaskMonitorTokenBreakdown(
     return undefined;
   }
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -4196,6 +4257,7 @@ function subtractTaskMonitorTokenUsage(
 ): TaskMonitorTokenUsageBreakdown | undefined {
   const result: TaskMonitorTokenUsageBreakdown = {};
   for (const key of [
+    "cacheWriteInputTokens",
     "cachedInputTokens",
     "inputTokens",
     "uncachedInputTokens",
@@ -4218,6 +4280,7 @@ function addTaskMonitorTokenUsage(
 ): TaskMonitorTokenUsageBreakdown | undefined {
   const result: TaskMonitorTokenUsageBreakdown = {};
   for (const key of [
+    "cacheWriteInputTokens",
     "cachedInputTokens",
     "inputTokens",
     "uncachedInputTokens",
@@ -4242,7 +4305,8 @@ function taskMonitorTokenUsageEqual(
     return false;
   }
   return (
-    first.cachedInputTokens === second.cachedInputTokens
+    first.cacheWriteInputTokens === second.cacheWriteInputTokens
+    && first.cachedInputTokens === second.cachedInputTokens
     && first.inputTokens === second.inputTokens
     && first.uncachedInputTokens === second.uncachedInputTokens
     && first.outputTokens === second.outputTokens
@@ -4257,6 +4321,7 @@ function canSubtractTaskMonitorTokenUsage(
 ): boolean {
   let compared = false;
   for (const key of [
+    "cacheWriteInputTokens",
     "cachedInputTokens",
     "inputTokens",
     "uncachedInputTokens",
@@ -4290,6 +4355,10 @@ function normalizeTaskMonitorPricingTokens(
     inputTokens,
     Math.max(0, tokens.cachedInputTokens ?? 0),
   );
+  const cacheWriteInputTokens = Math.min(
+    Math.max(0, inputTokens - cachedInputTokens),
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
   const uncachedInputTokens = Math.max(
     0,
     tokens.uncachedInputTokens ?? inputTokens - cachedInputTokens,
@@ -4301,12 +4370,110 @@ function normalizeTaskMonitorPricingTokens(
     tokens.totalTokens ?? inputTokens + outputTokens + reasoningOutputTokens,
   );
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
     reasoningOutputTokens,
     totalTokens,
     uncachedInputTokens,
+  };
+}
+
+function estimateRequestComponentsCost(params: {
+  at?: number;
+  fastMode?: boolean;
+  model?: string;
+  requests: readonly TaskMonitorTokenUsageBreakdown[];
+  serviceTier?: string;
+  turnTokenUsage: TaskMonitorTokenUsageBreakdown;
+}): RequestComponentsCost | undefined {
+  if (params.requests.length === 0) {
+    return undefined;
+  }
+  const requestTotal = params.requests.reduce<TaskMonitorTokenUsageBreakdown>(
+    (total, request) => addTaskMonitorTokenUsage(total, request) ?? total,
+    {},
+  );
+  const normalizedRequestTotal = normalizeTaskMonitorPricingTokens(requestTotal);
+  const normalizedTurnTotal = normalizeTaskMonitorPricingTokens(
+    params.turnTokenUsage,
+  );
+  if (
+    normalizedRequestTotal.cacheWriteInputTokens
+      !== normalizedTurnTotal.cacheWriteInputTokens
+    || normalizedRequestTotal.cachedInputTokens
+      !== normalizedTurnTotal.cachedInputTokens
+    || normalizedRequestTotal.inputTokens !== normalizedTurnTotal.inputTokens
+    || normalizedRequestTotal.outputTokens !== normalizedTurnTotal.outputTokens
+    || normalizedRequestTotal.reasoningOutputTokens
+      !== normalizedTurnTotal.reasoningOutputTokens
+  ) {
+    return undefined;
+  }
+
+  const costs = params.requests.map((request) => {
+    const tokens = normalizeTaskMonitorPricingTokens(request);
+    return estimateTokenUsageCost({
+      at: params.at,
+      cacheWriteInputTokens: tokens.cacheWriteInputTokens,
+      cachedInputTokens: tokens.cachedInputTokens,
+      fastMode: params.fastMode,
+      inputTokenScope: "request",
+      model: params.model,
+      outputTokens: tokens.outputTokens,
+      reasoningOutputTokens: tokens.reasoningOutputTokens,
+      serviceTier: params.serviceTier,
+      uncachedInputTokens: tokens.uncachedInputTokens,
+    });
+  });
+  if (costs.some((cost) => cost === undefined)) {
+    return undefined;
+  }
+  const priced = costs.filter(
+    (cost): cost is NonNullable<typeof cost> => cost !== undefined,
+  );
+  const first = priced[0]!;
+  if (
+    priced.some(
+      (cost) =>
+        cost.catalogId !== first.catalogId
+        || cost.catalogVersion !== first.catalogVersion
+        || cost.currency !== first.currency
+        || cost.provider !== first.provider
+        || cost.serviceTier !== first.serviceTier,
+    )
+  ) {
+    return undefined;
+  }
+  const rateIds = new Set(priced.map((cost) => cost.rateId));
+  return {
+    cacheWriteInputCostMicros: priced.reduce(
+      (total, cost) => total + cost.cacheWriteInputCostMicros,
+      0,
+    ),
+    cachedInputCostMicros: priced.reduce(
+      (total, cost) => total + cost.cachedInputCostMicros,
+      0,
+    ),
+    catalogId: first.catalogId,
+    catalogVersion: first.catalogVersion,
+    currency: first.currency,
+    outputCostMicros: priced.reduce(
+      (total, cost) => total + cost.outputCostMicros,
+      0,
+    ),
+    provider: first.provider,
+    ...(rateIds.size === 1 ? { rateId: first.rateId } : {}),
+    serviceTier: first.serviceTier,
+    totalCostMicros: priced.reduce(
+      (total, cost) => total + cost.totalCostMicros,
+      0,
+    ),
+    uncachedInputCostMicros: priced.reduce(
+      (total, cost) => total + cost.uncachedInputCostMicros,
+      0,
+    ),
   };
 }
 
@@ -4324,6 +4491,7 @@ function readTaskMonitorNumber(
 }
 
 function estimateTaskMonitorUsageCost(params: {
+  cacheWriteInputTokens?: number;
   cachedInputTokens: number;
   fastMode?: boolean;
   model?: string;
@@ -4378,6 +4546,10 @@ function buildTaskMonitorUsageLine(params: {
     inputTokens,
     Math.max(0, tokenUsage.cachedInputTokens ?? 0),
   );
+  const cacheWriteInputTokens = Math.min(
+    Math.max(0, inputTokens - cachedInputTokens),
+    Math.max(0, tokenUsage.cacheWriteInputTokens ?? 0),
+  );
   const uncachedInputTokens = Math.max(
     0,
     tokenUsage.uncachedInputTokens ?? inputTokens - cachedInputTokens,
@@ -4390,6 +4562,7 @@ function buildTaskMonitorUsageLine(params: {
   );
   const model = params.model ?? params.usage.model ?? params.usage.cost?.model;
   const cost = estimateTokenUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     model,
@@ -4398,21 +4571,21 @@ function buildTaskMonitorUsageLine(params: {
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
-  const pricingServiceTier = resolveOpenAiPricingServiceTier({
-    fastMode: params.fastMode,
-    serviceTier: params.serviceTier,
-  });
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          cachedInputTokens,
+          fastMode: params.fastMode,
+          model,
+          serviceTier: params.serviceTier,
+          uncachedInputTokens,
+        });
 
   return {
     backend: params.backend,
+    cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
+    cacheWriteInputTokens,
     cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
     cachedInputTokens,
     createdAt: Date.now(),
@@ -4997,6 +5170,7 @@ function buildLiveThreadUsageLine(params: {
   contextWindow?: LiveThreadContextWindowObservation;
   observedReplays?: ObservedContextReplayTally;
   reasoningEffort?: string;
+  requestTokenUsages?: readonly TaskMonitorTokenUsageBreakdown[];
   serviceTier?: string;
   startedAt?: number;
   threadId: string;
@@ -5009,6 +5183,7 @@ function buildLiveThreadUsageLine(params: {
   }
 
   const {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -5019,7 +5194,20 @@ function buildLiveThreadUsageLine(params: {
   const cumulativeTokens = params.cumulativeTokenUsage
     ? normalizeTaskMonitorPricingTokens(params.cumulativeTokenUsage)
     : undefined;
-  const cost = estimateTokenUsageCost({
+  const createdAt = params.createdAt ?? params.completedAt ?? Date.now();
+  const requestComponentsCost = params.requestTokenUsages
+    ? estimateRequestComponentsCost({
+        at: createdAt,
+        fastMode: params.fastMode,
+        model: params.model,
+        requests: params.requestTokenUsages,
+        serviceTier: params.serviceTier,
+        turnTokenUsage: tokens,
+      })
+    : undefined;
+  const cost = requestComponentsCost ?? estimateTokenUsageCost({
+    at: createdAt,
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,
@@ -5028,29 +5216,31 @@ function buildLiveThreadUsageLine(params: {
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
-  const pricingServiceTier = resolveOpenAiPricingServiceTier({
-    fastMode: params.fastMode,
-    serviceTier: params.serviceTier,
-  });
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !params.model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          cachedInputTokens,
+          fastMode: params.fastMode,
+          model: params.model,
+          serviceTier: params.serviceTier,
+          uncachedInputTokens,
+        });
 
   return {
     backend: params.backend,
+    cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
+    cacheWriteInputTokens,
     cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
     cachedInputTokens,
     ...(typeof params.completedAt === "number" ? { completedAt: params.completedAt } : {}),
-    createdAt: params.createdAt ?? params.completedAt ?? Date.now(),
+    createdAt,
     currency: cost?.currency ?? "USD",
     ...(cumulativeTokens
       ? {
           cumulativeCachedInputTokens: cumulativeTokens.cachedInputTokens,
+          cumulativeCacheWriteInputTokens:
+            cumulativeTokens.cacheWriteInputTokens,
           cumulativeInputTokens: cumulativeTokens.inputTokens,
           cumulativeOutputTokens: cumulativeTokens.outputTokens,
           cumulativeReasoningOutputTokens: cumulativeTokens.reasoningOutputTokens,
@@ -5085,6 +5275,7 @@ function buildLiveThreadUsageLine(params: {
     provider: cost?.provider ?? fallbackUsageProvider(params.backend),
     ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
     ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
+    ...(requestComponentsCost ? { pricingBasis: "request-components" as const } : {}),
     ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
     ...(params.reasoningEffort
       ? { reasoningEffort: params.reasoningEffort }
@@ -5138,6 +5329,7 @@ function buildForkBaselineUsageLine(params: {
   usageTiming: { completedAt?: number; createdAt?: number; startedAt?: number };
 }): ThreadUsageLineRecord | undefined {
   const {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -5162,6 +5354,8 @@ function buildForkBaselineUsageLine(params: {
     Date.now();
   return {
     backend: params.backend,
+    cacheWriteInputCostMicros: 0,
+    cacheWriteInputTokens,
     cachedInputCostMicros: 0,
     cachedInputTokens,
     createdAt: Math.max(0, anchorAt - 1),
@@ -7699,6 +7893,25 @@ type LiveThreadUsageAggregate = {
   usage: TaskMonitorTokenUsageBreakdown;
 };
 
+type LiveThreadRequestUsage = {
+  cumulativeInputTokens: number;
+  requests: TaskMonitorTokenUsageBreakdown[];
+};
+
+type RequestComponentsCost = {
+  cacheWriteInputCostMicros: number;
+  cachedInputCostMicros: number;
+  catalogId: string;
+  catalogVersion: string;
+  currency: "USD";
+  outputCostMicros: number;
+  provider: string;
+  rateId?: string;
+  serviceTier: string;
+  totalCostMicros: number;
+  uncachedInputCostMicros: number;
+};
+
 type DerivedLiveThreadTokenUsage = {
   // Whether turnTokenUsage is a real measurement of this turn — a per-turn
   // delta or a per-request "last" snapshot — vs a fallback to a whole-thread
@@ -7981,6 +8194,10 @@ export class DesktopBackendRegistry {
   private readonly liveThreadUsageAggregates = new Map<
     string,
     LiveThreadUsageAggregate
+  >();
+  private readonly liveThreadRequestUsage = new Map<
+    string,
+    LiveThreadRequestUsage
   >();
   private readonly recentlyCompletedThreadUsageTurns = new Map<
     string,
@@ -24509,6 +24726,32 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private observeLiveThreadRequestUsage(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    tokenUsage: unknown;
+    turnId?: string;
+  }): readonly TaskMonitorTokenUsageBreakdown[] | undefined {
+    if (!params.turnId) {
+      return undefined;
+    }
+    const key = [
+      params.backend,
+      params.threadId,
+      params.turnId,
+      "live-token-usage",
+    ].join(":");
+    const folded = foldLiveThreadRequestUsage({
+      current: this.liveThreadRequestUsage.get(key),
+      tokenUsage: params.tokenUsage,
+    });
+    if (!folded) {
+      return undefined;
+    }
+    this.liveThreadRequestUsage.set(key, folded);
+    return folded.requests;
+  }
+
   /**
    * Build usage for a forked sub-agent turn without charging the child for the
    * cumulative history inherited from its parent. Codex reports both the
@@ -24829,6 +25072,7 @@ export class DesktopBackendRegistry {
     let contextDrop: ObservedContextWindowDrop | undefined;
     let observedReplays: ObservedContextReplayTally | undefined;
     let contextWindow: LiveThreadContextWindowObservation | undefined;
+    let requestTokenUsages: readonly TaskMonitorTokenUsageBreakdown[] | undefined;
     try {
       if (
         event.backend === "codex"
@@ -24866,6 +25110,12 @@ export class DesktopBackendRegistry {
         appendLatestUsage: Boolean(recentlyCompletedTurn),
         backend: event.backend,
         observationSequence: work.observationSequence,
+        threadId,
+        tokenUsage,
+        turnId,
+      });
+      requestTokenUsages = this.observeLiveThreadRequestUsage({
+        backend: event.backend,
         threadId,
         tokenUsage,
         turnId,
@@ -24955,6 +25205,7 @@ export class DesktopBackendRegistry {
       model,
       observedReplays,
       reasoningEffort,
+      requestTokenUsages,
       serviceTier,
       threadId,
       tokenUsage: derivedUsage.turnTokenUsage,
@@ -36853,12 +37104,14 @@ export class DesktopBackendRegistry {
       const key = [event.backend, threadId].join(":");
       const completedTurn = this.recentlyCompletedThreadUsageTurns.get(key);
       if (completedTurn) {
-        this.liveThreadUsageAggregates.delete([
+        const completedTurnUsageKey = [
           event.backend,
           threadId,
           completedTurn.turnId,
           "live-token-usage",
-        ].join(":"));
+        ].join(":");
+        this.liveThreadUsageAggregates.delete(completedTurnUsageKey);
+        this.liveThreadRequestUsage.delete(completedTurnUsageKey);
       }
       this.recentlyCompletedThreadUsageTurns.delete(key);
       return;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1954,6 +1954,15 @@ const DEFAULT_REASONING_EFFORT = "medium";
 
 const OPENAI_FALLBACK_MODELS: BackendModelOption[] = [
   {
+    id: "gpt-6-astra",
+    label: "GPT-6-Astra",
+    defaultReasoningEffort: DEFAULT_REASONING_EFFORT,
+    reasoningEfforts: OPENAI_GPT56_REASONING_EFFORTS,
+    supportsReasoning: true,
+    supportsFast: true,
+    supportsSteering: true,
+  },
+  {
     id: "gpt-5.6-sol",
     label: "GPT-5.6-Sol",
     defaultReasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -5370,7 +5379,11 @@ function inferSupportsReasoning(
   }
 
   const id = model.id.toLowerCase();
-  return id.startsWith("gpt-5") || id.startsWith("o");
+  return (
+    id.startsWith("gpt-5")
+    || id.startsWith("gpt-6")
+    || id.startsWith("o")
+  );
 }
 
 function inferSupportsFast(

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -226,6 +226,7 @@ const LEGACY_CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["conf
 const CODEX_DEFAULT_MODE_REQUEST_USER_INPUT_CONFIG_KEY =
   "features.default_mode_request_user_input";
 const SUPPORTED_CODEX_MODEL_ORDER = [
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -3496,6 +3496,7 @@ function summarizeTokenUsageActivity(
     cachedInputTokens,
     at: createdAt,
     fastMode: resolvedPricingContext.fastMode,
+    inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
     model: resolvedPricingContext.model,
     outputTokens,
     reasoningOutputTokens,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -11,6 +11,7 @@ import {
   isToolManagedWorktreePath,
   parseCodexTurnErrorMessage,
   resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
   shortenDerivedThreadTitle,
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -3269,6 +3270,7 @@ function formatElapsedMs(elapsedMs: number): string {
 }
 
 type TokenUsageBreakdown = {
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -3295,6 +3297,11 @@ function readTokenUsageBreakdown(
 ): TokenUsageBreakdown | undefined {
   const explicitTotal = pickNumber(record, ["totalTokens", "total_tokens"]);
   const inputTokens = pickNumber(record, ["inputTokens", "input_tokens"]);
+  const cacheWriteInputTokens = pickNumber(record, [
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cache_write_tokens",
+  ]);
   const cachedInputTokens = pickNumber(record, [
     "cachedInputTokens",
     "cached_input_tokens",
@@ -3311,6 +3318,7 @@ function readTokenUsageBreakdown(
   if (
     totalTokens === undefined &&
     inputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     cachedInputTokens === undefined &&
     outputTokens === undefined &&
     reasoningOutputTokens === undefined
@@ -3319,6 +3327,7 @@ function readTokenUsageBreakdown(
   }
 
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -3485,6 +3494,11 @@ function summarizeTokenUsageActivity(
   const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
   const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cacheWriteInputTokens = Math.min(
+    uncachedInputTokens,
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
+  const regularInputTokens = uncachedInputTokens - cacheWriteInputTokens;
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const billedOutputTokens = outputTokens + reasoningOutputTokens;
@@ -3493,6 +3507,7 @@ function summarizeTokenUsageActivity(
     pricingContext
   );
   const cost = estimateTokenUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     at: createdAt,
     fastMode: resolvedPricingContext.fastMode,
@@ -3506,6 +3521,9 @@ function summarizeTokenUsageActivity(
   const idSuffix = typeof createdAt === "number" ? Math.round(createdAt) : "unknown";
   const summaryParts = [
     `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    cacheWriteInputTokens > 0
+      ? `${formatTokenCount(cacheWriteInputTokens)} cache writes`
+      : undefined,
     `${formatTokenCount(cachedInputTokens)} cached`,
     reasoningOutputTokens > 0
       ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(reasoningOutputTokens)} reasoning)`
@@ -3520,18 +3538,26 @@ function summarizeTokenUsageActivity(
   const sourceItemId =
     pickString(record, ["id", "itemId", "item_id", "callId", "call_id"]) ??
     `${idSuffix}`;
-  const pricingServiceTier = resolveOpenAiPricingServiceTier(resolvedPricingContext);
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !resolvedPricingContext.model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          at: createdAt,
+          cachedInputTokens,
+          fastMode: resolvedPricingContext.fastMode,
+          inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
+          model: resolvedPricingContext.model,
+          serviceTier: resolvedPricingContext.serviceTier,
+          uncachedInputTokens,
+        });
+  const pricingServiceTier = resolveOpenAiPricingServiceTier(
+    resolvedPricingContext,
+  );
   const usageLine: ThreadUsageLineRecord | undefined = threadId
     ? {
         backend: "codex",
+        cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
+        cacheWriteInputTokens,
         cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
         cachedInputTokens,
         ...(typeof turn?.completedAt === "number" ? { completedAt: turn.completedAt } : {}),
@@ -3607,7 +3633,7 @@ function summarizeTokenUsageActivity(
         id: `token-usage-${idSuffix}-uncached-input-cost`,
         kind: "read",
         label: `Uncached input cost: ${formatTokenCount(
-          uncachedInputTokens
+          regularInputTokens
         )} tokens at ${formatTokenUsageUsdPerMillion(
           cost.inputUsdPerMillion
         )}/M${formatTokenUsageStandardRateSuffix(
@@ -3640,14 +3666,29 @@ function summarizeTokenUsageActivity(
           cost.standardOutputRateMultiplier
         )} = ${formatTokenUsageUsd(cost.outputUsd)}`,
         status: "completed",
-      },
-      {
-        id: `token-usage-${idSuffix}-cost`,
-        kind: "read",
-        label: `Cost: ${formatTokenUsageUsd(cost.totalUsd)} list price for ${cost.displayName}`,
-        status: "completed",
       }
     );
+    if (
+      cacheWriteInputTokens > 0
+      && cost.cacheWriteInputUsdPerMillion !== undefined
+    ) {
+      details.push({
+        id: `token-usage-${idSuffix}-cache-write-input-cost`,
+        kind: "read",
+        label: `Cache write cost: ${formatTokenCount(
+          cacheWriteInputTokens
+        )} tokens at ${formatTokenUsageUsdPerMillion(
+          cost.cacheWriteInputUsdPerMillion
+        )}/M = ${formatTokenUsageUsd(cost.cacheWriteInputUsd)}`,
+        status: "completed",
+      });
+    }
+    details.push({
+      id: `token-usage-${idSuffix}-cost`,
+      kind: "read",
+      label: `Cost: ${formatTokenUsageUsd(cost.totalUsd)} list price for ${cost.displayName}`,
+      status: "completed",
+    });
   } else if (resolvedPricingContext.model) {
     details.push({
       id: `token-usage-${idSuffix}-cost-unavailable`,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -78,7 +78,7 @@ import {
   normalizeThreadIdentityKey,
   parseThreadIdentityKey,
   projectNavigationLaunchpadProviderSettings,
-  resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
 } from "@pwragent/shared";
 import type { StateDb } from "./state-db.js";
 import type {
@@ -1535,12 +1535,14 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             settings_source,
             settings_confidence,
             input_tokens,
+            cache_write_input_tokens,
             cached_input_tokens,
             uncached_input_tokens,
             output_tokens,
             reasoning_output_tokens,
             total_tokens,
             cumulative_input_tokens,
+            cumulative_cache_write_input_tokens,
             cumulative_cached_input_tokens,
             cumulative_uncached_input_tokens,
             cumulative_output_tokens,
@@ -1551,8 +1553,10 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             currency,
             pricing_catalog_id,
             pricing_catalog_version,
+            pricing_basis,
             pricing_rate_id,
             uncached_input_cost_micros,
+            cache_write_input_cost_micros,
             cached_input_cost_micros,
             output_cost_micros,
             total_cost_micros,
@@ -1584,12 +1588,14 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             @settingsSource,
             @settingsConfidence,
             @inputTokens,
+            @cacheWriteInputTokens,
             @cachedInputTokens,
             @uncachedInputTokens,
             @outputTokens,
             @reasoningOutputTokens,
             @totalTokens,
             @cumulativeInputTokens,
+            @cumulativeCacheWriteInputTokens,
             @cumulativeCachedInputTokens,
             @cumulativeUncachedInputTokens,
             @cumulativeOutputTokens,
@@ -1600,8 +1606,10 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             @currency,
             @pricingCatalogId,
             @pricingCatalogVersion,
+            @pricingBasis,
             @pricingRateId,
             @uncachedInputCostMicros,
+            @cacheWriteInputCostMicros,
             @cachedInputCostMicros,
             @outputCostMicros,
             @totalCostMicros,
@@ -1633,12 +1641,14 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             settings_source = excluded.settings_source,
             settings_confidence = excluded.settings_confidence,
             input_tokens = excluded.input_tokens,
+            cache_write_input_tokens = excluded.cache_write_input_tokens,
             cached_input_tokens = excluded.cached_input_tokens,
             uncached_input_tokens = excluded.uncached_input_tokens,
             output_tokens = excluded.output_tokens,
             reasoning_output_tokens = excluded.reasoning_output_tokens,
             total_tokens = excluded.total_tokens,
             cumulative_input_tokens = excluded.cumulative_input_tokens,
+            cumulative_cache_write_input_tokens = excluded.cumulative_cache_write_input_tokens,
             cumulative_cached_input_tokens = excluded.cumulative_cached_input_tokens,
             cumulative_uncached_input_tokens = excluded.cumulative_uncached_input_tokens,
             cumulative_output_tokens = excluded.cumulative_output_tokens,
@@ -1649,8 +1659,10 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
             currency = excluded.currency,
             pricing_catalog_id = excluded.pricing_catalog_id,
             pricing_catalog_version = excluded.pricing_catalog_version,
+            pricing_basis = excluded.pricing_basis,
             pricing_rate_id = excluded.pricing_rate_id,
             uncached_input_cost_micros = excluded.uncached_input_cost_micros,
+            cache_write_input_cost_micros = excluded.cache_write_input_cost_micros,
             cached_input_cost_micros = excluded.cached_input_cost_micros,
             output_cost_micros = excluded.output_cost_micros,
             total_cost_micros = excluded.total_cost_micros,
@@ -1854,6 +1866,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
          pricing_catalog_version = @pricingCatalogVersion,
          pricing_rate_id = @pricingRateId,
          uncached_input_cost_micros = @uncachedInputCostMicros,
+         cache_write_input_cost_micros = @cacheWriteInputCostMicros,
          cached_input_cost_micros = @cachedInputCostMicros,
          output_cost_micros = @outputCostMicros,
          provider = @provider,
@@ -1893,6 +1906,8 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     this.stateDb.raw.transaction(() => {
       for (const { existing, repaired } of repairs) {
         updateLine.run({
+          cacheWriteInputCostMicros:
+            repaired.cacheWriteInputCostMicros ?? 0,
           cachedInputCostMicros: repaired.cachedInputCostMicros,
           currency: repaired.currency,
           outputCostMicros: repaired.outputCostMicros,
@@ -6911,12 +6926,14 @@ type ThreadUsageLineRow = {
   settings_source: ThreadUsageLineRecord["settingsSource"] | null;
   settings_confidence: ThreadUsageLineRecord["settingsConfidence"] | null;
   input_tokens: number;
+  cache_write_input_tokens: number;
   cached_input_tokens: number;
   uncached_input_tokens: number;
   output_tokens: number;
   reasoning_output_tokens: number;
   total_tokens: number;
   cumulative_input_tokens: number | null;
+  cumulative_cache_write_input_tokens: number | null;
   cumulative_cached_input_tokens: number | null;
   cumulative_uncached_input_tokens: number | null;
   cumulative_output_tokens: number | null;
@@ -6927,8 +6944,10 @@ type ThreadUsageLineRow = {
   currency: string;
   pricing_catalog_id: string | null;
   pricing_catalog_version: string | null;
+  pricing_basis: ThreadUsageLineRecord["pricingBasis"] | null;
   pricing_rate_id: string | null;
   uncached_input_cost_micros: number;
+  cache_write_input_cost_micros: number;
   cached_input_cost_micros: number;
   output_cost_micros: number;
   total_cost_micros: number;
@@ -7173,6 +7192,10 @@ function normalizeThreadUsageLine(
 ): ThreadUsageLineRecord {
   const inputTokens = clampTokenCount(line.inputTokens);
   const cachedInputTokens = Math.min(inputTokens, clampTokenCount(line.cachedInputTokens));
+  const cacheWriteInputTokens = Math.min(
+    Math.max(0, inputTokens - cachedInputTokens),
+    clampTokenCount(line.cacheWriteInputTokens),
+  );
   const uncachedInputTokens = Math.max(
     0,
     line.uncachedInputTokens ?? inputTokens - cachedInputTokens,
@@ -7185,12 +7208,20 @@ function normalizeThreadUsageLine(
       : inputTokens + outputTokens + reasoningOutputTokens;
   return {
     ...line,
+    cacheWriteInputTokens,
     cachedInputTokens,
     completedAt: line.completedAt,
     createdAt: line.createdAt || updatedAt,
     currency: line.currency || "USD",
     ...(line.cumulativeCachedInputTokens !== undefined
       ? { cumulativeCachedInputTokens: clampTokenCount(line.cumulativeCachedInputTokens) }
+      : {}),
+    ...(line.cumulativeCacheWriteInputTokens !== undefined
+      ? {
+          cumulativeCacheWriteInputTokens: clampTokenCount(
+            line.cumulativeCacheWriteInputTokens,
+          ),
+        }
       : {}),
     ...(line.cumulativeInputTokens !== undefined
       ? { cumulativeInputTokens: clampTokenCount(line.cumulativeInputTokens) }
@@ -7317,6 +7348,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     } = line;
     return {
       ...forkBaseLine,
+      cacheWriteInputCostMicros: 0,
       cachedInputCostMicros: 0,
       outputCostMicros: 0,
       priceStatus: "priced",
@@ -7324,9 +7356,16 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
       uncachedInputCostMicros: 0,
     };
   }
+  // This line already contains the sum of individually priced requests. Its
+  // aggregate token count may span multiple context bands, so applying one
+  // catalog entry to the whole row would destroy the exact cost.
+  if (line.pricingBasis === "request-components") {
+    return line;
+  }
 
   const cost = estimateTokenUsageCost({
     at: line.createdAt,
+    cacheWriteInputTokens: line.cacheWriteInputTokens,
     cachedInputTokens: line.cachedInputTokens,
     fastMode: line.fastMode,
     inputTokenScope: line.scope === "latest-request" ? "request" : "aggregate",
@@ -7336,18 +7375,19 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     serviceTier: line.serviceTier,
     uncachedInputTokens: line.uncachedInputTokens,
   });
-  const pricingServiceTier = resolveOpenAiPricingServiceTier({
-    fastMode: line.fastMode,
-    serviceTier: line.serviceTier,
-  });
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !line.model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          at: line.createdAt,
+          cachedInputTokens: line.cachedInputTokens,
+          fastMode: line.fastMode,
+          inputTokenScope:
+            line.scope === "latest-request" ? "request" : "aggregate",
+          model: line.model,
+          serviceTier: line.serviceTier,
+          uncachedInputTokens: line.uncachedInputTokens,
+        });
   const {
     priceUnavailableReason: _discardedPriceUnavailableReason,
     pricingCatalogId: _discardedPricingCatalogId,
@@ -7358,6 +7398,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
 
   return {
     ...baseLine,
+    cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
     cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
     currency: cost?.currency ?? line.currency,
     outputCostMicros: cost?.outputCostMicros ?? 0,
@@ -7382,11 +7423,15 @@ function clampTokenCount(value: number | undefined): number {
 function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string, unknown> {
   return {
     backend: line.backend,
+    cacheWriteInputCostMicros: line.cacheWriteInputCostMicros ?? 0,
+    cacheWriteInputTokens: line.cacheWriteInputTokens ?? 0,
     cachedInputCostMicros: line.cachedInputCostMicros,
     cachedInputTokens: line.cachedInputTokens,
     completedAt: line.completedAt ?? null,
     createdAt: line.createdAt,
     cumulativeCachedInputTokens: line.cumulativeCachedInputTokens ?? null,
+    cumulativeCacheWriteInputTokens:
+      line.cumulativeCacheWriteInputTokens ?? null,
     cumulativeInputTokens: line.cumulativeInputTokens ?? null,
     cumulativeOutputTokens: line.cumulativeOutputTokens ?? null,
     cumulativeReasoningOutputTokens: line.cumulativeReasoningOutputTokens ?? null,
@@ -7418,6 +7463,7 @@ function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string,
     provider: line.provider,
     pricingCatalogId: line.pricingCatalogId ?? null,
     pricingCatalogVersion: line.pricingCatalogVersion ?? null,
+    pricingBasis: line.pricingBasis ?? null,
     pricingRateId: line.pricingRateId ?? null,
     reasoningEffort: line.reasoningEffort ?? null,
     reasoningOutputTokens: line.reasoningOutputTokens,
@@ -7512,12 +7558,20 @@ function toThreadToolInvocationAlertRowParams(
 function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord {
   return {
     backend: row.backend,
+    cacheWriteInputCostMicros: row.cache_write_input_cost_micros,
+    cacheWriteInputTokens: row.cache_write_input_tokens,
     cachedInputCostMicros: row.cached_input_cost_micros,
     cachedInputTokens: row.cached_input_tokens,
     ...(row.completed_at !== null ? { completedAt: row.completed_at } : {}),
     createdAt: row.created_at,
     ...(row.cumulative_cached_input_tokens !== null
       ? { cumulativeCachedInputTokens: row.cumulative_cached_input_tokens }
+      : {}),
+    ...(row.cumulative_cache_write_input_tokens !== null
+      ? {
+          cumulativeCacheWriteInputTokens:
+            row.cumulative_cache_write_input_tokens,
+        }
       : {}),
     ...(row.cumulative_input_tokens !== null
       ? { cumulativeInputTokens: row.cumulative_input_tokens }
@@ -7574,6 +7628,7 @@ function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord 
     ...(row.pricing_catalog_version
       ? { pricingCatalogVersion: row.pricing_catalog_version }
       : {}),
+    ...(row.pricing_basis ? { pricingBasis: row.pricing_basis } : {}),
     ...(row.pricing_rate_id ? { pricingRateId: row.pricing_rate_id } : {}),
     ...(row.reasoning_effort ? { reasoningEffort: row.reasoning_effort } : {}),
     reasoningOutputTokens: row.reasoning_output_tokens,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -7329,6 +7329,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     at: line.createdAt,
     cachedInputTokens: line.cachedInputTokens,
     fastMode: line.fastMode,
+    inputTokenScope: line.scope === "latest-request" ? "request" : "aggregate",
     model: line.model,
     outputTokens: line.outputTokens,
     reasoningOutputTokens: line.reasoningOutputTokens,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -2963,6 +2963,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          provider,
          reasoning_output_tokens,
          service_tier,
+         scope,
          uncached_input_tokens
        FROM thread_usage_lines
        WHERE provider IN ('openai', 'qwen', 'xai')
@@ -2979,6 +2980,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       provider: string;
       reasoning_output_tokens: number;
       service_tier: string | null;
+      scope: ThreadUsageLineRecord["scope"];
       uncached_input_tokens: number;
       usage_line_id: string;
     }>;
@@ -3005,6 +3007,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       at: row.created_at,
       cachedInputTokens: row.cached_input_tokens,
       fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+      inputTokenScope: row.scope === "latest-request" ? "request" : "aggregate",
       model: row.model ?? undefined,
       outputTokens: row.output_tokens,
       reasoningOutputTokens: row.reasoning_output_tokens,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -5,7 +5,7 @@ import type BetterSqlite3 from "better-sqlite3";
 import {
   encodeLegacyThreadIdentityKey,
   estimateTokenUsageCost,
-  resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 57;
+export const CURRENT_STATE_DB_USER_VERSION = 58;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -828,12 +828,14 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   settings_source            TEXT,
   settings_confidence        TEXT,
   input_tokens               INTEGER NOT NULL,
+  cache_write_input_tokens   INTEGER NOT NULL DEFAULT 0,
   cached_input_tokens        INTEGER NOT NULL,
   uncached_input_tokens      INTEGER NOT NULL,
   output_tokens              INTEGER NOT NULL,
   reasoning_output_tokens    INTEGER NOT NULL,
   total_tokens               INTEGER NOT NULL,
   cumulative_input_tokens    INTEGER,
+  cumulative_cache_write_input_tokens INTEGER,
   cumulative_cached_input_tokens INTEGER,
   cumulative_uncached_input_tokens INTEGER,
   cumulative_output_tokens   INTEGER,
@@ -844,8 +846,10 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   currency                   TEXT NOT NULL,
   pricing_catalog_id         TEXT,
   pricing_catalog_version    TEXT,
+  pricing_basis              TEXT,
   pricing_rate_id            TEXT,
   uncached_input_cost_micros INTEGER NOT NULL,
+  cache_write_input_cost_micros INTEGER NOT NULL DEFAULT 0,
   cached_input_cost_micros   INTEGER NOT NULL,
   output_cost_micros         INTEGER NOT NULL,
   total_cost_micros          INTEGER NOT NULL,
@@ -1641,8 +1645,14 @@ export class StateDb {
           if (!freshDatabase) {
             repairMisclassifiedHandoffSubAgents(db);
           }
-          db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
+          db.pragma("user_version = 57");
         }).immediate();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 58) {
+        db.transaction(() => {
+          ensureThreadUsageRequestPricingColumns(db);
+          db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
+        })();
       }
       // Keep current-version databases converged without asking pre-v36 profiles
       // to install the unique index before the migration above removes duplicates.
@@ -2319,6 +2329,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensurePullRequestProviderColumns(db);
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);
+    ensureThreadUsageRequestPricingColumns(db);
     ensureThreadUsagePricingIndexes(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
     ensureThreadToolIncidentExplorerSchema(db);
@@ -2664,6 +2675,37 @@ function ensureThreadUsagePricingCumulativeColumns(db: BetterSqlite3.Database): 
   }
 }
 
+function ensureThreadUsageRequestPricingColumns(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_usage_lines")) {
+    db.exec(THREAD_USAGE_PRICING_SCHEMA);
+    return;
+  }
+
+  const columns: Array<{ name: string; sql: string }> = [
+    {
+      name: "cache_write_input_tokens",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN cache_write_input_tokens INTEGER NOT NULL DEFAULT 0",
+    },
+    {
+      name: "cumulative_cache_write_input_tokens",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN cumulative_cache_write_input_tokens INTEGER",
+    },
+    {
+      name: "cache_write_input_cost_micros",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN cache_write_input_cost_micros INTEGER NOT NULL DEFAULT 0",
+    },
+    {
+      name: "pricing_basis",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN pricing_basis TEXT",
+    },
+  ];
+  for (const column of columns) {
+    if (!tableColumnExists(db, "thread_usage_lines", column.name)) {
+      db.exec(column.sql);
+    }
+  }
+}
+
 // DEPRECATED (see issue #947): observed context-replay tally on the usage line.
 // Kept only to dual-write the columns so older locally-run builds keep working
 // during the transition to thread_usage_turns. Remove with the dual-write.
@@ -2947,12 +2989,14 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   ) {
     return;
   }
+  ensureThreadUsageRequestPricingColumns(db);
 
   const now = Date.now();
   const rows = db
     .prepare(
       `SELECT
          usage_line_id,
+         cache_write_input_tokens,
          cached_input_tokens,
          created_at,
          currency,
@@ -2960,6 +3004,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          model,
          output_tokens,
          price_status,
+         pricing_basis,
          provider,
          reasoning_output_tokens,
          service_tier,
@@ -2970,6 +3015,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          AND scope != 'fork-baseline'`,
     )
     .all() as Array<{
+      cache_write_input_tokens: number;
       cached_input_tokens: number;
       created_at: number;
       currency: string;
@@ -2977,6 +3023,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       model: string | null;
       output_tokens: number;
       price_status: string;
+      pricing_basis: ThreadUsageLineRecord["pricingBasis"] | null;
       provider: string;
       reasoning_output_tokens: number;
       service_tier: string | null;
@@ -2994,6 +3041,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
        pricing_catalog_version = @pricingCatalogVersion,
        pricing_rate_id = @pricingRateId,
        uncached_input_cost_micros = @uncachedInputCostMicros,
+       cache_write_input_cost_micros = @cacheWriteInputCostMicros,
        cached_input_cost_micros = @cachedInputCostMicros,
        output_cost_micros = @outputCostMicros,
        provider = @provider,
@@ -3003,8 +3051,12 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   );
 
   for (const row of rows) {
+    if (row.pricing_basis === "request-components") {
+      continue;
+    }
     const cost = estimateTokenUsageCost({
       at: row.created_at,
+      cacheWriteInputTokens: row.cache_write_input_tokens,
       cachedInputTokens: row.cached_input_tokens,
       fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
       inputTokenScope: row.scope === "latest-request" ? "request" : "aggregate",
@@ -3018,20 +3070,21 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       continue;
     }
 
-    const pricingServiceTier = resolveOpenAiPricingServiceTier({
-      fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
-      serviceTier: row.service_tier ?? undefined,
-    });
     const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | null =
       cost
         ? null
-        : !row.model
-          ? "missing-model"
-          : pricingServiceTier === undefined
-            ? "unsupported-service-tier"
-            : "missing-rate";
+        : resolveTokenUsagePriceUnavailableReason({
+            at: row.created_at,
+            cachedInputTokens: row.cached_input_tokens,
+            fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+            inputTokenScope: row.scope === "latest-request" ? "request" : "aggregate",
+            model: row.model ?? undefined,
+            serviceTier: row.service_tier ?? undefined,
+            uncachedInputTokens: row.uncached_input_tokens,
+          });
 
     updateLine.run({
+      cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
       cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
       currency: cost?.currency ?? row.currency,
       outputCostMicros: cost?.outputCostMicros ?? 0,
@@ -3216,18 +3269,18 @@ function repairCodexTurnUsageFromCumulativeSnapshots(
       serviceTier: row.service_tier ?? undefined,
       uncachedInputTokens,
     });
-    const pricingServiceTier = resolveOpenAiPricingServiceTier({
-      fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
-      serviceTier: row.service_tier ?? undefined,
-    });
     const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | null =
       cost
         ? null
-        : !row.model
-          ? "missing-model"
-          : pricingServiceTier === undefined
-            ? "unsupported-service-tier"
-            : "missing-rate";
+        : resolveTokenUsagePriceUnavailableReason({
+            at: row.created_at,
+            cachedInputTokens,
+            fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+            inputTokenScope: "aggregate",
+            model: row.model ?? undefined,
+            serviceTier: row.service_tier ?? undefined,
+            uncachedInputTokens,
+          });
     updateLine.run({
       cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
       cachedInputTokens,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -4,6 +4,7 @@ import {
   buildLiveToolDetails,
   buildTaskMonitorUsageActivityEntry,
   buildTokenUsageActivityEntry,
+  buildTurnUsageActivityEntryFromLine,
   mergeActivityDetails,
   mergeCommandDetail,
   summarizeLiveActivity,
@@ -571,6 +572,47 @@ describe("buildTokenUsageActivityEntry", () => {
       "Output cost: 199 tokens at $30.00/M = $0.006",
       "Cost: $0.11 list price for GPT-5.5 Standard",
     ]);
+  });
+
+  it("uses an exact request-component total for a mixed-band Astra turn", () => {
+    const entry = buildTurnUsageActivityEntryFromLine({
+      line: {
+        backend: "codex",
+        cacheWriteInputCostMicros: 375_000,
+        cacheWriteInputTokens: 20_000,
+        cachedInputCostMicros: 300_000,
+        cachedInputTokens: 200_000,
+        createdAt: Date.UTC(2026, 8, 5),
+        currency: "USD",
+        inputTokens: 500_000,
+        model: "gpt-6-astra",
+        outputCostMicros: 1_250_000,
+        outputTokens: 20_000,
+        priceStatus: "priced",
+        pricingBasis: "request-components",
+        provider: "openai",
+        reasoningOutputTokens: 0,
+        scope: "turn",
+        serviceTier: "standard",
+        source: "live",
+        status: "finalized",
+        threadId: "thread-1",
+        totalCostMicros: 6_625_000,
+        totalTokens: 520_000,
+        turnId: "turn-1",
+        uncachedInputCostMicros: 4_700_000,
+        uncachedInputTokens: 300_000,
+        usageLineId: "codex:thread-1:turn-1:turn",
+      },
+      turn: { id: "turn-1", status: "completed" },
+    });
+
+    expect(entry?.summary).toContain("20,000 cache writes");
+    expect(entry?.summary).toContain("$6.63 list price");
+    expect(entry?.details.map((detail) => detail.label)).not.toContainEqual(
+      expect.stringContaining("Cost unavailable"),
+    );
+    expect(entry?.details.at(-1)?.label).toBe("Cost: $6.63 list price");
   });
 
   it("prices the Grok ACP build model alias without double-billing reasoning", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -364,6 +364,7 @@ function buildLiveCommandDetail(
 }
 
 type TokenUsageBreakdown = {
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -398,10 +399,16 @@ export function buildTokenUsageActivityEntry(params: {
   const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
   const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cacheWriteInputTokens = Math.min(
+    uncachedInputTokens,
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
+  const regularInputTokens = uncachedInputTokens - cacheWriteInputTokens;
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const cost = estimateTokenUsageCost({
     at: params.pricingAt,
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
@@ -416,6 +423,9 @@ export function buildTokenUsageActivityEntry(params: {
     : outputTokens + reasoningOutputTokens;
   const summaryParts = [
     `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    cacheWriteInputTokens > 0
+      ? `${formatTokenCount(cacheWriteInputTokens)} cache writes`
+      : undefined,
     `${formatTokenCount(cachedInputTokens)} cached`,
     reasoningOutputTokens > 0
       ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(reasoningOutputTokens)} reasoning)`
@@ -452,7 +462,7 @@ export function buildTokenUsageActivityEntry(params: {
         id: `${params.id}-uncached-input-cost`,
         kind: "read",
         label: `Uncached input cost: ${formatTokenCount(
-          uncachedInputTokens,
+          regularInputTokens,
         )} tokens at ${formatTokenUsageUsdPerMillion(
           cost.inputUsdPerMillion,
         )}/M${formatTokenUsageStandardRateSuffix(
@@ -487,6 +497,21 @@ export function buildTokenUsageActivityEntry(params: {
         status: "completed",
       },
     );
+    if (
+      cacheWriteInputTokens > 0
+      && cost.cacheWriteInputUsdPerMillion !== undefined
+    ) {
+      details.push({
+        id: `${params.id}-cache-write-input-cost`,
+        kind: "read",
+        label: `Cache write cost: ${formatTokenCount(
+          cacheWriteInputTokens,
+        )} tokens at ${formatTokenUsageUsdPerMillion(
+          cost.cacheWriteInputUsdPerMillion,
+        )}/M = ${formatTokenUsageUsd(cost.cacheWriteInputUsd)}`,
+        status: "completed",
+      });
+    }
     details.push({
       id: `${params.id}-cost`,
       kind: "read",
@@ -537,6 +562,7 @@ export function buildTurnUsageActivityEntryFromLine(params: {
     summaryPrefix: "Turn usage",
     tokenUsage: {
       total: {
+        cacheWriteInputTokens: line.cacheWriteInputTokens,
         cachedInputTokens: line.cachedInputTokens,
         inputTokens: line.inputTokens,
         outputTokens: line.outputTokens,
@@ -552,6 +578,9 @@ export function buildTurnUsageActivityEntryFromLine(params: {
 
   const summaryParts = [
     `${formatTokenCount(line.uncachedInputTokens)} uncached in`,
+    (line.cacheWriteInputTokens ?? 0) > 0
+      ? `${formatTokenCount(line.cacheWriteInputTokens ?? 0)} cache writes`
+      : undefined,
     `${formatTokenCount(line.cachedInputTokens)} cached`,
     line.reasoningOutputTokens > 0
       ? `${formatTokenCount(line.outputTokens)} out (${formatTokenCount(
@@ -564,31 +593,38 @@ export function buildTurnUsageActivityEntryFromLine(params: {
   ].filter((part): part is string => Boolean(part));
   const exactCostsByDetailId = new Map([
     [`${id}-uncached-input-cost`, line.uncachedInputCostMicros],
+    [`${id}-cache-write-input-cost`, line.cacheWriteInputCostMicros ?? 0],
     [`${id}-cached-input-cost`, line.cachedInputCostMicros],
     [`${id}-output-cost`, line.outputCostMicros],
   ]);
-  const details = entry.details.map((detail) => {
-    const exactCostMicros = exactCostsByDetailId.get(detail.id);
-    if (exactCostMicros !== undefined && detail.label.includes(" = ")) {
-      return {
-        ...detail,
-        label: detail.label.replace(
-          / = [^=]+$/,
-          ` = ${formatTokenUsageMicrosAsUsd(exactCostMicros)}`,
-        ),
-      };
-    }
-    if (detail.id === `${id}-cost`) {
-      return {
-        ...detail,
-        label: detail.label.replace(
-          /^Cost: .*? list price/,
-          `Cost: ${formatTokenUsageMicrosAsUsd(line.totalCostMicros)} list price`,
-        ),
-      };
-    }
-    return detail;
-  });
+  const details = entry.details
+    .filter(
+      (detail) =>
+        line.priceStatus !== "priced"
+        || detail.id !== `${id}-cost-unavailable`,
+    )
+    .map((detail) => {
+      const exactCostMicros = exactCostsByDetailId.get(detail.id);
+      if (exactCostMicros !== undefined && detail.label.includes(" = ")) {
+        return {
+          ...detail,
+          label: detail.label.replace(
+            / = [^=]+$/,
+            ` = ${formatTokenUsageMicrosAsUsd(exactCostMicros)}`,
+          ),
+        };
+      }
+      if (detail.id === `${id}-cost`) {
+        return {
+          ...detail,
+          label: detail.label.replace(
+            /^Cost: .*? list price/,
+            `Cost: ${formatTokenUsageMicrosAsUsd(line.totalCostMicros)} list price`,
+          ),
+        };
+      }
+      return detail;
+    });
   if (
     line.priceStatus === "priced"
     && !details.some((detail) => detail.id === `${id}-cost`)
@@ -669,6 +705,11 @@ function normalizeTokenUsage(tokenUsage: unknown): NormalizedTokenUsage | undefi
 function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdown | undefined {
   const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
   const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]);
+  const cacheWriteInputTokens = readFiniteNumber(record, [
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cache_write_tokens",
+  ]);
   const cachedInputTokens = readFiniteNumber(record, [
     "cachedInputTokens",
     "cached_input_tokens",
@@ -685,6 +726,7 @@ function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdow
   if (
     totalTokens === undefined &&
     inputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     cachedInputTokens === undefined &&
     outputTokens === undefined &&
     reasoningOutputTokens === undefined
@@ -693,6 +735,7 @@ function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdow
   }
 
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -404,6 +404,7 @@ export function buildTokenUsageActivityEntry(params: {
     at: params.pricingAt,
     cachedInputTokens,
     fastMode: params.fastMode,
+    inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
     model: params.model,
     outputTokens,
     reasoningOutputTokens,

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -337,6 +337,71 @@ describe("token usage pricing", () => {
     }
   });
 
+  it("prices GPT-6 Astra at the short-context boundary", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_000,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+
+    expect(cost).toMatchObject({
+      catalogVersion: "2026-09-04",
+      displayName: "GPT-6 Astra Standard (<=272K input)",
+      inputUsdPerMillion: 10,
+      cachedInputUsdPerMillion: 1,
+      outputUsdPerMillion: 50,
+      rateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      serviceTier: "standard",
+      uncachedInputCostMicros: 2_000_000,
+      cachedInputCostMicros: 72_000,
+      outputCostMicros: 5_000_000,
+      totalCostMicros: 7_072_000,
+    });
+  });
+
+  it("prices GPT-6 Astra above 272K input at the long-context rates", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_001,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+
+    expect(cost).toMatchObject({
+      catalogVersion: "2026-09-04",
+      displayName: "GPT-6 Astra Standard (>272K input)",
+      inputUsdPerMillion: 20,
+      cachedInputUsdPerMillion: 2,
+      outputUsdPerMillion: 75,
+      rateId: "openai:2026-09-04:gpt-6-astra:standard:input-gt-272k",
+      serviceTier: "standard",
+      uncachedInputCostMicros: 4_000_000,
+      cachedInputCostMicros: 144_002,
+      outputCostMicros: 7_500_000,
+      totalCostMicros: 11_644_002,
+    });
+  });
+
+  it("keeps unsupported GPT-6 Astra pricing modes unpriced", () => {
+    const usage = {
+      cachedInputTokens: 1_000,
+      model: "gpt-6-astra",
+      outputTokens: 1_000,
+      uncachedInputTokens: 1_000,
+    };
+
+    expect(
+      estimateOpenAiTokenUsageCost({ ...usage, fastMode: true }),
+    ).toBeUndefined();
+    expect(
+      estimateOpenAiTokenUsageCost({ ...usage, serviceTier: "flex" }),
+    ).toBeUndefined();
+    expect(estimateOpenAiCodexCreditUsage(usage)).toBeUndefined();
+  });
+
   it("does not price GPT-5.6 usage before its catalog effective date", () => {
     expect(
       estimateOpenAiTokenUsageCost({

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -365,6 +365,7 @@ describe("token usage pricing", () => {
     const cost = estimateOpenAiTokenUsageCost({
       at: Date.UTC(2026, 8, 4),
       cachedInputTokens: 72_001,
+      inputTokenScope: "request",
       model: "gpt-6-astra",
       outputTokens: 100_000,
       uncachedInputTokens: 200_000,
@@ -385,7 +386,58 @@ describe("token usage pricing", () => {
     });
   });
 
-  it("keeps unsupported GPT-6 Astra pricing modes unpriced", () => {
+  it("prices GPT-6 Astra Fast usage in both context bands", () => {
+    const shortContext = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_000,
+      fastMode: true,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+    const longContext = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_001,
+      inputTokenScope: "request",
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      serviceTier: "priority",
+      uncachedInputTokens: 200_000,
+    });
+
+    expect(shortContext).toMatchObject({
+      displayName: "GPT-6 Astra Fast (<=272K input)",
+      inputUsdPerMillion: 20,
+      cachedInputUsdPerMillion: 2,
+      outputUsdPerMillion: 100,
+      rateId: "openai:2026-09-04:gpt-6-astra:priority:input-lte-272k",
+      serviceTier: "priority",
+      totalCostMicros: 14_144_000,
+    });
+    expect(longContext).toMatchObject({
+      displayName: "GPT-6 Astra Fast (>272K input)",
+      inputUsdPerMillion: 40,
+      cachedInputUsdPerMillion: 4,
+      outputUsdPerMillion: 150,
+      rateId: "openai:2026-09-04:gpt-6-astra:priority:input-gt-272k",
+      serviceTier: "priority",
+      totalCostMicros: 23_288_004,
+    });
+  });
+
+  it("leaves ambiguous multi-request Astra aggregates unpriced", () => {
+    expect(
+      estimateOpenAiTokenUsageCost({
+        at: Date.UTC(2026, 8, 4),
+        cachedInputTokens: 72_001,
+        model: "gpt-6-astra",
+        outputTokens: 100_000,
+        uncachedInputTokens: 200_000,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps unsupported GPT-6 Astra billing modes unpriced", () => {
     const usage = {
       cachedInputTokens: 1_000,
       model: "gpt-6-astra",
@@ -393,9 +445,6 @@ describe("token usage pricing", () => {
       uncachedInputTokens: 1_000,
     };
 
-    expect(
-      estimateOpenAiTokenUsageCost({ ...usage, fastMode: true }),
-    ).toBeUndefined();
     expect(
       estimateOpenAiTokenUsageCost({ ...usage, serviceTier: "flex" }),
     ).toBeUndefined();

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -6,6 +6,7 @@ import {
   listOpenAiTokenUsagePricingRates,
   listTokenUsagePricingRates,
   resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
 } from "../token-usage-pricing";
 
 describe("token usage pricing", () => {
@@ -386,6 +387,40 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("prices and lists GPT-6 Astra cache writes", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cacheWriteInputTokens: 20_000,
+      cachedInputTokens: 72_001,
+      inputTokenScope: "request",
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+    const cacheWriteRates = listOpenAiTokenUsagePricingRates()
+      .filter((rate) => rate.model === "gpt-6-astra")
+      .map((rate) => [rate.serviceTier, rate.cacheWriteInputUsdPerMillion]);
+
+    expect(cost).toMatchObject({
+      cacheWriteInputCostMicros: 500_000,
+      cacheWriteInputUsd: 0.5,
+      cacheWriteInputUsdPerMillion: 25,
+      totalCostMicros: 11_744_002,
+      uncachedInputCostMicros: 3_600_000,
+    });
+    expect(cacheWriteRates).toEqual([
+      ["standard", 12.5],
+      ["standard", 25],
+      ["priority", 25],
+      ["priority", 50],
+    ]);
+    expect(
+      listOpenAiTokenUsagePricingRates().find(
+        (rate) => rate.rateId.endsWith(":standard:input-gt-272k"),
+      )?.cacheWriteInputMicrosPerMillion,
+    ).toBe(25_000_000);
+  });
+
   it("prices GPT-6 Astra Fast usage in both context bands", () => {
     const shortContext = estimateOpenAiTokenUsageCost({
       at: Date.UTC(2026, 8, 4),
@@ -435,6 +470,16 @@ describe("token usage pricing", () => {
         uncachedInputTokens: 200_000,
       }),
     ).toBeUndefined();
+    expect(
+      resolveTokenUsagePriceUnavailableReason({
+        at: Date.UTC(2026, 8, 4),
+        cachedInputTokens: 72_001,
+        inputTokenScope: "aggregate",
+        model: "gpt-6-astra",
+        serviceTier: "standard",
+        uncachedInputTokens: 200_000,
+      }),
+    ).toBe("insufficient-token-breakdown");
   });
 
   it("keeps unsupported GPT-6 Astra billing modes unpriced", () => {

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -68,6 +68,7 @@ export type TaskMonitorUsageSnapshot = {
   serviceTier?: string;
   summary: string;
   tokenUsage: {
+    cacheWriteInputTokens?: number;
     cachedInputTokens?: number;
     inputTokens?: number;
     outputTokens?: number;

--- a/packages/shared/src/thread-pricing-projection.ts
+++ b/packages/shared/src/thread-pricing-projection.ts
@@ -1,5 +1,6 @@
 import {
   estimateTokenUsageCost,
+  resolveTokenUsagePriceUnavailableReason,
   type ThreadUsageLineRecord,
 } from "./token-usage-pricing";
 
@@ -230,7 +231,17 @@ function buildEstimatedHistoricalGapLine(params: {
     + params.gapTokens.outputTokens
     + params.gapTokens.reasoningOutputTokens;
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
-    cost ? undefined : params.anchorLine.model ? "missing-rate" : "missing-model";
+    cost
+      ? undefined
+      : resolveTokenUsagePriceUnavailableReason({
+          at: params.anchorLine.createdAt,
+          cachedInputTokens: params.gapTokens.cachedInputTokens,
+          fastMode: false,
+          inputTokenScope: "aggregate",
+          model: params.anchorLine.model,
+          serviceTier: "standard",
+          uncachedInputTokens: params.gapTokens.uncachedInputTokens,
+        });
 
   return {
     backend: params.anchorLine.backend,

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -13,6 +13,8 @@ export type TokenUsagePriceUnavailableReason =
   | "insufficient-token-breakdown";
 
 export type ThreadUsageTokenBreakdown = {
+  // Provider-reported subset of uncached input that populated a prompt cache.
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -47,12 +49,17 @@ export type ThreadUsageLineStatus = "pending" | "finalized" | "superseded";
 
 export type ThreadUsageLineRecord = {
   backend: string;
+  // Cache-write cost is separate from uncachedInputCostMicros; the tokens are
+  // still a subset of uncachedInputTokens.
+  cacheWriteInputCostMicros?: number;
+  cacheWriteInputTokens?: number;
   cachedInputCostMicros: number;
   cachedInputTokens: number;
   completedAt?: number;
   createdAt: number;
   currency: string;
   cumulativeCachedInputTokens?: number;
+  cumulativeCacheWriteInputTokens?: number;
   cumulativeInputTokens?: number;
   cumulativeOutputTokens?: number;
   cumulativeReasoningOutputTokens?: number;
@@ -86,6 +93,7 @@ export type ThreadUsageLineRecord = {
   provider: string;
   pricingCatalogId?: string;
   pricingCatalogVersion?: string;
+  pricingBasis?: "aggregate" | "request-components";
   pricingRateId?: string;
   reasoningEffort?: string;
   reasoningOutputTokens: number;
@@ -109,6 +117,7 @@ export type ThreadUsageLineRecord = {
   // persisted before this field existed). The renderer treats `false` as a
   // historical summary instead of guessing from raw token counts.
   turnUsageAttributed?: boolean;
+  // Cost of regular uncached input after removing cache-write tokens.
   uncachedInputCostMicros: number;
   uncachedInputTokens: number;
   usageLineId: string;
@@ -145,6 +154,8 @@ export type ThreadSpendAlert = {
 };
 
 export type TokenUsagePricingCatalogRate = {
+  cacheWriteInputMicrosPerMillion?: number;
+  cacheWriteInputUsdPerMillion?: number;
   cachedInputMicrosPerMillion: number;
   cachedInputUsdPerMillion: number;
   catalogId: string;
@@ -166,6 +177,9 @@ export type TokenUsagePricingCatalogRate = {
 };
 
 export type TokenUsageCostEstimate = {
+  cacheWriteInputCostMicros: number;
+  cacheWriteInputUsd: number;
+  cacheWriteInputUsdPerMillion?: number;
   cachedInputCostMicros: number;
   cachedInputUsd: number;
   cachedInputUsdPerMillion: number;
@@ -219,6 +233,7 @@ export type TokenUsageCreditEstimate = {
 
 type PricingCatalogEntry = {
   aliases?: readonly string[];
+  cacheWriteInputUsdPerMillion?: number;
   cachedInputUsdPerMillion: number;
   catalogId: string;
   catalogVersion: string;
@@ -302,9 +317,8 @@ const QWEN_PRICING_CATALOG_VERSION = "2026-07-15";
 const QWEN37_PLUS_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 4, 26);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
-  // The usage schema cannot distinguish cache writes from ordinary uncached
-  // input. Keep cache-write charges outside the estimate instead of applying
-  // the higher write rate to every uncached token.
+  // Codex App Server reports cache-write tokens separately. They remain a
+  // subset of uncached input tokens and are charged at the write rate below.
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
@@ -314,6 +328,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "standard",
+    cacheWriteInputUsdPerMillion: 12.5,
     inputUsdPerMillion: 10,
     cachedInputUsdPerMillion: 1,
     outputUsdPerMillion: 50,
@@ -331,6 +346,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "standard",
+    cacheWriteInputUsdPerMillion: 25,
     inputUsdPerMillion: 20,
     cachedInputUsdPerMillion: 2,
     outputUsdPerMillion: 75,
@@ -347,6 +363,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "priority",
+    cacheWriteInputUsdPerMillion: 25,
     inputUsdPerMillion: 20,
     cachedInputUsdPerMillion: 2,
     outputUsdPerMillion: 100,
@@ -362,6 +379,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "priority",
+    cacheWriteInputUsdPerMillion: 50,
     inputUsdPerMillion: 40,
     cachedInputUsdPerMillion: 4,
     outputUsdPerMillion: 150,
@@ -852,6 +870,7 @@ export function listTokenUsagePricingRates(): TokenUsagePricingCatalogRate[] {
 }
 
 export function estimateOpenAiTokenUsageCost(params: {
+  cacheWriteInputTokens?: number;
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
@@ -867,6 +886,7 @@ export function estimateOpenAiTokenUsageCost(params: {
 }
 
 export function estimateTokenUsageCost(params: {
+  cacheWriteInputTokens?: number;
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
@@ -883,6 +903,7 @@ export function estimateTokenUsageCost(params: {
 
 function estimateTokenUsageCostFromCatalog(
   params: {
+    cacheWriteInputTokens?: number;
     cachedInputTokens: number;
     at?: number;
     fastMode?: boolean;
@@ -927,6 +948,17 @@ function estimateTokenUsageCostFromCatalog(
     return undefined;
   }
 
+  const cacheWriteInputTokens = Math.max(0, params.cacheWriteInputTokens ?? 0);
+  if (
+    cacheWriteInputTokens > params.uncachedInputTokens
+    || (
+      cacheWriteInputTokens > 0
+      && entry.cacheWriteInputUsdPerMillion === undefined
+    )
+  ) {
+    return undefined;
+  }
+
   const standardEntry = catalog.find(
     (candidate) =>
       candidate.model === entry.model
@@ -940,8 +972,12 @@ function estimateTokenUsageCostFromCatalog(
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
-    params.uncachedInputTokens,
+    params.uncachedInputTokens - cacheWriteInputTokens,
     entry.inputUsdPerMillion,
+  );
+  const cacheWriteInputCostMicros = calculateTokenCostMicros(
+    cacheWriteInputTokens,
+    entry.cacheWriteInputUsdPerMillion ?? 0,
   );
   const cachedInputCostMicros = calculateTokenCostMicros(
     params.cachedInputTokens,
@@ -959,12 +995,21 @@ function estimateTokenUsageCostFromCatalog(
     entry.outputUsdPerMillion,
   );
   const totalCostMicros =
-    uncachedInputCostMicros + cachedInputCostMicros + outputCostMicros;
+    uncachedInputCostMicros
+    + cacheWriteInputCostMicros
+    + cachedInputCostMicros
+    + outputCostMicros;
   const uncachedInputUsd = microsToCurrencyUnits(uncachedInputCostMicros);
+  const cacheWriteInputUsd = microsToCurrencyUnits(cacheWriteInputCostMicros);
   const cachedInputUsd = microsToCurrencyUnits(cachedInputCostMicros);
   const outputUsd = microsToCurrencyUnits(outputCostMicros);
 
   return {
+    cacheWriteInputCostMicros,
+    cacheWriteInputUsd,
+    ...(entry.cacheWriteInputUsdPerMillion !== undefined
+      ? { cacheWriteInputUsdPerMillion: entry.cacheWriteInputUsdPerMillion }
+      : {}),
     cachedInputCostMicros,
     cachedInputUsd,
     cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
@@ -1094,6 +1139,53 @@ export function resolveOpenAiPricingServiceTier(params: {
   return params.fastMode === true ? "priority" : "standard";
 }
 
+export function resolveTokenUsagePriceUnavailableReason(params: {
+  at?: number;
+  cachedInputTokens: number;
+  fastMode?: boolean;
+  inputTokenScope?: TokenUsagePricingInputScope;
+  model?: string;
+  serviceTier?: string;
+  uncachedInputTokens: number;
+}): TokenUsagePriceUnavailableReason {
+  const model = params.model?.trim();
+  if (!model) {
+    return "missing-model";
+  }
+
+  const inputTokens = params.cachedInputTokens + params.uncachedInputTokens;
+  const matchingEntries = TOKEN_USAGE_PRICING_CATALOG.filter(
+    (candidate) =>
+      pricingEntryMatchesModel(candidate, model)
+      && pricingEntryAppliesAt(candidate, params.at)
+      // A request scope answers only whether the token count belongs in this
+      // entry's numeric band. The caller's actual scope is checked below.
+      && pricingEntryMatchesInputTokens(candidate, inputTokens, "request"),
+  );
+  const provider = matchingEntries[0]?.provider;
+  const serviceTier =
+    provider === "xai" || provider === "qwen"
+      ? resolveStandardOnlyPricingServiceTier(params.serviceTier)
+      : resolveOpenAiPricingServiceTier({
+          fastMode: params.fastMode,
+          serviceTier: params.serviceTier,
+        });
+  if (serviceTier === undefined) {
+    return "unsupported-service-tier";
+  }
+
+  const entry = matchingEntries.find(
+    (candidate) => candidate.serviceTier === serviceTier,
+  );
+  if (
+    entry?.requiresRequestInputTokens
+    && params.inputTokenScope !== "request"
+  ) {
+    return "insufficient-token-breakdown";
+  }
+  return "missing-rate";
+}
+
 function resolveStandardOnlyPricingServiceTier(
   serviceTier: string | undefined,
 ): TokenUsagePricingServiceTier | undefined {
@@ -1173,6 +1265,14 @@ function tokenUsageRateMultiplier(
 
 function toPublicRate(entry: PricingCatalogEntry): TokenUsagePricingCatalogRate {
   return {
+    ...(entry.cacheWriteInputUsdPerMillion !== undefined
+      ? {
+          cacheWriteInputMicrosPerMillion: dollarsToMicros(
+            entry.cacheWriteInputUsdPerMillion,
+          ),
+          cacheWriteInputUsdPerMillion: entry.cacheWriteInputUsdPerMillion,
+        }
+      : {}),
     cachedInputMicrosPerMillion: dollarsToMicros(entry.cachedInputUsdPerMillion),
     cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
     catalogId: entry.catalogId,

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -226,6 +226,7 @@ type PricingCatalogEntry = {
   effectiveTo?: number;
   inputUsdPerMillion: number;
   maximumInputTokens?: number;
+  minimumInputTokens?: number;
   model: string;
   outputUsdPerMillion: number;
   outputTokensIncludeReasoning?: boolean;
@@ -268,6 +269,9 @@ const OPENAI_GPT56_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 30);
 // https://developers.openai.com/api/docs/models/gpt-5.6-sol
 const OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION = "2026-08-21";
 const OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 7, 21);
+// https://developers.openai.com/api/docs/models/gpt-6-astra
+const OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION = "2026-09-04";
+const OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 8, 4);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
 const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-27";
@@ -295,6 +299,39 @@ const QWEN_PRICING_CATALOG_VERSION = "2026-07-15";
 const QWEN37_PLUS_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 4, 26);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  // The usage schema cannot distinguish cache writes from ordinary uncached
+  // input. Keep cache-write charges outside the estimate instead of applying
+  // the higher write rate to every uncached token.
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Standard (<=272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 10,
+    cachedInputUsdPerMillion: 1,
+    outputUsdPerMillion: 50,
+    maximumInputTokens: 272_000,
+    rateBandId: "input-lte-272k",
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Standard (>272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 20,
+    cachedInputUsdPerMillion: 2,
+    outputUsdPerMillion: 75,
+    minimumInputTokens: 272_001,
+    rateBandId: "input-gt-272k",
+  },
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
@@ -1137,8 +1174,14 @@ function pricingEntryMatchesInputTokens(
   inputTokens: number,
 ): boolean {
   return (
-    entry.maximumInputTokens === undefined
-    || inputTokens <= entry.maximumInputTokens
+    (
+      entry.minimumInputTokens === undefined
+      || inputTokens >= entry.minimumInputTokens
+    )
+    && (
+      entry.maximumInputTokens === undefined
+      || inputTokens <= entry.maximumInputTokens
+    )
   );
 }
 

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -2,6 +2,8 @@ export type TokenUsagePricingServiceTier = "standard" | "priority";
 
 export type TokenUsagePricingProvider = "openai" | "qwen" | "xai";
 
+export type TokenUsagePricingInputScope = "aggregate" | "request";
+
 export type TokenUsagePriceStatus = "priced" | "unpriced";
 
 export type TokenUsagePriceUnavailableReason =
@@ -232,6 +234,7 @@ type PricingCatalogEntry = {
   outputTokensIncludeReasoning?: boolean;
   provider: TokenUsagePricingProvider;
   rateBandId?: string;
+  requiresRequestInputTokens?: boolean;
   serviceTier: TokenUsagePricingServiceTier;
 };
 
@@ -317,6 +320,8 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     maximumInputTokens: 272_000,
     rateBandId: "input-lte-272k",
   },
+  // OpenAI applies the higher band per request. Turn-wide totals above the
+  // boundary are ambiguous and must not select this rate.
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
@@ -331,6 +336,38 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     outputUsdPerMillion: 75,
     minimumInputTokens: 272_001,
     rateBandId: "input-gt-272k",
+    requiresRequestInputTokens: true,
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Fast (<=272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "priority",
+    inputUsdPerMillion: 20,
+    cachedInputUsdPerMillion: 2,
+    outputUsdPerMillion: 100,
+    maximumInputTokens: 272_000,
+    rateBandId: "input-lte-272k",
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Fast (>272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "priority",
+    inputUsdPerMillion: 40,
+    cachedInputUsdPerMillion: 4,
+    outputUsdPerMillion: 150,
+    minimumInputTokens: 272_001,
+    rateBandId: "input-gt-272k",
+    requiresRequestInputTokens: true,
   },
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
@@ -818,6 +855,7 @@ export function estimateOpenAiTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
+  inputTokenScope?: TokenUsagePricingInputScope;
   outputTokensIncludeReasoning?: boolean;
   model?: string;
   outputTokens: number;
@@ -832,6 +870,7 @@ export function estimateTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
+  inputTokenScope?: TokenUsagePricingInputScope;
   outputTokensIncludeReasoning?: boolean;
   model?: string;
   outputTokens: number;
@@ -847,6 +886,7 @@ function estimateTokenUsageCostFromCatalog(
     cachedInputTokens: number;
     at?: number;
     fastMode?: boolean;
+    inputTokenScope?: TokenUsagePricingInputScope;
     outputTokensIncludeReasoning?: boolean;
     model?: string;
     outputTokens: number;
@@ -868,6 +908,7 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
+        params.inputTokenScope,
       ),
   );
   const provider = matchingEntries[0]?.provider;
@@ -895,6 +936,7 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
+        params.inputTokenScope,
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
@@ -1172,9 +1214,11 @@ function pricingEntryMatchesModel(
 function pricingEntryMatchesInputTokens(
   entry: PricingCatalogEntry,
   inputTokens: number,
+  inputTokenScope: TokenUsagePricingInputScope | undefined,
 ): boolean {
   return (
-    (
+    (!entry.requiresRequestInputTokens || inputTokenScope === "request")
+    && (
       entry.minimumInputTokens === undefined
       || inputTokens >= entry.minimumInputTokens
     )


### PR DESCRIPTION
## Summary

- allow and order `gpt-6-astra` in both generated and legacy Codex model-list paths
- include Astra in desktop fallback model metadata without changing the preferred default
- add Standard and Fast API rates for both context bands at the exact 272K input boundary
- accumulate Codex App Server's per-request `last` usage so multi-request turns are priced exactly even when requests span both context bands
- price separately reported cache-write tokens at the official rate and persist each cost component
- leave historical Astra aggregates without a request breakdown, unsupported service tiers, and unsupported Codex-credit modes unpriced

## Official OpenAI sources

- [GPT-6 Astra model details](https://developers.openai.com/api/docs/models/gpt-6-astra) confirm the exact model ID, staged availability, the separate 1,050,000-token context capacity, and that long-context pricing applies when an individual request's prompt exceeds 272K input tokens. The configured context capacity does not select the pricing band. The page also specifies that Fast mode costs 2x the applicable rate.
- [OpenAI API pricing](https://developers.openai.com/api/docs/pricing) lists Standard prices per 1M tokens: short context at $10 input, $1 cached input, $12.50 cache writes, and $50 output; long context at $20 input, $2 cached input, $25 cache writes, and $75 output.

Both the stock Codex App Server schema and PwrAgent's managed Codex build expose `tokenUsage.last` and `tokenUsage.total`, including separately reported cache-write input tokens. PwrAgent now deduplicates/replaces repeated observations at the same cumulative-input boundary, prices each completed model request in its own band, and sums those components into the turn ledger. This telemetry is part of the normal App Server protocol; the managed build remains necessary for Token Miser interception and savings reporting, not for request-level token usage.

Older hydrated records can contain only an aggregate. An aggregate at or below 272K is safely in the short band, but one above 272K may represent several individually short requests. PwrAgent therefore preserves those ambiguous records as unpriced with the explicit `insufficient-token-breakdown` reason instead of overcharging the entire turn.

## Validation

- focused Vitest runs covering 8 files and 952 tests: shared pricing, Codex hydration, live backend accumulation, SQLite ledger/repricing, database creation/migrations, and renderer activity
- `pnpm typecheck`
- `pnpm lint:eslint` (0 errors; 46 warning-only baseline findings)
- `pnpm lint:sql`
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check origin/main...HEAD`

## Scope

The branch was cut from `origin/main` at `d209d2723` and does not include the separate changes from PR #1974 (`fix/codex-rate-limit-refresh`).
