### PR TITLE
fix(desktop): surface Codex retry and connection warnings

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -7147,6 +7147,40 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("forwards structured reconnect details and fallback warnings to UI subscribers", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    await client.getInitializeResult();
+    const notifications: unknown[] = [];
+    client.onNotification((notification) => { notifications.push(notification); });
+    const expected = [
+      {
+        method: "error",
+        params: {
+          threadId: "thread-2", turnId: "turn-1", willRetry: true,
+          error: {
+            message: "Reconnecting... 2/5",
+            codexErrorInfo: { httpConnectionFailed: { httpStatusCode: null } },
+            additionalDetails: "websocket connection closed",
+          },
+        },
+      },
+      {
+        method: "warning",
+        params: { threadId: "thread-2", message: "Falling back from WebSockets to HTTPS transport." },
+      },
+    ];
+    for (const notification of expected) {
+      MockTransport.instances.at(-1)!.emitInbound({ jsonrpc: "2.0", ...notification });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(notifications).toEqual(expected);
+    await client.close();
+  });
+
   it("does not log a Codex error notification as an unknown notification", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
 

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -117,6 +117,7 @@ import {
   NO_STARTUP_BACKEND_NOTICE_ID,
 } from "./features/notifications/provider-startup-notice";
 import { QuitBlockerQueueToast } from "./features/notifications/QuitBlockerQueueToast";
+import { isCodexStreamNoticeMethod } from "./features/notifications/codex-stream-notice";
 import {
   appNoticeReducer,
   INITIAL_APP_NOTICE_STATE,
@@ -851,6 +852,21 @@ function DesktopAppShell(props: {
       const instanceId = event.federationTarget?.scope === "remote"
         ? event.federationTarget.instanceId
         : undefined;
+      if (
+        event.backend === "codex"
+        && isCodexStreamNoticeMethod(event.notification.method)
+      ) {
+        const params = event.notification.params as Record<string, unknown>;
+        dispatchAppNotice({
+          type: "codex-stream-event",
+          notification: { method: event.notification.method, params },
+          ...(instanceId ? { instanceId } : {}),
+          threadLabel: labelForThread(
+            "codex",
+            typeof params.threadId === "string" ? params.threadId : undefined,
+          ),
+        });
+      }
       if (event.notification.method === "thread/pricing/updated") {
         const params = event.notification.params;
         const spendAlerts = params.triggeredSpendAlerts as

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -1009,6 +1009,46 @@ describe("App", () => {
     expect(screen.getByText("3 of 3")).toBeInTheDocument();
   });
 
+  it("shows Codex retries for background threads and reports recovery", async () => {
+    const listeners = new Set<(event: AgentEvent) => void>();
+    Object.defineProperty(window, "pwragent", {
+      configurable: true,
+      value: {
+        getNavigationSnapshot: async () => ({
+          backend: "all", fetchedAt: Date.now(), unchanged: false,
+          inboxThreadKeys: [], threads: [], directories: [],
+          launchpadDefaults: { backend: "codex", executionMode: "default" },
+        }),
+        listBackends: async () => ({ fetchedAt: Date.now(), backends: [] }),
+        onAgentEvent: (listener: (event: AgentEvent) => void) => {
+          listeners.add(listener);
+          return () => { listeners.delete(listener); };
+        },
+        readSettings: async () => await new Promise<never>(() => {}),
+      },
+    });
+    render(<App />);
+    await waitFor(() => expect(listeners.size).toBeGreaterThan(0));
+    const emit = (notification: AgentEvent["notification"]) => act(() => {
+      for (const listener of listeners) listener({ backend: "codex", notification });
+    });
+    for (const threadId of ["thread-a", "thread-b", "thread-c"]) {
+      emit({ method: "error", params: {
+        threadId, turnId: "turn-1", willRetry: true,
+        error: { message: "Reconnecting... waiting for network" },
+      } });
+    }
+    expect(screen.getByText("Codex is retrying")).toBeInTheDocument();
+    expect(screen.getByText("1 of 3")).toBeInTheDocument();
+    expect(screen.getByText("Reconnecting... waiting for network")).toBeInTheDocument();
+    emit({ method: "item/agentMessage/delta", params: {
+      threadId: "thread-a", turnId: "turn-1", itemId: "message-1", delta: "Resumed output",
+    } });
+    expect(screen.getByText("Codex resumed")).toBeInTheDocument();
+    expect(screen.getByText("Codex is retrying")).toBeInTheDocument();
+    expect(screen.getByText("1 of 2")).toBeInTheDocument();
+  });
+
   it("opens the incident explorer from a replay-risk notice", async () => {
     const agentEventListeners = new Set<(event: AgentEvent) => void>();
     const openToolOutputIncidentExplorerWindow = vi.fn(async () => ({

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -455,7 +455,10 @@ describe("Codex stream notices", () => {
     "reports recovery on %s for the affected turn only", (method) => {
       let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
       state = appNoticeReducer(state, retry({ threadId: "thread-b" }));
-      state = appNoticeReducer(state, event(method, { delta: "back online" }));
+      state = appNoticeReducer(state, event(method, {
+        delta: "back online",
+        ...(method === "turn/completed" ? { turn: { status: "completed" } } : {}),
+      }));
       expect(state.durable).toHaveLength(1);
       expect(state.durable[0]?.threadLink?.threadId).toBe("thread-b");
       expect(state.transient[0]).toMatchObject({
@@ -463,6 +466,28 @@ describe("Codex stream notices", () => {
         autoDismiss: true,
         tone: "success",
       });
+    },
+  );
+
+  it.each(["interrupted", "cancelled", "failed"])(
+    "dismisses a retry on %s completion without reporting recovery", (status) => {
+      let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
+      state = appNoticeReducer(state, retry({ threadId: "thread-b" }));
+      state = appNoticeReducer(state, event("turn/completed", {
+        turn: { id: "turn-1", status },
+      }));
+      expect(state.durable).toHaveLength(1);
+      expect(state.durable[0]?.threadLink?.threadId).toBe("thread-b");
+      expect(state.transient).toEqual([]);
+    },
+  );
+
+  it.each([undefined, "inProgress", "unknown"])(
+    "does not infer recovery from completion status %s", (status) => {
+      const state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
+      expect(appNoticeReducer(state, event("turn/completed", {
+        turn: { status },
+      }))).toBe(state);
     },
   );
 
@@ -491,7 +516,7 @@ describe("Codex stream notices", () => {
   it("isolates peers with identical thread and turn IDs", () => {
     let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
     state = appNoticeReducer(state, { ...retry(), instanceId: "peer-a" });
-    state = appNoticeReducer(state, event("turn/completed"));
+    state = appNoticeReducer(state, event("turn/completed", { turn: { status: "completed" } }));
     expect(state.durable).toHaveLength(1);
     expect(state.durable[0]?.threadLink?.instanceId).toBe("peer-a");
   });

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/app-notice-state.test.ts
@@ -405,3 +405,100 @@ function costNotice(params: {
     title: params.title,
   } as AppNoticeToastNotice;
 }
+
+
+describe("Codex stream notices", () => {
+  const event = (method: string, params: Record<string, unknown> = {}) => ({
+    type: "codex-stream-event" as const,
+    notification: {
+      method,
+      params: { threadId: "thread-a", turnId: "turn-1", ...params },
+    },
+    threadLabel: "Fix connectivity",
+  });
+  const retry = (params: Record<string, unknown> = {}) => event("error", {
+    willRetry: true,
+    error: { message: "Reconnecting... 2/5", additionalDetails: "stream disconnected" },
+    ...params,
+  });
+
+  it("keeps three affected threads visible and updates retry attempts in place", () => {
+    let state = INITIAL_APP_NOTICE_STATE;
+    for (const threadId of ["thread-a", "thread-b", "thread-c"]) {
+      state = appNoticeReducer(state, retry({ threadId }));
+    }
+    state = appNoticeReducer(state, retry({ error: { message: "Reconnecting... 3/5" } }));
+    expect(state.durable).toHaveLength(3);
+    expect(state.durable[0]).toMatchObject({
+      title: "Codex is retrying",
+      message: "Reconnecting... 3/5",
+      autoDismiss: false,
+      tone: "warning",
+      threadLink: { threadId: "thread-a" },
+    });
+  });
+
+  it("shows details and keeps retrying through local tool output and unrelated turns", () => {
+    const state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
+    expect(state.durable[0]?.message).toContain("stream disconnected");
+    for (const notification of [
+      event("item/commandExecution/outputDelta"),
+      event("item/completed"),
+      event("thread/status/changed", { status: { type: "active" } }),
+      event("item/agentMessage/delta", { turnId: "old-turn", delta: "text" }),
+    ]) {
+      expect(appNoticeReducer(state, notification)).toBe(state);
+    }
+  });
+
+  it.each(["item/agentMessage/delta", "item/reasoning/textDelta", "turn/completed"])(
+    "reports recovery on %s for the affected turn only", (method) => {
+      let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
+      state = appNoticeReducer(state, retry({ threadId: "thread-b" }));
+      state = appNoticeReducer(state, event(method, { delta: "back online" }));
+      expect(state.durable).toHaveLength(1);
+      expect(state.durable[0]?.threadLink?.threadId).toBe("thread-b");
+      expect(state.transient[0]).toMatchObject({
+        title: method === "turn/completed" ? "Codex turn completed" : "Codex resumed",
+        autoDismiss: true,
+        tone: "success",
+      });
+    },
+  );
+
+  it("replaces retrying with an error when retries stop, then retires it for the durable failure", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
+    state = appNoticeReducer(state, event("error", {
+      willRetry: false, error: { message: "retry limit exceeded" },
+    }));
+    expect(state.durable).toHaveLength(1);
+    expect(state.durable[0]).toMatchObject({ title: "Codex error", tone: "error" });
+    state = appNoticeReducer(state, event("turn/failed"));
+    expect(state.durable).toEqual([]);
+    expect(state.transient).toEqual([]);
+  });
+
+  it("surfaces transport fallback warnings without claiming the turn failed", () => {
+    const state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, event("warning", {
+      turnId: undefined, message: "Falling back from WebSockets to HTTPS transport.",
+    }));
+    expect(state.durable).toEqual([]);
+    expect(state.transient[0]).toMatchObject({
+      title: "Codex warning", tone: "warning", autoDismiss: true,
+    });
+  });
+
+  it("isolates peers with identical thread and turn IDs", () => {
+    let state = appNoticeReducer(INITIAL_APP_NOTICE_STATE, retry());
+    state = appNoticeReducer(state, { ...retry(), instanceId: "peer-a" });
+    state = appNoticeReducer(state, event("turn/completed"));
+    expect(state.durable).toHaveLength(1);
+    expect(state.durable[0]?.threadLink?.instanceId).toBe("peer-a");
+  });
+
+  it("ignores malformed error payloads and does not invent recovery without an incident", () => {
+    for (const notification of [event("error"), event("warning"), event("turn/completed")]) {
+      expect(appNoticeReducer(INITIAL_APP_NOTICE_STATE, notification)).toBe(INITIAL_APP_NOTICE_STATE);
+    }
+  });
+});

--- a/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/app-notice-state.ts
@@ -1,3 +1,7 @@
+import {
+  resolveCodexStreamNotice,
+  type CodexStreamSignal,
+} from "./codex-stream-notice";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 import {
   resolveBackendErrorNotice,
@@ -10,6 +14,7 @@ export type AppNoticeState = {
 };
 
 export type AppNoticeAction =
+  | ({ type: "codex-stream-event" } & CodexStreamSignal)
   | { type: "show"; notice: AppNoticeToastNotice }
   | { type: "backend-error"; signal: BackendErrorSignal }
   | { type: "dismiss"; id: string }
@@ -24,6 +29,17 @@ export function appNoticeReducer(
   state: AppNoticeState,
   action: AppNoticeAction,
 ): AppNoticeState {
+  if (action.type === "codex-stream-event") {
+    const result = resolveCodexStreamNotice(action, [
+      ...state.durable,
+      ...state.transient,
+    ]);
+    if (!result) return state;
+    return appNoticeReducer(state, "notice" in result
+      ? { type: "show", notice: result.notice }
+      : { type: "dismiss", id: result.dismissId });
+  }
+
   if (action.type === "show") {
     return showNotice(state, action.notice);
   }

--- a/apps/desktop/src/renderer/src/features/notifications/codex-stream-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/codex-stream-notice.ts
@@ -1,0 +1,102 @@
+import type { FederationInstanceId } from "@pwragent/shared";
+import type { AppNoticeToastNotice } from "./AppNoticeToast";
+
+export type CodexStreamSignal = {
+  notification: { method: string; params: Record<string, unknown> };
+  instanceId?: FederationInstanceId;
+  threadLabel: string;
+};
+
+const MODEL_PROGRESS_METHODS = new Set([
+  "item/agentMessage/delta",
+  "item/reasoning/textDelta",
+  "item/reasoning/summaryTextDelta",
+  "item/plan/delta",
+]);
+
+export function isCodexStreamNoticeMethod(method: string): boolean {
+  return method === "error"
+    || method === "warning"
+    || method === "turn/completed"
+    || method === "turn/failed"
+    || method === "turn/cancelled"
+    || MODEL_PROGRESS_METHODS.has(method);
+}
+
+/** Structured App Server errors describe upstream retries; stdio can remain healthy. */
+export function resolveCodexStreamNotice(
+  signal: CodexStreamSignal,
+  notices: readonly AppNoticeToastNotice[],
+): { notice: AppNoticeToastNotice } | { dismissId: string } | undefined {
+  const { method, params } = signal.notification;
+  if (!isCodexStreamNoticeMethod(method)) return undefined;
+  const threadId = readText(params.threadId);
+  if (!threadId) return undefined;
+  const turnId = readText(params.turnId);
+  const id = `codex-stream:${JSON.stringify([
+    signal.instanceId ?? "local",
+    threadId,
+    turnId ?? null,
+  ])}`;
+  const current = notices.find((notice) => notice.id === id);
+
+  if (method === "error" || method === "warning") {
+    const error = params.error && typeof params.error === "object"
+      ? params.error as Record<string, unknown>
+      : undefined;
+    const message = readText(method === "warning" ? params.message : error?.message);
+    if (!message) return undefined;
+    const details = readText(error?.additionalDetails);
+    const retrying = method === "error" && params.willRetry === true;
+    return {
+      notice: {
+        id,
+        // Warnings have no turn ID or matching completion signal. Show the
+        // fallback information without leaving a stale retry incident behind.
+        autoDismiss: method === "warning",
+        title: method === "warning"
+          ? "Codex warning"
+          : retrying ? "Codex is retrying" : "Codex error",
+        message: details ? `${message}\n${details}` : message,
+        tone: method === "warning" || retrying ? "warning" : "error",
+        detail: signal.threadLabel,
+        threadLink: {
+          backend: "codex",
+          threadId,
+          title: signal.threadLabel,
+          ...(signal.instanceId ? { instanceId: signal.instanceId } : {}),
+        },
+        ...(retrying ? {
+          status: {
+            label: "The turn is still active. Codex will retry automatically.",
+            state: "progress" as const,
+          },
+        } : {}),
+      },
+    };
+  }
+
+  if (!current || current.autoDismiss !== false) return undefined;
+  if (method === "turn/failed" || method === "turn/cancelled") {
+    return { dismissId: id };
+  }
+  // A running local command can emit output while the model is unreachable.
+  // Only new model text or successful completion establishes recovery.
+  if (MODEL_PROGRESS_METHODS.has(method) && !readText(params.delta)) return undefined;
+  return {
+    notice: {
+      ...current,
+      autoDismiss: true,
+      title: method === "turn/completed" ? "Codex turn completed" : "Codex resumed",
+      message: method === "turn/completed"
+        ? "The turn completed after the reported problem."
+        : "Codex is producing output again.",
+      tone: "success",
+      status: { label: "Reported problem cleared.", state: "success" },
+    },
+  };
+}
+
+function readText(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}

--- a/apps/desktop/src/renderer/src/features/notifications/codex-stream-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/codex-stream-notice.ts
@@ -80,6 +80,18 @@ export function resolveCodexStreamNotice(
   if (method === "turn/failed" || method === "turn/cancelled") {
     return { dismissId: id };
   }
+  if (method === "turn/completed") {
+    const turn = params.turn && typeof params.turn === "object"
+      ? params.turn as Record<string, unknown>
+      : undefined;
+    const status = readText(turn?.status);
+    // Codex also uses turn/completed for interrupted turns. Only an
+    // explicitly successful terminal status establishes recovery.
+    if (status === "interrupted" || status === "cancelled" || status === "failed") {
+      return { dismissId: id };
+    }
+    if (status !== "completed") return undefined;
+  }
   // A running local command can emit output while the model is unreachable.
   // Only new model text or successful completion establishes recovery.
   if (MODEL_PROGRESS_METHODS.has(method) && !readText(params.delta)) return undefined;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1480,6 +1480,23 @@ export type AppServerMcpElicitationRequestNotification = {
 
 export type AppServerNotification =
   | {
+      method: "error";
+      params: {
+        threadId: string;
+        turnId: string;
+        willRetry: boolean;
+        error: {
+          message: string;
+          codexErrorInfo?: unknown;
+          additionalDetails?: string | null;
+        };
+      };
+    }
+  | {
+      method: "warning";
+      params: { threadId?: string | null; message: string };
+    }
+  | {
       method: "turn/started";
       params: {
         threadId: string;


### PR DESCRIPTION
Codex turns could remain busy during an upstream connection outage without any UI explanation. The App Server client already forwarded `error` and `warning` notifications, but the desktop notice handler ignored them.

This displays a persistent, thread-linked notice for each retrying turn, including Codex's retry message and additional details. Repeated attempts update the same notice. New model text or successful completion replaces it with a brief recovery notice; cancellation and failed-turn completion remove the retry notice, preserving existing terminal failure handling. Local tool output and another turn's events cannot clear it. Notice identity includes the federation instance, thread, and turn.

Non-retry errors are also visible, and warnings such as WebSocket-to-HTTPS fallback appear briefly. Warnings have no turn ID, so they do not become persistent retry incidents. This changes no turn lifecycle and adds no SQLite writes.

Verified the protocol against the local Codex checkout at `7d5f6bdfa9aef727069ea30edd3a56246b062762`, particularly `codex-rs/app-server/src/bespoke_event_handling.rs` and `codex-rs/core/src/responses_retry.rs`. This surfaces structured notifications, not stderr guesses or an independent internet-connectivity probe. Codex release builds intentionally suppress the first brief WebSocket retry notification.

### Validation

- Added regression tests first: eight new notice tests failed before implementation; the warning-lifetime test also failed before its fix.
- 244 focused tests pass across the notice reducer, app shell, and Codex client. Coverage includes three background threads, changing retry attempts, recovery, exhausted retries, malformed payloads, unrelated local activity, and peer isolation.
- `pnpm typecheck`, `pnpm lint:eslint`, and `pnpm lint:boundaries` pass. ESLint reports existing warnings and zero errors.
- Visually checked the actual notice components in headless Chromium using only contrived fixture data. No live user transcript or account data appears below.

### Retrying

![Retry notice with three affected threads](https://github.com/user-attachments/assets/132cd83f-bc6c-45e9-a4d8-a6b3e4d80c9d)

### Recovered

![Recovery notice after model output resumes](https://github.com/user-attachments/assets/419b40a0-36ff-4545-a86e-93b6bdd7d686)
