### PR TITLE
fix(desktop): retain live review cards across lagging refreshes

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -12453,7 +12453,7 @@ describe("useThreadSessionState", () => {
             params: {
               threadId: "thread-1",
               turnId: "review-turn",
-              turn: { id: "review-turn", status: "completed" },
+              turn: { id: "review-turn", status: "completed", output: [] },
             },
           },
         });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -12373,6 +12373,114 @@ describe("useThreadSessionState", () => {
     ]);
   });
 
+  it.each([false, true])(
+    "retains live review cards through lagging refreshes (pagination: %s)",
+    async (supportsPagination) => {
+      let agentEventHandler:
+        | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]
+        | undefined;
+      let hydratedEntries: AppServerThreadEntry[] = [];
+      const desktopApi: DesktopApi = {
+        onAgentEvent: (listener) => {
+          agentEventHandler = listener;
+          return () => undefined;
+        },
+        readThread: async ({ backend, threadId }) => ({
+          backend: backend ?? "codex",
+          fetchedAt: Date.now(),
+          threadId,
+          replay: {
+            entries: hydratedEntries,
+            messages: [],
+            pagination: { supportsPagination, hasPreviousPage: false },
+          },
+        }),
+      };
+      const { result } = renderHook(() => useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt: 1_000 }),
+      }));
+      await waitForThreadHydration(result);
+
+      act(() => {
+        result.current.addOptimisticReviewEntry("Review changes against main");
+      });
+      expect(result.current.entries).toHaveLength(1);
+      const emitReview = (type: "enteredReviewMode" | "exitedReviewMode") => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "item/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "review-turn",
+              item: {
+                id: type,
+                type,
+                createdAt: type === "enteredReviewMode" ? 2_000 : 3_000,
+                review: type === "enteredReviewMode"
+                  ? "Review changes against main"
+                  : "No findings.",
+              },
+            },
+          },
+        });
+      };
+      act(() => emitReview("enteredReviewMode"));
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "enteredReviewMode",
+      ]);
+
+      // The live notification has replaced the optimistic placeholder, but
+      // thread/read has not caught up. Repeated reads must not erase the card.
+      for (let refresh = 0; refresh < 2; refresh += 1) {
+        await act(async () => { await result.current.reload(); });
+        expect(result.current.entries.map((entry) => entry.id)).toEqual([
+          "enteredReviewMode",
+        ]);
+      }
+
+      act(() => emitReview("exitedReviewMode"));
+      const liveEntries = result.current.entries;
+      expect(liveEntries.map((entry) => entry.id)).toEqual([
+        "enteredReviewMode", "exitedReviewMode",
+      ]);
+      act(() => {
+        agentEventHandler?.({
+          backend: "codex",
+          notification: {
+            method: "turn/completed",
+            params: {
+              threadId: "thread-1",
+              turnId: "review-turn",
+              turn: { id: "review-turn", status: "completed" },
+            },
+          },
+        });
+      });
+      await act(async () => { await result.current.reload(); });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "enteredReviewMode", "exitedReviewMode",
+      ]);
+      expect(result.current.threadBusy).toBe(false);
+
+      // Authoritative replay can use different IDs. It must supersede the
+      // retained live entries without leaving duplicate or stale cards.
+      hydratedEntries = liveEntries.map((entry) => ({
+        ...entry,
+        id: `hydrated-${entry.id}`,
+        turn: { id: "review-turn", status: "completed" },
+      }));
+      await act(async () => { await result.current.reload(); });
+      expect(result.current.entries.map((entry) => entry.id)).toEqual([
+        "hydrated-enteredReviewMode", "hydrated-exitedReviewMode",
+      ]);
+      expect(result.current.entries.every((entry) =>
+        entry.turn?.status === "completed"
+      )).toBe(true);
+    },
+  );
+
   it("keeps the review start marker when only the final review item arrives live", async () => {
     let agentEventHandler:
       | Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -6168,10 +6168,13 @@ export function useThreadSessionState(params: {
               expectOwnUpdate: true,
               interacted: true,
               lastTouchedAt: nextLastTouchedAt,
-              optimisticEntries: current.optimisticEntries.filter(
-                (entry) =>
-                  entry.type !== "review" ||
-                  !reviewEntriesMatch(reviewEntry, entry)
+              // The live item replaces the placeholder, but a thread/read
+              // snapshot can still omit it. Retain it until hydration returns
+              // a matching review; pruneOptimisticEntries then retires it.
+              // Merge only the pending entries here, never the full transcript.
+              optimisticEntries: mergeTranscriptEntries(
+                current.optimisticEntries,
+                [reviewEntry],
               ),
               response: nextResponse,
             };


### PR DESCRIPTION
A live review start card could appear, disappear during the review, and return with the result after completion. The `item/completed` review handler moved the start into the current replay and removed its optimistic placeholder. A later `thread/read` response that omitted the live item replaced that replay, leaving no retained card. Tail retention only covered sessions with loaded history.

Keep live review start and result entries in the pending collection until hydration returns a matching review. Existing reconciliation replaces the placeholder, accepts authoritative replay IDs, and updates retained entries when the turn completes.

The additional merge runs only for review notifications and only over pending entries. Transcript message insertion is unchanged; there is no new per-message scan of the transcript.

Validation:
- Added a regression for paginated and non-paginated reads. Both failed before the fix with an empty transcript after the first lagging refresh.
- Covers repeated lagging reads, completion, and authoritative replacement under different item IDs without duplicate cards.
- All 151 thread-session tests passed, including existing linear-work assertions for paging, refreshes, and batched live appends. The extended completion regression also passed separately.
- `pnpm typecheck`, `pnpm lint:eslint` (no errors), `pnpm lint:boundaries`, and `pnpm lint:codex-storage` passed.
