### PR TITLE
fix(desktop): back off GitHub polling after outages

### DIFF
--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -622,6 +622,32 @@ describe("GithubGraphqlPrClient", () => {
     expect(request).toHaveBeenCalledTimes(12);
   });
 
+  it("allows one reconnect probe through an active failure backoff", async () => {
+    const now = 1_000_000;
+    let mode: "fail" | "succeed" = "fail";
+    const request = vi.fn(async () => {
+      if (mode === "fail") {
+        throw new Error("connect timeout");
+      }
+      return { r0: { pullRequest: node() } };
+    });
+    const graphqlClient = client(request, { now: () => now });
+
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(4);
+
+    mode = "succeed";
+    await expect(
+      graphqlClient.fetchPullRequestsAfterReconnect([refs[0]!]),
+    ).resolves.toHaveLength(1);
+    expect(request).toHaveBeenCalledTimes(5);
+
+    // The successful probe clears slow mode immediately.
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(6);
+    expect(now).toBe(1_000_000);
+  });
+
   it("returns to the initial backoff after GitHub recovers", async () => {
     let now = 1_000_000;
     let mode: "fail" | "succeed" = "fail";

--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -424,6 +424,7 @@ describe("GithubGraphqlPrClient", () => {
     request: (query: string, variables: Record<string, string | number>) => Promise<unknown>,
     options: {
       batchSize?: number;
+      now?: () => number;
       onRepositoryAccess?: (event: GithubRepositoryAccessEvent) => void;
     } = {},
   ): GithubGraphqlPrClient {
@@ -588,6 +589,72 @@ describe("GithubGraphqlPrClient", () => {
 
     expect(request).toHaveBeenCalledTimes(2);
     expect(prs).toHaveLength(1);
+  });
+
+  it("backs every GitHub poll off after repeated transport failures", async () => {
+    let now = 1_000_000;
+    const request = vi.fn(async () => {
+      throw new Error("connect timeout");
+    });
+    const graphqlClient = client(request, { now: () => now });
+
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(4);
+
+    // Branch discovery shares the same client and must respect the outage
+    // detected by status polling rather than starting another retry storm.
+    await graphqlClient.fetchPullRequestsForBranches([
+      { owner: "pwrdrvr", repo: "PwrAgent", branch: "main" },
+    ]);
+    expect(request).toHaveBeenCalledTimes(4);
+
+    now += 60_000;
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(8);
+
+    // A second failed cycle doubles the quiet period.
+    now += 60_000;
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(8);
+
+    now += 60_000;
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(12);
+  });
+
+  it("returns to the initial backoff after GitHub recovers", async () => {
+    let now = 1_000_000;
+    let mode: "fail" | "succeed" = "fail";
+    const request = vi.fn(async () => {
+      if (mode === "fail") {
+        throw new Error("connect timeout");
+      }
+      return { r0: { pullRequest: node() } };
+    });
+    const graphqlClient = client(request, { now: () => now });
+
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(4);
+
+    now += 60_000;
+    mode = "succeed";
+    await expect(graphqlClient.fetchPullRequests([refs[0]!]))
+      .resolves.toHaveLength(1);
+    expect(request).toHaveBeenCalledTimes(5);
+
+    mode = "fail";
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(9);
+
+    now += 59_999;
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(9);
+
+    now += 1;
+    mode = "succeed";
+    await expect(graphqlClient.fetchPullRequests([refs[0]!]))
+      .resolves.toHaveLength(1);
+    expect(request).toHaveBeenCalledTimes(10);
   });
 
   it("gives up on a batch without throwing, so one bad batch cannot kill a sweep", async () => {

--- a/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
+++ b/apps/desktop/src/main/__tests__/github-graphql-client.test.ts
@@ -637,6 +637,7 @@ describe("GithubGraphqlPrClient", () => {
     expect(request).toHaveBeenCalledTimes(4);
 
     mode = "succeed";
+    expect(graphqlClient.noteNetworkReconnect()).toBe(true);
     await expect(
       graphqlClient.fetchPullRequestsAfterReconnect([refs[0]!]),
     ).resolves.toHaveLength(1);
@@ -646,6 +647,53 @@ describe("GithubGraphqlPrClient", () => {
     await graphqlClient.fetchPullRequests([refs[0]!]);
     expect(request).toHaveBeenCalledTimes(6);
     expect(now).toBe(1_000_000);
+  });
+
+  it("preserves reconnect recovery for the next foreground branch lookup", async () => {
+    const now = 1_000_000;
+    let mode: "fail" | "succeed" = "fail";
+    const request = vi.fn(async () => {
+      if (mode === "fail") {
+        throw new Error("connect timeout");
+      }
+      return { r0: { pullRequests: { nodes: [] } } };
+    });
+    const graphqlClient = client(request, { now: () => now });
+    const branchRefs = [
+      { owner: "pwrdrvr", repo: "PwrAgent", branch: "main" },
+    ];
+
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(4);
+
+    // This is the scheduler-disabled / no-known-PR path: the online signal
+    // arrives, but no background status batch exists to consume it.
+    expect(graphqlClient.noteNetworkReconnect()).toBe(true);
+    mode = "succeed";
+    const result = await graphqlClient.fetchPullRequestsForBranches(branchRefs);
+
+    expect(request).toHaveBeenCalledTimes(5);
+    expect(result.has("pwrdrvr/pwragent#main")).toBe(true);
+  });
+
+  it("deduplicates reconnect permits and lets only one request consume one", async () => {
+    let now = 1_000_000;
+    const request = vi.fn(async () => {
+      throw new Error("connect timeout");
+    });
+    const graphqlClient = client(request, { now: () => now });
+
+    await graphqlClient.fetchPullRequests([refs[0]!]);
+    expect(graphqlClient.noteNetworkReconnect()).toBe(true);
+    expect(graphqlClient.noteNetworkReconnect()).toBe(false);
+
+    await graphqlClient.fetchPullRequestsAfterReconnect([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(8);
+    await graphqlClient.fetchPullRequestsAfterReconnect([refs[0]!]);
+    expect(request).toHaveBeenCalledTimes(8);
+
+    now += 30_000;
+    expect(graphqlClient.noteNetworkReconnect()).toBe(true);
   });
 
   it("returns to the initial backoff after GitHub recovers", async () => {

--- a/apps/desktop/src/main/__tests__/pr-polling-scheduler.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-polling-scheduler.test.ts
@@ -269,6 +269,77 @@ describe("PrPollingScheduler", () => {
     expect(h.fetched[0]).toHaveLength(40);
   });
 
+  it("runs one bounded reconnect probe and deduplicates network events", async () => {
+    const targets = Array.from({ length: 90 }, (_, index) => target(index + 1));
+    const reconnectFetch = vi.fn(async (refs: PrRef[]) =>
+      refs.map((ref) => pr({ number: ref.number })),
+    );
+    const tryTakeToken = vi.fn(() => true);
+    const h = harness({
+      listTargets: () => targets,
+      fetchPullRequestsAfterReconnect: reconnectFetch,
+      tryTakeToken,
+    });
+
+    await h.scheduler.probeAfterNetworkReconnect();
+    expect(reconnectFetch).toHaveBeenCalledOnce();
+    expect(reconnectFetch.mock.calls[0]?.[0]).toHaveLength(40);
+    expect(tryTakeToken).toHaveBeenCalledOnce();
+
+    // Multiple renderer windows can observe the same Chromium event.
+    await h.scheduler.probeAfterNetworkReconnect();
+    expect(reconnectFetch).toHaveBeenCalledOnce();
+    expect(tryTakeToken).toHaveBeenCalledOnce();
+
+    h.advance(30_000);
+    await h.scheduler.probeAfterNetworkReconnect();
+    expect(reconnectFetch).toHaveBeenCalledTimes(2);
+    expect(tryTakeToken).toHaveBeenCalledTimes(2);
+  });
+
+  it("queues a reconnect probe behind an in-flight polling batch", async () => {
+    let resolveFetch: (() => void) | undefined;
+    const fetchPullRequests = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        resolveFetch = resolve;
+      });
+      return [] as PrSummary[];
+    });
+    const fetchPullRequestsAfterReconnect = vi.fn(async () => [] as PrSummary[]);
+    const h = harness({
+      listTargets: () => [target(1)],
+      fetchPullRequests,
+      fetchPullRequestsAfterReconnect,
+    });
+
+    const tick = h.scheduler.tick();
+    expect(fetchPullRequests).toHaveBeenCalledOnce();
+
+    await h.scheduler.probeAfterNetworkReconnect();
+    expect(fetchPullRequestsAfterReconnect).not.toHaveBeenCalled();
+
+    resolveFetch?.();
+    await tick;
+    expect(fetchPullRequestsAfterReconnect).toHaveBeenCalledOnce();
+  });
+
+  it("holds a reconnect probe until the normal token budget refills", async () => {
+    let hasToken = false;
+    const fetchPullRequestsAfterReconnect = vi.fn(async () => [] as PrSummary[]);
+    const h = harness({
+      listTargets: () => [target(1)],
+      tryTakeToken: () => hasToken,
+      fetchPullRequestsAfterReconnect,
+    });
+
+    await h.scheduler.probeAfterNetworkReconnect();
+    expect(fetchPullRequestsAfterReconnect).not.toHaveBeenCalled();
+
+    hasToken = true;
+    await h.scheduler.tick();
+    expect(fetchPullRequestsAfterReconnect).toHaveBeenCalledOnce();
+  });
+
   it("round-robins so a long tail is not starved by the head of the list", async () => {
     // 50 targets, batch size 40 → the first tick can only cover 40. The next
     // tick must pick up the 10 that were skipped, not re-poll the first 40.

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -256,6 +256,7 @@ import {
   NAVIGATION_REMOVE_REMOTE_THREAD_PIN_CHANNEL,
   NAVIGATION_SET_REMOTE_THREAD_LOCAL_PIN_CHANNEL,
   NAVIGATION_DETACH_THREAD_PR_CHANNEL,
+  NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
   NAVIGATION_REORDER_DIRECTORY_PINS_CHANNEL,
@@ -5109,6 +5110,10 @@ class DesktopAppServerService {
     this.prPollingFocus.clearSender(senderKey);
   }
 
+  async probePullRequestPollingAfterReconnect(): Promise<void> {
+    await this.prPollingScheduler?.probeAfterNetworkReconnect();
+  }
+
   private getPrGraphqlClient(): GithubGraphqlPrClient {
     if (!this.prGraphqlClient) {
       this.prGraphqlClient = new GithubGraphqlPrClient({
@@ -5381,6 +5386,8 @@ class DesktopAppServerService {
       tryTakeToken: () => this.prStatusTokenBucket.tryTake(),
       fetchPullRequests: async (refs) =>
         await this.getPrGraphqlClient().fetchPullRequests(refs),
+      fetchPullRequestsAfterReconnect: async (refs) =>
+        await this.getPrGraphqlClient().fetchPullRequestsAfterReconnect(refs),
       getObservationTimestamp: () => this.nextPrObservationTimestamp(),
       applyResults: async (prs, fetchedAt) =>
         await this.applyPolledPrStatuses(prs, fetchedAt),
@@ -8175,6 +8182,13 @@ export function registerAppServerIpcHandlers(): void {
       }
     },
   );
+  ipcMain.removeHandler(NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL);
+  ipcMain.handle(
+    NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL,
+    async (): Promise<void> => {
+      await appServerService.probePullRequestPollingAfterReconnect();
+    },
+  );
   ipcMain.removeHandler(NAVIGATION_DETACH_THREAD_PR_CHANNEL);
   ipcMain.handle(
     NAVIGATION_DETACH_THREAD_PR_CHANNEL,
@@ -8581,6 +8595,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
   ipcMain.removeHandler(NAVIGATION_SET_THREAD_AGENT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_PRS_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL);
+  ipcMain.removeHandler(NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_DETACH_THREAD_PR_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL);
   ipcMain.removeHandler(NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL);

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -5111,6 +5111,11 @@ class DesktopAppServerService {
   }
 
   async probePullRequestPollingAfterReconnect(): Promise<void> {
+    // Arm the shared client even when background polling is disabled or has no
+    // eligible target; the next foreground lookup can consume the bypass.
+    if (!this.getPrGraphqlClient().noteNetworkReconnect()) {
+      return;
+    }
     await this.prPollingScheduler?.probeAfterNetworkReconnect();
   }
 

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -713,10 +713,26 @@ export class GithubGraphqlPrClient {
    * correctness — a stale chip beats a crashed sweep.
    */
   async fetchPullRequests(refs: PrRef[]): Promise<PrSummary[]> {
+    return await this.fetchPullRequestsWithBackoffPolicy(refs, false);
+  }
+
+  /**
+   * Allow the first batch through slow mode after Chromium reports that a
+   * network interface came back. The request still uses the normal retry
+   * ceiling; only a real GitHub response clears the accumulated failure state.
+   */
+  async fetchPullRequestsAfterReconnect(refs: PrRef[]): Promise<PrSummary[]> {
+    return await this.fetchPullRequestsWithBackoffPolicy(refs, true);
+  }
+
+  private async fetchPullRequestsWithBackoffPolicy(
+    refs: PrRef[],
+    bypassFailureBackoff: boolean,
+  ): Promise<PrSummary[]> {
     if (refs.length === 0) {
       return [];
     }
-    if (this.deferForFailureBackoff("PR poll")) {
+    if (!bypassFailureBackoff && this.deferForFailureBackoff("PR poll")) {
       return [];
     }
     const token = await this.resolveToken();
@@ -726,8 +742,10 @@ export class GithubGraphqlPrClient {
     }
 
     const results: PrSummary[] = [];
+    let bypassNextBatchBackoff = bypassFailureBackoff;
     for (const batch of chunk(refs, this.batchSize)) {
-      const prs = await this.fetchBatch(batch, token);
+      const prs = await this.fetchBatch(batch, token, bypassNextBatchBackoff);
+      bypassNextBatchBackoff = false;
       results.push(...prs);
     }
     return results;
@@ -996,8 +1014,15 @@ export class GithubGraphqlPrClient {
     return undefined;
   }
 
-  private async fetchBatch(refs: PrRef[], token: string): Promise<PrSummary[]> {
-    if (this.deferForFailureBackoff("PR poll batch")) {
+  private async fetchBatch(
+    refs: PrRef[],
+    token: string,
+    bypassFailureBackoff = false,
+  ): Promise<PrSummary[]> {
+    if (
+      !bypassFailureBackoff
+      && this.deferForFailureBackoff("PR poll batch")
+    ) {
       return [];
     }
     const { query, variables } = buildBatchedPrQuery(refs);

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -53,6 +53,8 @@ const MAX_BACKOFF_MS = 60_000;
 const FAILURE_BACKOFF_BASE_MS = 60_000;
 /** Keep probing occasionally so recovery is discovered without user action. */
 const MAX_FAILURE_BACKOFF_MS = 15 * 60_000;
+/** Collapse duplicate Chromium online events from multiple renderer windows. */
+export const GITHUB_RECONNECT_DEDUP_MS = 30_000;
 /** How long a minted `gh auth token` stays fresh in memory. */
 const TOKEN_TTL_MS = 5 * 60_000;
 
@@ -684,6 +686,8 @@ export class GithubGraphqlPrClient {
   private tokenCache: { token: string; fetchedAt: number } | undefined;
   private consecutiveRetryableFailures = 0;
   private failureBackoffUntil = 0;
+  private reconnectBypassAvailable = false;
+  private lastNetworkReconnectAt = Number.NEGATIVE_INFINITY;
 
   constructor(options: GithubGraphqlPrClientOptions = {}) {
     this.requestOverride = options.request;
@@ -701,6 +705,20 @@ export class GithubGraphqlPrClient {
   /** Force the next request to re-mint a token (e.g. after `gh auth login`). */
   invalidateToken(): void {
     this.tokenCache = undefined;
+  }
+
+  /**
+   * Preserve one slow-mode bypass for whichever GitHub lookup runs next.
+   * Returns false when another renderer already reported the same transition.
+   */
+  noteNetworkReconnect(): boolean {
+    const now = this.now();
+    if (now - this.lastNetworkReconnectAt < GITHUB_RECONNECT_DEDUP_MS) {
+      return false;
+    }
+    this.lastNetworkReconnectAt = now;
+    this.reconnectBypassAvailable = true;
+    return true;
   }
 
   /**
@@ -727,9 +745,13 @@ export class GithubGraphqlPrClient {
 
   private async fetchPullRequestsWithBackoffPolicy(
     refs: PrRef[],
-    bypassFailureBackoff: boolean,
+    requireReconnectBypass: boolean,
   ): Promise<PrSummary[]> {
     if (refs.length === 0) {
+      return [];
+    }
+    const bypassFailureBackoff = this.consumeReconnectBypass();
+    if (requireReconnectBypass && !bypassFailureBackoff) {
       return [];
     }
     if (!bypassFailureBackoff && this.deferForFailureBackoff("PR poll")) {
@@ -737,6 +759,7 @@ export class GithubGraphqlPrClient {
     }
     const token = await this.resolveToken();
     if (!token) {
+      this.reconnectBypassAvailable ||= bypassFailureBackoff;
       graphqlLog.debug("skipping PR poll: no GitHub token from gh");
       return [];
     }
@@ -768,22 +791,30 @@ export class GithubGraphqlPrClient {
     if (refs.length === 0) {
       return results;
     }
-    if (this.deferForFailureBackoff("branch PR lookup")) {
+    const bypassFailureBackoff = this.consumeReconnectBypass();
+    if (
+      !bypassFailureBackoff
+      && this.deferForFailureBackoff("branch PR lookup")
+    ) {
       return results;
     }
     const token = await this.resolveToken();
     if (!token) {
+      this.reconnectBypassAvailable ||= bypassFailureBackoff;
       graphqlLog.debug("skipping branch PR lookup: no GitHub token from gh");
       return results;
     }
 
+    let bypassNextBatchBackoff = bypassFailureBackoff;
     for (const batch of chunk(refs, this.batchSize)) {
       const data = await this.runBatchQuery(
         buildBranchPrQuery(batch),
         token,
         batch.length,
         batch,
+        bypassNextBatchBackoff,
       );
+      bypassNextBatchBackoff = false;
       if (!data) {
         continue;
       }
@@ -968,8 +999,12 @@ export class GithubGraphqlPrClient {
     token: string,
     refCount: number,
     repositoryRefs?: Array<Pick<BranchRef, "owner" | "repo" | "branch">>,
+    bypassFailureBackoff = false,
   ): Promise<Record<string, unknown> | undefined> {
-    if (this.deferForFailureBackoff("PR batch")) {
+    if (
+      !bypassFailureBackoff
+      && this.deferForFailureBackoff("PR batch")
+    ) {
       return undefined;
     }
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
@@ -1118,6 +1153,14 @@ export class GithubGraphqlPrClient {
     return true;
   }
 
+  private consumeReconnectBypass(): boolean {
+    if (!this.reconnectBypassAvailable) {
+      return false;
+    }
+    this.reconnectBypassAvailable = false;
+    return true;
+  }
+
   private recordRequestCompletion(
     retryDelay: number | null,
   ): { backoffMs: number; consecutiveFailures: number } | undefined {
@@ -1143,6 +1186,7 @@ export class GithubGraphqlPrClient {
   }
 
   private recordRequestSuccess(): void {
+    this.reconnectBypassAvailable = false;
     if (this.consecutiveRetryableFailures === 0) {
       return;
     }

--- a/apps/desktop/src/main/pr-status/github-graphql-client.ts
+++ b/apps/desktop/src/main/pr-status/github-graphql-client.ts
@@ -31,6 +31,11 @@ const graphqlLog = getMainLogger("pwragent:pr-graphql");
  * `gh` subprocess is limited to exporting its auth token and reporting
  * installation/login status in Settings.
  *
+ * An exhausted retry cycle puts every operation on this shared client into a
+ * bounded slow mode. That prevents status polling and branch discovery from
+ * independently retrying through the same outage. Any GitHub response resets
+ * the failure count so normal polling resumes as soon as connectivity returns.
+ *
  * Auth is still `gh`'s: we read the token from `gh` rather than asking the
  * operator for a PAT, so there is no new credential to store. Newer CLIs have
  * `gh auth token`; older CLIs only have `gh auth status --show-token`.
@@ -44,6 +49,10 @@ const STATUS_CONTEXT_PAGE_SIZE = 100;
 const MAX_RETRIES = 4;
 /** Upper bound on any single backoff wait. */
 const MAX_BACKOFF_MS = 60_000;
+/** Cooldown after one complete retry cycle still cannot reach GitHub. */
+const FAILURE_BACKOFF_BASE_MS = 60_000;
+/** Keep probing occasionally so recovery is discovered without user action. */
+const MAX_FAILURE_BACKOFF_MS = 15 * 60_000;
 /** How long a minted `gh auth token` stays fresh in memory. */
 const TOKEN_TTL_MS = 5 * 60_000;
 
@@ -638,6 +647,8 @@ export type GithubGraphqlPrClientOptions = {
   getConfiguredGhCommand?: () => string | undefined;
   /** Override the retry sleep — tests make backoff instant. */
   sleep?: (ms: number) => Promise<void>;
+  /** Override the cooldown clock for deterministic tests. */
+  now?: () => number;
   batchSize?: number;
   onRepositoryAccess?: (event: GithubRepositoryAccessEvent) => void;
   onAuthenticationFailure?: (event: GithubAuthenticationFailureEvent) => void;
@@ -662,6 +673,7 @@ export class GithubGraphqlPrClient {
     | NonNullable<GithubGraphqlPrClientOptions["getConfiguredGhCommand"]>
     | undefined;
   private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => number;
   private readonly batchSize: number;
   private readonly onRepositoryAccess:
     | NonNullable<GithubGraphqlPrClientOptions["onRepositoryAccess"]>
@@ -670,6 +682,8 @@ export class GithubGraphqlPrClient {
     | NonNullable<GithubGraphqlPrClientOptions["onAuthenticationFailure"]>
     | undefined;
   private tokenCache: { token: string; fetchedAt: number } | undefined;
+  private consecutiveRetryableFailures = 0;
+  private failureBackoffUntil = 0;
 
   constructor(options: GithubGraphqlPrClientOptions = {}) {
     this.requestOverride = options.request;
@@ -678,6 +692,7 @@ export class GithubGraphqlPrClient {
     this.sleep =
       options.sleep
       ?? ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    this.now = options.now ?? (() => Date.now());
     this.batchSize = Math.max(1, options.batchSize ?? DEFAULT_BATCH_SIZE);
     this.onRepositoryAccess = options.onRepositoryAccess;
     this.onAuthenticationFailure = options.onAuthenticationFailure;
@@ -699,6 +714,9 @@ export class GithubGraphqlPrClient {
    */
   async fetchPullRequests(refs: PrRef[]): Promise<PrSummary[]> {
     if (refs.length === 0) {
+      return [];
+    }
+    if (this.deferForFailureBackoff("PR poll")) {
       return [];
     }
     const token = await this.resolveToken();
@@ -730,6 +748,9 @@ export class GithubGraphqlPrClient {
   ): Promise<Map<string, PrSummary[]>> {
     const results = new Map<string, PrSummary[]>();
     if (refs.length === 0) {
+      return results;
+    }
+    if (this.deferForFailureBackoff("branch PR lookup")) {
       return results;
     }
     const token = await this.resolveToken();
@@ -930,16 +951,26 @@ export class GithubGraphqlPrClient {
     refCount: number,
     repositoryRefs?: Array<Pick<BranchRef, "owner" | "repo" | "branch">>,
   ): Promise<Record<string, unknown> | undefined> {
+    if (this.deferForFailureBackoff("PR batch")) {
+      return undefined;
+    }
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
       try {
-        return (await this.runRequest(built.query, built.variables, token)) as Record<
+        const data = (await this.runRequest(
+          built.query,
+          built.variables,
+          token,
+        )) as Record<
           string,
           unknown
         >;
+        this.recordRequestSuccess();
+        return data;
       } catch (error) {
         const partial = (error as { data?: Record<string, unknown> } | null)?.data;
         this.notifySamlEnforcement(error, repositoryRefs, partial);
         if (partial) {
+          this.recordRequestSuccess();
           graphqlLog.debug("PR batch returned partial data", {
             refCount,
             error: error instanceof Error ? error.message : String(error),
@@ -949,10 +980,12 @@ export class GithubGraphqlPrClient {
 
         const delay = retryDelayMs(error, attempt);
         if (delay === null || attempt === MAX_RETRIES) {
+          const failureBackoff = this.recordRequestCompletion(delay);
           graphqlLog.warn("PR batch failed", {
             refCount,
             attempt,
             retryable: delay !== null,
+            ...failureBackoff,
             error: error instanceof Error ? error.message : String(error),
           });
           return undefined;
@@ -964,12 +997,16 @@ export class GithubGraphqlPrClient {
   }
 
   private async fetchBatch(refs: PrRef[], token: string): Promise<PrSummary[]> {
+    if (this.deferForFailureBackoff("PR poll batch")) {
+      return [];
+    }
     const { query, variables } = buildBatchedPrQuery(refs);
 
     let data: BatchedPrResponse | undefined;
     for (let attempt = 1; attempt <= MAX_RETRIES; attempt += 1) {
       try {
         data = (await this.runRequest(query, variables, token)) as BatchedPrResponse;
+        this.recordRequestSuccess();
         break;
       } catch (error) {
         // A GraphQL-level error still carries whatever aliases DID resolve.
@@ -977,6 +1014,7 @@ export class GithubGraphqlPrClient {
         const partial = (error as { data?: BatchedPrResponse } | null)?.data;
         this.notifySamlEnforcement(error, refs, partial);
         if (partial) {
+          this.recordRequestSuccess();
           graphqlLog.debug("PR poll batch returned partial data", {
             refCount: refs.length,
             error: error instanceof Error ? error.message : String(error),
@@ -987,10 +1025,12 @@ export class GithubGraphqlPrClient {
 
         const delay = retryDelayMs(error, attempt);
         if (delay === null || attempt === MAX_RETRIES) {
+          const failureBackoff = this.recordRequestCompletion(delay);
           graphqlLog.warn("PR poll batch failed", {
             refCount: refs.length,
             attempt,
             retryable: delay !== null,
+            ...failureBackoff,
             error: error instanceof Error ? error.message : String(error),
           });
           return [];
@@ -1038,6 +1078,54 @@ export class GithubGraphqlPrClient {
       });
     }
     return prs;
+  }
+
+  private deferForFailureBackoff(operation: string): boolean {
+    const retryInMs = this.failureBackoffUntil - this.now();
+    if (retryInMs <= 0) {
+      return false;
+    }
+    graphqlLog.debug("GitHub request deferred during slow mode", {
+      operation,
+      retryInMs,
+      consecutiveFailures: this.consecutiveRetryableFailures,
+    });
+    return true;
+  }
+
+  private recordRequestCompletion(
+    retryDelay: number | null,
+  ): { backoffMs: number; consecutiveFailures: number } | undefined {
+    if (retryDelay === null) {
+      // Authentication, permission, and not-found responses prove the network
+      // path is working even though retrying that particular request cannot.
+      this.recordRequestSuccess();
+      return undefined;
+    }
+
+    this.consecutiveRetryableFailures += 1;
+    const exponentialDelay = Math.min(
+      FAILURE_BACKOFF_BASE_MS
+        * 2 ** Math.min(this.consecutiveRetryableFailures - 1, 30),
+      MAX_FAILURE_BACKOFF_MS,
+    );
+    const backoffMs = Math.max(retryDelay, exponentialDelay);
+    this.failureBackoffUntil = this.now() + backoffMs;
+    return {
+      backoffMs,
+      consecutiveFailures: this.consecutiveRetryableFailures,
+    };
+  }
+
+  private recordRequestSuccess(): void {
+    if (this.consecutiveRetryableFailures === 0) {
+      return;
+    }
+    graphqlLog.info("GitHub requests leaving slow mode", {
+      failedCycles: this.consecutiveRetryableFailures,
+    });
+    this.consecutiveRetryableFailures = 0;
+    this.failureBackoffUntil = 0;
   }
 
   private notifySamlEnforcement(
@@ -1102,14 +1190,14 @@ export class GithubGraphqlPrClient {
     }
     if (
       this.tokenCache
-      && Date.now() - this.tokenCache.fetchedAt < TOKEN_TTL_MS
+      && this.now() - this.tokenCache.fetchedAt < TOKEN_TTL_MS
     ) {
       return this.tokenCache.token;
     }
 
     const envToken = process.env.GITHUB_TOKEN?.trim();
     if (envToken) {
-      this.tokenCache = { token: envToken, fetchedAt: Date.now() };
+      this.tokenCache = { token: envToken, fetchedAt: this.now() };
       return envToken;
     }
 
@@ -1128,7 +1216,7 @@ export class GithubGraphqlPrClient {
         this.onAuthenticationFailure?.({ reason: "token-unavailable" });
         return null;
       }
-      this.tokenCache = { token, fetchedAt: Date.now() };
+      this.tokenCache = { token, fetchedAt: this.now() };
       return token;
     } catch (error) {
       // gh missing, or not logged in. The poller simply idles.

--- a/apps/desktop/src/main/pr-status/pr-polling-scheduler.ts
+++ b/apps/desktop/src/main/pr-status/pr-polling-scheduler.ts
@@ -1,7 +1,10 @@
 import type { PrSummary } from "@pwragent/shared";
 import { getMainLogger } from "../log";
 import type { PrRef } from "./github-graphql-client";
-import { parsePrRefFromUrl } from "./github-graphql-client";
+import {
+  GITHUB_RECONNECT_DEDUP_MS,
+  parsePrRefFromUrl,
+} from "./github-graphql-client";
 import { isTerminalPullRequest } from "./pr-derivations";
 
 const schedulerLog = getMainLogger("pwragent:pr-poller");
@@ -73,8 +76,6 @@ const HIDDEN_WINDOW_CADENCE_MULTIPLIER = 4;
 
 const TICK_INTERVAL_MS = 15_000;
 const BATCH_SIZE = 40;
-/** Collapse duplicate Chromium online events from multiple renderer windows. */
-const RECONNECT_PROBE_DEDUP_MS = 30_000;
 /**
  * Cap requests per tick. Bounds concurrency by construction (the batches below
  * this cap run together) and spreads a large backlog across ticks instead of
@@ -220,7 +221,7 @@ export class PrPollingScheduler {
    */
   async probeAfterNetworkReconnect(): Promise<void> {
     const now = this.now();
-    if (now - this.lastReconnectProbeAt < RECONNECT_PROBE_DEDUP_MS) {
+    if (now - this.lastReconnectProbeAt < GITHUB_RECONNECT_DEDUP_MS) {
       return;
     }
     this.lastReconnectProbeAt = now;

--- a/apps/desktop/src/main/pr-status/pr-polling-scheduler.ts
+++ b/apps/desktop/src/main/pr-status/pr-polling-scheduler.ts
@@ -73,6 +73,8 @@ const HIDDEN_WINDOW_CADENCE_MULTIPLIER = 4;
 
 const TICK_INTERVAL_MS = 15_000;
 const BATCH_SIZE = 40;
+/** Collapse duplicate Chromium online events from multiple renderer windows. */
+const RECONNECT_PROBE_DEDUP_MS = 30_000;
 /**
  * Cap requests per tick. Bounds concurrency by construction (the batches below
  * this cap run together) and spreads a large backlog across ticks instead of
@@ -95,6 +97,8 @@ export type PrPollingSchedulerDeps = {
   /** Global scheduled-fetch ceiling. One token per REQUEST, not per PR. */
   tryTakeToken: () => boolean;
   fetchPullRequests: (refs: PrRef[]) => Promise<PrSummary[]>;
+  /** One token-bounded probe allowed through the client's outage cooldown. */
+  fetchPullRequestsAfterReconnect?: (refs: PrRef[]) => Promise<PrSummary[]>;
   /** Persist + publish. Returns the prKeys whose status actually changed. */
   applyResults: (prs: PrSummary[], fetchedAt: number) => Promise<string[]>;
   /** Allocate a globally ordered token immediately before starting a request. */
@@ -160,6 +164,9 @@ export class PrPollingScheduler {
   private readonly pendingInteractionThreadKeys = new Set<string>();
   private timer: NodeJS.Timeout | undefined;
   private ticking = false;
+  private reconnectProbePending = false;
+  private reconnectProbeWaitingForBudget = false;
+  private lastReconnectProbeAt = Number.NEGATIVE_INFINITY;
 
   constructor(deps: PrPollingSchedulerDeps) {
     this.deps = deps;
@@ -187,6 +194,9 @@ export class PrPollingScheduler {
     }
     this.pollState.clear();
     this.pendingInteractionThreadKeys.clear();
+    this.reconnectProbePending = false;
+    this.reconnectProbeWaitingForBudget = false;
+    this.lastReconnectProbeAt = Number.NEGATIVE_INFINITY;
   }
 
   /**
@@ -203,6 +213,24 @@ export class PrPollingScheduler {
     }
   }
 
+  /**
+   * Chromium observed an offline → online transition. Force one batch through
+   * the normal token budget so a successful GitHub response can end slow mode
+   * early. Multiple windows can emit the same event, so dedupe globally here.
+   */
+  async probeAfterNetworkReconnect(): Promise<void> {
+    const now = this.now();
+    if (now - this.lastReconnectProbeAt < RECONNECT_PROBE_DEDUP_MS) {
+      return;
+    }
+    this.lastReconnectProbeAt = now;
+    if (this.ticking) {
+      this.reconnectProbePending = true;
+      return;
+    }
+    await this.runReconnectProbeExclusive();
+  }
+
   /** One scheduling pass. Exposed so tests can drive it without timers. */
   async tick(): Promise<void> {
     // Ticks must not overlap: a slow sweep would otherwise stack requests and
@@ -212,14 +240,40 @@ export class PrPollingScheduler {
     }
     this.ticking = true;
     try {
-      await this.runTick();
+      if (this.reconnectProbeWaitingForBudget) {
+        await this.runReconnectProbe();
+      } else {
+        await this.runTick();
+      }
     } catch (error) {
       schedulerLog.warn("PR poll tick failed", {
         error: error instanceof Error ? error.message : String(error),
       });
     } finally {
-      this.ticking = false;
+      this.finishTick();
     }
+  }
+
+  private async runReconnectProbeExclusive(): Promise<void> {
+    this.ticking = true;
+    try {
+      await this.runReconnectProbe();
+    } catch (error) {
+      schedulerLog.warn("PR reconnect probe failed", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      this.finishTick();
+    }
+  }
+
+  private finishTick(): void {
+    this.ticking = false;
+    if (!this.reconnectProbePending) {
+      return;
+    }
+    this.reconnectProbePending = false;
+    void this.runReconnectProbeExclusive();
   }
 
   private async runTick(): Promise<void> {
@@ -249,7 +303,31 @@ export class PrPollingScheduler {
     await Promise.all(admitted.map(async (batch) => await this.pollBatch(batch)));
   }
 
-  private selectDueTargets(targets: PrPollTarget[], now: number): PrPollTarget[] {
+  private async runReconnectProbe(): Promise<void> {
+    this.reconnectProbeWaitingForBudget = false;
+    const now = this.now();
+    const targets = this.deps.listTargets();
+    this.prunePollState(targets);
+    const batch = this.selectDueTargets(targets, now, true).slice(0, BATCH_SIZE);
+    if (batch.length === 0) {
+      return;
+    }
+    if (!this.deps.tryTakeToken()) {
+      this.reconnectProbeWaitingForBudget = true;
+      schedulerLog.debug("PR reconnect probe deferred: token bucket empty");
+      return;
+    }
+    await this.pollBatch(
+      batch,
+      this.deps.fetchPullRequestsAfterReconnect ?? this.deps.fetchPullRequests,
+    );
+  }
+
+  private selectDueTargets(
+    targets: PrPollTarget[],
+    now: number,
+    ignoreCadence = false,
+  ): PrPollTarget[] {
     const focusedThreadKeys = this.deps.getFocusedThreadKeys();
     const cadenceMultiplier = this.deps.isWindowVisible()
       ? 1
@@ -289,7 +367,7 @@ export class PrPollingScheduler {
         continue;
       }
       const cadence = TIER_CADENCE_MS[tier] * cadenceMultiplier;
-      if (now - state.lastPolledAt < cadence) {
+      if (!ignoreCadence && now - state.lastPolledAt < cadence) {
         continue;
       }
       due.push({ target, tier, lastPolledAt: state.lastPolledAt });
@@ -305,7 +383,10 @@ export class PrPollingScheduler {
     return due.map((entry) => entry.target);
   }
 
-  private async pollBatch(batch: PrPollTarget[]): Promise<void> {
+  private async pollBatch(
+    batch: PrPollTarget[],
+    fetchPullRequests = this.deps.fetchPullRequests,
+  ): Promise<void> {
     const refs: PrRef[] = [];
     for (const target of batch) {
       const ref = parsePrRefFromUrl(target.pr.url);
@@ -331,7 +412,7 @@ export class PrPollingScheduler {
       return;
     }
 
-    const prs = await this.deps.fetchPullRequests(refs);
+    const prs = await fetchPullRequests(refs);
     if (prs.length === 0) {
       return;
     }

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -668,6 +668,7 @@ import {
   NAVIGATION_RECORD_RECENT_FILE_REFERENCES_CHANNEL,
   NAVIGATION_REFRESH_THREAD_PRS_CHANNEL,
   NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL,
+  NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL,
   NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL,
   NAVIGATION_REFRESH_DIRECTORY_GIT_STATUSES_CHANNEL,
   NAVIGATION_RESOLVE_EDIT_COMMIT_STATES_CHANNEL,
@@ -1934,6 +1935,10 @@ const desktopApi = Object.freeze({
     request: SetPullRequestPollingFocusRequest,
   ): Promise<void> =>
     await ipcRenderer.invoke(NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL, request),
+  probePullRequestPollingAfterReconnect: async (): Promise<void> =>
+    await ipcRenderer.invoke(
+      NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL,
+    ),
   detachThreadPullRequest: async (
     request: DetachThreadPullRequestRequest,
   ): Promise<DetachThreadPullRequestResponse> =>

--- a/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
+++ b/apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx
@@ -55,6 +55,26 @@ function buildResponse(
 }
 
 describe("usePullRequestRefresh", () => {
+  it("notifies main once when Chromium reports that the network returned", async () => {
+    const probePullRequestPollingAfterReconnect = vi.fn(async () => undefined);
+    const desktopApi = {
+      probePullRequestPollingAfterReconnect,
+    } satisfies DesktopApi;
+
+    const { unmount } = renderHook(() =>
+      usePullRequestRefresh({ desktopApi }),
+    );
+
+    window.dispatchEvent(new Event("online"));
+    await waitFor(() => {
+      expect(probePullRequestPollingAfterReconnect).toHaveBeenCalledOnce();
+    });
+
+    unmount();
+    window.dispatchEvent(new Event("online"));
+    expect(probePullRequestPollingAfterReconnect).toHaveBeenCalledOnce();
+  });
+
   it("refreshes navigation when the PR probe returns changed PRs", async () => {
     const onRefreshNavigation = vi.fn(async () => undefined);
     const refreshThreadPullRequests = vi.fn(async () => buildResponse());

--- a/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/pr-status/usePullRequestRefresh.ts
@@ -104,6 +104,25 @@ export function usePullRequestRefresh(params: {
     selectedRef.current = selected;
   }, [selected]);
 
+  // Chromium owns network-change detection in Electron renderer processes.
+  // Treat `online` as permission for one main-process probe, not proof that
+  // GitHub is reachable; the scheduler deduplicates windows and keeps the
+  // request inside its existing batch/token ceilings.
+  useEffect(() => {
+    const probeAfterReconnect =
+      desktopApi?.probePullRequestPollingAfterReconnect;
+    if (!probeAfterReconnect) return;
+    const handleOnline = (): void => {
+      void probeAfterReconnect().catch(() => {
+        // Logged in main — keep the renderer silent.
+      });
+    };
+    window.addEventListener("online", handleOnline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+    };
+  }, [desktopApi]);
+
   // Selection trigger + 60s ticker: collapse into a single effect keyed on
   // the selected thread's fetchable PR request. Re-running on every
   // snapshot would burn fetches needlessly — the snapshot mutates during

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -1092,6 +1092,8 @@ export type DesktopApi = {
   setPullRequestPollingFocus?: (
     request: SetPullRequestPollingFocusRequest
   ) => Promise<void>;
+  /** Allow one token-bounded GitHub probe after Chromium reports reconnection. */
+  probePullRequestPollingAfterReconnect?: () => Promise<void>;
   detachThreadPullRequest?: (
     request: DetachThreadPullRequestRequest
   ) => Promise<DetachThreadPullRequestResponse>;

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -214,6 +214,8 @@ export const NAVIGATION_REFRESH_THREAD_GIT_WORKING_STATE_CHANNEL =
   "navigation:refresh-thread-git-working-state";
 export const NAVIGATION_SET_PR_POLLING_FOCUS_CHANNEL =
   "navigation:set-pr-polling-focus";
+export const NAVIGATION_PROBE_PR_POLLING_AFTER_RECONNECT_CHANNEL =
+  "navigation:probe-pr-polling-after-reconnect";
 export const NAVIGATION_DETACH_THREAD_PR_CHANNEL =
   "navigation:detach-thread-pr";
 export const NAVIGATION_ATTACH_DIRECTORY_TO_THREAD_CHANNEL =


### PR DESCRIPTION
## Summary

- add a shared GitHub-client slow mode after an entire retry cycle fails with a retryable transport, server, or rate-limit error
- exponentially extend the cross-poll cooldown from 1 minute up to a 15-minute cap, covering both PR status polling and branch discovery
- listen for Chromium renderer `online` transitions and arm one recovery bypass on the shared GitHub client
- preserve that bypass for the next foreground branch/status lookup when background polling is disabled or has no eligible PR target
- deduplicate reconnect signals for 30 seconds, limit optional scheduler recovery to one 40-PR batch, and spend one token from the existing global budget
- queue the scheduler probe behind an active polling batch and retain it until the token budget refills
- let exactly one request bypass slow mode; normal cadence resumes only after GitHub actually responds
- include slow-mode timing and failure-count fields in the existing terminal batch warning without adding another warning per failure

## Tests

- `pnpm test apps/desktop/src/main/__tests__/github-graphql-client.test.ts apps/desktop/src/main/__tests__/pr-polling-scheduler.test.ts apps/desktop/src/renderer/src/features/pr-status/__tests__/usePullRequestRefresh.test.tsx` (96 passed)
- `pnpm test apps/desktop/src/main/__tests__/app-server-ipc.test.ts` (134 passed)
- `pnpm --filter @pwragent/desktop typecheck`
- `pnpm lint:eslint` (0 errors; existing warnings)
- `pnpm lint:boundaries`
- `pnpm test` before the reconnect follow-up (10,067 passed, 6 skipped; 6 unrelated failures in `codex-environment-runtime.test.ts` because local npm-config deprecation warnings were captured as child-process output)