### PR TITLE
feat(desktop): add Federation network activity monitor

### DIFF
--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -86,12 +86,18 @@ for (const theme of ["dark", "light"] as const) {
         .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"]).analyze();
       expect(audit.violations).toEqual([]);
       await activity.screenshot({ path: testInfo.outputPath(`federation-activity-${theme}.png`) });
+      const titlebar = activity.locator(".activity-titlebar");
+      const titlebarBeforeScroll = await titlebar.boundingBox();
       const totals = activity.locator(".federation-activity__tables").first();
       await expect(totals.getByRole("columnheader", { name: "Last 10m", exact: true })).toHaveCount(2);
       await totals.scrollIntoViewIfNeeded();
       await activity.screenshot({ path: testInfo.outputPath(`federation-totals-${theme}.png`) });
       const sizes = activity.getByRole("table", { name: "Lifetime request/response sizes · uncompressed", exact: true });
       await sizes.scrollIntoViewIfNeeded();
+      await expect(titlebar).toBeVisible();
+      expect(await titlebar.boundingBox()).toEqual(titlebarBeforeScroll);
+      expect(await activity.locator(".activity-content").evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+      expect(await activity.evaluate(() => document.scrollingElement?.scrollTop)).toBe(0);
       await expect(sizes.getByRole("columnheader", { name: "p50 ≈", exact: true })).toBeVisible();
       await activity.screenshot({ path: testInfo.outputPath(`federation-sizes-${theme}.png`) });
       await activity.close();

--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -69,6 +69,7 @@ for (const theme of ["dark", "light"] as const) {
       const activity = await opened;
       await activity.emulateMedia({ reducedMotion: "reduce" });
       await expect(activity.getByText("Running · connected")).toBeVisible();
+      await expect(activity.getByRole("switch", { name: "Federation enabled" })).toHaveClass(/settings-switch/);
       await expect(activity.getByRole("img", { name: /Data and wire rates/ })).toBeVisible();
       const topmost = activity.getByRole("checkbox", { name: "Always on top", exact: true });
       await topmost.click();
@@ -100,6 +101,27 @@ for (const theme of ["dark", "light"] as const) {
       expect(await activity.evaluate(() => document.scrollingElement?.scrollTop)).toBe(0);
       await expect(sizes.getByRole("columnheader", { name: "p50 ≈", exact: true })).toBeVisible();
       await activity.screenshot({ path: testInfo.outputPath(`federation-sizes-${theme}.png`) });
+      await activity.getByRole("button", { name: "Copy Federation activity" }).click();
+      await expect(activity.getByRole("status")).toHaveText("Federation activity copied");
+      const copied = await app.electronApp.evaluate(({ clipboard }) => clipboard.readText());
+      expect(copied).toContain("Last 1m\tLast 10m\tLast 1h\tTotal");
+      expect(copied).toContain("Samples\tAvg\tp50 (approx.)\tMin\tMax");
+      // Reset still crosses the real preload/IPC bridge, with contrived returned totals.
+      await app.electronApp.evaluate(({ ipcMain }, activity) => {
+        ipcMain.removeHandler("federation:reset-activity");
+        const cleared = {
+          activity, configuredMode: "dual", running: true,
+          health: { enabled: true, role: "dual", status: "connected", peers: [] },
+        };
+        ipcMain.handle("federation:reset-activity", () => {
+          ipcMain.removeHandler("federation:read-activity");
+          ipcMain.handle("federation:read-activity", () => cleared);
+          return cleared;
+        });
+      }, new FederationActivityLedger().snapshot());
+      await activity.getByRole("button", { name: "Reset", exact: true }).click();
+      await sizes.scrollIntoViewIfNeeded();
+      await expect(sizes.getByRole("row", { name: "Sent requests 0 — — — —", exact: true })).toBeVisible();
       await activity.close();
       await expect(trigger).toBeVisible();
     } finally { await app.close(); }

--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -86,10 +86,14 @@ for (const theme of ["dark", "light"] as const) {
         .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"]).analyze();
       expect(audit.violations).toEqual([]);
       await activity.screenshot({ path: testInfo.outputPath(`federation-activity-${theme}.png`) });
-      const totals = activity.locator(".federation-activity__tables");
+      const totals = activity.locator(".federation-activity__tables").first();
       await expect(totals.getByRole("columnheader", { name: "Last 10m", exact: true })).toHaveCount(2);
       await totals.scrollIntoViewIfNeeded();
       await activity.screenshot({ path: testInfo.outputPath(`federation-totals-${theme}.png`) });
+      const sizes = activity.getByRole("table", { name: "Lifetime request/response sizes · uncompressed", exact: true });
+      await sizes.scrollIntoViewIfNeeded();
+      await expect(sizes.getByRole("columnheader", { name: "p50 ≈", exact: true })).toBeVisible();
+      await activity.screenshot({ path: testInfo.outputPath(`federation-sizes-${theme}.png`) });
       await activity.close();
       await expect(trigger).toBeVisible();
     } finally { await app.close(); }

--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import AxeBuilder from "@axe-core/playwright";
+import { expect, test } from "@playwright/test";
+import type { ReadFederationActivityResponse } from "@pwragent/shared";
+import { FederationActivityLedger } from "../src/main/federation/federation-activity-ledger";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+const specDir = path.dirname(fileURLToPath(import.meta.url));
+function activityFixture(): ReadFederationActivityResponse {
+  const now = Date.UTC(2026, 8, 5, 12);
+  const ledger = new FederationActivityLedger(now - 3_600_000);
+  for (let index = 0; index < 360; index += 1) {
+    for (const direction of ["sent", "received"] as const) {
+      ledger.record({
+        at: now - 3_590_000 + index * 10_000,
+        peerId: "pwr_fixture_gateway", localInstanceId: "pwr_fixture_local", direction,
+        dataByteCount: (direction === "sent" ? 8_000 : 4_000) + Math.round(Math.abs(Math.sin(index / 3)) * 12_000),
+        byteCount: (direction === "sent" ? 3_000 : 1_000) + Math.round(Math.abs(Math.sin(index / 3)) * 6_000),
+        envelope: { kind: direction === "sent" ? "request" : "response",
+          sourceInstanceId: direction === "sent" ? "pwr_fixture_local" : "pwr_fixture_remote",
+          targetInstanceId: direction === "sent" ? "pwr_fixture_remote" : "pwr_fixture_local" },
+      });
+    }
+  }
+  return {
+    activity: ledger.snapshot(now), configuredMode: "dual", running: true,
+    health: { enabled: true, role: "dual", status: "connected", peers: [] },
+  };
+}
+
+for (const theme of ["dark", "light"] as const) {
+  test(`Federation hover activity and detachable window (${theme})`, async ({}, testInfo) => {
+    const app = await launchElectronApp({
+      fixturePath: path.join(specDir, "fixtures/smoke/replay.fixture.json"),
+      appearance: { theme },
+    });
+    try {
+      // Contrived numeric fixture only; the real native window, preload and UI are exercised.
+      await app.electronApp.evaluate(({ ipcMain }, snapshot) => {
+        ipcMain.removeHandler("federation:read-activity");
+        ipcMain.handle("federation:read-activity", () => snapshot);
+      }, activityFixture());
+      await app.window.emulateMedia({ reducedMotion: "reduce" });
+      const trigger = app.window.getByRole("button", { name: "Open Star Map", exact: true });
+      await trigger.hover();
+      const panel = app.window.getByRole("dialog", { name: "Federation activity", exact: true });
+      await expect(panel.getByText("Running · connected")).toBeVisible();
+      const popoverAudit = await new AxeBuilder({ page: app.window })
+        .setLegacyMode(true)
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"]).analyze();
+      expect(popoverAudit.violations).toEqual([]);
+      await panel.screenshot({ path: testInfo.outputPath(`federation-popover-${theme}.png`) });
+      const opened = app.electronApp.waitForEvent("window", {
+        predicate: (page) => page !== app.window,
+      });
+      await panel.getByRole("button", { name: "Open Federation Activity", exact: true }).click();
+      const activity = await opened;
+      await activity.emulateMedia({ reducedMotion: "reduce" });
+      await expect(activity.getByText("Running · connected")).toBeVisible();
+      await expect(activity.getByRole("img", { name: /Data and wire rates/ })).toBeVisible();
+      const topmost = activity.getByRole("checkbox", { name: "Always on top", exact: true });
+      await topmost.click();
+      await expect(topmost).toBeChecked();
+      await expect.poll(() => app.electronApp.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().find((window) => window.getTitle() === "Federation Activity")?.isAlwaysOnTop(),
+      )).toBe(true);
+      await topmost.click();
+      await expect(topmost).not.toBeChecked();
+      await expect.poll(() => app.electronApp.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows().find((window) => window.getTitle() === "Federation Activity")?.isAlwaysOnTop(),
+      )).toBe(false);
+      const audit = await new AxeBuilder({ page: activity })
+        .setLegacyMode(true)
+        .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"]).analyze();
+      expect(audit.violations).toEqual([]);
+      await activity.screenshot({ path: testInfo.outputPath(`federation-activity-${theme}.png`) });
+      await activity.close();
+      await expect(trigger).toBeVisible();
+    } finally { await app.close(); }
+  });
+}

--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -86,6 +86,10 @@ for (const theme of ["dark", "light"] as const) {
         .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"]).analyze();
       expect(audit.violations).toEqual([]);
       await activity.screenshot({ path: testInfo.outputPath(`federation-activity-${theme}.png`) });
+      const totals = activity.locator(".federation-activity__tables");
+      await expect(totals.getByRole("columnheader", { name: "Last 10m", exact: true })).toHaveCount(2);
+      await totals.scrollIntoViewIfNeeded();
+      await activity.screenshot({ path: testInfo.outputPath(`federation-totals-${theme}.png`) });
       await activity.close();
       await expect(trigger).toBeVisible();
     } finally { await app.close(); }

--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -43,6 +43,17 @@ for (const theme of ["dark", "light"] as const) {
       }, activityFixture());
       await app.window.emulateMedia({ reducedMotion: "reduce" });
       const trigger = app.window.getByRole("button", { name: "Open Star Map", exact: true });
+      await expect(trigger).toBeVisible();
+      expect(await trigger.evaluate((button) => {
+        const control = button.getBoundingClientRect();
+        const wrapper = button.parentElement!.getBoundingClientRect();
+        return {
+          width: wrapper.width - control.width,
+          height: wrapper.height - control.height,
+          left: wrapper.left - control.left,
+          top: wrapper.top - control.top,
+        };
+      })).toEqual({ width: 0, height: 0, left: 0, top: 0 });
       await trigger.hover();
       const panel = app.window.getByRole("dialog", { name: "Federation activity", exact: true });
       await expect(panel.getByText("Running · connected")).toBeVisible();

--- a/apps/desktop/src/main/__tests__/federation-activity-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ipc.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FEDERATION_ACTIVITY_TOPMOST_CHANNEL, FEDERATION_OPEN_ACTIVITY_CHANNEL,
+  FEDERATION_READ_ACTIVITY_CHANNEL, FEDERATION_SET_ENABLED_CHANNEL,
+} from "../../shared/ipc";
+
+const mocks = vi.hoisted(() => ({
+  handlers: new Map<string, (...args: unknown[]) => unknown>(),
+  runtime: { activity: vi.fn(), restart: vi.fn() },
+  service: { readFederationConfig: vi.fn(), writeConfigPatchTargeted: vi.fn() },
+  show: vi.fn(), topmost: vi.fn(), fromWebContents: vi.fn(),
+}));
+vi.mock("electron", () => ({
+  BrowserWindow: { fromWebContents: mocks.fromWebContents },
+  ipcMain: {
+    handle: (name: string, handler: (...args: unknown[]) => unknown) => mocks.handlers.set(name, handler),
+    removeHandler: (name: string) => mocks.handlers.delete(name),
+  },
+}));
+vi.mock("../federation/federation-runtime", () => ({ getDesktopFederationRuntime: () => mocks.runtime }));
+vi.mock("../settings/desktop-settings-singleton", () => ({ getDesktopSettingsService: () => mocks.service }));
+vi.mock("../federation/federation-window", () => ({ createFederationWindow: vi.fn() }));
+vi.mock("../federation/federation-tailscale", () => ({ getFederationTailscaleService: () => ({}) }));
+vi.mock("../federation-activity-window", () => ({ showFederationActivityWindow: mocks.show, setFederationActivityTopmost: mocks.topmost }));
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  mocks.handlers.clear();
+  mocks.runtime.activity.mockResolvedValue({ configuredMode: "dual", running: false,
+    health: { leaseHolder: { instanceId: "holder", processId: 55 }, unavailableReason: "Profile already served" } });
+  mocks.runtime.restart.mockResolvedValue(undefined);
+  mocks.service.readFederationConfig.mockReturnValue({ mode: "dual" });
+  mocks.service.writeConfigPatchTargeted.mockResolvedValue({});
+  const { registerFederationIpcHandlers } = await import("../ipc/federation");
+  registerFederationIpcHandlers();
+});
+const invoke = (channel: string, request?: unknown) => mocks.handlers.get(channel)!({ sender: { id: 42 } }, request);
+
+describe("Federation Activity IPC", () => {
+  it("reads only local aggregates and forwards the selected history view", async () => {
+    await invoke(FEDERATION_READ_ACTIVITY_CHANNEL, { historyPeerId: "peer", historyView: "logical" });
+    expect(mocks.runtime.activity).toHaveBeenCalledWith({ includeHistory: true, historyPeerId: "peer", historyView: "logical" });
+    expect(mocks.service.writeConfigPatchTargeted).not.toHaveBeenCalled();
+    expect(mocks.runtime.restart).not.toHaveBeenCalled();
+  });
+
+  it("disables then restores the previous mode and reports actual lease-denied runtime state", async () => {
+    await invoke(FEDERATION_SET_ENABLED_CHANNEL, false);
+    expect(mocks.service.writeConfigPatchTargeted).toHaveBeenLastCalledWith({ federation: { mode: "disabled" } });
+    mocks.service.readFederationConfig.mockReturnValue({ mode: "disabled" });
+    const result = await invoke(FEDERATION_SET_ENABLED_CHANNEL, true);
+    expect(mocks.service.writeConfigPatchTargeted).toHaveBeenLastCalledWith({ federation: { mode: "dual" } });
+    expect(mocks.runtime.restart).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({ configuredMode: "dual", running: false, health: { leaseHolder: { instanceId: "holder" } } });
+  });
+
+  it("uses enrollment endpoints to restore a client after a process starts disabled", async () => {
+    mocks.service.readFederationConfig.mockReturnValue({ mode: "disabled", gatewayEndpoints: ["wss://fixture.invalid"] });
+    await invoke(FEDERATION_SET_ENABLED_CHANNEL, true);
+    expect(mocks.service.writeConfigPatchTargeted).toHaveBeenCalledWith({ federation: { mode: "client" } });
+  });
+
+  it("does not restart on failed writes and rejects malformed toggle/topmost requests", async () => {
+    mocks.service.writeConfigPatchTargeted.mockRejectedValue(new Error("Read-only settings"));
+    await expect(invoke(FEDERATION_SET_ENABLED_CHANNEL, false)).rejects.toThrow("Read-only settings");
+    expect(mocks.runtime.restart).not.toHaveBeenCalled();
+    expect(() => invoke(FEDERATION_SET_ENABLED_CHANNEL, "false")).toThrow("boolean");
+    expect(() => invoke(FEDERATION_ACTIVITY_TOPMOST_CHANNEL, {})).toThrow("boolean");
+  });
+
+  it("opens on the caller's display and passes caller identity to the topmost guard", () => {
+    mocks.fromWebContents.mockReturnValue({ id: 7 });
+    invoke(FEDERATION_OPEN_ACTIVITY_CHANNEL);
+    expect(mocks.show).toHaveBeenCalledWith({ sourceWindow: { id: 7 } });
+    invoke(FEDERATION_ACTIVITY_TOPMOST_CHANNEL, true);
+    expect(mocks.topmost).toHaveBeenCalledWith(42, true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-activity-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ipc.test.ts
@@ -1,12 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   FEDERATION_ACTIVITY_TOPMOST_CHANNEL, FEDERATION_OPEN_ACTIVITY_CHANNEL,
-  FEDERATION_READ_ACTIVITY_CHANNEL, FEDERATION_SET_ENABLED_CHANNEL,
+  FEDERATION_READ_ACTIVITY_CHANNEL, FEDERATION_SET_ENABLED_CHANNEL, FEDERATION_RESET_ACTIVITY_CHANNEL,
 } from "../../shared/ipc";
 
 const mocks = vi.hoisted(() => ({
   handlers: new Map<string, (...args: unknown[]) => unknown>(),
-  runtime: { activity: vi.fn(), restart: vi.fn() },
+  runtime: { activity: vi.fn(), resetActivity: vi.fn(), restart: vi.fn() },
   service: { readFederationConfig: vi.fn(), writeConfigPatchTargeted: vi.fn() },
   show: vi.fn(), topmost: vi.fn(), fromWebContents: vi.fn(),
 }));
@@ -38,6 +38,14 @@ beforeEach(async () => {
 const invoke = (channel: string, request?: unknown) => mocks.handlers.get(channel)!({ sender: { id: 42 } }, request);
 
 describe("Federation Activity IPC", () => {
+  it("resets only local activity without restarting or changing configuration", async () => {
+    mocks.runtime.resetActivity.mockResolvedValue({ activity: { since: 123 } });
+    expect(await invoke(FEDERATION_RESET_ACTIVITY_CHANNEL)).toEqual({ activity: { since: 123 } });
+    expect(mocks.runtime.resetActivity).toHaveBeenCalledTimes(1);
+    expect(mocks.runtime.restart).not.toHaveBeenCalled();
+    expect(mocks.service.writeConfigPatchTargeted).not.toHaveBeenCalled();
+  });
+
   it("reads only local aggregates and forwards the selected history view", async () => {
     await invoke(FEDERATION_READ_ACTIVITY_CHANNEL, { historyPeerId: "peer", historyView: "logical" });
     expect(mocks.runtime.activity).toHaveBeenCalledWith({ includeHistory: true, historyPeerId: "peer", historyView: "logical" });

--- a/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
@@ -101,11 +101,14 @@ describe("Federation activity ledger", () => {
     expect(snapshot.peers.reduce((sum, peer) => sum + peer.series.lifetime.sent.requests, 0)).toBe(8_000);
     // Numeric bucket retention remains bounded even without snapshot polling.
     const internals = ledger as unknown as {
-      physical: { buckets: Map<number, unknown> };
-      peers: Map<string, { buckets: Map<number, unknown> }>;
+      physical: { times: Float64Array; values: Float64Array };
+      peers: Map<string, { times: Float64Array; values: Float64Array }>;
     };
-    expect(internals.physical.buckets.size).toBeLessThanOrEqual(3_600);
-    for (const peer of internals.peers.values()) expect(peer.buckets.size).toBeLessThanOrEqual(3_600);
+    for (const series of [internals.physical, ...internals.peers.values()]) {
+      expect(series.times).toHaveLength(3_600);
+      expect(series.values).toHaveLength(3_600 * 12);
+      expect(series.times.byteLength + series.values.byteLength).toBe(374_400);
+    }
     expect(JSON.stringify(snapshot).length).toBeLessThan(180_000);
   });
 
@@ -126,7 +129,7 @@ describe("Federation activity ledger", () => {
     ledger.record({ ...base, envelope: { ...base.envelope, targetInstanceId: "x".repeat(1_000_000) } });
     const snapshot = ledger.snapshot(1_000, { includeHistory: false });
     expect(snapshot.logical[0].peerId).toBe("Unknown endpoint");
-    expect(inspect(ledger, { depth: 12 }).length).toBeLessThan(10_000);
+    expect(inspect(ledger, { depth: 12 })).not.toContain("x".repeat(121));
   });
 
   it("tracks lifetime uncompressed sizes by direction and kind using the same attribution rules", () => {
@@ -174,4 +177,33 @@ it("reset clears all history, peers and size distributions and starts a fresh me
   const next = ledger.snapshot(3_000);
   expect(next.physical.lifetime.sent.requests).toBe(1);
   expect(next.physical.sizes.sent.requests).toEqual({ count: 1, averageBytes: 50, p50Bytes: 50, minBytes: 50, maxBytes: 50 });
+});
+
+
+it("caps all numeric storage at 28.73 MB even when every peer and size histogram is populated", () => {
+  const ledger = new FederationActivityLedger(0);
+  function retainedBytes(value: unknown): number {
+    if (ArrayBuffer.isView(value)) return value.byteLength;
+    if (value instanceof Map) return [...value.values()].reduce((sum, item) => sum + retainedBytes(item), 0);
+    if (value && typeof value === "object") return Object.values(value).reduce<number>((sum, item) => sum + retainedBytes(item), 0);
+    return 0;
+  }
+  for (let second = 0; second < 7_200; second += 1) {
+    for (let peer = 0; peer < 40; peer += 1) {
+      for (const direction of ["sent", "received"] as const) {
+        for (const kind of ["request", "response"] as const) ledger.record({ ...base, at: second * 1_000,
+          peerId: `peer-${peer}`, direction, envelope: { kind,
+            sourceInstanceId: direction === "sent" ? "local" : `peer-${peer}`,
+            targetInstanceId: direction === "sent" ? `peer-${peer}` : "local" },
+        });
+      }
+    }
+    if (second === 0 || second === 3_599 || second === 7_199) expect(retainedBytes(ledger)).toBe(28_725_312);
+  }
+  const snapshot = ledger.snapshot(7_199_000);
+  expect(snapshot.physical.lifetime.sent.requests).toBe(7_200 * 40);
+  expect(snapshot.physical.windows["1h"].sent.requests).toBe(3_600 * 40);
+  expect(snapshot.physical.history.every((bucket) => bucket.totals.sent.requests === 400)).toBe(true);
+  ledger.reset();
+  expect(retainedBytes(ledger)).toBe(0);
 });

--- a/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
@@ -129,4 +129,28 @@ describe("Federation activity ledger", () => {
     expect(inspect(ledger, { depth: 12 }).length).toBeLessThan(10_000);
   });
 
+  it("tracks lifetime uncompressed sizes by direction and kind using the same attribution rules", () => {
+    const ledger = new FederationActivityLedger(0);
+    ledger.record({ ...base, dataByteCount: 1_000, byteCount: 100 });
+    ledger.record({ ...base, dataByteCount: 3_000, byteCount: 100 });
+    for (const kind of ["response", "error"] as const) {
+      ledger.record({ ...base, direction: "received", dataByteCount: 50_000_000, byteCount: 500,
+        envelope: { kind, sourceInstanceId: "remote", targetInstanceId: "local" } });
+    }
+    ledger.record({ ...base, dataByteCount: 500_000, envelope: { ...base.envelope, kind: "notification" } });
+    // Relayed response: visible physically, excluded from this gateway's logical endpoint view.
+    ledger.record({ ...base, direction: "received", dataByteCount: 100, envelope: {
+      kind: "response", sourceInstanceId: "transit", targetInstanceId: "elsewhere",
+    } });
+    const snapshot = ledger.snapshot(10_000_000);
+    expect(snapshot.physical.windows["1h"].sent.requests).toBe(0);
+    expect(snapshot.physical.sizes.sent.requests).toMatchObject({ count: 2, averageBytes: 2_000, minBytes: 1_000, maxBytes: 3_000 });
+    expect(snapshot.physical.sizes.sent.responses).toEqual({ count: 0 });
+    expect(snapshot.physical.sizes.received.responses.count).toBe(3);
+    expect(snapshot.logical[0].series.sizes.received.responses).toEqual({
+      count: 2, averageBytes: 50_000_000, p50Bytes: 50_000_000, minBytes: 50_000_000, maxBytes: 50_000_000,
+    });
+    expect(snapshot.peers[0].series.sizes).toEqual(snapshot.physical.sizes);
+  });
+
 });

--- a/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
@@ -68,6 +68,8 @@ describe("Federation activity ledger", () => {
     expect(ledger.snapshot(61_000).physical.windows["1m"].sent.requests).toBe(0);
     expect(ledger.snapshot(300_000).physical.windows["5m"].sent.requests).toBe(1);
     expect(ledger.snapshot(301_000).physical.windows["5m"].sent.requests).toBe(0);
+    expect(ledger.snapshot(600_000).physical.windows["10m"].sent.requests).toBe(1);
+    expect(ledger.snapshot(601_000).physical.windows["10m"].sent.requests).toBe(0);
     const expired = ledger.snapshot(3_601_000);
     expect(expired.physical.windows["1h"].sent.requests).toBe(0);
     expect(expired.physical.lifetime.sent.requests).toBe(1);

--- a/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
@@ -1,0 +1,130 @@
+import { inspect } from "node:util";
+import { describe, expect, it } from "vitest";
+import { FederationActivityLedger } from "../federation/federation-activity-ledger";
+
+const base = {
+  peerId: "gateway", localInstanceId: "local", direction: "sent" as const,
+  byteCount: 116, dataByteCount: 100,
+  envelope: { kind: "request" as const, sourceInstanceId: "local", targetInstanceId: "remote" },
+  at: 1_000,
+};
+
+describe("Federation activity ledger", () => {
+  it("counts request, successful/error responses, notifications and blobs in both directions exactly", () => {
+    const ledger = new FederationActivityLedger(0);
+    for (const direction of ["sent", "received"] as const) {
+      for (const kind of ["request", "response", "error", "notification", "blob_chunk"] as const) {
+        ledger.record({ ...base, direction, envelope: { ...base.envelope, kind } });
+      }
+    }
+    const snapshot = ledger.snapshot(1_000);
+    for (const direction of ["sent", "received"] as const) {
+      expect(snapshot.physical.lifetime[direction]).toEqual({
+        requests: 1, responses: 2, notifications: 1, other: 1, dataBytes: 500, wireBytes: 580,
+      });
+    }
+    expect(snapshot.peers[0].series.lifetime).toEqual(snapshot.physical.lifetime);
+  });
+
+  it("attributes endpoint traffic to its logical peer while keeping physical gateway traffic separate", () => {
+    const ledger = new FederationActivityLedger(0);
+    ledger.record(base);
+    ledger.record({ ...base, direction: "received", envelope: {
+      kind: "response", sourceInstanceId: "remote", targetInstanceId: "local",
+    } });
+    const snapshot = ledger.snapshot(1_000);
+    expect(snapshot.peers.map((peer) => peer.peerId)).toEqual(["gateway"]);
+    expect(snapshot.logical.map((peer) => peer.peerId)).toEqual(["remote"]);
+    expect(snapshot.logical[0].series.lifetime).toEqual(snapshot.physical.lifetime);
+    expect(snapshot.physical.lifetime.sent.requests).toBe(1);
+  });
+
+  it("counts both physical relay hops but no transit traffic as local endpoint traffic", () => {
+    const ledger = new FederationActivityLedger(0);
+    const envelope = { kind: "request" as const, sourceInstanceId: "client", targetInstanceId: "remote" };
+    ledger.record({ ...base, peerId: "client", direction: "received", envelope });
+    ledger.record({ ...base, peerId: "remote", direction: "sent", envelope });
+    const snapshot = ledger.snapshot(1_000);
+    expect(snapshot.physical.lifetime.sent.requests).toBe(1);
+    expect(snapshot.physical.lifetime.received.requests).toBe(1);
+    expect(snapshot.logical).toEqual([]);
+    expect(snapshot.peers).toHaveLength(2);
+  });
+
+  it("counts broadcast deliveries on receiving endpoints, excluding forwarding sends", () => {
+    const ledger = new FederationActivityLedger(0);
+    const envelope = { kind: "notification" as const, sourceInstanceId: "remote" };
+    ledger.record({ ...base, direction: "received", envelope });
+    ledger.record({ ...base, direction: "sent", peerId: "leaf", envelope });
+    const snapshot = ledger.snapshot(1_000);
+    expect(snapshot.logical[0].series.lifetime.received.notifications).toBe(1);
+    expect(snapshot.logical[0].series.lifetime.sent.notifications).toBe(0);
+  });
+
+  it("expires rolling buckets at second boundaries and retains process totals through long idle periods", () => {
+    const ledger = new FederationActivityLedger(0);
+    ledger.record(base);
+    expect(ledger.snapshot(60_999).physical.windows["1m"].sent.requests).toBe(1);
+    expect(ledger.snapshot(61_000).physical.windows["1m"].sent.requests).toBe(0);
+    expect(ledger.snapshot(300_000).physical.windows["5m"].sent.requests).toBe(1);
+    expect(ledger.snapshot(301_000).physical.windows["5m"].sent.requests).toBe(0);
+    const expired = ledger.snapshot(3_601_000);
+    expect(expired.physical.windows["1h"].sent.requests).toBe(0);
+    expect(expired.physical.lifetime.sent.requests).toBe(1);
+    expect(expired.physical.history.every((point) => point.totals.sent.requests === 0)).toBe(true);
+    expect(ledger.snapshot(9_000_000).peers[0].series.lifetime.sent.wireBytes).toBe(116);
+  });
+
+  it("handles mixed uncompressed, encrypted and simulated compressed frames independently", () => {
+    const ledger = new FederationActivityLedger(0);
+    for (const byteCount of [100, 116, 36]) ledger.record({ ...base, byteCount });
+    const snapshot = ledger.snapshot(1_000);
+    expect(snapshot.physical.lifetime.sent.dataBytes).toBe(300);
+    expect(snapshot.physical.lifetime.sent.wireBytes).toBe(252);
+    expect(snapshot.physical.lifetime.sent.requests).toBe(3);
+  });
+
+  it("bounds history and peer cardinality while overflow and lifetime counters retain every event", () => {
+    const ledger = new FederationActivityLedger(0);
+    for (let index = 1; index <= 8_000; index += 1) {
+      ledger.record({ ...base, at: index * 1_000, peerId: `peer-${index}`,
+        envelope: { ...base.envelope, targetInstanceId: `target-${index}` } });
+    }
+    const snapshot = ledger.snapshot(8_000_000);
+    expect(snapshot.physical.lifetime.sent.requests).toBe(8_000);
+    expect(snapshot.physical.windows["1h"].sent.requests).toBe(3_600);
+    expect(snapshot.physical.history).toHaveLength(360);
+    expect(snapshot.peers).toHaveLength(33);
+    expect(snapshot.logical).toHaveLength(33);
+    expect(snapshot.peers.reduce((sum, peer) => sum + peer.series.lifetime.sent.requests, 0)).toBe(8_000);
+    // Numeric bucket retention remains bounded even without snapshot polling.
+    const internals = ledger as unknown as {
+      physical: { buckets: Map<number, unknown> };
+      peers: Map<string, { buckets: Map<number, unknown> }>;
+    };
+    expect(internals.physical.buckets.size).toBeLessThanOrEqual(3_600);
+    for (const peer of internals.peers.values()) expect(peer.buckets.size).toBeLessThanOrEqual(3_600);
+    expect(JSON.stringify(snapshot).length).toBeLessThan(180_000);
+  });
+
+  it("returns independent copies, retains no payloads, and only returns requested peer history", () => {
+    const ledger = new FederationActivityLedger(0);
+    const envelope = { ...base.envelope, params: { secret: "private payload" } };
+    ledger.record({ ...base, envelope });
+    const snapshot = ledger.snapshot(1_000, { historyView: "logical", historyPeerId: "remote" });
+    expect(snapshot.physical.history).toHaveLength(0);
+    expect(snapshot.peers[0].series.history).toHaveLength(0);
+    expect(snapshot.logical[0].series.history).toHaveLength(360);
+    expect(inspect(ledger, { depth: 12 })).not.toContain("private payload");
+    snapshot.physical.lifetime.sent.requests = 9_999;
+    expect(ledger.snapshot(1_000, { includeHistory: false }).physical.lifetime.sent.requests).toBe(1);
+  });
+  it("bounds remote metadata lengths instead of retaining payload-sized endpoint IDs", () => {
+    const ledger = new FederationActivityLedger(0);
+    ledger.record({ ...base, envelope: { ...base.envelope, targetInstanceId: "x".repeat(1_000_000) } });
+    const snapshot = ledger.snapshot(1_000, { includeHistory: false });
+    expect(snapshot.logical[0].peerId).toBe("Unknown endpoint");
+    expect(inspect(ledger, { depth: 12 }).length).toBeLessThan(10_000);
+  });
+
+});

--- a/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
@@ -154,3 +154,24 @@ describe("Federation activity ledger", () => {
   });
 
 });
+
+
+it("reset clears all history, peers and size distributions and starts a fresh measurement interval", () => {
+  const ledger = new FederationActivityLedger(0);
+  ledger.record(base);
+  const previous = ledger.snapshot(1_000);
+  ledger.reset(2_000);
+  const cleared = ledger.snapshot(2_000);
+  expect(cleared.since).toBe(2_000);
+  expect(cleared.peers).toEqual([]);
+  expect(cleared.logical).toEqual([]);
+  expect(cleared.physical.lifetime.sent.requests).toBe(0);
+  expect(cleared.physical.sizes.sent.requests).toEqual({ count: 0 });
+  expect(cleared.physical.history.every((bucket) => bucket.totals.sent.dataBytes === 0)).toBe(true);
+  for (const totals of Object.values(cleared.physical.windows)) expect(totals.sent.requests).toBe(0);
+  expect(previous.physical.lifetime.sent.requests).toBe(1);
+  ledger.record({ ...base, at: 3_000, dataByteCount: 50 });
+  const next = ledger.snapshot(3_000);
+  expect(next.physical.lifetime.sent.requests).toBe(1);
+  expect(next.physical.sizes.sent.requests).toEqual({ count: 1, averageBytes: 50, p50Bytes: 50, minBytes: 50, maxBytes: 50 });
+});

--- a/apps/desktop/src/main/__tests__/federation-activity-window.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-window.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  windows: [] as Array<{
+    options: Record<string, unknown>; webContents: { id: number }; on: ReturnType<typeof vi.fn>;
+    loadFile: ReturnType<typeof vi.fn>; loadURL: ReturnType<typeof vi.fn>;
+    setAlwaysOnTop: ReturnType<typeof vi.fn>; isAlwaysOnTop: () => boolean; isDestroyed: () => boolean;
+  }>,
+}));
+vi.mock("electron", () => ({
+  BrowserWindow: class {
+    webContents = { id: state.windows.length + 1 };
+    on = vi.fn();
+    loadFile = vi.fn();
+    loadURL = vi.fn();
+    private topmost = false;
+    setAlwaysOnTop = vi.fn((enabled: boolean) => { this.topmost = enabled; });
+    isAlwaysOnTop = () => this.topmost;
+    isDestroyed = () => false;
+    constructor(public options: Record<string, unknown>) { state.windows.push(this); }
+  },
+}));
+vi.mock("../window", () => ({
+  applyWindowSecurityHardening: vi.fn(), getPreloadPath: () => "/fixture/preload.js",
+  getRendererEntry: () => ({ kind: "file", value: "/fixture/index.html" }),
+}));
+vi.mock("../window-channels", () => ({ WINDOW_KIND_FEDERATION_ACTIVITY: "federation-activity", registerWindowChannels: vi.fn() }));
+vi.mock("../settings/appearance-bootstrap", () => ({ readBootstrapAppearance: () => ({}), themedWindowAdditionalArguments: () => [] }));
+vi.mock("../native-appearance", () => ({ themedWindowBackgroundColor: () => "theme-background" }));
+vi.mock("../auxiliary-window-chrome", () => ({
+  auxiliaryWindowChromeOptions: () => ({ titleBarStyle: "hiddenInset" }),
+  hideAuxiliaryWindowMenuBar: vi.fn(), registerAuxiliaryWindowTitle: vi.fn(),
+  showAndFocusAuxiliaryWindow: vi.fn(), showAuxiliaryWindowWhenReady: vi.fn(),
+}));
+vi.mock("../window-placement", () => ({ placementForSourceDisplay: () => ({}), positionWindowForSourceDisplay: vi.fn() }));
+
+beforeEach(() => { state.windows.length = 0; vi.resetModules(); });
+
+describe("Federation Activity native window", () => {
+  it("creates one independent secure themed window and focuses it on repeated open", async () => {
+    const { showFederationActivityWindow } = await import("../federation-activity-window");
+    const { showAndFocusAuxiliaryWindow } = await import("../auxiliary-window-chrome");
+    const { registerWindowChannels } = await import("../window-channels");
+    showFederationActivityWindow();
+    showFederationActivityWindow();
+    expect(state.windows).toHaveLength(1);
+    expect(state.windows[0].options).toMatchObject({
+      title: "Federation Activity", width: 760, height: 620, show: false,
+      backgroundColor: "theme-background", titleBarStyle: "hiddenInset",
+      webPreferences: { contextIsolation: true, sandbox: true, nodeIntegration: false },
+    });
+    expect(state.windows[0].options).not.toHaveProperty("parent");
+    expect(state.windows[0].loadFile).toHaveBeenCalledWith("/fixture/index.html", { hash: "federation-activity" });
+    expect(showAndFocusAuxiliaryWindow).toHaveBeenCalledWith(state.windows[0]);
+    expect(registerWindowChannels).toHaveBeenCalledWith(state.windows[0], "federation-activity", ["appearance:changed"]);
+    const closed = state.windows[0].on.mock.calls.find(([name]) => name === "closed")![1];
+    closed();
+    showFederationActivityWindow();
+    expect(state.windows).toHaveLength(2);
+  });
+
+  it("only lets the activity renderer change its own topmost state", async () => {
+    const { showFederationActivityWindow, setFederationActivityTopmost } = await import("../federation-activity-window");
+    expect(() => setFederationActivityTopmost(1, true)).toThrow("not the caller");
+    showFederationActivityWindow();
+    expect(() => setFederationActivityTopmost(999, true)).toThrow("not the caller");
+    expect(setFederationActivityTopmost(1, true)).toBe(true);
+    expect(setFederationActivityTopmost(1, false)).toBe(false);
+    expect(state.windows[0].setAlwaysOnTop.mock.calls).toEqual([[true], [false]]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-activity-write-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-write-budget.test.ts
@@ -1,0 +1,33 @@
+import { expect, it, vi } from "vitest";
+import { FederationActivityLedger } from "../federation/federation-activity-ledger";
+import { FederationTransferLedger } from "../federation/federation-transfer-ledger";
+import { measureSqliteWrites, readSqliteWriteMetrics, SQLITE_WRITE_METRICS_ENV } from "../state/sqlite-write-metrics";
+import { openInMemoryStateDb } from "./sqlite-test-utils";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
+
+it("adds zero SQLite writes for transfer accounting, snapshots and reset", async () => {
+  vi.stubEnv(SQLITE_WRITE_METRICS_ENV, "1");
+  const db = openInMemoryStateDb();
+  try {
+    // Verify that instrumentation is live, rather than accepting an absent collector as zero.
+    expect(readSqliteWriteMetrics()).toBeDefined();
+    const ledger = new FederationActivityLedger(0);
+    const transfers = new FederationTransferLedger();
+    const { writes } = await measureSqliteWrites(() => {
+      for (let index = 0; index < 10_000; index += 1) {
+        const info = { peerId: "peer", localInstanceId: "local", direction: "received" as const,
+          byteCount: 116, dataByteCount: 100, at: index * 1_000,
+          envelope: { kind: "response" as const, sourceInstanceId: "peer", targetInstanceId: "local" } };
+        transfers.record(info);
+        ledger.record(info);
+        if (index % 100 === 0) { ledger.snapshot(index * 1_000); transfers.snapshot("peer"); }
+      }
+      ledger.reset(10_000_000);
+      ledger.snapshot(10_000_000);
+    });
+    expectSqliteWriteBudget({ scenario: "federation-activity-monitor",
+      note: "10,000 transfers, local snapshots and reset: in-memory only; 0 MB/day added WAL",
+      writes });
+    expect(writes.walBytes).toBe(0);
+  } finally { db.close(); vi.unstubAllEnvs(); }
+});

--- a/apps/desktop/src/main/__tests__/federation-size-statistics.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-size-statistics.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { FederationSizeStatistics } from "../federation/federation-size-statistics";
+
+describe("Federation lifetime payload size statistics", () => {
+  it("distinguishes no observations from zero-byte observations", () => {
+    const stats = new FederationSizeStatistics();
+    expect(stats.snapshot()).toEqual({ count: 0 });
+    stats.record(0);
+    expect(stats.snapshot()).toEqual({ count: 1, averageBytes: 0, p50Bytes: 0, minBytes: 0, maxBytes: 0 });
+  });
+
+  it("preserves exact count/average/extrema while exposing a large-response outlier", () => {
+    const stats = new FederationSizeStatistics();
+    for (const size of [1_000, 1_000, 1_000, 1_000, 50_000_000]) stats.record(size);
+    const snapshot = stats.snapshot();
+    expect(snapshot).toMatchObject({ count: 5, averageBytes: 10_000_800, minBytes: 1_000, maxBytes: 50_000_000 });
+    expect(snapshot.p50Bytes).toBeGreaterThanOrEqual(989);
+    expect(snapshot.p50Bytes).toBeLessThanOrEqual(1011);
+  });
+
+  it("estimates the nearest-rank median within 1.1% across the safe integer range", () => {
+    for (let octave = 0; octave < 53; octave += 1) {
+      for (const fraction of [1, 1.1, 1.5, 1.99]) {
+        const value = Math.min(Number.MAX_SAFE_INTEGER, Math.floor(2 ** octave * fraction));
+        const stats = new FederationSizeStatistics();
+        for (const size of [0, value, Number.MAX_SAFE_INTEGER]) stats.record(size);
+        expect(Math.abs(stats.snapshot().p50Bytes! - value) / value).toBeLessThan(0.011);
+      }
+    }
+    const even = new FederationSizeStatistics();
+    for (const size of [100, 200, 300, 400]) even.record(size);
+    expect(even.snapshot().p50Bytes!).toBeGreaterThan(197.8);
+    expect(even.snapshot().p50Bytes!).toBeLessThan(202.2);
+  });
+
+  it("keeps fixed numeric storage rather than a growing sample list", () => {
+    const stats = new FederationSizeStatistics();
+    for (let size = 1; size <= 100_000; size += 1) stats.record(size);
+    const histogram = (stats as unknown as { histogram: Float64Array }).histogram;
+    expect(histogram.length).toBe(1698);
+    expect(histogram.byteLength).toBe(13_584);
+    expect(stats.snapshot()).toMatchObject({ count: 100_000, minBytes: 1, maxBytes: 100_000, averageBytes: 50_000.5 });
+  });
+
+  it("ignores invalid lengths and returns detached snapshots", () => {
+    const stats = new FederationSizeStatistics();
+    for (const value of [-1, NaN, Infinity, 0.5, Number.MAX_SAFE_INTEGER + 1]) stats.record(value);
+    expect(stats.snapshot()).toEqual({ count: 0 });
+    stats.record(1024);
+    stats.snapshot().maxBytes = 99;
+    expect(stats.snapshot().maxBytes).toBe(1024);
+    expect(stats.snapshot().p50Bytes).toBe(1024);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-transfer-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transfer-ledger.test.ts
@@ -68,4 +68,13 @@ describe("federation transfer ledger", () => {
 
     expect(ledger.snapshot("pwr_studio")?.bytesSent).toBe(10);
   });
+  it("bounds the legacy health-only peer map", () => {
+    const ledger = new FederationTransferLedger();
+    for (let index = 0; index < 129; index += 1) {
+      ledger.record({ peerId: `peer-${index}`, direction: "sent", byteCount: 1, at: index });
+    }
+    expect(ledger.snapshot("peer-0")).toBeUndefined();
+    expect(ledger.snapshot("peer-128")?.bytesSent).toBe(1);
+  });
+
 });

--- a/apps/desktop/src/main/__tests__/federation-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-transport.test.ts
@@ -206,6 +206,7 @@ describe("federation transport", () => {
   });
 
   it("carries attachment bytes in the binary blob frame instead of JSON", async () => {
+    const transfers: Array<{ direction: "sent" | "received"; dataByteCount: number; byteCount: number }> = [];
     const clientKeyPair = generateFederationIdentityKeyPair();
     const invite = createFederationEnrollmentInvite({
       store,
@@ -223,6 +224,7 @@ describe("federation transport", () => {
         port: 0,
         store,
         onEnvelope: resolve,
+        onEnvelopeTransfer: (info) => transfers.push(info),
       });
     });
     const { url } = await server!.start();
@@ -238,10 +240,11 @@ describe("federation transport", () => {
       inviteToken: invite.token,
       label: "Client",
       role: "client",
+      onEnvelopeTransfer: (info) => transfers.push(info),
     });
     const bytes = Buffer.from([0, 1, 2, 0xff]);
 
-    client.sendEnvelope({
+    await client.sendEnvelopeWithBackpressure!({
       id: "blob-1",
       kind: "blob_chunk",
       protocolVersion: 1,
@@ -263,19 +266,32 @@ describe("federation transport", () => {
       transferId: "transfer-1",
       data: bytes,
     });
+    const expectedBytes = federationTransportCodecForTest.encodeEnvelope(await received).byteLength;
+    expect(transfers).toHaveLength(2);
+    expect(transfers.map(({ direction, dataByteCount, byteCount }) => ({ direction, dataByteCount, byteCount })))
+      .toEqual([
+        { direction: "sent", dataByteCount: expectedBytes, byteCount: expectedBytes },
+        { direction: "received", dataByteCount: expectedBytes, byteCount: expectedBytes },
+      ]);
     client.close();
   });
 
-  it("reports envelope wire bytes to both ends' transfer taps", async () => {
+  it.each([false, true])("reports exact data and encoded bytes at both ends (Noise: %s)", async (encrypted) => {
+    const gatewayNoise = generateNoiseStaticKeyPair();
+    const clientNoise = generateNoiseStaticKeyPair();
     const clientKeyPair = generateFederationIdentityKeyPair();
     const gatewayTransfers: Array<{
       peerId: string;
       direction: "sent" | "received";
       byteCount: number;
+      dataByteCount: number;
+      envelope: FederationProtocolEnvelope;
     }> = [];
     const clientTransfers: Array<{
       direction: "sent" | "received";
       byteCount: number;
+      dataByteCount: number;
+      envelope: FederationProtocolEnvelope;
     }> = [];
     const invite = createFederationEnrollmentInvite({
       store,
@@ -288,6 +304,7 @@ describe("federation transport", () => {
       gatewayInstanceId: "gateway_one",
       gatewayPrivateKeyPem: gatewayKeyPair.privateKeyPem,
       gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
+      noiseStatic: encrypted ? gatewayNoise : undefined,
       host: "127.0.0.1",
       port: 0,
       store,
@@ -310,6 +327,8 @@ describe("federation transport", () => {
     const reply = new Promise<FederationProtocolEnvelope>((resolve) => {
       void connectFederationClient({
         url,
+        noiseStatic: encrypted ? clientNoise : undefined,
+        gatewayNoisePublicKey: encrypted ? gatewayNoise.publicKeyRaw : undefined,
         mode: "enroll",
         gatewayInstanceId: "gateway_one",
         gatewayPublicKeyPem: gatewayKeyPair.publicKeyPem,
@@ -362,6 +381,12 @@ describe("federation transport", () => {
     expect(clientReceived.byteCount).toBe(gatewaySent.byteCount);
     expect(clientSent.byteCount).toBeGreaterThan(0);
     expect(gatewaySent.byteCount).toBeGreaterThan(0);
+    for (const transfer of [...gatewayTransfers, ...clientTransfers]) {
+      expect(transfer.dataByteCount).toBe(Buffer.byteLength(JSON.stringify({
+        kind: "envelope", envelope: transfer.envelope,
+      }), "utf8"));
+      expect(transfer.byteCount).toBe(transfer.dataByteCount + (encrypted ? 16 : 0));
+    }
   });
 
   it("evicts a duplicated peer id with close code 4001 and audits the replacement", async () => {

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -97,6 +97,13 @@
     "rowsChanged": 0,
     "statements": 0
   },
+  "federation-activity-monitor": {
+    "commits": 0,
+    "note": "10,000 transfers, local snapshots and reset: in-memory only; 0 MB/day added WAL",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "held-scheduled-action-retry": {
     "commits": 3,
     "note": "one operator-triggered held retry: claim, queue admission, and successful turn start; no timer or automatic retry",

--- a/apps/desktop/src/main/federation-activity-window.ts
+++ b/apps/desktop/src/main/federation-activity-window.ts
@@ -1,0 +1,127 @@
+import { BrowserWindow } from "electron";
+import { getMainLogger } from "./log";
+import {
+  applyWindowSecurityHardening,
+  getPreloadPath,
+  getRendererEntry,
+} from "./window";
+import {
+  WINDOW_KIND_FEDERATION_ACTIVITY,
+  registerWindowChannels,
+} from "./window-channels";
+import { APPEARANCE_CHANGED_EVENT_CHANNEL } from "../shared/ipc";
+import {
+  readBootstrapAppearance,
+  themedWindowAdditionalArguments,
+} from "./settings/appearance-bootstrap";
+import { themedWindowBackgroundColor } from "./native-appearance";
+import {
+  auxiliaryWindowChromeOptions,
+  hideAuxiliaryWindowMenuBar,
+  registerAuxiliaryWindowTitle,
+  showAndFocusAuxiliaryWindow,
+  showAuxiliaryWindowWhenReady,
+} from "./auxiliary-window-chrome";
+import {
+  placementForSourceDisplay,
+  positionWindowForSourceDisplay,
+  type WindowPlacementSource,
+} from "./window-placement";
+
+const log = getMainLogger("pwragent:federation-activity-window");
+const ACTIVITY_WINDOW_TITLE = "Federation Activity";
+const ACTIVITY_WINDOW_WIDTH = 760;
+const ACTIVITY_WINDOW_HEIGHT = 620;
+
+/**
+ * Hash that the renderer (`main.tsx`) reads to decide whether to mount
+ * the full app shell or just the federation-activity surface. Loaded
+ * windows pass through unchanged on reload, so the hash survives DevTools
+ * refreshes and renderer crashes.
+ */
+const ACTIVITY_HASH = "federation-activity";
+
+let activityWindow: BrowserWindow | undefined;
+
+/**
+ * Spawn (or focus, if already open) the dedicated Federation Activity
+ * window. The window reuses the same renderer bundle as the main
+ * window — `main.tsx` reads `window.location.hash` and mounts a
+ * standalone activity surface instead of the full app shell.
+ *
+ * Distinct OS window: own traffic lights, own focus, own lifecycle.
+ * Closing the window does NOT affect the main window. Reopening
+ * focuses the existing window when one is already open.
+ */
+export function showFederationActivityWindow(
+  source: WindowPlacementSource = {},
+): void {
+  if (activityWindow && !activityWindow.isDestroyed()) {
+    positionWindowForSourceDisplay(activityWindow, source);
+    showAndFocusAuxiliaryWindow(activityWindow);
+    return;
+  }
+
+  const appearance = readBootstrapAppearance();
+  const window = new BrowserWindow({
+    ...placementForSourceDisplay(
+      ACTIVITY_WINDOW_WIDTH,
+      ACTIVITY_WINDOW_HEIGHT,
+      source,
+    ),
+    width: ACTIVITY_WINDOW_WIDTH,
+    height: ACTIVITY_WINDOW_HEIGHT,
+    minWidth: 640,
+    minHeight: 480,
+    show: false,
+    title: ACTIVITY_WINDOW_TITLE,
+    ...auxiliaryWindowChromeOptions(),
+    backgroundColor: themedWindowBackgroundColor(appearance),
+    webPreferences: {
+      preload: getPreloadPath(),
+      contextIsolation: true,
+      sandbox: true,
+      nodeIntegration: false,
+      additionalArguments: themedWindowAdditionalArguments(appearance),
+    },
+  });
+  registerAuxiliaryWindowTitle(window, ACTIVITY_WINDOW_TITLE);
+  hideAuxiliaryWindowMenuBar(window);
+
+  applyWindowSecurityHardening(window);
+  // Local activity polling needs no federation or backend push subscriptions.
+  // Appearance broadcasts keep detached windows synchronized with Settings.
+  registerWindowChannels(window, WINDOW_KIND_FEDERATION_ACTIVITY, [
+    APPEARANCE_CHANGED_EVENT_CHANNEL,
+  ]);
+
+  const rendererEntry = getRendererEntry();
+  if (rendererEntry.kind === "url") {
+    void window.loadURL(`${rendererEntry.value}#${ACTIVITY_HASH}`);
+  } else {
+    void window.loadFile(rendererEntry.value, { hash: ACTIVITY_HASH });
+  }
+
+  showAuxiliaryWindowWhenReady(window);
+
+  window.on("closed", () => {
+    // The top-of-function "already-open" guard prevents two activity
+    // windows from coexisting, so the singleton always points at the
+    // window that just closed. No need to compare references.
+    activityWindow = undefined;
+    log.debug("activity window closed");
+  });
+
+  activityWindow = window;
+  log.debug("activity window created");
+}
+
+/** Only the activity window itself may change its topmost state. */
+export function setFederationActivityTopmost(senderId: number, enabled: boolean): boolean {
+  if (!activityWindow || activityWindow.isDestroyed()
+    || activityWindow.webContents.id !== senderId) {
+    throw new Error("Federation Activity window is not the caller.");
+  }
+  activityWindow.setAlwaysOnTop(enabled);
+  return activityWindow.isAlwaysOnTop();
+}

--- a/apps/desktop/src/main/federation/federation-activity-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-activity-ledger.ts
@@ -1,0 +1,129 @@
+import type {
+  ReadFederationActivityRequest,
+  FederationActivityCounts,
+  FederationActivityTotals,
+  FederationActivitySeries,
+  FederationActivitySnapshot,
+  FederationProtocolEnvelope,
+} from "@pwragent/shared";
+
+const SECOND = 1_000;
+const HOUR = 3_600;
+// Retain at most 32 attributed peers per view; overflow remains counted.
+const MAX_PEERS = 32;
+const OTHER = "Other peers (attribution limit)";
+const counts = (): FederationActivityCounts => ({
+  requests: 0, responses: 0, notifications: 0, other: 0,
+  dataBytes: 0, wireBytes: 0,
+});
+const totals = (): FederationActivityTotals => ({ sent: counts(), received: counts() });
+function add(target: FederationActivityTotals, source: FederationActivityTotals) {
+  for (const direction of ["sent", "received"] as const) {
+    for (const key of Object.keys(target[direction]) as Array<keyof FederationActivityCounts>) {
+      target[direction][key] += source[direction][key];
+    }
+  }
+}
+class Series {
+  readonly lifetime = totals();
+  readonly buckets = new Map<number, FederationActivityTotals>();
+  record(at: number, delta: FederationActivityTotals) {
+    add(this.lifetime, delta);
+    const bucket = this.buckets.get(at) ?? totals();
+    add(bucket, delta);
+    this.buckets.set(at, bucket);
+    this.expire(at);
+  }
+  expire(at: number) {
+    for (const time of this.buckets.keys()) {
+      if (time > at - HOUR) break;
+      this.buckets.delete(time);
+    }
+  }
+  snapshot(at: number, includeHistory: boolean): FederationActivitySeries {
+    this.expire(at);
+    const windows = { "1m": totals(), "5m": totals(), "1h": totals() };
+    const history: FederationActivitySeries["history"] = [];
+    const first = at - HOUR + 1;
+    // Ten-second chart bins, with rolling totals evaluated at second boundaries.
+    if (includeHistory) {
+      for (let start = first; start <= at; start += 10) {
+        history.push({ at: start * SECOND, totals: totals() });
+      }
+    }
+    for (const [time, bucket] of this.buckets) {
+      add(windows["1h"], bucket);
+      if (time > at - 300) add(windows["5m"], bucket);
+      if (time > at - 60) add(windows["1m"], bucket);
+      if (includeHistory) add(history[Math.floor((time - first) / 10)].totals, bucket);
+    }
+    return { lifetime: structuredClone(this.lifetime), windows, history };
+  }
+}
+
+/** Numeric aggregates only: no envelope, method, request ID or payload retention. */
+export class FederationActivityLedger {
+  private readonly physical = new Series();
+  private readonly peers = new Map<string, Series>();
+  private readonly logical = new Map<string, Series>();
+  private lastSecond: number;
+  constructor(private readonly since = Date.now()) {
+    this.lastSecond = Math.floor(since / SECOND);
+  }
+  private series(map: Map<string, Series>, peer: string) {
+    // Envelope metadata is remote input. Bound retained strings as well as
+    // map cardinality; malformed IDs must never retain a payload-sized value.
+    const name = typeof peer === "string" && peer.length > 0 && peer.length <= 120
+      ? peer
+      : "Unknown endpoint";
+    const key = map.has(name) || map.size < MAX_PEERS ? name : OTHER;
+    let value = map.get(key);
+    if (!value) { value = new Series(); map.set(key, value); }
+    return value;
+  }
+  record(info: {
+    peerId: string;
+    localInstanceId: string;
+    direction: "sent" | "received";
+    byteCount: number;
+    dataByteCount: number;
+    envelope: Pick<FederationProtocolEnvelope, "kind" | "sourceInstanceId" | "targetInstanceId">;
+    at?: number;
+  }) {
+    if (!Number.isFinite(info.byteCount) || info.byteCount < 0
+      || !Number.isFinite(info.dataByteCount) || info.dataByteCount < 0) return;
+    const second = Math.max(this.lastSecond, Math.floor((info.at ?? Date.now()) / SECOND));
+    this.lastSecond = second;
+    const delta = totals();
+    const value = delta[info.direction];
+    const kind = info.envelope.kind;
+    value[kind === "request" ? "requests" : kind === "response" || kind === "error"
+      ? "responses" : kind === "notification" ? "notifications" : "other"] = 1;
+    value.dataBytes = info.dataByteCount;
+    value.wireBytes = info.byteCount;
+    this.physical.record(second, delta);
+    this.series(this.peers, info.peerId).record(second, delta);
+    // A gateway's forwarding leg is physical traffic, never a second logical event.
+    if (info.direction === "sent" && info.envelope.sourceInstanceId === info.localInstanceId) {
+      this.series(this.logical, info.envelope.targetInstanceId ?? "Broadcast").record(second, delta);
+    } else if (info.direction === "received"
+      && (!info.envelope.targetInstanceId || info.envelope.targetInstanceId === info.localInstanceId)) {
+      this.series(this.logical, info.envelope.sourceInstanceId).record(second, delta);
+    }
+  }
+  snapshot(now = Date.now(), request: ReadFederationActivityRequest = {}): FederationActivitySnapshot {
+    const at = Math.max(this.lastSecond, Math.floor(now / SECOND));
+    this.lastSecond = at;
+    const snapshotMap = (map: Map<string, Series>, view: "physical" | "logical") =>
+      [...map].map(([peerId, series]) => ({
+        peerId,
+        series: series.snapshot(at, request.includeHistory !== false
+          && request.historyPeerId === peerId && request.historyView === view),
+      }));
+    return {
+      since: this.since, at: at * SECOND, bucketMs: SECOND,
+      physical: this.physical.snapshot(at, request.includeHistory !== false && !request.historyPeerId),
+      peers: snapshotMap(this.peers, "physical"), logical: snapshotMap(this.logical, "logical"),
+    };
+  }
+}

--- a/apps/desktop/src/main/federation/federation-activity-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-activity-ledger.ts
@@ -80,12 +80,19 @@ class Series {
 
 /** Numeric aggregates only: no envelope, method, request ID or payload retention. */
 export class FederationActivityLedger {
-  private readonly physical = new Series();
+  private physical = new Series();
   private readonly peers = new Map<string, Series>();
   private readonly logical = new Map<string, Series>();
   private lastSecond: number;
-  constructor(private readonly since = Date.now()) {
+  constructor(private since = Date.now()) {
     this.lastSecond = Math.floor(since / SECOND);
+  }
+  reset(at = Date.now()): void {
+    this.physical = new Series();
+    this.peers.clear();
+    this.logical.clear();
+    this.since = at;
+    this.lastSecond = Math.floor(at / SECOND);
   }
   private series(map: Map<string, Series>, peer: string) {
     // Envelope metadata is remote input. Bound retained strings as well as

--- a/apps/desktop/src/main/federation/federation-activity-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-activity-ledger.ts
@@ -1,3 +1,4 @@
+import { FederationSizeStatistics } from "./federation-size-statistics";
 import type {
   ReadFederationActivityRequest,
   FederationActivityCounts,
@@ -26,9 +27,18 @@ function add(target: FederationActivityTotals, source: FederationActivityTotals)
 }
 class Series {
   readonly lifetime = totals();
+  private readonly sizes = {
+    sent: { requests: new FederationSizeStatistics(), responses: new FederationSizeStatistics() },
+    received: { requests: new FederationSizeStatistics(), responses: new FederationSizeStatistics() },
+  };
   readonly buckets = new Map<number, FederationActivityTotals>();
   record(at: number, delta: FederationActivityTotals) {
     add(this.lifetime, delta);
+    for (const direction of ["sent", "received"] as const) {
+      const value = delta[direction];
+      if (value.requests) this.sizes[direction].requests.record(value.dataBytes);
+      if (value.responses) this.sizes[direction].responses.record(value.dataBytes);
+    }
     const bucket = this.buckets.get(at) ?? totals();
     add(bucket, delta);
     this.buckets.set(at, bucket);
@@ -58,7 +68,13 @@ class Series {
       if (time > at - 60) add(windows["1m"], bucket);
       if (includeHistory) add(history[Math.floor((time - first) / 10)].totals, bucket);
     }
-    return { lifetime: structuredClone(this.lifetime), windows, history };
+    return {
+      lifetime: structuredClone(this.lifetime), windows, history,
+      sizes: {
+        sent: { requests: this.sizes.sent.requests.snapshot(), responses: this.sizes.sent.responses.snapshot() },
+        received: { requests: this.sizes.received.requests.snapshot(), responses: this.sizes.received.responses.snapshot() },
+      },
+    };
   }
 }
 
@@ -91,8 +107,8 @@ export class FederationActivityLedger {
     envelope: Pick<FederationProtocolEnvelope, "kind" | "sourceInstanceId" | "targetInstanceId">;
     at?: number;
   }) {
-    if (!Number.isFinite(info.byteCount) || info.byteCount < 0
-      || !Number.isFinite(info.dataByteCount) || info.dataByteCount < 0) return;
+    if (!Number.isSafeInteger(info.byteCount) || info.byteCount < 0
+      || !Number.isSafeInteger(info.dataByteCount) || info.dataByteCount < 0) return;
     const second = Math.max(this.lastSecond, Math.floor((info.at ?? Date.now()) / SECOND));
     this.lastSecond = second;
     const delta = totals();

--- a/apps/desktop/src/main/federation/federation-activity-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-activity-ledger.ts
@@ -42,7 +42,7 @@ class Series {
   }
   snapshot(at: number, includeHistory: boolean): FederationActivitySeries {
     this.expire(at);
-    const windows = { "1m": totals(), "5m": totals(), "1h": totals() };
+    const windows = { "1m": totals(), "5m": totals(), "10m": totals(), "1h": totals() };
     const history: FederationActivitySeries["history"] = [];
     const first = at - HOUR + 1;
     // Ten-second chart bins, with rolling totals evaluated at second boundaries.
@@ -53,6 +53,7 @@ class Series {
     }
     for (const [time, bucket] of this.buckets) {
       add(windows["1h"], bucket);
+      if (time > at - 600) add(windows["10m"], bucket);
       if (time > at - 300) add(windows["5m"], bucket);
       if (time > at - 60) add(windows["1m"], bucket);
       if (includeHistory) add(history[Math.floor((time - first) / 10)].totals, bucket);

--- a/apps/desktop/src/main/federation/federation-activity-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-activity-ledger.ts
@@ -18,11 +18,28 @@ const counts = (): FederationActivityCounts => ({
   dataBytes: 0, wireBytes: 0,
 });
 const totals = (): FederationActivityTotals => ({ sent: counts(), received: counts() });
+const COUNT_FIELDS = ["requests", "responses", "notifications", "other", "dataBytes", "wireBytes"] as const;
+function addCounts(target: FederationActivityCounts, source: FederationActivityCounts) {
+  target.requests += source.requests;
+  target.responses += source.responses;
+  target.notifications += source.notifications;
+  target.other += source.other;
+  target.dataBytes += source.dataBytes;
+  target.wireBytes += source.wireBytes;
+}
 function add(target: FederationActivityTotals, source: FederationActivityTotals) {
+  addCounts(target.sent, source.sent);
+  addCounts(target.received, source.received);
+}
+function addBucket(target: FederationActivityTotals, values: Float64Array, offset: number) {
   for (const direction of ["sent", "received"] as const) {
-    for (const key of Object.keys(target[direction]) as Array<keyof FederationActivityCounts>) {
-      target[direction][key] += source[direction][key];
-    }
+    const value = target[direction];
+    value.requests += values[offset++];
+    value.responses += values[offset++];
+    value.notifications += values[offset++];
+    value.other += values[offset++];
+    value.dataBytes += values[offset++];
+    value.wireBytes += values[offset++];
   }
 }
 class Series {
@@ -31,7 +48,10 @@ class Series {
     sent: { requests: new FederationSizeStatistics(), responses: new FederationSizeStatistics() },
     received: { requests: new FederationSizeStatistics(), responses: new FederationSizeStatistics() },
   };
-  readonly buckets = new Map<number, FederationActivityTotals>();
+  // Fixed ring storage, allocated only after this series receives traffic.
+  // Timestamp tags make idle/expired slots invisible without a per-event sweep.
+  private times?: Float64Array;
+  private values?: Float64Array;
   record(at: number, delta: FederationActivityTotals) {
     add(this.lifetime, delta);
     for (const direction of ["sent", "received"] as const) {
@@ -39,19 +59,19 @@ class Series {
       if (value.requests) this.sizes[direction].requests.record(value.dataBytes);
       if (value.responses) this.sizes[direction].responses.record(value.dataBytes);
     }
-    const bucket = this.buckets.get(at) ?? totals();
-    add(bucket, delta);
-    this.buckets.set(at, bucket);
-    this.expire(at);
-  }
-  expire(at: number) {
-    for (const time of this.buckets.keys()) {
-      if (time > at - HOUR) break;
-      this.buckets.delete(time);
+    this.times ??= new Float64Array(HOUR).fill(-Infinity);
+    this.values ??= new Float64Array(HOUR * 12);
+    const slot = ((at % HOUR) + HOUR) % HOUR;
+    let offset = slot * 12;
+    if (this.times[slot] !== at) {
+      this.values.fill(0, offset, offset + 12);
+      this.times[slot] = at;
+    }
+    for (const direction of ["sent", "received"] as const) {
+      for (const field of COUNT_FIELDS) this.values[offset++] += delta[direction][field];
     }
   }
   snapshot(at: number, includeHistory: boolean): FederationActivitySeries {
-    this.expire(at);
     const windows = { "1m": totals(), "5m": totals(), "10m": totals(), "1h": totals() };
     const history: FederationActivitySeries["history"] = [];
     const first = at - HOUR + 1;
@@ -61,12 +81,17 @@ class Series {
         history.push({ at: start * SECOND, totals: totals() });
       }
     }
-    for (const [time, bucket] of this.buckets) {
-      add(windows["1h"], bucket);
-      if (time > at - 600) add(windows["10m"], bucket);
-      if (time > at - 300) add(windows["5m"], bucket);
-      if (time > at - 60) add(windows["1m"], bucket);
-      if (includeHistory) add(history[Math.floor((time - first) / 10)].totals, bucket);
+    if (this.times && this.values) {
+      for (let slot = 0; slot < HOUR; slot += 1) {
+        const time = this.times[slot];
+        if (time <= at - HOUR || time > at) continue;
+        const offset = slot * 12;
+        addBucket(windows["1h"], this.values, offset);
+        if (time > at - 600) addBucket(windows["10m"], this.values, offset);
+        if (time > at - 300) addBucket(windows["5m"], this.values, offset);
+        if (time > at - 60) addBucket(windows["1m"], this.values, offset);
+        if (includeHistory) addBucket(history[Math.floor((time - first) / 10)].totals, this.values, offset);
+      }
     }
     return {
       lifetime: structuredClone(this.lifetime), windows, history,

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2,6 +2,8 @@ import { randomBytes, randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import path from "node:path";
 import type {
+  ReadFederationActivityRequest,
+  ReadFederationActivityResponse,
   AnalyzeThreadToolHistoryRequest,
   AnalyzeThreadToolHistoryResponse,
   AgentEvent,
@@ -230,6 +232,7 @@ import {
   collectFederationHostInfo,
   collectFederationLoadStatus,
 } from "./federation-host-info";
+import { FederationActivityLedger } from "./federation-activity-ledger";
 import { FederationTransferLedger } from "./federation-transfer-ledger";
 import { RemoteThreadSummaryCache } from "./remote-thread-summary-cache";
 import { hydrateFederatedThreadMessageOrigins } from "./federated-thread-origin-hydrator";
@@ -879,6 +882,7 @@ export class DesktopFederationRuntime {
    * the operator's baseline-vs-optimized comparison spans reconnects.
    */
   private readonly transferLedger = new FederationTransferLedger();
+  private readonly activityLedger = new FederationActivityLedger();
   private gatewayListenerError?: string;
 
   setAgentEventPublisher(publisher: (event: AgentEvent) => void): void {
@@ -1127,6 +1131,15 @@ export class DesktopFederationRuntime {
     this.lastConnectionError = undefined;
     this.lastConnectionFailureKind = undefined;
     this.gatewayListenerError = undefined;
+  }
+
+  async activity(request?: ReadFederationActivityRequest): Promise<ReadFederationActivityResponse> {
+    return {
+      activity: this.activityLedger.snapshot(Date.now(), request),
+      health: await this.health(),
+      configuredMode: this.readRuntimeConfig().mode,
+      running: Boolean(this.listenUrl || this.client || this.reconnectTimer),
+    };
   }
 
   async health(): Promise<FederationHealthStatus> {
@@ -2642,7 +2655,13 @@ export class DesktopFederationRuntime {
         },
         onEnvelope: (envelope, connection) =>
           void this.receiveEnvelope(envelope, connection.peerId),
-        onEnvelopeTransfer: (info) => this.transferLedger.record(info),
+        onEnvelopeTransfer: (info) => {
+          this.transferLedger.record(info);
+          this.activityLedger.record({
+            ...info,
+            localInstanceId: this.ensureLocalInstanceId(),
+          });
+        },
       });
       this.server = server;
       try {
@@ -2870,8 +2889,14 @@ export class DesktopFederationRuntime {
       host: this.localHostInfo,
       // All client traffic rides this one socket, so the counters land
       // on the gateway's row — including relayed sibling traffic.
-      onEnvelopeTransfer: (info) =>
-        this.transferLedger.record({ ...info, peerId: gatewayInstanceId }),
+      onEnvelopeTransfer: (info) => {
+        this.transferLedger.record({ ...info, peerId: gatewayInstanceId });
+        this.activityLedger.record({
+          ...info,
+          peerId: gatewayInstanceId,
+          localInstanceId: this.ensureLocalInstanceId(),
+        });
+      },
       role: "client",
       headers: cloudflareAccessEnabled
         ? {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1134,6 +1134,11 @@ export class DesktopFederationRuntime {
     this.gatewayListenerError = undefined;
   }
 
+  async resetActivity(): Promise<ReadFederationActivityResponse> {
+    this.activityLedger.reset();
+    return this.activity();
+  }
+
   async activity(request?: ReadFederationActivityRequest): Promise<ReadFederationActivityResponse> {
     return {
       activity: this.activityLedger.snapshot(Date.now(), request),

--- a/apps/desktop/src/main/federation/federation-size-statistics.ts
+++ b/apps/desktop/src/main/federation/federation-size-statistics.ts
@@ -1,0 +1,47 @@
+import type { FederationPayloadSizeStats } from "@pwragent/shared";
+
+// 32 bins per power of two cover every nonnegative safe integer byte size.
+// Fixed storage: at most 1,698 numeric bins, independent of traffic volume.
+const BINS_PER_OCTAVE = 32;
+const BIN_COUNT = 53 * BINS_PER_OCTAVE + 2;
+
+export class FederationSizeStatistics {
+  private histogram?: Float64Array;
+  private count = 0;
+  private sum = 0;
+  private min = Infinity;
+  private max = 0;
+
+  record(bytes: number): void {
+    if (!Number.isSafeInteger(bytes) || bytes < 0) return;
+    this.histogram ??= new Float64Array(BIN_COUNT);
+    const bin = bytes === 0 ? 0 : Math.ceil(Math.log2(bytes) * BINS_PER_OCTAVE) + 1;
+    this.histogram[bin] += 1;
+    this.count += 1;
+    this.sum += bytes;
+    this.min = Math.min(this.min, bytes);
+    this.max = Math.max(this.max, bytes);
+  }
+
+  snapshot(): FederationPayloadSizeStats {
+    if (!this.count || !this.histogram) return { count: 0 };
+    const rank = Math.ceil(this.count / 2);
+    let seen = 0;
+    let median = 0;
+    for (let bin = 0; bin < this.histogram.length; bin += 1) {
+      seen += this.histogram[bin];
+      if (seen < rank) continue;
+      // The midpoint differs from any integer in this bin by about 1.1%
+      // or less. Clamp to observed extrema, including constant-size streams.
+      median = bin === 0 ? 0 : 2 ** ((bin - 1.5) / BINS_PER_OCTAVE);
+      break;
+    }
+    return {
+      count: this.count,
+      averageBytes: this.sum / this.count,
+      p50Bytes: Math.max(this.min, Math.min(this.max, median)),
+      minBytes: this.min,
+      maxBytes: this.max,
+    };
+  }
+}

--- a/apps/desktop/src/main/federation/federation-transfer-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-transfer-ledger.ts
@@ -42,6 +42,11 @@ export class FederationTransferLedger {
       stats.envelopesReceived += 1;
     }
     stats.lastActivityAt = at;
+    // Health's legacy per-peer counters are bounded as well. The activity
+    // ledger separately retains all process totals, including overflow peers.
+    if (!this.byPeer.has(params.peerId) && this.byPeer.size >= 128) {
+      this.byPeer.delete(this.byPeer.keys().next().value!);
+    }
     this.byPeer.set(params.peerId, stats);
   }
 

--- a/apps/desktop/src/main/federation/federation-transport.ts
+++ b/apps/desktop/src/main/federation/federation-transport.ts
@@ -304,12 +304,15 @@ export type FederationGatewayWebSocketServerOptions = {
   /**
    * Wire-byte tap for envelope frames only (handshake/auth frames and
    * WebSocket keepalives are not reported). `byteCount` is the frame's
-   * post-encryption length — what actually crossed the wire.
+   * encoded application-message length including Noise tags, excluding
+   * WebSocket headers, TCP/TLS overhead, handshake and ping/pong/close frames.
    */
   onEnvelopeTransfer?: (info: {
     peerId: FederationInstanceId;
     direction: "sent" | "received";
     byteCount: number;
+    dataByteCount: number;
+    envelope: FederationProtocolEnvelope;
   }) => void;
 };
 
@@ -597,6 +600,8 @@ export class FederationGatewayWebSocketServer {
             peerId: decision.peer.id,
             direction: "sent",
             byteCount,
+            dataByteCount: envelopeDataBytes.get(envelope)!,
+            envelope,
           });
         }
       },
@@ -612,6 +617,8 @@ export class FederationGatewayWebSocketServer {
             peerId: decision.peer.id,
             direction: "sent",
             byteCount,
+            dataByteCount: envelopeDataBytes.get(envelope)!,
+            envelope,
           });
         }
       },
@@ -748,6 +755,8 @@ export class FederationGatewayWebSocketServer {
         peerId: connection.peerId,
         direction: "received",
         byteCount: frame.byteLength,
+        dataByteCount: envelopeDataBytes.get(next.envelope)!,
+        envelope: next.envelope,
       });
       this.options.onEnvelope?.(next.envelope, connection);
     }
@@ -868,6 +877,8 @@ export async function connectFederationClient(params: {
   onEnvelopeTransfer?: (info: {
     direction: "sent" | "received";
     byteCount: number;
+    dataByteCount: number;
+    envelope: FederationProtocolEnvelope;
   }) => void;
   /**
    * Called once when the transport ends. `info` carries the WebSocket
@@ -1134,6 +1145,8 @@ async function establishFederationClient(
         params.onEnvelopeTransfer?.({
           direction: "received",
           byteCount: frame.byteLength,
+          dataByteCount: envelopeDataBytes.get(message.envelope)!,
+          envelope: message.envelope,
         });
         params.onEnvelope?.(message.envelope);
       }
@@ -1154,7 +1167,10 @@ async function establishFederationClient(
         maxFrameBytes,
       );
       if (byteCount > 0) {
-        params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
+        params.onEnvelopeTransfer?.({
+          direction: "sent", byteCount,
+          dataByteCount: envelopeDataBytes.get(envelope)!, envelope,
+        });
       }
     },
     sendEnvelopeWithBackpressure: async (envelope) => {
@@ -1165,7 +1181,10 @@ async function establishFederationClient(
         maxFrameBytes,
       );
       if (byteCount > 0) {
-        params.onEnvelopeTransfer?.({ direction: "sent", byteCount });
+        params.onEnvelopeTransfer?.({
+          direction: "sent", byteCount,
+          dataByteCount: envelopeDataBytes.get(envelope)!, envelope,
+        });
       }
     },
     close: () => socket.close(),
@@ -1354,7 +1373,18 @@ function decodeFrame(
   return decodeFederationSocketPayload(payload);
 }
 
-function encodeFederationSocketPayload(
+// Weak keys never extend envelope lifetime. Capture the serialization length at
+// the codec boundary, before #1255's compression and Noise encryption. On receive
+// this runs after decompression. No second JSON serialization is necessary.
+const envelopeDataBytes = new WeakMap<FederationProtocolEnvelope, number>();
+
+function encodeFederationSocketPayload(message: FederationSocketMessage): Buffer {
+  const payload = encodeRawFederationSocketPayload(message);
+  if (message.kind === "envelope") envelopeDataBytes.set(message.envelope, payload.byteLength);
+  return payload;
+}
+
+function encodeRawFederationSocketPayload(
   message: FederationSocketMessage,
 ): Buffer {
   if (
@@ -1377,7 +1407,13 @@ function encodeFederationSocketPayload(
   return Buffer.concat([prefix, header, Buffer.from(data)]);
 }
 
-function decodeFederationSocketPayload(
+function decodeFederationSocketPayload(payload: Buffer): FederationSocketMessage | undefined {
+  const message = decodeRawFederationSocketPayload(payload);
+  if (message?.kind === "envelope") envelopeDataBytes.set(message.envelope, payload.byteLength);
+  return message;
+}
+
+function decodeRawFederationSocketPayload(
   payload: Buffer,
 ): FederationSocketMessage | undefined {
   if (

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -1,5 +1,6 @@
-import { ipcMain } from "electron";
+import { BrowserWindow, ipcMain } from "electron";
 import type {
+  ReadFederationActivityRequest,
   ConfigureFederationTailscaleRequest,
   ConfigureFederationTailscaleResponse,
   FederationPinDisposition,
@@ -35,6 +36,10 @@ import {
   isFederationPinDisposition,
 } from "@pwragent/shared";
 import {
+  FEDERATION_READ_ACTIVITY_CHANNEL,
+  FEDERATION_SET_ENABLED_CHANNEL,
+  FEDERATION_OPEN_ACTIVITY_CHANNEL,
+  FEDERATION_ACTIVITY_TOPMOST_CHANNEL,
   FEDERATION_GET_HEALTH_CHANNEL,
   FEDERATION_GET_DIAGNOSTICS_CHANNEL,
   FEDERATION_READ_INSTANCE_LOAD_CHANNEL,
@@ -49,6 +54,11 @@ import {
   FEDERATION_TAILSCALE_CONFIGURE_CHANNEL,
   FEDERATION_TAILSCALE_STATUS_CHANNEL,
 } from "../../shared/ipc";
+import {
+  showFederationActivityWindow,
+  setFederationActivityTopmost,
+} from "../federation-activity-window";
+import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import {
   federationTailscaleAdvertisementFromStatus,
@@ -78,7 +88,51 @@ function peerAllowsEventClass(
   }
 }
 
+let previousEnabledMode: "client" | "gateway" | "dual" | undefined;
+let activityToggle: Promise<unknown> = Promise.resolve();
+
 export function registerFederationIpcHandlers(): void {
+  for (const channel of [
+    FEDERATION_READ_ACTIVITY_CHANNEL,
+    FEDERATION_SET_ENABLED_CHANNEL,
+    FEDERATION_OPEN_ACTIVITY_CHANNEL,
+    FEDERATION_ACTIVITY_TOPMOST_CHANNEL,
+  ]) {
+    ipcMain.removeHandler(channel);
+  }
+  ipcMain.handle(FEDERATION_READ_ACTIVITY_CHANNEL, (_event, request?: ReadFederationActivityRequest) =>
+    getDesktopFederationRuntime().activity({
+      includeHistory: request?.includeHistory !== false,
+      historyPeerId: typeof request?.historyPeerId === "string"
+        ? request.historyPeerId.slice(0, 256)
+        : undefined,
+      historyView: request?.historyView === "logical" ? "logical" : "physical",
+    }));
+  ipcMain.handle(FEDERATION_OPEN_ACTIVITY_CHANNEL, (event) => {
+    showFederationActivityWindow({
+      sourceWindow: BrowserWindow.fromWebContents(event.sender) ?? undefined,
+    });
+  });
+  ipcMain.handle(FEDERATION_ACTIVITY_TOPMOST_CHANNEL, (event, enabled: unknown) => {
+    if (typeof enabled !== "boolean") throw new Error("Expected a boolean.");
+    return setFederationActivityTopmost(event.sender.id, enabled);
+  });
+  ipcMain.handle(FEDERATION_SET_ENABLED_CHANNEL, (_event, enabled: unknown) => {
+    if (typeof enabled !== "boolean") throw new Error("Expected a boolean.");
+    const change = activityToggle.catch(() => undefined).then(async () => {
+      const service = getDesktopSettingsService();
+      const current = service.readFederationConfig();
+      if (current.mode !== "disabled") previousEnabledMode = current.mode;
+      const resumeMode = previousEnabledMode
+        ?? (current.gatewayUrl || current.gatewayEndpoints?.length ? "client" : "gateway");
+      const mode = enabled ? resumeMode : "disabled";
+      await service.writeConfigPatchTargeted({ federation: { mode } });
+      await getDesktopFederationRuntime().restart();
+      return getDesktopFederationRuntime().activity();
+    });
+    activityToggle = change;
+    return change;
+  });
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
   ipcMain.removeHandler(FEDERATION_READ_INSTANCE_LOAD_CHANNEL);

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -37,6 +37,7 @@ import {
 } from "@pwragent/shared";
 import {
   FEDERATION_READ_ACTIVITY_CHANNEL,
+  FEDERATION_RESET_ACTIVITY_CHANNEL,
   FEDERATION_SET_ENABLED_CHANNEL,
   FEDERATION_OPEN_ACTIVITY_CHANNEL,
   FEDERATION_ACTIVITY_TOPMOST_CHANNEL,
@@ -94,6 +95,7 @@ let activityToggle: Promise<unknown> = Promise.resolve();
 export function registerFederationIpcHandlers(): void {
   for (const channel of [
     FEDERATION_READ_ACTIVITY_CHANNEL,
+    FEDERATION_RESET_ACTIVITY_CHANNEL,
     FEDERATION_SET_ENABLED_CHANNEL,
     FEDERATION_OPEN_ACTIVITY_CHANNEL,
     FEDERATION_ACTIVITY_TOPMOST_CHANNEL,
@@ -108,6 +110,7 @@ export function registerFederationIpcHandlers(): void {
         : undefined,
       historyView: request?.historyView === "logical" ? "logical" : "physical",
     }));
+  ipcMain.handle(FEDERATION_RESET_ACTIVITY_CHANNEL, () => getDesktopFederationRuntime().resetActivity());
   ipcMain.handle(FEDERATION_OPEN_ACTIVITY_CHANNEL, (event) => {
     showFederationActivityWindow({
       sourceWindow: BrowserWindow.fromWebContents(event.sender) ?? undefined,
@@ -439,6 +442,7 @@ function readPinDisposition(value: unknown): FederationPinDisposition {
 }
 
 export function disposeFederationIpcHandlers(): void {
+  ipcMain.removeHandler(FEDERATION_RESET_ACTIVITY_CHANNEL);
   ipcMain.removeHandler(FEDERATION_OPEN_WINDOW_CHANNEL);
   ipcMain.removeHandler(FEDERATION_GET_HEALTH_CHANNEL);
   ipcMain.removeHandler(FEDERATION_READ_INSTANCE_LOAD_CHANNEL);

--- a/apps/desktop/src/main/window-channels.ts
+++ b/apps/desktop/src/main/window-channels.ts
@@ -32,6 +32,7 @@ import type { FederationRemoteTarget } from "@pwragent/shared";
 
 /** Identifier for each known window kind. Keep in sync with the
  *  per-window registration sites. */
+export const WINDOW_KIND_FEDERATION_ACTIVITY = "federation-activity" as const;
 export const WINDOW_KIND_MAIN = "main" as const;
 export const WINDOW_KIND_MESSAGING_ACTIVITY = "messaging-activity" as const;
 export const WINDOW_KIND_STAR_MAP = "star-map" as const;
@@ -44,6 +45,7 @@ export const WINDOW_KIND_TOOL_OUTPUT_INCIDENT_EXPLORER =
   "tool-output-incident-explorer" as const;
 export const WINDOW_KIND_AUTOMATION_RUN = "automation-run" as const;
 export type WindowKind =
+  | typeof WINDOW_KIND_FEDERATION_ACTIVITY
   | typeof WINDOW_KIND_MAIN
   | typeof WINDOW_KIND_MESSAGING_ACTIVITY
   | typeof WINDOW_KIND_STAR_MAP

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -344,6 +344,8 @@ import type {
   ReadMarkdownFileViewerSnapshotResponse,
   OpenDesktopPwrAgentProfileRequest,
   OpenDesktopPwrAgentProfileResponse,
+  ReadFederationActivityRequest,
+  ReadFederationActivityResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
   ReadFederationInstanceLoadRequest,
@@ -588,6 +590,10 @@ import {
   PATH_OPEN_CHANNEL,
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
+  FEDERATION_READ_ACTIVITY_CHANNEL,
+  FEDERATION_SET_ENABLED_CHANNEL,
+  FEDERATION_OPEN_ACTIVITY_CHANNEL,
+  FEDERATION_ACTIVITY_TOPMOST_CHANNEL,
   FEDERATION_GET_HEALTH_CHANNEL,
   FEDERATION_READ_INSTANCE_LOAD_CHANNEL,
   FEDERATION_GET_DIAGNOSTICS_CHANNEL,
@@ -1070,6 +1076,14 @@ const desktopApi = Object.freeze({
     request: OpenFederationWindowRequest,
   ): Promise<OpenFederationWindowResponse> =>
     await ipcRenderer.invoke(FEDERATION_OPEN_WINDOW_CHANNEL, request),
+  readFederationActivity: async (request?: ReadFederationActivityRequest): Promise<ReadFederationActivityResponse> =>
+    await ipcRenderer.invoke(FEDERATION_READ_ACTIVITY_CHANNEL, request),
+  setFederationEnabled: async (enabled: boolean): Promise<ReadFederationActivityResponse> =>
+    await ipcRenderer.invoke(FEDERATION_SET_ENABLED_CHANNEL, enabled),
+  openFederationActivity: async (): Promise<void> =>
+    await ipcRenderer.invoke(FEDERATION_OPEN_ACTIVITY_CHANNEL),
+  setFederationActivityTopmost: async (enabled: boolean): Promise<boolean> =>
+    await ipcRenderer.invoke(FEDERATION_ACTIVITY_TOPMOST_CHANNEL, enabled),
   readFederationHealth: async (
     request?: ReadFederationHealthRequest,
   ): Promise<ReadFederationHealthResponse> =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -594,6 +594,7 @@ import {
   PATH_REVEAL_CHANNEL,
   BACKEND_LIST_CHANNEL,
   FEDERATION_READ_ACTIVITY_CHANNEL,
+  FEDERATION_RESET_ACTIVITY_CHANNEL,
   FEDERATION_SET_ENABLED_CHANNEL,
   FEDERATION_OPEN_ACTIVITY_CHANNEL,
   FEDERATION_ACTIVITY_TOPMOST_CHANNEL,
@@ -1081,6 +1082,8 @@ const desktopApi = Object.freeze({
     await ipcRenderer.invoke(FEDERATION_OPEN_WINDOW_CHANNEL, request),
   readFederationActivity: async (request?: ReadFederationActivityRequest): Promise<ReadFederationActivityResponse> =>
     await ipcRenderer.invoke(FEDERATION_READ_ACTIVITY_CHANNEL, request),
+  resetFederationActivity: async (): Promise<ReadFederationActivityResponse> =>
+    await ipcRenderer.invoke(FEDERATION_RESET_ACTIVITY_CHANNEL),
   setFederationEnabled: async (enabled: boolean): Promise<ReadFederationActivityResponse> =>
     await ipcRenderer.invoke(FEDERATION_SET_ENABLED_CHANNEL, enabled),
   openFederationActivity: async (): Promise<void> =>

--- a/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/AppTitleBar.tsx
@@ -7,7 +7,7 @@ import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
 import { AppMenuBar } from "./AppMenuBar";
 import { NewThreadButton } from "./NewThreadButton";
 import { PanelToggleButtons } from "./PanelToggleButtons";
-import { StarMapIcon } from "../../icons/StarMapIcon";
+import { FederationStatusControl } from "../federation-activity/FederationStatusControl";
 import type { StarMapToggleControls } from "../thread-detail/ThreadHeader";
 
 export type AppTitleBarLayoutControls = {
@@ -128,14 +128,7 @@ export function AppTitleBar(props: {
             />
           ) : null}
           {props.starMap && !isFederationWindow ? (
-            <button
-              type="button"
-              aria-label="Open Star Map"
-              className="thread-header__star-map-toggle"
-              onClick={props.starMap.onOpen}
-            >
-              <StarMapIcon size={14} />
-            </button>
+            <FederationStatusControl desktopApi={props.desktopApi} onOpen={props.starMap.onOpen} />
           ) : null}
           {props.desktopApi ? (
             <MessagingStatusBar

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -1,0 +1,119 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { FederationActivityTotals, ReadFederationActivityResponse } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { FederationStatusControl } from "./FederationStatusControl";
+import { FederationActivityScreen } from "./FederationActivityWindow";
+
+const totals = (): FederationActivityTotals => ({
+  sent: { requests: 12, responses: 3, notifications: 9, other: 0, dataBytes: 2_000, wireBytes: 800 },
+  received: { requests: 3, responses: 12, notifications: 4, other: 1, dataBytes: 4_000, wireBytes: 1_600 },
+});
+function fixture(): ReadFederationActivityResponse {
+  const series = {
+    lifetime: totals(), windows: { "1m": totals(), "5m": totals(), "1h": totals() },
+    history: Array.from({ length: 360 }, (_, index) => ({ at: index * 10_000, totals: totals() })),
+  };
+  return {
+    activity: { since: 0, at: 3_600_000, bucketMs: 1_000, physical: series,
+      peers: [{ peerId: "gateway", series }], logical: [{ peerId: "remote", series }] },
+    configuredMode: "gateway", running: true,
+    health: { enabled: true, role: "gateway", status: "connected", peers: [] },
+  };
+}
+afterEach(() => { cleanup(); vi.useRealTimers(); });
+
+describe("Federation activity surfaces", () => {
+  it("opens on hover without navigating, preserves pointer grace, and clicking still opens Star Map", async () => {
+    const onOpen = vi.fn();
+    const readFederationActivity = vi.fn(async () => fixture());
+    const { container } = render(<FederationStatusControl desktopApi={{ readFederationActivity }} onOpen={onOpen} />);
+    expect(readFederationActivity).not.toHaveBeenCalled();
+    const root = container.firstElementChild!;
+    fireEvent.pointerEnter(root);
+    await screen.findByText("Running · connected");
+    expect(onOpen).not.toHaveBeenCalled();
+    vi.useFakeTimers();
+    fireEvent.pointerLeave(root);
+    act(() => vi.advanceTimersByTime(100));
+    fireEvent.pointerEnter(screen.getByRole("dialog"));
+    act(() => vi.advanceTimersByTime(200));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open Star Map" }));
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps keyboard focus inside the interactive panel, opens Activity, and dismisses with Escape", async () => {
+    const openFederationActivity = vi.fn(async () => {});
+    render(<FederationStatusControl desktopApi={{ readFederationActivity: async () => fixture(), openFederationActivity }} onOpen={vi.fn()} />);
+    const trigger = screen.getByRole("button", { name: "Open Star Map" });
+    act(() => trigger.focus());
+    await screen.findByText("Running · connected");
+    const action = screen.getByRole("button", { name: "Open Federation Activity" });
+    act(() => action.focus());
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    fireEvent.keyDown(action, { key: "Escape" });
+    expect(trigger).toHaveFocus();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    fireEvent.pointerEnter(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "Open Federation Activity" }));
+    await waitFor(() => expect(openFederationActivity).toHaveBeenCalledTimes(1));
+  });
+
+  it("shows configured-on separately from a lease-denied runtime and applies toggle results", async () => {
+    const denied = fixture();
+    denied.running = false;
+    denied.health.enabled = false;
+    denied.health.leaseHolder = { instanceId: "other-app", processId: 123, cwdHint: "/fixture/other" };
+    denied.health.unavailableReason = "This profile is already served by another app.";
+    const off = { ...fixture(), configuredMode: "disabled" as const, running: false };
+    const setFederationEnabled = vi.fn(async () => off);
+    render(<FederationStatusControl desktopApi={{ readFederationActivity: async () => denied, setFederationEnabled }} onOpen={vi.fn()} />);
+    fireEvent.focus(screen.getByRole("button", { name: "Open Star Map" }));
+    await screen.findByText("Not running · lease held by another instance");
+    expect(screen.getByText("Configured on · gateway")).toBeInTheDocument();
+    expect(screen.getByText(/Holder: other-app · PID 123/)).toBeInTheDocument();
+    const toggle = screen.getByRole("switch", { name: "Federation enabled" });
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(toggle);
+    await screen.findByText("Configured off");
+    expect(setFederationEnabled).toHaveBeenCalledWith(false);
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("labels chart axes with numeric rates and units, exposes periods and per-peer attribution, and confirms topmost", async () => {
+    const readFederationActivity = vi.fn(async () => fixture());
+    const setFederationActivityTopmost = vi.fn(async (enabled: boolean) => enabled);
+    const api: DesktopApi = { readFederationActivity, setFederationActivityTopmost };
+    render(<FederationActivityScreen desktopApi={api} />);
+    await screen.findByText("Running · connected");
+    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("2.4")).toBeInTheDocument();
+    expect(screen.getByRole("columnheader", { name: "Sent" })).toBeInTheDocument();
+    for (const period of ["1m", "5m", "1h", "lifetime"]) {
+      fireEvent.change(screen.getByLabelText("Period"), { target: { value: period } });
+      expect(screen.getByLabelText("Period")).toHaveValue(period);
+    }
+    fireEvent.change(screen.getByLabelText("Attribution"), { target: { value: "logical" } });
+    await waitFor(() => expect(readFederationActivity).toHaveBeenLastCalledWith({
+      historyPeerId: "remote", historyView: "logical", includeHistory: undefined,
+    }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Always on top" }));
+    await waitFor(() => expect(screen.getByRole("checkbox")).toBeChecked());
+    expect(setFederationActivityTopmost).toHaveBeenCalledWith(true);
+  });
+
+  it("keeps the switch state and reports errors if a configuration change fails", async () => {
+    render(<FederationStatusControl desktopApi={{
+      readFederationActivity: async () => fixture(),
+      setFederationEnabled: async () => { throw new Error("Config is read-only"); },
+    }} onOpen={vi.fn()} />);
+    fireEvent.focus(screen.getByRole("button", { name: "Open Star Map" }));
+    await screen.findByText("Running · connected");
+    fireEvent.click(screen.getByRole("switch"));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Config is read-only");
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -161,3 +161,57 @@ describe("Federation activity surfaces", () => {
   });
 
 });
+
+
+describe("Activity report controls", () => {
+  it("uses the standard switch and copies the selected peer with recent totals and sizes", async () => {
+    const data = fixture();
+    data.activity.peers[0].series = structuredClone(data.activity.physical);
+    data.activity.peers[0].series.lifetime.sent.requests = 987;
+    const copyText = vi.fn(async (_text: string) => {});
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => data, copyText }} />);
+    await screen.findByText("Running · connected");
+    expect(screen.getByRole("switch")).toHaveClass("settings-switch", "is-on");
+    expect(screen.getByRole("switch").querySelector(".settings-switch__thumb")).not.toBeNull();
+    fireEvent.change(screen.getByRole("combobox", { name: "Peer" }), { target: { value: "gateway" } });
+    fireEvent.click(screen.getByRole("button", { name: "Copy Federation activity" }));
+    await waitFor(() => expect(copyText).toHaveBeenCalledTimes(1));
+    const text = copyText.mock.calls[0][0];
+    expect(text).toContain("Physical connections: gateway");
+    expect(text).toContain("Requests\t12\t12\t12\t987");
+    expect(text).toContain("2 KB (2000 bytes)");
+    expect(text).toContain("Samples\tAvg\tp50 (approx.)\tMin\tMax");
+    expect(text).toContain("Since: 1970-01-01T00:00:00.000Z");
+    expect(text).toContain("excludes WebSocket framing");
+    await screen.findByText("Federation activity copied");
+  });
+
+  it("resets immediately and ignores a read that started before reset", async () => {
+    const data = fixture();
+    const cleared = fixture();
+    cleared.activity.since = 12345;
+    cleared.activity.physical.lifetime.sent.requests = 0;
+    let finishRead!: (value: ReadFederationActivityResponse) => void;
+    const readFederationActivity = vi.fn().mockResolvedValueOnce(data)
+      .mockImplementation(() => new Promise((resolve) => { finishRead = resolve; }));
+    const resetFederationActivity = vi.fn(async () => cleared);
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity, resetFederationActivity }} />);
+    await screen.findByText("Running · connected");
+    fireEvent.change(screen.getByRole("combobox", { name: "Peer" }), { target: { value: "gateway" } });
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    await waitFor(() => expect(resetFederationActivity).toHaveBeenCalledOnce());
+    await act(async () => finishRead(data));
+    fireEvent.change(screen.getByRole("combobox", { name: "Peer" }), { target: { value: "" } });
+    const row = within(screen.getByRole("table", { name: "Sent traffic" })).getByRole("row", { name: /^Requests / });
+    expect(within(row).getAllByRole("cell").at(-1)).toHaveTextContent("0");
+  });
+
+  it("reports reset failures and leaves existing totals intact", async () => {
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => fixture(),
+      resetFederationActivity: async () => { throw new Error("Reset failed"); } }} />);
+    await screen.findByText("Running · connected");
+    fireEvent.click(screen.getByRole("button", { name: "Reset" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Reset failed");
+    expect(screen.getByRole("table", { name: "Sent traffic" })).toHaveTextContent("12");
+  });
+});

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom/vitest";
-import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { FederationActivityTotals, ReadFederationActivityResponse } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
@@ -12,7 +12,7 @@ const totals = (): FederationActivityTotals => ({
 });
 function fixture(): ReadFederationActivityResponse {
   const series = {
-    lifetime: totals(), windows: { "1m": totals(), "5m": totals(), "1h": totals() },
+    lifetime: totals(), windows: { "1m": totals(), "5m": totals(), "10m": totals(), "1h": totals() },
     history: Array.from({ length: 360 }, (_, index) => ({ at: index * 10_000, totals: totals() })),
   };
   return {
@@ -89,12 +89,17 @@ describe("Federation activity surfaces", () => {
     const api: DesktopApi = { readFederationActivity, setFederationActivityTopmost };
     render(<FederationActivityScreen desktopApi={api} />);
     await screen.findByText("Running · connected");
-    expect(screen.getByText("200")).toBeInTheDocument();
+    expect(screen.getByText("0.2")).toBeInTheDocument();
     expect(screen.getByText("2.4")).toBeInTheDocument();
-    expect(screen.getByRole("columnheader", { name: "Sent" })).toBeInTheDocument();
-    for (const period of ["1m", "5m", "1h", "lifetime"]) {
-      fireEvent.change(screen.getByLabelText("Period"), { target: { value: period } });
-      expect(screen.getByLabelText("Period")).toHaveValue(period);
+    for (const name of ["Sent traffic", "Received traffic"]) {
+      const table = within(screen.getByRole("table", { name }));
+      for (const column of ["Last 1m", "Last 10m", "Last 1h", "Total"]) {
+        expect(table.getByRole("columnheader", { name: column })).toBeInTheDocument();
+      }
+    }
+    for (const period of ["1m", "10m", "1h"]) {
+      fireEvent.change(screen.getByLabelText("Chart window"), { target: { value: period } });
+      expect(screen.getByLabelText("Chart window")).toHaveValue(period);
     }
     fireEvent.change(screen.getByLabelText("Attribution"), { target: { value: "logical" } });
     await waitFor(() => expect(readFederationActivity).toHaveBeenLastCalledWith({
@@ -116,4 +121,22 @@ describe("Federation activity surfaces", () => {
     expect(await screen.findByRole("alert")).toHaveTextContent("Config is read-only");
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
   });
+  it("shows recent bursts beside lifetime totals regardless of chart range", async () => {
+    const snapshot = fixture();
+    const series = snapshot.activity.physical;
+    series.windows["1m"].received.wireBytes = 50_000_000;
+    series.windows["10m"].received.wireBytes = 1_000_000_000;
+    series.windows["1h"].received.wireBytes = 2_000_000_000;
+    series.lifetime.received.wireBytes = 50_000_000_000;
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => snapshot }} />);
+    const table = within(await screen.findByRole("table", { name: "Received traffic" }));
+    const row = table.getByRole("row", { name: /Wire · encoded/ });
+    expect(within(row).getAllByRole("cell").map((cell) => cell.textContent?.trim()))
+      .toEqual(["50 MB", "1 GB", "2 GB", "50 GB"]);
+    fireEvent.change(screen.getByLabelText("Chart window"), { target: { value: "1h" } });
+    expect(within(row).getAllByRole("cell").map((cell) => cell.textContent?.trim()))
+      .toEqual(["50 MB", "1 GB", "2 GB", "50 GB"]);
+    expect(within(row).getByText("50 MB")).toHaveAttribute("title", "50,000,000 bytes");
+  });
+
 });

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -12,6 +12,10 @@ const totals = (): FederationActivityTotals => ({
 });
 function fixture(): ReadFederationActivityResponse {
   const series = {
+    sizes: {
+      sent: { requests: { count: 0 }, responses: { count: 0 } },
+      received: { requests: { count: 0 }, responses: { count: 0 } },
+    },
     lifetime: totals(), windows: { "1m": totals(), "5m": totals(), "10m": totals(), "1h": totals() },
     history: Array.from({ length: 360 }, (_, index) => ({ at: index * 10_000, totals: totals() })),
   };
@@ -137,6 +141,23 @@ describe("Federation activity surfaces", () => {
     expect(within(row).getAllByRole("cell").map((cell) => cell.textContent?.trim()))
       .toEqual(["50 MB", "1 GB", "2 GB", "50 GB"]);
     expect(within(row).getByText("50 MB")).toHaveAttribute("title", "50,000,000 bytes");
+  });
+
+  it("shows lifetime request/response size statistics without time-bucket columns", async () => {
+    const snapshot = fixture();
+    snapshot.activity.physical.sizes.received.responses = {
+      count: 5, averageBytes: 10_000_800, p50Bytes: 1_000, minBytes: 1_000, maxBytes: 50_000_000,
+    };
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => snapshot }} />);
+    const table = within(await screen.findByRole("table", { name: "Lifetime request/response sizes · uncompressed" }));
+    expect(table.getAllByRole("columnheader").map((cell) => cell.textContent))
+      .toEqual(["Traffic", "Samples", "Avg", "p50 ≈", "Min", "Max"]);
+    expect(within(table.getByRole("row", { name: /Received responses/ })).getAllByRole("cell").map((cell) => cell.textContent))
+      .toEqual(["5", "10 MB", "1 KB", "1 KB", "50 MB"]);
+    expect(within(table.getByRole("row", { name: /Sent requests/ })).getAllByRole("cell").map((cell) => cell.textContent))
+      .toEqual(["0", "—", "—", "—", "—"]);
+    fireEvent.change(screen.getByLabelText("Chart window"), { target: { value: "10m" } });
+    expect(table.getByText("50 MB")).toBeInTheDocument();
   });
 
 });

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -1,30 +1,47 @@
 import { useEffect, useId, useState } from "react";
-import type { FederationActivitySeries, FederationActivityTotals } from "@pwragent/shared";
+import type { FederationActivitySeries } from "@pwragent/shared";
 import { useDesktopApi, type DesktopApi } from "../../lib/desktop-api";
+import { formatTrafficBytes, trafficByteUnit } from "./format-traffic-bytes";
 import { federationRuntimeLabel, useFederationActivity } from "./useFederationActivity";
 
-type Period = "1m" | "5m" | "1h" | "lifetime";
-const PERIODS: Period[] = ["1m", "5m", "1h", "lifetime"];
+type Period = "1m" | "10m" | "1h";
+const PERIODS: Period[] = ["1m", "10m", "1h"];
 const number = (value: number) => value.toLocaleString(undefined, { maximumFractionDigits: 2 });
 const fields = [
   ["requests", "Requests"], ["responses", "Responses (including errors)"],
   ["notifications", "Notifications"], ["other", "Other envelopes (including blobs)"],
-  ["dataBytes", "Data · uncompressed B"], ["wireBytes", "Wire · encoded B"],
+  ["dataBytes", "Data · uncompressed"], ["wireBytes", "Wire · encoded"],
 ] as const;
 
-function Totals({ value }: { value: FederationActivityTotals }) {
-  return <table className="federation-activity__totals">
-    <thead><tr><th scope="col">Traffic</th><th scope="col">Sent</th><th scope="col">Received</th></tr></thead>
-    <tbody>{fields.map(([key, label]) => <tr key={key}><th scope="row">{label}</th>
-      <td>{number(value.sent[key])}</td><td>{number(value.received[key])}</td></tr>)}</tbody>
-  </table>;
+function Totals({ series }: { series: FederationActivitySeries }) {
+  const periods = [series.windows["1m"], series.windows["10m"], series.windows["1h"], series.lifetime];
+  return <div className="federation-activity__tables">
+    {(["sent", "received"] as const).map((direction) => (
+      <table className="federation-activity__totals" key={direction}>
+        <caption>{direction === "sent" ? "Sent traffic" : "Received traffic"}</caption>
+        <thead><tr><th scope="col">Traffic</th>
+          <th scope="col">Last 1m</th><th scope="col">Last 10m</th>
+          <th scope="col">Last 1h</th><th scope="col">Total</th>
+        </tr></thead>
+        <tbody>{fields.map(([key, label]) => <tr key={key}><th scope="row">{label}</th>
+          {periods.map((period, index) => {
+            const value = period[direction][key];
+            const bytes = key === "dataBytes" || key === "wireBytes";
+            return <td key={index} title={bytes ? `${number(value)} bytes` : undefined}>
+              {bytes ? formatTrafficBytes(value) : number(value)}
+            </td>;
+          })}
+        </tr>)}</tbody>
+      </table>
+    ))}
+  </div>;
 }
 
 export function FederationRateChart({ history, period, bytes }: {
   history: FederationActivitySeries["history"]; period: Period; bytes: boolean;
 }) {
   const id = useId();
-  const length = period === "1m" ? 6 : period === "5m" ? 30 : 360;
+  const length = period === "1m" ? 6 : period === "10m" ? 60 : 360;
   const points = history.slice(-length);
   const lines = bytes ? [
     { direction: "sent", field: "wireBytes", label: "Sent wire", dashed: false },
@@ -41,25 +58,26 @@ export function FederationRateChart({ history, period, bytes }: {
       : value[line.field]) / 10;
   }));
   const max = Math.max(0, ...values.flat()) || 1;
-  const exponent = bytes ? Math.min(3, Math.max(0, Math.floor(Math.log(max) / Math.log(1024)))) : 0;
-  const scale = 1024 ** exponent;
-  const unit = bytes ? ["B/s", "KiB/s", "MiB/s", "GiB/s"][exponent] : "envelopes/s";
+  const byteUnit = trafficByteUnit(max);
+  const scale = bytes ? byteUnit.scale : 1;
+  const unit = bytes ? `${byteUnit.unit}/s` : "envelopes/s";
+  const axisNumber = (value: number) => value.toLocaleString(undefined, { maximumSignificantDigits: 3 });
   return <figure className="federation-activity__chart">
     <figcaption>{bytes ? "Data and wire rate" : "Envelope rate"} · {unit}</figcaption>
     <svg viewBox="0 0 640 165" role="img" aria-labelledby={`${id}-title ${id}-description`}>
       <title id={`${id}-title`}>{bytes ? "Data and wire" : "Envelope"} rates, {unit}</title>
-      <desc id={`${id}-description`}>Ten-second averages. Peak {number(max / scale)} {unit}. Sent uses the accent line,
+      <desc id={`${id}-description`}>Ten-second averages. Peak {axisNumber(max / scale)} {unit}. Sent uses the accent line,
         received uses the neutral line. Dashed lines show uncompressed data.</desc>
       <text x="87" y="12" textAnchor="end">{unit}</text>
       {[0, 0.5, 1].map((fraction) => <g key={fraction}>
         <line x1="95" x2="630" y1={130 - fraction * 110} y2={130 - fraction * 110} className="federation-activity__grid" />
-        <text x="87" y={134 - fraction * 110} textAnchor="end">{number(max * fraction / scale)}</text>
+        <text x="87" y={134 - fraction * 110} textAnchor="end">{axisNumber(max * fraction / scale)}</text>
       </g>)}
       {lines.map((line, index) => <polyline key={line.label}
         className={`federation-activity__line federation-activity__line--${line.direction}`}
         strokeDasharray={line.dashed ? "5 4" : undefined}
         points={values[index].map((value, point) => `${95 + point * 535 / Math.max(1, points.length - 1)},${130 - value / max * 110}`).join(" ")} />)}
-      <text x="95" y="155">{period === "lifetime" ? "1h" : period} ago</text>
+      <text x="95" y="155">{period} ago</text>
       <text x="630" y="155" textAnchor="end">Now</text>
     </svg>
     <div className="federation-activity__legend">{lines.map((line) => <span key={line.label}
@@ -80,7 +98,6 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
   });
   const peers = snapshot ? view === "physical" ? snapshot.activity.peers : snapshot.activity.logical : [];
   const series = peerId ? peers.find((peer) => peer.peerId === peerId)?.series : snapshot?.activity.physical;
-  const value = period === "lifetime" ? series?.lifetime : series?.windows[period];
   const labelFor = (id: string) => snapshot?.health.peers.find((peer) => peer.id === id)?.label || id;
   return <div className="federation-activity">
     <div className="federation-activity__toolbar">
@@ -114,8 +131,8 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
         {view === "physical" ? <option value="">All physical connections</option> : <option value="" disabled>Select an endpoint</option>}
         {peers.map((peer) => <option value={peer.peerId} key={peer.peerId}>{labelFor(peer.peerId)}</option>)}
       </select></label>
-      <label>Period <select value={period} onChange={(event) => setPeriod(event.target.value as Period)}>
-        {PERIODS.map((value) => <option key={value} value={value}>{value === "lifetime" ? "Process lifetime" : value}</option>)}
+      <label>Chart window <select value={period} onChange={(event) => setPeriod(event.target.value as Period)}>
+        {PERIODS.map((value) => <option key={value} value={value}>{value}</option>)}
       </select></label>
     </div>
     <p className="federation-activity__muted">{view === "physical"
@@ -124,7 +141,7 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
     {series && (view === "physical" || peerId) ? <>
       <FederationRateChart history={series.history} period={period} bytes />
       <FederationRateChart history={series.history} period={period} bytes={false} />
-      {value ? <Totals value={value} /> : null}
+      <Totals series={series} />
     </> : <p>No endpoint traffic recorded.</p>}
     {snapshot ? <p className="federation-activity__muted">Process totals since {new Date(snapshot.activity.since).toLocaleString()}.
       Rolling totals have one-second resolution; charts show ten-second averages for up to one hour.</p> : null}

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -1,4 +1,7 @@
 import { useEffect, useId, useState } from "react";
+import { CheckIcon, CopyIcon } from "../../icons";
+import { copyText } from "../../lib/copy-text";
+import { formatActivityReport } from "./format-activity-report";
 import type { FederationActivitySeries } from "@pwragent/shared";
 import { useDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { formatTrafficBytes, trafficByteUnit } from "./format-traffic-bytes";
@@ -59,7 +62,7 @@ function PayloadSizes({ series }: { series: FederationActivitySeries }) {
           </tr>;
         }))}</tbody>
     </table>
-    <p className="federation-activity__muted">Across this process lifetime for the selected traffic view.
+    <p className="federation-activity__muted">Since start or reset for the selected traffic view.
       Responses include errors. p50 is an estimate within about 1.1%; no payloads are retained.</p>
   </div>;
 }
@@ -119,21 +122,31 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
   const [peerId, setPeerId] = useState("");
   const [topmost, setTopmost] = useState(false);
   const [topmostPending, setTopmostPending] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [copyPending, setCopyPending] = useState(false);
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2_000);
+    return () => clearTimeout(timer);
+  }, [copied]);
   const [actionError, setActionError] = useState<string>();
-  const { snapshot, error, pending, toggle } = useFederationActivity(desktopApi, true, {
+  const { snapshot, error, pending, toggle, reset } = useFederationActivity(desktopApi, true, {
     historyPeerId: peerId || undefined, historyView: view,
   });
   const peers = snapshot ? view === "physical" ? snapshot.activity.peers : snapshot.activity.logical : [];
   const series = peerId ? peers.find((peer) => peer.peerId === peerId)?.series : snapshot?.activity.physical;
+  const enabled = Boolean(snapshot && snapshot.configuredMode !== "disabled");
   const labelFor = (id: string) => snapshot?.health.peers.find((peer) => peer.id === id)?.label || id;
   return <div className="federation-activity">
     <div className="federation-activity__toolbar">
       <div><strong>{snapshot ? federationRuntimeLabel(snapshot) : "Loading Federation activity…"}</strong>
         {snapshot ? <p>Configured {snapshot.configuredMode === "disabled" ? "off" : `on · ${snapshot.configuredMode}`}</p> : null}</div>
       <button type="button" role="switch" aria-label="Federation enabled"
-        aria-checked={Boolean(snapshot && snapshot.configuredMode !== "disabled")}
+        aria-checked={enabled}
+        className={`settings-switch messaging-status-popover__switch${enabled ? " is-on" : ""}`}
         disabled={!snapshot || pending || !desktopApi?.setFederationEnabled} onClick={() => void toggle()}>
-        Federation {snapshot?.configuredMode === "disabled" ? "off" : "on"}
+        <span className="settings-switch__track" aria-hidden="true"><span className="settings-switch__thumb" /></span>
+        <span>{enabled ? "On" : "Off"}</span>
       </button>
       <label><input type="checkbox" checked={topmost} disabled={topmostPending || !desktopApi?.setFederationActivityTopmost}
         onChange={(event) => {
@@ -143,6 +156,25 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
             setActionError(cause instanceof Error ? cause.message : String(cause));
           }).finally(() => setTopmostPending(false));
         }} /> Always on top</label>
+      <button type="button" disabled={pending || !desktopApi?.resetFederationActivity}
+        title="Clear all Federation activity totals, size statistics and history for every peer"
+        onClick={() => { setCopied(false); void reset(); }}>Reset</button>
+      <button type="button" aria-label="Copy Federation activity" title={copied ? "Copied" : "Copy selected activity view"}
+        disabled={!snapshot || !series || (view === "logical" && !peerId) || copyPending}
+        onClick={() => {
+          if (!snapshot || !series) return;
+          setCopyPending(true);
+          setActionError(undefined);
+          void copyText(formatActivityReport(series,
+            `${view === "physical" ? "Physical connections" : "Logical endpoint"}: ${peerId ? labelFor(peerId) : "All physical connections"}`,
+            snapshot.activity.since, snapshot.activity.at), desktopApi)
+            .then(() => setCopied(true))
+            .catch((cause: unknown) => setActionError(cause instanceof Error ? cause.message : String(cause)))
+            .finally(() => setCopyPending(false));
+        }}>
+        {copied ? <CheckIcon size={16} aria-hidden="true" /> : <CopyIcon size={16} aria-hidden="true" />}
+      </button>
+      <span role="status" className="federation-activity__muted">{copied ? "Federation activity copied" : ""}</span>
     </div>
     {snapshot?.health.leaseHolder ? <p>Lease holder: {snapshot.health.leaseHolder.instanceId}
       {snapshot.health.leaseHolder.processId ? ` · PID ${snapshot.health.leaseHolder.processId}` : ""}
@@ -171,7 +203,7 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
       <Totals series={series} />
       <PayloadSizes series={series} />
     </> : <p>No endpoint traffic recorded.</p>}
-    {snapshot ? <p className="federation-activity__muted">Process totals since {new Date(snapshot.activity.since).toLocaleString()}.
+    {snapshot ? <p className="federation-activity__muted">Totals since {new Date(snapshot.activity.since).toLocaleString()}.
       Rolling totals have one-second resolution; charts show ten-second averages for up to one hour.</p> : null}
     <details className="federation-activity__boundaries"><summary>What is measured</summary>
       <p>Data is the serialized envelope before compression and encryption, including its protocol metadata and binary blob data.

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -37,6 +37,33 @@ function Totals({ series }: { series: FederationActivitySeries }) {
   </div>;
 }
 
+function PayloadSizes({ series }: { series: FederationActivitySeries }) {
+  return <div className="federation-activity__tables">
+    <table className="federation-activity__totals federation-activity__sizes">
+      <caption>Lifetime request/response sizes · uncompressed</caption>
+      <thead><tr><th scope="col">Traffic</th><th scope="col">Samples</th>
+        <th scope="col">Avg</th>
+        <th scope="col" title="Estimated nearest-rank median; logarithmic buckets within about 1.1%">p50 ≈</th>
+        <th scope="col">Min</th><th scope="col">Max</th>
+      </tr></thead>
+      <tbody>{(["requests", "responses"] as const).flatMap((kind) =>
+        (["sent", "received"] as const).map((direction) => {
+          const stats = series.sizes[direction][kind];
+          return <tr key={`${direction}-${kind}`}>
+            <th scope="row">{direction === "sent" ? "Sent" : "Received"} {kind}</th>
+            <td>{number(stats.count)}</td>
+            {[stats.averageBytes, stats.p50Bytes, stats.minBytes, stats.maxBytes].map((value, index) =>
+              <td key={index} title={value === undefined ? "No samples" : `${number(value)} bytes`}>
+                {value === undefined ? "—" : formatTrafficBytes(value)}
+              </td>)}
+          </tr>;
+        }))}</tbody>
+    </table>
+    <p className="federation-activity__muted">Across this process lifetime for the selected traffic view.
+      Responses include errors. p50 is an estimate within about 1.1%; no payloads are retained.</p>
+  </div>;
+}
+
 export function FederationRateChart({ history, period, bytes }: {
   history: FederationActivitySeries["history"]; period: Period; bytes: boolean;
 }) {
@@ -142,6 +169,7 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
       <FederationRateChart history={series.history} period={period} bytes />
       <FederationRateChart history={series.history} period={period} bytes={false} />
       <Totals series={series} />
+      <PayloadSizes series={series} />
     </> : <p>No endpoint traffic recorded.</p>}
     {snapshot ? <p className="federation-activity__muted">Process totals since {new Date(snapshot.activity.since).toLocaleString()}.
       Rolling totals have one-second resolution; charts show ten-second averages for up to one hour.</p> : null}

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -197,6 +197,6 @@ export function FederationActivityWindow() {
         <span className="activity-titlebar__current">Activity</span></div>
       <div className="activity-titlebar__spacer" />
     </header>
-    <div className="activity-content"><FederationActivityScreen desktopApi={desktopApi} /></div>
+    <div className="activity-content federation-activity-content"><FederationActivityScreen desktopApi={desktopApi} /></div>
   </section></div>;
 }

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useId, useState } from "react";
+import type { FederationActivitySeries, FederationActivityTotals } from "@pwragent/shared";
+import { useDesktopApi, type DesktopApi } from "../../lib/desktop-api";
+import { federationRuntimeLabel, useFederationActivity } from "./useFederationActivity";
+
+type Period = "1m" | "5m" | "1h" | "lifetime";
+const PERIODS: Period[] = ["1m", "5m", "1h", "lifetime"];
+const number = (value: number) => value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+const fields = [
+  ["requests", "Requests"], ["responses", "Responses (including errors)"],
+  ["notifications", "Notifications"], ["other", "Other envelopes (including blobs)"],
+  ["dataBytes", "Data · uncompressed B"], ["wireBytes", "Wire · encoded B"],
+] as const;
+
+function Totals({ value }: { value: FederationActivityTotals }) {
+  return <table className="federation-activity__totals">
+    <thead><tr><th scope="col">Traffic</th><th scope="col">Sent</th><th scope="col">Received</th></tr></thead>
+    <tbody>{fields.map(([key, label]) => <tr key={key}><th scope="row">{label}</th>
+      <td>{number(value.sent[key])}</td><td>{number(value.received[key])}</td></tr>)}</tbody>
+  </table>;
+}
+
+export function FederationRateChart({ history, period, bytes }: {
+  history: FederationActivitySeries["history"]; period: Period; bytes: boolean;
+}) {
+  const id = useId();
+  const length = period === "1m" ? 6 : period === "5m" ? 30 : 360;
+  const points = history.slice(-length);
+  const lines = bytes ? [
+    { direction: "sent", field: "wireBytes", label: "Sent wire", dashed: false },
+    { direction: "received", field: "wireBytes", label: "Received wire", dashed: false },
+    { direction: "sent", field: "dataBytes", label: "Sent data", dashed: true },
+    { direction: "received", field: "dataBytes", label: "Received data", dashed: true },
+  ] as const : [
+    { direction: "sent", field: "events", label: "Sent", dashed: false },
+    { direction: "received", field: "events", label: "Received", dashed: false },
+  ] as const;
+  const values = lines.map((line) => points.map(({ totals }) => {
+    const value = totals[line.direction];
+    return (line.field === "events" ? value.requests + value.responses + value.notifications + value.other
+      : value[line.field]) / 10;
+  }));
+  const max = Math.max(0, ...values.flat()) || 1;
+  const exponent = bytes ? Math.min(3, Math.max(0, Math.floor(Math.log(max) / Math.log(1024)))) : 0;
+  const scale = 1024 ** exponent;
+  const unit = bytes ? ["B/s", "KiB/s", "MiB/s", "GiB/s"][exponent] : "envelopes/s";
+  return <figure className="federation-activity__chart">
+    <figcaption>{bytes ? "Data and wire rate" : "Envelope rate"} · {unit}</figcaption>
+    <svg viewBox="0 0 640 165" role="img" aria-labelledby={`${id}-title ${id}-description`}>
+      <title id={`${id}-title`}>{bytes ? "Data and wire" : "Envelope"} rates, {unit}</title>
+      <desc id={`${id}-description`}>Ten-second averages. Peak {number(max / scale)} {unit}. Sent uses the accent line,
+        received uses the neutral line. Dashed lines show uncompressed data.</desc>
+      <text x="87" y="12" textAnchor="end">{unit}</text>
+      {[0, 0.5, 1].map((fraction) => <g key={fraction}>
+        <line x1="95" x2="630" y1={130 - fraction * 110} y2={130 - fraction * 110} className="federation-activity__grid" />
+        <text x="87" y={134 - fraction * 110} textAnchor="end">{number(max * fraction / scale)}</text>
+      </g>)}
+      {lines.map((line, index) => <polyline key={line.label}
+        className={`federation-activity__line federation-activity__line--${line.direction}`}
+        strokeDasharray={line.dashed ? "5 4" : undefined}
+        points={values[index].map((value, point) => `${95 + point * 535 / Math.max(1, points.length - 1)},${130 - value / max * 110}`).join(" ")} />)}
+      <text x="95" y="155">{period === "lifetime" ? "1h" : period} ago</text>
+      <text x="630" y="155" textAnchor="end">Now</text>
+    </svg>
+    <div className="federation-activity__legend">{lines.map((line) => <span key={line.label}
+      className={`federation-activity__legend--${line.direction}`}>
+      {line.dashed ? "┄" : "━"} {line.label}</span>)}</div>
+  </figure>;
+}
+
+export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopApi }) {
+  const [period, setPeriod] = useState<Period>("1m");
+  const [view, setView] = useState<"physical" | "logical">("physical");
+  const [peerId, setPeerId] = useState("");
+  const [topmost, setTopmost] = useState(false);
+  const [topmostPending, setTopmostPending] = useState(false);
+  const [actionError, setActionError] = useState<string>();
+  const { snapshot, error, pending, toggle } = useFederationActivity(desktopApi, true, {
+    historyPeerId: peerId || undefined, historyView: view,
+  });
+  const peers = snapshot ? view === "physical" ? snapshot.activity.peers : snapshot.activity.logical : [];
+  const series = peerId ? peers.find((peer) => peer.peerId === peerId)?.series : snapshot?.activity.physical;
+  const value = period === "lifetime" ? series?.lifetime : series?.windows[period];
+  const labelFor = (id: string) => snapshot?.health.peers.find((peer) => peer.id === id)?.label || id;
+  return <div className="federation-activity">
+    <div className="federation-activity__toolbar">
+      <div><strong>{snapshot ? federationRuntimeLabel(snapshot) : "Loading Federation activity…"}</strong>
+        {snapshot ? <p>Configured {snapshot.configuredMode === "disabled" ? "off" : `on · ${snapshot.configuredMode}`}</p> : null}</div>
+      <button type="button" role="switch" aria-label="Federation enabled"
+        aria-checked={Boolean(snapshot && snapshot.configuredMode !== "disabled")}
+        disabled={!snapshot || pending || !desktopApi?.setFederationEnabled} onClick={() => void toggle()}>
+        Federation {snapshot?.configuredMode === "disabled" ? "off" : "on"}
+      </button>
+      <label><input type="checkbox" checked={topmost} disabled={topmostPending || !desktopApi?.setFederationActivityTopmost}
+        onChange={(event) => {
+          const enabled = event.target.checked;
+          setTopmostPending(true);
+          void desktopApi?.setFederationActivityTopmost?.(enabled).then(setTopmost).catch((cause: unknown) => {
+            setActionError(cause instanceof Error ? cause.message : String(cause));
+          }).finally(() => setTopmostPending(false));
+        }} /> Always on top</label>
+    </div>
+    {snapshot?.health.leaseHolder ? <p>Lease holder: {snapshot.health.leaseHolder.instanceId}
+      {snapshot.health.leaseHolder.processId ? ` · PID ${snapshot.health.leaseHolder.processId}` : ""}
+      {snapshot.health.leaseHolder.cwdHint ? ` · ${snapshot.health.leaseHolder.cwdHint}` : ""}</p> : null}
+    {snapshot?.health.unavailableReason ? <p>{snapshot.health.unavailableReason}</p> : null}
+    {error || actionError ? <p role="alert">{error || actionError}</p> : null}
+    <div className="federation-activity__toolbar">
+      <label>Attribution <select value={view} onChange={(event) => {
+        const next = event.target.value as "physical" | "logical";
+        setView(next); setPeerId(next === "logical" ? snapshot?.activity.logical[0]?.peerId || "" : "");
+      }}><option value="physical">Physical connections</option><option value="logical">Logical endpoints</option></select></label>
+      <label>Peer <select value={peerId} onChange={(event) => setPeerId(event.target.value)}>
+        {view === "physical" ? <option value="">All physical connections</option> : <option value="" disabled>Select an endpoint</option>}
+        {peers.map((peer) => <option value={peer.peerId} key={peer.peerId}>{labelFor(peer.peerId)}</option>)}
+      </select></label>
+      <label>Period <select value={period} onChange={(event) => setPeriod(event.target.value as Period)}>
+        {PERIODS.map((value) => <option key={value} value={value}>{value === "lifetime" ? "Process lifetime" : value}</option>)}
+      </select></label>
+    </div>
+    <p className="federation-activity__muted">{view === "physical"
+      ? "Each direct or gateway connection counts its own transfers. A relayed envelope crosses two connections at a gateway."
+      : "Only traffic sent or received by this instance as an endpoint; transit forwarding is excluded. This is an alternate view, not extra traffic."}</p>
+    {series && (view === "physical" || peerId) ? <>
+      <FederationRateChart history={series.history} period={period} bytes />
+      <FederationRateChart history={series.history} period={period} bytes={false} />
+      {value ? <Totals value={value} /> : null}
+    </> : <p>No endpoint traffic recorded.</p>}
+    {snapshot ? <p className="federation-activity__muted">Process totals since {new Date(snapshot.activity.since).toLocaleString()}.
+      Rolling totals have one-second resolution; charts show ten-second averages for up to one hour.</p> : null}
+    <details className="federation-activity__boundaries"><summary>What is measured</summary>
+      <p>Data is the serialized envelope before compression and encryption, including its protocol metadata and binary blob data.
+        Wire is the encoded WebSocket application-message payload, including Noise authentication tags when present.
+        It excludes WebSocket headers, TCP/TLS overhead, handshake/authentication messages and WebSocket ping, pong and close frames.</p>
+      <p>Requests, responses (including errors), notifications and blob chunks count once per successful transport send
+        or decoded receive. Sends mean accepted by the local socket, not acknowledged delivery. Broadcasts count each endpoint delivery.
+        Logical byte totals describe the endpoint’s physical hop, not the complete route.</p>
+      <p>Only numeric aggregates are retained in memory. History is limited to one hour and 32 named peers per view;
+        additional peers are combined under Other peers. Lifetime totals survive reconnects and reset when the app process exits.</p>
+    </details>
+  </div>;
+}
+
+export function FederationActivityWindow() {
+  const desktopApi = useDesktopApi();
+  useEffect(() => { document.title = "Federation Activity"; }, []);
+  return <div className="messaging-activity-window"><section aria-label="Federation activity" className="activity-screen">
+    <header className="activity-titlebar">
+      <p className="activity-titlebar__brand">Pwr<span className="activity-titlebar__brand-accent">Agent</span></p>
+      <div className="activity-titlebar__breadcrumb"><span className="activity-titlebar__eyebrow">Federation</span>
+        <span aria-hidden="true" className="activity-titlebar__separator">›</span>
+        <span className="activity-titlebar__current">Activity</span></div>
+      <div className="activity-titlebar__spacer" />
+    </header>
+    <div className="activity-content"><FederationActivityScreen desktopApi={desktopApi} /></div>
+  </section></div>;
+}

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationStatusControl.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationStatusControl.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useRef, useState } from "react";
 import type { DesktopApi } from "../../lib/desktop-api";
+import { formatTrafficBytes } from "./format-traffic-bytes";
 import { StarMapIcon } from "../../icons/StarMapIcon";
 import { federationRuntimeLabel, useFederationActivity } from "./useFederationActivity";
 
@@ -73,8 +74,8 @@ export function FederationStatusControl(props: { desktopApi?: DesktopApi; onOpen
                   {snapshot.health.leaseHolder.processId ? ` · PID ${snapshot.health.leaseHolder.processId}` : ""}
                   {snapshot.health.leaseHolder.cwdHint ? ` · ${snapshot.health.leaseHolder.cwdHint}` : ""}</p> : null}
                 {snapshot.health.unavailableReason ? <p>{snapshot.health.unavailableReason}</p> : null}
-                <p>Last minute: {snapshot.activity.physical.windows["1m"].sent.wireBytes.toLocaleString()} B sent
-                  {" · "}{snapshot.activity.physical.windows["1m"].received.wireBytes.toLocaleString()} B received</p>
+                <p>Last minute: {formatTrafficBytes(snapshot.activity.physical.windows["1m"].sent.wireBytes)} sent
+                  {" · "}{formatTrafficBytes(snapshot.activity.physical.windows["1m"].received.wireBytes)} received</p>
                 <p className="federation-activity__muted">Encoded envelope bytes on physical connections</p>
               </div>
             ) : null}

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationStatusControl.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationStatusControl.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useId, useRef, useState } from "react";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { StarMapIcon } from "../../icons/StarMapIcon";
+import { federationRuntimeLabel, useFederationActivity } from "./useFederationActivity";
+
+export function FederationStatusControl(props: { desktopApi?: DesktopApi; onOpen: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [actionError, setActionError] = useState<string>();
+  const root = useRef<HTMLDivElement>(null);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const id = useId();
+  const { snapshot, error, pending, toggle } = useFederationActivity(props.desktopApi, open, { includeHistory: false });
+  const cancelDismiss = () => clearTimeout(timer.current);
+  useEffect(() => () => clearTimeout(timer.current), []);
+  useEffect(() => {
+    if (!open) return;
+    const dismiss = (event: PointerEvent) => {
+      if (!root.current?.contains(event.target as Node)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", dismiss);
+    return () => document.removeEventListener("pointerdown", dismiss);
+  }, [open]);
+  const enabled = Boolean(snapshot && snapshot.configuredMode !== "disabled");
+  return (
+    <div ref={root} className="messaging-status-bar federation-status-control"
+      onPointerEnter={() => { cancelDismiss(); setOpen(true); }}
+      onPointerLeave={() => {
+        cancelDismiss();
+        timer.current = setTimeout(() => {
+          if (!root.current?.contains(document.activeElement)) setOpen(false);
+        }, 180);
+      }}
+      onFocus={() => { cancelDismiss(); setOpen(true); }}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setOpen(false);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") {
+          event.stopPropagation();
+          trigger.current?.focus();
+          setOpen(false);
+        }
+      }}>
+      <button ref={trigger} type="button" className="thread-header__star-map-toggle"
+        aria-label="Open Star Map" aria-haspopup="dialog" aria-expanded={open}
+        aria-controls={open ? id : undefined}
+        onClick={() => { cancelDismiss(); setOpen(false); props.onOpen(); }}>
+        <StarMapIcon size={14} />
+      </button>
+      {open ? (
+        <div id={id} className="messaging-status-popover" role="dialog" aria-label="Federation activity">
+          <div className="messaging-status-popover__panel">
+            <div className="messaging-status-popover__head">
+              <div>
+                <div className="messaging-status-popover__title">Federation</div>
+                <div className="messaging-status-popover__summary">
+                  {snapshot ? `Configured ${enabled ? `on · ${snapshot.configuredMode}` : "off"}` : "Loading…"}
+                </div>
+              </div>
+              <button type="button" role="switch" aria-label="Federation enabled"
+                aria-checked={Boolean(snapshot && enabled)} disabled={!snapshot || pending || !props.desktopApi?.setFederationEnabled}
+                className={`settings-switch messaging-status-popover__switch${enabled ? " is-on" : ""}`}
+                onClick={() => void toggle()}>
+                <span className="settings-switch__track" aria-hidden="true"><span className="settings-switch__thumb" /></span>
+                <span>{enabled ? "On" : "Off"}</span>
+              </button>
+            </div>
+            {snapshot ? (
+              <div className="federation-status-control__details">
+                <strong>{federationRuntimeLabel(snapshot)}</strong>
+                {snapshot.health.leaseHolder ? <p>Holder: {snapshot.health.leaseHolder.instanceId}
+                  {snapshot.health.leaseHolder.processId ? ` · PID ${snapshot.health.leaseHolder.processId}` : ""}
+                  {snapshot.health.leaseHolder.cwdHint ? ` · ${snapshot.health.leaseHolder.cwdHint}` : ""}</p> : null}
+                {snapshot.health.unavailableReason ? <p>{snapshot.health.unavailableReason}</p> : null}
+                <p>Last minute: {snapshot.activity.physical.windows["1m"].sent.wireBytes.toLocaleString()} B sent
+                  {" · "}{snapshot.activity.physical.windows["1m"].received.wireBytes.toLocaleString()} B received</p>
+                <p className="federation-activity__muted">Encoded envelope bytes on physical connections</p>
+              </div>
+            ) : null}
+            {error || actionError ? <p role="alert">{error || actionError}</p> : null}
+            <button type="button" className="messaging-status-popover__activity"
+              disabled={!props.desktopApi?.openFederationActivity}
+              onClick={() => {
+                void props.desktopApi?.openFederationActivity?.().then(() => setOpen(false)).catch((cause: unknown) => {
+                  setActionError(cause instanceof Error ? cause.message : String(cause));
+                });
+              }}>Open Federation Activity</button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/federation-activity/format-activity-report.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/format-activity-report.ts
@@ -1,0 +1,34 @@
+import type { FederationActivitySeries } from "@pwragent/shared";
+import { formatTrafficBytes } from "./format-traffic-bytes";
+
+export function formatActivityReport(series: FederationActivitySeries, view: string, since: number, at: number): string {
+  const lines = ["Federation Activity", view, `Since: ${new Date(since).toISOString()}`,
+    `Captured: ${new Date(at).toISOString()}`, ""];
+  for (const direction of ["sent", "received"] as const) {
+    lines.push(direction === "sent" ? "Sent traffic" : "Received traffic", "Traffic\tLast 1m\tLast 10m\tLast 1h\tTotal");
+    for (const [key, label] of [
+      ["requests", "Requests"], ["responses", "Responses (including errors)"],
+      ["notifications", "Notifications"], ["other", "Other envelopes (including blobs)"],
+      ["dataBytes", "Data (uncompressed)"], ["wireBytes", "Wire (encoded)"],
+    ] as const) {
+      lines.push([label, ...[series.windows["1m"], series.windows["10m"], series.windows["1h"], series.lifetime]
+        .map((totals) => key === "dataBytes" || key === "wireBytes"
+          ? `${formatTrafficBytes(totals[direction][key])} (${totals[direction][key]} bytes)`
+          : String(totals[direction][key]))].join("\t"));
+    }
+    lines.push("");
+  }
+  lines.push("Request/response sizes (uncompressed, since start or reset)", "Traffic\tSamples\tAvg\tp50 (approx.)\tMin\tMax");
+  for (const kind of ["requests", "responses"] as const) {
+    for (const direction of ["sent", "received"] as const) {
+      const stats = series.sizes[direction][kind];
+      lines.push([`${direction} ${kind}`, stats.count,
+        ...[stats.averageBytes, stats.p50Bytes, stats.minBytes, stats.maxBytes]
+          .map((value) => value === undefined ? "—" : `${formatTrafficBytes(value)} (${value} bytes)`)].join("\t"));
+    }
+  }
+  lines.push("", "p50 is estimated within about 1.1%. Responses include errors.",
+    "Wire counts encoded WebSocket application-message payload bytes, including Noise tags; excludes WebSocket framing, handshakes, ping/pong/close, TCP/TLS/IP overhead.",
+    "Physical connections count each hop; logical endpoints exclude transit. These are alternate views, not additive totals.");
+  return lines.join("\n");
+}

--- a/apps/desktop/src/renderer/src/features/federation-activity/format-traffic-bytes.test.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/format-traffic-bytes.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { formatTrafficBytes, trafficByteUnit } from "./format-traffic-bytes";
+
+describe("network byte display", () => {
+  it.each([
+    [0, "0 KB"], [1, "<0.01 KB"], [1_000, "1 KB"],
+    [31_826, "31.83 KB"], [4_260_270, "4.26 MB"],
+    [50_000_000_000, "50 GB"], [1_000_000_000_000, "1 TB"],
+  ])("formats %s bytes as %s", (value, expected) => {
+    expect(formatTrafficBytes(value)).toBe(expected);
+  });
+  it("uses the same decimal scale for chart units", () => {
+    expect(trafficByteUnit(400)).toEqual({ scale: 1000, unit: "KB" });
+    expect(trafficByteUnit(4_000_000)).toEqual({ scale: 1_000_000, unit: "MB" });
+  });
+});

--- a/apps/desktop/src/renderer/src/features/federation-activity/format-traffic-bytes.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/format-traffic-bytes.ts
@@ -1,0 +1,12 @@
+/** Decimal network units: 1 KB = 1,000 bytes. Keep exact counters in IPC. */
+export function trafficByteUnit(value: number) {
+  const exponent = Math.min(4, Math.max(1, Math.floor(Math.log10(Math.max(1, value)) / 3)));
+  return { scale: 1000 ** exponent, unit: ["B", "KB", "MB", "GB", "TB"][exponent] };
+}
+
+export function formatTrafficBytes(value: number): string {
+  const { scale, unit } = trafficByteUnit(value);
+  const scaled = value / scale;
+  if (scaled > 0 && scaled < 0.01) return `<0.01 ${unit}`;
+  return `${scaled.toLocaleString(undefined, { maximumFractionDigits: 2 })} ${unit}`;
+}

--- a/apps/desktop/src/renderer/src/features/federation-activity/useFederationActivity.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/useFederationActivity.ts
@@ -23,7 +23,7 @@ export function useFederationActivity(
         const next = await desktopApi.readFederationActivity!({ includeHistory, historyPeerId, historyView });
         if (!disposed && generation === toggleGeneration.current) { setSnapshot(next); setError(undefined); }
       } catch (cause) {
-        if (!disposed) setError(cause instanceof Error ? cause.message : String(cause));
+        if (!disposed && generation === toggleGeneration.current) setError(cause instanceof Error ? cause.message : String(cause));
       } finally {
         if (!disposed) timer = setTimeout(() => void poll(), 2_000);
       }
@@ -44,7 +44,18 @@ export function useFederationActivity(
       setError(cause instanceof Error ? cause.message : String(cause));
     } finally { toggleGeneration.current += 1; setPending(false); }
   }, [desktopApi, pending, snapshot]);
-  return { snapshot, error, pending, toggle };
+  const reset = useCallback(async () => {
+    if (pending || !desktopApi?.resetFederationActivity) return;
+    setPending(true);
+    toggleGeneration.current += 1;
+    try {
+      setSnapshot(await desktopApi.resetFederationActivity());
+      setError(undefined);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally { toggleGeneration.current += 1; setPending(false); }
+  }, [desktopApi, pending]);
+  return { snapshot, error, pending, toggle, reset };
 }
 
 export function federationRuntimeLabel(snapshot: ReadFederationActivityResponse): string {

--- a/apps/desktop/src/renderer/src/features/federation-activity/useFederationActivity.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/useFederationActivity.ts
@@ -1,0 +1,54 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ReadFederationActivityRequest, ReadFederationActivityResponse } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+
+/** Local-only polling, active only while a surface is visible; never overlaps reads. */
+export function useFederationActivity(
+  desktopApi: DesktopApi | undefined,
+  active: boolean,
+  request: ReadFederationActivityRequest = {},
+) {
+  const [snapshot, setSnapshot] = useState<ReadFederationActivityResponse>();
+  const [error, setError] = useState<string>();
+  const [pending, setPending] = useState(false);
+  const toggleGeneration = useRef(0);
+  const { includeHistory, historyPeerId, historyView } = request;
+  useEffect(() => {
+    if (!active || !desktopApi?.readFederationActivity) return;
+    let disposed = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const poll = async () => {
+      const generation = toggleGeneration.current;
+      try {
+        const next = await desktopApi.readFederationActivity!({ includeHistory, historyPeerId, historyView });
+        if (!disposed && generation === toggleGeneration.current) { setSnapshot(next); setError(undefined); }
+      } catch (cause) {
+        if (!disposed) setError(cause instanceof Error ? cause.message : String(cause));
+      } finally {
+        if (!disposed) timer = setTimeout(() => void poll(), 2_000);
+      }
+    };
+    void poll();
+    return () => { disposed = true; clearTimeout(timer); };
+  }, [desktopApi, active, includeHistory, historyPeerId, historyView]);
+  const toggle = useCallback(async () => {
+    if (!snapshot || pending || !desktopApi?.setFederationEnabled) return;
+    setPending(true);
+    toggleGeneration.current += 1;
+    try {
+      const next = await desktopApi.setFederationEnabled(snapshot.configuredMode === "disabled");
+      // Preserve the selected chart until the next poll refreshes its history.
+      setSnapshot((previous) => ({ ...next, activity: previous?.activity ?? next.activity }));
+      setError(undefined);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+    } finally { toggleGeneration.current += 1; setPending(false); }
+  }, [desktopApi, pending, snapshot]);
+  return { snapshot, error, pending, toggle };
+}
+
+export function federationRuntimeLabel(snapshot: ReadFederationActivityResponse): string {
+  if (snapshot.health.leaseHolder) return "Not running · lease held by another instance";
+  if (snapshot.running) return `Running · ${snapshot.health.status}`;
+  return snapshot.configuredMode === "disabled" ? "Stopped" : "Not running";
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadHeader.tsx
@@ -11,7 +11,7 @@ import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { TerminalIcon } from "../../icons/TerminalIcon";
 import { HistoryIcon } from "../../icons/HistoryIcon";
 import { SubAgentsIcon } from "../../icons/SubAgentsIcon";
-import { StarMapIcon } from "../../icons/StarMapIcon";
+import { FederationStatusControl } from "../federation-activity/FederationStatusControl";
 import { PanelToggleButtons } from "../chrome/PanelToggleButtons";
 import {
   HistoryNavButtons,
@@ -132,10 +132,8 @@ export function ThreadHeader(props: ThreadHeaderProps) {
       : {}),
     threadId: props.thread.id,
   });
-  const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const rewindTooltip = useViewportTooltip({ className: "viewport-tooltip" });
   const workflowBudgetTooltip = useViewportTooltip({ className: "viewport-tooltip" });
-  const starMapLabel = "Open Star Map";
   // A collapsed-but-running terminal gets its own affordance: the toggle wears
   // a live dot and says so, otherwise the shell is invisible from here.
   const terminalCollapsedRunning =
@@ -340,27 +338,8 @@ export function ThreadHeader(props: ThreadHeaderProps) {
           ) : null}
           {terminalTooltip.tooltipNode}
           {props.starMap && !isWindows ? (
-            <button
-              type="button"
-              className="thread-header__star-map-toggle"
-              aria-label={starMapLabel}
-              onClick={() => {
-                starMapTooltip.hide();
-                props.starMap?.onOpen();
-              }}
-              onMouseEnter={(event) =>
-                starMapTooltip.show(event.currentTarget, starMapLabel)
-              }
-              onMouseLeave={starMapTooltip.hide}
-              onFocus={(event) =>
-                starMapTooltip.show(event.currentTarget, starMapLabel)
-              }
-              onBlur={starMapTooltip.hide}
-            >
-              <StarMapIcon size={14} />
-            </button>
+            <FederationStatusControl desktopApi={props.desktopApi} onOpen={props.starMap.onOpen} />
           ) : null}
-          {starMapTooltip.tooltipNode}
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={props.onOpenMessagingActivity}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadPlaceholderHeader.tsx
@@ -2,7 +2,7 @@ import type { MessagingChannelKind } from "@pwragent/shared";
 import { getDesktopApi, type DesktopApi } from "../../lib/desktop-api";
 import { useViewportTooltip } from "../../lib/useViewportTooltip";
 import { MessagingStatusBar } from "../messaging-status/MessagingStatusBar";
-import { StarMapIcon } from "../../icons/StarMapIcon";
+import { FederationStatusControl } from "../federation-activity/FederationStatusControl";
 import { PanelToggleButtons } from "../chrome/PanelToggleButtons";
 import type { StarMapToggleControls } from "./ThreadHeader";
 import {
@@ -59,8 +59,6 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
   const isWindows = getDesktopApi()?.platform === "win32";
   const sidebarHidden = props.layout ? !props.layout.sidebarOpen : false;
   const showMasthead = sidebarHidden && !isWindows && Boolean(props.masthead);
-  const starMapTooltip = useViewportTooltip({ className: "viewport-tooltip" });
-  const starMapLabel = "Open Star Map";
 
   return (
     <header className="thread-header thread-header--placeholder">
@@ -113,27 +111,8 @@ export function ThreadPlaceholderHeader(props: ThreadPlaceholderHeaderProps) {
             />
           ) : null}
           {props.starMap && !isWindows ? (
-            <button
-              type="button"
-              className="thread-header__star-map-toggle"
-              aria-label={starMapLabel}
-              onClick={() => {
-                starMapTooltip.hide();
-                props.starMap?.onOpen();
-              }}
-              onMouseEnter={(event) =>
-                starMapTooltip.show(event.currentTarget, starMapLabel)
-              }
-              onMouseLeave={starMapTooltip.hide}
-              onFocus={(event) =>
-                starMapTooltip.show(event.currentTarget, starMapLabel)
-              }
-              onBlur={starMapTooltip.hide}
-            >
-              <StarMapIcon size={14} />
-            </button>
+            <FederationStatusControl desktopApi={props.desktopApi} onOpen={props.starMap.onOpen} />
           ) : null}
-          {starMapTooltip.tooltipNode}
           <MessagingStatusBar
             desktopApi={props.desktopApi}
             onOpenActivity={props.onOpenMessagingActivity}

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -598,6 +598,7 @@ export type DesktopApi = {
     request: OpenFederationWindowRequest,
   ) => Promise<OpenFederationWindowResponse>;
   readFederationActivity?: (request?: ReadFederationActivityRequest) => Promise<ReadFederationActivityResponse>;
+  resetFederationActivity?: () => Promise<ReadFederationActivityResponse>;
   setFederationEnabled?: (enabled: boolean) => Promise<ReadFederationActivityResponse>;
   openFederationActivity?: () => Promise<void>;
   setFederationActivityTopmost?: (enabled: boolean) => Promise<boolean>;

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -135,6 +135,8 @@ import type {
   MarkThreadSeenRequest,
   OpenFederationWindowRequest,
   OpenFederationWindowResponse,
+  ReadFederationActivityRequest,
+  ReadFederationActivityResponse,
   ReadFederationHealthRequest,
   ReadFederationHealthResponse,
   ReadFederationInstanceLoadRequest,
@@ -593,6 +595,10 @@ export type DesktopApi = {
   openFederationWindow?: (
     request: OpenFederationWindowRequest,
   ) => Promise<OpenFederationWindowResponse>;
+  readFederationActivity?: (request?: ReadFederationActivityRequest) => Promise<ReadFederationActivityResponse>;
+  setFederationEnabled?: (enabled: boolean) => Promise<ReadFederationActivityResponse>;
+  openFederationActivity?: () => Promise<void>;
+  setFederationActivityTopmost?: (enabled: boolean) => Promise<boolean>;
   readFederationHealth?: (
     request?: ReadFederationHealthRequest,
   ) => Promise<ReadFederationHealthResponse>;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -126,6 +126,9 @@ const LicenseDocumentWindow = lazy(async () => ({
   default: (await import("./features/license/LicenseDocumentWindow"))
     .LicenseDocumentWindow,
 }));
+const FederationActivityWindow = lazy(async () => ({
+  default: (await import("./features/federation-activity/FederationActivityWindow")).FederationActivityWindow,
+}));
 const MessagingActivityWindow = lazy(async () => ({
   default: (await import("./features/messaging-activity/MessagingActivityWindow"))
     .MessagingActivityWindow,
@@ -166,6 +169,10 @@ const routes: Array<{
   match: (hash: string) => boolean;
   render: () => ReactElement;
 }> = [
+  {
+    match: (hash) => hash === "federation-activity",
+    render: () => <FederationActivityWindow />,
+  },
   {
     match: (hash) => hash === "messaging-activity",
     render: () => <MessagingActivityWindow />,

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33811,7 +33811,9 @@ button.pricing-token-miser__folded:focus-visible {
 }
 
 /* Federation monitor reuses the activity-window chrome and MSG hover panel. */
-.federation-status-control { position: relative; }
+/* The Star Map trigger already owns its 24px hit target. Reusing MSG's
+   wrapper must not add its padding or shift the existing title-bar controls. */
+.federation-status-control { position: relative; padding: 0; }
 .federation-status-control__details { padding: 10px; overflow-wrap: anywhere; }
 .federation-status-control__details p { margin: 6px 0; }
 .federation-activity { max-width: 1000px; margin: 0 auto; padding: 16px; font-size: 13px; }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33842,3 +33842,8 @@ button.pricing-token-miser__folded:focus-visible {
 .federation-activity__totals th:first-child { text-align: left; }
 .federation-activity__boundaries { margin-top: 16px; color: var(--text-secondary); line-height: 1.5; }
 .federation-activity__boundaries summary { cursor: pointer; color: var(--text-primary); }
+
+.federation-activity__tables { overflow-x: auto; }
+.federation-activity__totals + .federation-activity__totals { margin-top: 18px; }
+.federation-activity__totals caption { text-align: left; font-weight: 600; padding: 8px; }
+.federation-activity__totals td { white-space: nowrap; }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33847,3 +33847,5 @@ button.pricing-token-miser__folded:focus-visible {
 .federation-activity__totals + .federation-activity__totals { margin-top: 18px; }
 .federation-activity__totals caption { text-align: left; font-weight: 600; padding: 8px; }
 .federation-activity__totals td { white-space: nowrap; }
+
+.federation-activity__sizes { margin-top: 18px; }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33809,3 +33809,34 @@ button.pricing-token-miser__folded:focus-visible {
 .star-map-satellite-card__body .context-rail {
   max-width: 100%;
 }
+
+/* Federation monitor reuses the activity-window chrome and MSG hover panel. */
+.federation-status-control { position: relative; }
+.federation-status-control__details { padding: 10px; overflow-wrap: anywhere; }
+.federation-status-control__details p { margin: 6px 0; }
+.federation-activity { max-width: 1000px; margin: 0 auto; padding: 16px; font-size: 13px; }
+.federation-activity__toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-bottom: 12px; }
+.federation-activity__toolbar p { margin: 4px 0; }
+.federation-activity__toolbar label { display: flex; align-items: center; gap: 6px; }
+.federation-activity__toolbar select, .federation-activity__toolbar button {
+  color: var(--text-primary); background: var(--bg-input); border: 1px solid var(--border-strong);
+  border-radius: 5px; padding: 5px 8px; max-width: 260px;
+}
+.federation-activity__toolbar :focus-visible { outline: 2px solid var(--focus-ring); outline-offset: 2px; }
+.federation-activity__muted { color: var(--text-secondary); }
+.federation-activity__chart { margin: 16px 0; }
+.federation-activity__chart figcaption { font-weight: 600; }
+.federation-activity__chart svg { display: block; width: 100%; }
+.federation-activity__chart text { fill: var(--text-secondary); font-size: 11px; font-variant-numeric: tabular-nums; }
+.federation-activity__grid { stroke: var(--border-subtle); }
+.federation-activity__line { fill: none; stroke-width: 1.8; }
+.federation-activity__line--sent { stroke: var(--accent); }
+.federation-activity__line--received { stroke: var(--text-secondary); }
+.federation-activity__legend { display: flex; flex-wrap: wrap; gap: 14px; font-size: 12px; }
+.federation-activity__legend--sent { color: var(--accent); }
+.federation-activity__legend--received { color: var(--text-secondary); }
+.federation-activity__totals { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+.federation-activity__totals th, .federation-activity__totals td { padding: 6px 8px; border-bottom: 1px solid var(--border-subtle); text-align: right; }
+.federation-activity__totals th:first-child { text-align: left; }
+.federation-activity__boundaries { margin-top: 16px; color: var(--text-secondary); line-height: 1.5; }
+.federation-activity__boundaries summary { cursor: pointer; color: var(--text-primary); }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33816,6 +33816,8 @@ button.pricing-token-miser__folded:focus-visible {
 .federation-status-control { position: relative; padding: 0; }
 .federation-status-control__details { padding: 10px; overflow-wrap: anywhere; }
 .federation-status-control__details p { margin: 6px 0; }
+/* This report owns its scroll area; the shared Activity chrome stays outside it. */
+.federation-activity-content { display: block; overflow: auto; }
 .federation-activity { max-width: 1000px; margin: 0 auto; padding: 16px; font-size: 13px; }
 .federation-activity__toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-bottom: 12px; }
 .federation-activity__toolbar p { margin: 4px 0; }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33822,7 +33822,7 @@ button.pricing-token-miser__folded:focus-visible {
 .federation-activity__toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 12px; margin-bottom: 12px; }
 .federation-activity__toolbar p { margin: 4px 0; }
 .federation-activity__toolbar label { display: flex; align-items: center; gap: 6px; }
-.federation-activity__toolbar select, .federation-activity__toolbar button {
+.federation-activity__toolbar select, .federation-activity__toolbar button:not(.settings-switch) {
   color: var(--text-primary); background: var(--bg-input); border: 1px solid var(--border-strong);
   border-radius: 5px; padding: 5px 8px; max-width: 260px;
 }

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,3 +1,4 @@
+export const FEDERATION_RESET_ACTIVITY_CHANNEL = "federation:reset-activity";
 export const FEDERATION_READ_ACTIVITY_CHANNEL = "federation:read-activity";
 export const FEDERATION_SET_ENABLED_CHANNEL = "federation:set-enabled";
 export const FEDERATION_OPEN_ACTIVITY_CHANNEL = "federation:open-activity";

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -1,3 +1,7 @@
+export const FEDERATION_READ_ACTIVITY_CHANNEL = "federation:read-activity";
+export const FEDERATION_SET_ENABLED_CHANNEL = "federation:set-enabled";
+export const FEDERATION_OPEN_ACTIVITY_CHANNEL = "federation:open-activity";
+export const FEDERATION_ACTIVITY_TOPMOST_CHANNEL = "federation:activity-topmost";
 export const APP_SERVER_LIST_THREADS_CHANNEL = "app-server:list-threads";
 export const THREAD_SEARCH_CHANNEL = "thread-search:search";
 export const FEDERATION_OPEN_WINDOW_CHANNEL = "federation:open-window";

--- a/docs/federation-activity-accounting.md
+++ b/docs/federation-activity-accounting.md
@@ -1,0 +1,110 @@
+# Federation activity accounting
+
+The monitor is process-owned, local-only instrumentation. Opening the status
+popover or detached Activity window polls local IPC every two seconds. It never
+polls a remote peer and never subscribes another window to backend event fanout.
+Closing the popover stops its polling. Each surface has at most one read in flight.
+
+## Byte and event boundaries
+
+The transport reports **envelope messages only**. These measurements are not NIC
+traffic totals or TCP/TLS bandwidth measurements.
+
+| Field | Measurement |
+| --- | --- |
+| Requests | Successful transport sends / decoded receives of request envelopes |
+| Responses | Response and error envelopes (including errors without a request ID) |
+| Notifications | Notification envelopes |
+| Other envelopes | Binary attachment chunks and unrecognized decoded envelope kinds |
+| Data bytes | Serialized socket payload before compression or Noise encryption |
+| Wire bytes | Encoded WebSocket application-message payload, including a Noise tag when present |
+
+Data includes the socket envelope wrapper, protocol metadata, UTF-8 JSON and the
+binary blob prefix/header/tail. It is not just RPC result or attachment content.
+Wire excludes WebSocket headers/masking, TCP, TLS, retransmission and IP overhead.
+Noise/authentication handshakes, WebSocket ping/pong/close control frames and
+frames that fail socket-payload decoding are excluded. A routing or authorization
+rejection after decoding does not remove an already measured transfer. Protocol control RPCs and notifications
+that use ordinary envelopes are included in their respective event categories.
+The UI's **What is measured** disclosure repeats these limits.
+
+A send means accepted by the local WebSocket send call; it is not acknowledged
+remote delivery. A closed socket that sends nothing produces no transfer sample.
+A receive is sampled after decoding succeeds and before routing. Regular and
+backpressure-aware sends have the same accounting boundary.
+
+The encoder and decoder retain the serialization length in a weak-key numeric
+map. The keys cannot extend envelope lifetime; the ledger retains no envelopes,
+methods, request IDs, text, attachments or other payloads. This avoids a second
+serialization just to measure bytes.
+
+## Compatibility with compression PR #1255
+
+The existing `onEnvelopeTransfer.byteCount` remains the encoded byte count.
+`dataByteCount` is captured inside `encodeFederationSocketPayload`, before the
+proposed Brotli codec, and inside `decodeFederationSocketPayload`, after the
+proposed decompression. That boundary works for plain, Noise-encrypted and
+mixed compressed/uncompressed connections. Binary blobs use their actual binary
+representation, not JSON serialization of a byte array. This PR adds no
+compression negotiation or codec from #1255.
+
+Transport tests measure both ends of a real loopback plain/Noise connection,
+including the exact 16-byte Noise tag and a binary backpressure send. Ledger
+regressions simulate mixed 100/116/36-byte encoded frames for equal 100-byte data
+payloads. The compression PR should retain these taps and extend its codec tests
+to assert decoded versus encoded lengths when it lands.
+
+## Physical and logical attribution
+
+Physical totals are the sum of transfers on this process's immediate direct or
+gateway connections. At a gateway, receiving from A and forwarding to B are two
+physical transfers, on different connections. This is real local traffic.
+
+Logical endpoints are an **alternate view**, never added to physical totals.
+An outgoing envelope is logical traffic only when this instance is its source;
+an incoming envelope is logical traffic only when addressed to this instance or
+broadcast without a target. Transit forwarding is excluded. An endpoint using a
+gateway therefore shows one physical peer (the gateway) and its actual logical
+counterpart. Logical encoded bytes measure that endpoint's hop, not a whole route.
+Broadcast fanout counts endpoint deliveries, not unique broadcast IDs.
+
+## Retention and cost
+
+The ledger retains one-second buckets for at most one hour and process-lifetime
+counters. Rolling windows use the last 60/300/3600 second buckets including the
+current second; expiry is quantized to one second. Charts aggregate these into
+360 ten-second bins, including idle zero bins. Process-lifetime selection keeps
+the last hour of rate history while displaying lifetime totals.
+
+Physical and logical peer maps each keep at most 32 distinct named peers plus an
+**Other peers** overflow aggregate. Peer IDs are bounded to 120 characters;
+malformed endpoint IDs use a fixed Unknown endpoint label. Global totals and the overflow retain every
+transfer even when attribution is full. Reconnects and Federation stop/start do
+not reset counters; exiting the app process does. The legacy health-only ledger
+is also capped at 128 peers.
+
+The hard storage bound is 67 series, each with at most 3600 bucket records and one
+lifetime record. Only the selected series returns chart history over IPC; the
+popover requests no chart history. There are no per-event timers or SQLite
+writes. The monitor's added SQLite commit and WAL budget is **0 commits and
+0 MB/day**, independent of event volume. User toggles use the existing settings
+write and runtime restart boundary; monitoring does not persist anything.
+
+## UI and runtime ownership
+
+The Star Map trigger opens its existing map on click. Hover or keyboard focus
+opens an interactive, nonmodal status panel with focus retention, pointer grace,
+outside dismissal and Escape. The panel and Activity screen distinguish the
+saved mode from `running` and display the existing lease holder and reason.
+Saving an enabled mode does not imply a successful lease acquisition.
+
+The on/off toggle saves `disabled` and restores the last enabled mode within this
+process. If the process starts disabled, On infers client from saved gateway
+enrollment endpoints, otherwise gateway; a different role remains selectable in
+Federation Settings. Concurrent toggle operations are serialized and await the
+normal runtime restart. Failed writes leave the previous state visible.
+
+The detached window uses existing auxiliary-window placement, security, theme,
+titlebar and appearance-broadcast helpers. Reopening focuses its singleton;
+closing it leaves the main window running. Only its own renderer may change its
+always-on-top state. Topmost is optional and resets when the window closes.

--- a/docs/federation-activity-accounting.md
+++ b/docs/federation-activity-accounting.md
@@ -85,8 +85,9 @@ transfer even when attribution is full. Reconnects and Federation stop/start do
 not reset counters; exiting the app process does. The legacy health-only ledger
 is also capped at 128 peers.
 
-The hard storage bound is 67 series, each with at most 3600 bucket records and one
-lifetime record. Only the selected series returns chart history over IPC; the
+The hard storage bound is 67 series, each with a fixed 3600-slot numeric ring and one
+lifetime record. A timestamp tag makes expired slots invisible; recording overwrites
+only its one-second slot and never scans or deletes an accumulated event list. Only the selected series returns chart history over IPC; the
 popover requests no chart history. There are no per-event timers or SQLite
 writes. The monitor's added SQLite commit and WAL budget is **0 commits and
 0 MB/day**, independent of event volume. User toggles use the existing settings
@@ -146,3 +147,39 @@ Copy exports the selected attribution/peer as tab-separated plain text through
 the existing clipboard bridge. It includes capture and interval-start timestamps,
 all recent/total columns, size statistics, scaled and exact byte values, and the
 accounting boundaries. It excludes payloads and chart samples.
+
+
+### Performance and write-budget audit
+
+Each transfer updates at most three series (global physical, physical peer, and
+logical endpoint). Recording is O(1) with no peer scan, history scan, serialization,
+logging, or persistence. A ring allocates lazily on its first transfer and holds
+374,400 bytes: 3,600 timestamps and 12 counters per timestamp. The maximum across
+67 series is 25,084,800 bytes for rings plus 3,640,512 bytes for size histograms,
+**28,725,312 bytes total numeric backing storage**, plus small object/map overhead.
+Reset releases those arrays. Old numeric slots remain allocated but cannot appear
+in rolling totals after expiry; no payloads are retained.
+
+Snapshots scan the fixed rings and fixed histograms: O(P × (H + B)), with P ≤ 67,
+H = 3,600 and B = 4 × 1,698. Cost does not increase with message count or process
+age. Only the selected chart's 360 points cross IPC. Each visible activity surface
+polls locally every two seconds, after the previous read finishes. Closed surfaces
+do not poll. The transport byte-length seam reuses existing serialization lengths
+and weak envelope keys, without extending payload lifetime.
+
+A local Node 24 stress audit on 2026-09-05 recorded 40 peers, requests and responses
+in both directions every simulated second for two hours (1,152,000 transfers).
+After both the first and second hour, numeric storage was exactly 28,725,312 bytes.
+The second 576,000 transfers took 383 ms; 30 full snapshots had a 5.2 ms median and
+9.0 ms maximum, with approximately 196 KB JSON per snapshot. These are local
+microbenchmark measurements, not a latency guarantee for all machines. The prior
+object-map representation measured approximately 68 MB retained and 85 ms median
+snapshot time in the same audit; the fixed rings replace that implementation.
+
+Regression coverage fills and wraps every ring with more than one million events,
+asserts the exact storage cap and rolling counts, and checks Reset releases it.
+`federation-activity-write-budget.test.ts` measures 10,000 transfers, reads, and
+Reset with SQLite instrumentation enabled. Its checked-in budget is zero commits,
+zero write statements and zero WAL bytes: **0 MB/day additional monitoring WAL**.
+The monitored path also contains no filesystem or log calls. Explicit configuration
+toggles still use the normal settings write boundary; clipboard export is user-driven.

--- a/docs/federation-activity-accounting.md
+++ b/docs/federation-activity-accounting.md
@@ -71,10 +71,12 @@ Broadcast fanout counts endpoint deliveries, not unique broadcast IDs.
 ## Retention and cost
 
 The ledger retains one-second buckets for at most one hour and process-lifetime
-counters. Rolling windows use the last 60/300/3600 second buckets including the
+counters. Rolling windows use the last 60/300/600/3600 second buckets including the
 current second; expiry is quantized to one second. Charts aggregate these into
-360 ten-second bins, including idle zero bins. Process-lifetime selection keeps
-the last hour of rate history while displaying lifetime totals.
+360 ten-second bins, including idle zero bins. Sent and received tables show Last 1m, Last 10m, Last 1h and Total side by side,
+independent of the chart range. The five-minute aggregate remains available in
+IPC. Byte displays use decimal KB/MB/GB/TB (1 KB = 1,000 bytes), automatically
+scaled per value; exact byte counts remain available in cell tooltips and IPC.
 
 Physical and logical peer maps each keep at most 32 distinct named peers plus an
 **Other peers** overflow aggregate. Peer IDs are bounded to 120 characters;

--- a/docs/federation-activity-accounting.md
+++ b/docs/federation-activity-accounting.md
@@ -92,6 +92,27 @@ writes. The monitor's added SQLite commit and WAL budget is **0 commits and
 0 MB/day**, independent of event volume. User toggles use the existing settings
 write and runtime restart boundary; monitoring does not persist anything.
 
+## Lifetime request/response size statistics
+
+Each physical or logical series also exposes sample count, average, p50, minimum
+and maximum uncompressed envelope size for sent/received requests and responses.
+Responses include error envelopes; notifications and blob chunks do not enter
+these distributions. These statistics span the process lifetime, survive rolling
+expiry and reconnects, and follow the same per-peer/relay attribution as totals.
+They do not depend on the selected chart window.
+
+Count, sum and extrema are accumulated from all observations. Average is
+sample-weighted. p50 uses the nearest-rank definition and is explicitly displayed
+as an estimate: a fixed logarithmic histogram has 32 bins per power of two, with
+midpoint relative error below 1.1%. Observed extrema bound the estimate. Empty
+distributions show no size values instead of implying a zero-byte response.
+
+Each populated distribution uses 1,698 numeric histogram bins (13,584 bytes),
+covering all nonnegative safe-integer byte sizes. With at most four distributions
+per series and 67 series, histogram storage is bounded to 3,640,512 bytes. It is
+allocated lazily and does not grow with event count. No payloads or per-event size
+lists are retained, and this adds no SQLite writes.
+
 ## UI and runtime ownership
 
 The Star Map trigger opens its existing map on click. Hover or keyboard focus

--- a/docs/federation-activity-accounting.md
+++ b/docs/federation-activity-accounting.md
@@ -131,3 +131,18 @@ The detached window uses existing auxiliary-window placement, security, theme,
 titlebar and appearance-broadcast helpers. Reopening focuses its singleton;
 closing it leaves the main window running. Only its own renderer may change its
 always-on-top state. Topmost is optional and resets when the window closes.
+
+
+### Operator controls
+
+The Activity window uses the shared On/Off switch. Reset clears the in-memory
+monitor for every physical connection and logical endpoint: rolling history,
+measurement-lifetime totals, peer entries, and request/response size histograms.
+The "since" timestamp starts a new measurement interval. Reset does not restart
+Federation, change configuration, reset transport health counters, or write SQLite.
+Other open activity surfaces observe the reset on their next local poll.
+
+Copy exports the selected attribution/peer as tab-separated plain text through
+the existing clipboard bridge. It includes capture and interval-start timestamps,
+all recent/total columns, size statistics, scaled and exact byte values, and the
+accounting boundaries. It excludes payloads and chart samples.

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -841,7 +841,20 @@ export type FederationActivityTotals = {
   sent: FederationActivityCounts;
   received: FederationActivityCounts;
 };
+export type FederationPayloadSizeStats = {
+  count: number;
+  averageBytes?: number;
+  /** Estimated nearest-rank median; logarithmic bucket midpoint (~1.1% error). */
+  p50Bytes?: number;
+  minBytes?: number;
+  maxBytes?: number;
+};
+export type FederationActivitySizes = Record<
+  "sent" | "received",
+  Record<"requests" | "responses", FederationPayloadSizeStats>
+>;
 export type FederationActivitySeries = {
+  sizes: FederationActivitySizes;
   lifetime: FederationActivityTotals;
   windows: Record<"1m" | "5m" | "10m" | "1h", FederationActivityTotals>;
   history: Array<{ at: number; totals: FederationActivityTotals }>;

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -843,7 +843,7 @@ export type FederationActivityTotals = {
 };
 export type FederationActivitySeries = {
   lifetime: FederationActivityTotals;
-  windows: Record<"1m" | "5m" | "1h", FederationActivityTotals>;
+  windows: Record<"1m" | "5m" | "10m" | "1h", FederationActivityTotals>;
   history: Array<{ at: number; totals: FederationActivityTotals }>;
 };
 export type FederationActivitySnapshot = {

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -827,3 +827,42 @@ export function federationTargetKey(target: FederationTarget): string {
 export function federatedThreadIdentityKey(ref: FederatedThreadRef): string {
   return `${federationTargetKey(ref.target)}:${ref.backend}:${ref.threadId}`;
 }
+
+/** Process-local envelope traffic. Bytes exclude WebSocket/TCP/TLS framing. */
+export type FederationActivityCounts = {
+  requests: number;
+  responses: number;
+  notifications: number;
+  other: number;
+  dataBytes: number;
+  wireBytes: number;
+};
+export type FederationActivityTotals = {
+  sent: FederationActivityCounts;
+  received: FederationActivityCounts;
+};
+export type FederationActivitySeries = {
+  lifetime: FederationActivityTotals;
+  windows: Record<"1m" | "5m" | "1h", FederationActivityTotals>;
+  history: Array<{ at: number; totals: FederationActivityTotals }>;
+};
+export type FederationActivitySnapshot = {
+  since: number;
+  at: number;
+  bucketMs: number;
+  physical: FederationActivitySeries;
+  peers: Array<{ peerId: string; series: FederationActivitySeries }>;
+  logical: Array<{ peerId: string; series: FederationActivitySeries }>;
+};
+export type ReadFederationActivityResponse = {
+  activity: FederationActivitySnapshot;
+  health: FederationHealthStatus;
+  configuredMode: "disabled" | "client" | "gateway" | "dual";
+  running: boolean;
+};
+
+export type ReadFederationActivityRequest = {
+  includeHistory?: boolean;
+  historyPeerId?: string;
+  historyView?: "physical" | "logical";
+};


### PR DESCRIPTION
Federation's existing transfer counters expose neither recent rates nor the distinction between saved configuration and a runtime stopped by another lease holder. This adds a Star Map hover/focus activity panel and a separate native Federation Activity window; clicking the Star Map control still opens Star Map.

- Numeric, unit-labelled historical byte and envelope rate charts. Separate sent/received tables keep Last 1m, Last 10m, Last 1h and Total columns visible side by side, independent of chart range. Byte values automatically scale through decimal KB/MB/GB/TB; exact bytes remain in cell tooltips.
- Lifetime request/response size statistics show Samples, Avg, estimated p50, Min and Max, split by sent/received for the selected traffic view. Sizes are uncompressed; a bounded logarithmic histogram estimates p50 within about 1.1% without retaining payloads or individual samples.
- Separate physical connection and logical endpoint attribution. Gateway forwarding counts each physical hop but never adds transit traffic to the logical endpoint view.
- Standard MSG On/Off switch in the Activity window. Reset clears all monitor history/totals/size distributions without restarting Federation or changing settings. The existing copy icon exports the selected view as readable tab-separated text, including recent totals, size statistics, timestamps and byte semantics.
- Configured on/off mode shown independently of actual running/lease-denied status, with holder/reason and a serialized toggle. The native window reuses Activity chrome, placement/security/theme helpers and supports optional always-on-top.
- Bounded one-hour numeric ring history, 32 named peers plus overflow per view, bounded endpoint-ID lengths, no payload retention, and no per-event SQLite writes. Added monitoring WAL cost: 0 MB/day. Polling is local-only and stops when the popover closes.

### Measurement boundaries

“Wire” means encoded WebSocket application-message payload bytes, including Noise tags. It excludes WebSocket framing/masking, TCP/TLS/IP overhead, handshakes and WebSocket ping/pong/close. “Data” is the serialized socket payload before compression/encryption, including binary blob framing. Sends mean local socket acceptance, not acknowledged delivery. Routing rejection after successful decoding does not erase measured traffic.

Reviewed compression PR #1255. The new pre-codec byte-length seam preserves its existing encoded-byte tap without merging compression or serializing payloads twice. Plain/Noise connections are exercised directly; mixed compressed/uncompressed lengths are simulated in ledger tests. Detailed retention, relay, control-frame and compression semantics are in [docs/federation-activity-accounting.md](docs/federation-activity-accounting.md).

The toggle restores the last enabled role within this process. If the app starts with Federation disabled, it infers client from saved gateway endpoints, otherwise gateway; explicit role selection remains in Settings.

### Validation

- Performance audit: replaced object-map history with fixed numeric rings. In a local Node 24 stress run (40 peers, 1,152,000 events over two simulated hours), numeric storage stayed at 28,725,312 bytes; median full snapshot fell from 85 ms to 5.2 ms. Recording updates at most three slots, independent of message count. The exact storage cap is regression-tested.
- Added a checked-in zero-write SQLite budget for 10,000 transfers, snapshots and Reset: zero commits, write statements and WAL bytes (0 MB/day additional monitoring WAL). No per-message filesystem or log calls.
- Performance update: 46 focused tests, typecheck, ESLint and boundaries pass. Details and limitations are documented in the accounting document.

- Controls update: 35 focused tests pass, including complete reset, stale-poll exclusion, reset failures, selected-peer export and shared switch styling. Typecheck, ESLint, colors and boundaries pass. Native clipboard/reset assertions added for CI.

- Size-statistics update: 30 focused tests pass, including outliers, median error bounds, constant memory, lifetime retention, routing attribution, and renderer values.

- Current table/unit update: 107 focused tests pass, covering window expiry, recent bursts beside large lifetime totals, chart-range independence, scaled units, IPC and theme contracts.
- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:colors`, `pnpm lint:boundaries`: pass. ESLint has existing warnings and no errors.
- Inspected the actual table components in both themes using headless Chrome at the native window's default width.
- Native Electron theme/accessibility/topmost checks and the complete CI suite passed on preceding head `9947bca85`. Native E2E now also asserts both tables expose Last 10m columns and captures the tables for review; that addition awaits CI on the new head.

### Screenshots

Contrived burst/lifetime data rendered by the actual table components. The received wire row shows 50 MB in the last minute alongside 50 GB total.

![Recent and lifetime traffic, dark theme](https://github.com/user-attachments/assets/6f05bfb4-8852-4706-aa44-b3e3657df2e3)

![Recent and lifetime traffic, light theme](https://github.com/user-attachments/assets/ec270a99-a059-49e6-b81b-cf3f42dc9adc)


Lifetime sizes with entirely contrived data, rendered by the actual component:

![Request and response sizes, dark theme](https://github.com/user-attachments/assets/f1cc2610-5a51-4ebb-9858-d64d12f423e5)

![Request and response sizes, light theme](https://github.com/user-attachments/assets/c27c9e69-8eaa-40b5-ba5e-d9ecc704d5ca)


Updated controls rendered from the actual component with contrived data:

![Federation controls, light theme](https://github.com/user-attachments/assets/ed852294-c975-4b70-ab5e-e83525e0ea96)

![Federation controls, dark theme](https://github.com/user-attachments/assets/0fd302b8-d5ec-4491-9d49-b16408562376)

