### PR TITLE
fix(desktop): prefer local harness threads over remembered federation owners

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -35108,6 +35108,10 @@ script = "printf setup"
       overlayStore: createOverlayStoreMock(),
       threadTitleGenerationService: null,
     });
+    const federatedControl = vi.fn(async () => {
+      throw new PwrAgentFederatedThreadMessageError("peer_unavailable", "Remembered peer is offline.");
+    });
+    registry.setFederatedThreadControlHandler(federatedControl);
     await discoverCodexBackendForTest(registry);
     for (const [threadId, turnId] of [
       ["target-thread", "target-turn"],
@@ -35223,6 +35227,7 @@ script = "printf setup"
     });
     expect(codexClient.interruptTurnCallCount).toBe(1);
 
+    expect(federatedControl).not.toHaveBeenCalled();
     await registry.close();
   });
 
@@ -36507,73 +36512,98 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("routes a remembered remote owner before a colliding local thread", async () => {
-    const codexClient = new MockBackendClient({
-      initializeResult: { methods: ["turn/start"] },
-      threads: [{
-        source: "codex",
-        id: "shared-thread-id",
-        title: "Local collision",
-        titleSource: "explicit",
-        linkedDirectories: [],
-      }],
-    });
-    const registry = new DesktopBackendRegistry({
-      codexClient,
-      overlayStore: createOverlayStoreMock(),
-      threadTitleGenerationService: null,
-    });
-    const federatedSend = vi.fn(async () => ({
-      backend: "codex" as const,
-      threadId: "shared-thread-id",
-      turnId: "remote-turn-1",
-      title: "Remembered remote thread",
-      instanceId: "pwr_studio",
-      instanceLabel: "Studio Mac",
-    }));
-    registry.setFederatedThreadMessageHandler(federatedSend);
-    await registry.publishLocalEvent({
-      backend: "codex",
-      notification: {
-        method: "turn/started",
-        params: {
-          threadId: "parent-thread",
-          turnId: "turn-1",
-          turn: { id: "turn-1" },
-        },
-      },
-    });
-
-    const response = await callRegistryMcpTool({
-      registry,
-      backend: "codex",
-      threadId: "parent-thread",
-      turnId: "turn-1",
-      tool: "send_message_to_thread",
-      args: {
+  it.each(["connected", "disconnected", "explicit", "writer-conflict"])(
+    "prefers the local harness over a %s remembered owner unless explicitly addressed",
+    async (owner) => {
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["turn/start"] },
+        ...(owner === "writer-conflict"
+          ? { startTurnError: new Error("thread shared-thread-id already has an active writer") }
+          : {}),
+        threads: [{
+          source: "codex",
+          id: "shared-thread-id",
+          title: "Shared Codex profile thread",
+          titleSource: "explicit",
+          linkedDirectories: [],
+        }],
+      });
+      const registry = new DesktopBackendRegistry({
+        codexClient,
+        overlayStore: createOverlayStoreMock(),
+        threadTitleGenerationService: null,
+      });
+      const federatedSend = vi.fn(async () => {
+        if (owner === "disconnected") {
+          throw new PwrAgentFederatedThreadMessageError("peer_unavailable", "Peer is offline.");
+        }
+        return {
+          backend: "codex" as const,
+          threadId: "shared-thread-id",
+          turnId: "remote-turn-1",
+          title: "Remembered remote thread",
+          instanceId: "pwr_studio",
+          instanceLabel: "Studio Mac",
+        };
+      });
+      registry.setFederatedThreadMessageHandler(federatedSend);
+      await registry.publishLocalEvent({
         backend: "codex",
-        threadId: "shared-thread-id",
-        prompt: "Continue on the remembered owner.",
-      },
-    });
+        notification: {
+          method: "turn/started",
+          params: {
+            threadId: "parent-thread",
+            turnId: "turn-1",
+            turn: { id: "turn-1" },
+          },
+        },
+      });
 
-    expect(response).toMatchObject({
-      structuredContent: {
-        instanceId: "pwr_studio",
-        threadId: "shared-thread-id",
-        turnId: "remote-turn-1",
-      },
-    });
-    expect(codexClient.startTurnCallCount).toBe(0);
-    expect(federatedSend).toHaveBeenCalledOnce();
-    expect(federatedSend).toHaveBeenCalledWith(expect.objectContaining({
-      backend: "codex",
-      threadId: "shared-thread-id",
-      resolutionMode: "remembered_only",
-    }));
+      const response = await callRegistryMcpTool({
+        registry,
+        backend: "codex",
+        threadId: "parent-thread",
+        turnId: "turn-1",
+        tool: "send_message_to_thread",
+        args: {
+          backend: "codex",
+          threadId: "shared-thread-id",
+          prompt: "Continue on the resolved thread.",
+          ...(owner === "explicit" ? { instanceId: "pwr_studio" } : {}),
+        },
+      });
 
-    await registry.close();
-  });
+      if (owner === "writer-conflict") {
+        expect(response).toMatchObject({
+          isError: true,
+          structuredContent: {
+            message: expect.stringContaining("already has an active writer"),
+          },
+        });
+        expect(codexClient.startTurnCallCount).toBe(1);
+        expect(federatedSend).not.toHaveBeenCalled();
+        await registry.close();
+        return;
+      }
+
+      expect(response).toMatchObject({
+        structuredContent: {
+          threadId: "shared-thread-id",
+          ...(owner === "explicit" ? { instanceId: "pwr_studio", turnId: "remote-turn-1" } : {}),
+        },
+      });
+      if (owner === "explicit") {
+        expect(codexClient.startTurnCallCount).toBe(0);
+        expect(federatedSend).toHaveBeenCalledOnce();
+      } else {
+        expect(response.structuredContent).not.toHaveProperty("instanceId");
+        expect(codexClient.startTurnCallCount).toBe(1);
+        expect(federatedSend).not.toHaveBeenCalled();
+      }
+
+      await registry.close();
+    },
+  );
 
   it("returns peer_unavailable for an addressed remote owner without a local turn attempt", async () => {
     const codexClient = new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -10908,6 +10908,30 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it.each([undefined, []])("preserves an active-writer conflict without attempting turn/start (tools: %s)", async (dynamicTools) => {
+    const message = "thread shared-thread already has an active writer";
+    MockTransport.threadResumeError = { code: -32600, message };
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    try {
+      await expect(client.startTurn({
+        threadId: "shared-thread",
+        input: [{ type: "text", text: "Continue through the local harness." }],
+        dynamicTools,
+      })).rejects.toThrow(message);
+      const methods = MockTransport.instances.at(-1)!.sentMessages
+        .map((message) => JSON.parse(message).method);
+      expect(methods).toContain("thread/resume");
+      expect(methods).not.toContain("turn/start");
+    } finally {
+      await client.close();
+    }
+  });
+
   it("still emits the per-turn permission overrides on turn/start when thread/resume fails", async () => {
     // The defense-in-depth behavior: thread/resume primes codex's
     // per-thread profile, but if it fails (rare race or transient

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -31784,8 +31784,19 @@ export class DesktopBackendRegistry {
         approvalPolicy: request.args.approvalPolicy,
         sandbox: request.args.sandbox,
       };
+      // The provider listing is the same local ownership evidence used by
+      // navigation. A remembered peer is only a fallback: two PwrAgent
+      // profiles can share one harness profile and see the same thread UUID.
+      // An explicitly addressed instance still selects that remote target.
+      if (!instanceId) {
+        try {
+          localThread = await this.resolveThread({ backend, threadId });
+        } catch (error) {
+          localResolutionError = error;
+        }
+      }
       const rememberedRemoteTurn =
-        includeRemote && this.federatedThreadMessageHandler
+        !localThread && includeRemote && this.federatedThreadMessageHandler
         ? await this.federatedThreadMessageHandler({
             ...remoteRequest,
             ...(instanceId
@@ -31800,11 +31811,6 @@ export class DesktopBackendRegistry {
       } else if (instanceId) {
         throw new Error(`Thread not found: ${threadId}`);
       } else {
-        try {
-          localThread = await this.resolveThread({ backend, threadId });
-        } catch (error) {
-          localResolutionError = error;
-        }
         if (localThread) {
           const submitted = await this.submitTurn({
             backend,
@@ -32122,8 +32128,13 @@ export class DesktopBackendRegistry {
             idempotentReplay?: boolean;
           }
         | undefined;
+      // Match send and inspection routing: resolve through our provider
+      // before consulting remembered federation ownership.
+      const localThread = !instanceId
+        ? await this.resolveThread({ backend, threadId }).catch(() => undefined)
+        : undefined;
       const rememberedRemote =
-        includeRemote && this.federatedThreadControlHandler
+        !localThread && includeRemote && this.federatedThreadControlHandler
           ? await this.federatedThreadControlHandler({
               ...remoteRequest,
               ...(instanceId
@@ -32145,12 +32156,6 @@ export class DesktopBackendRegistry {
           { backend, instanceId, threadId },
         );
       } else {
-        let localThread: AppServerThreadSummary | undefined;
-        try {
-          localThread = await this.resolveThread({ backend, threadId });
-        } catch {
-          localThread = undefined;
-        }
         if (localThread) {
           const backendSummary = (
             await this.listBackends({ includeUnavailable: true })

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -8669,6 +8669,13 @@ export class CodexAppServerClient {
       resumeResult = params.dynamicTools !== undefined
         ? await resume
         : await resume.catch((error: unknown) => {
+            // A shared Codex profile can be readable here while another
+            // app-server holds its writer. turn/start cannot claim that
+            // thread and would mask the conflict with "thread not found".
+            const message = error instanceof Error ? error.message : String(error);
+            if (message.toLowerCase().includes("already has an active writer")) {
+              throw error;
+            }
             codexClientLog.warn("thread/resume failed before turn/start", {
               threadId: params.threadId,
               requestedApprovalPolicy: params.approvalPolicy ?? null,


### PR DESCRIPTION
When two PwrAgent profiles share a Codex profile and participate in Federation, a thread can be listed locally and remembered on a peer. Send, steer, and stop previously consulted that remembered peer first, while navigation and inspection preferred the local provider. Resolve automatic turn routing through the existing registry provider lookup before consulting remembered or discovered peers. Explicit `instanceId` targets still select the requested peer.

The reported dev-profile failure also exposed a separate error-handling bug: local `thread/resume` failed because Codex already had an active writer in another process, but the client swallowed that error and attempted `turn/start`, replacing it with “thread not found.” Preserve the writer-conflict error and stop before `turn/start`. This does not release or take over another Codex process’s writer lock, and local admission failures do not trigger a remote send.

Regression tests were run before the fixes and reproduced four failures. Coverage includes connected/offline remembered peers, explicit remote selection, local stop/steer, writer-conflict propagation with and without dynamic tools, and no remote fallback after local admission failure.

Validation: 817 tests passed across backend-registry, codex-client, and federated-thread-message-service; `pnpm typecheck`, `pnpm lint:eslint` (zero errors), `pnpm lint:boundaries`, `pnpm lint:codex-storage`, and `git diff --check` passed. No new persistence or SQLite writes.
