### PR TITLE
fix(desktop): preserve cross-thread message content and provenance

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -178,6 +178,7 @@ const registry = {
 
 const federationMock = vi.hoisted(() => {
   const remoteBackend = {
+    readQueuedTurn: vi.fn(),
     listBackends: vi.fn(async () => ({ fetchedAt: 1, backends: [] })),
     startThread: vi.fn(async (request: StartThreadRequest) => ({
       backend: request.backend,
@@ -868,6 +869,37 @@ describe("agent ipc", () => {
     });
 
     disposeAgentIpcHandlers();
+  });
+
+  it("preserves directly renderable queued images from a federation peer", async () => {
+    const { registerAgentIpcHandlers, disposeAgentIpcHandlers } = await import("../ipc/agent-ipc");
+    const { AGENT_READ_QUEUED_TURN_CHANNEL } = await import("../../shared/ipc");
+    const { toTranscriptImageProtocolUrl, toFederatedTranscriptImageProtocolUrl } = await import("../transcript-image-protocol");
+    const ownerUrl = toTranscriptImageProtocolUrl("file:///tmp/fixture.png");
+    const imageParts = [
+      { type: "image", url: "data:image/png;base64,AQID", alt: "Inline diagram" },
+      { type: "image", url: "https://example.com/fixture.png", alt: "Hosted diagram" },
+      { type: "image", url: ownerUrl, alt: "Owner diagram" },
+    ];
+    const response = { queueEntryId: "queue-1", contentHash: "hash", input: [], imageParts };
+    federationMock.remoteBackend.readQueuedTurn.mockResolvedValueOnce(response);
+    registerAgentIpcHandlers();
+    try {
+      const request = { backend: "codex", threadId: "thread-1", queueEntryId: "queue-1" };
+      const result = await handlers.get(AGENT_READ_QUEUED_TURN_CHANNEL)?.({}, {
+        ...request, federationTarget: { scope: "remote", instanceId: "peer-1" },
+      });
+      expect(federationMock.remoteBackend.readQueuedTurn).toHaveBeenCalledWith(request);
+      expect(result).toEqual({
+        ...response,
+        imageParts: [
+          imageParts[0], imageParts[1],
+          { ...imageParts[2], url: toFederatedTranscriptImageProtocolUrl("peer-1", ownerUrl) },
+        ],
+      });
+    } finally {
+      disposeAgentIpcHandlers();
+    }
   });
 
   it("loads backend summaries from the selected federation peer", async () => {

--- a/apps/desktop/src/main/__tests__/agent-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-ipc.test.ts
@@ -1013,6 +1013,7 @@ describe("agent ipc", () => {
     expect(registry.cancelQueuedTurnWithDisposition).toHaveBeenCalledWith(
       "queue-2",
       "Cancelled from the desktop composer.",
+      undefined,
     );
     expect(
       await handlers.get(AGENT_RELEASE_QUEUED_TURN_CHANNEL)?.({}, {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -1,3 +1,4 @@
+import { ThreadCorrespondenceStore } from "../app-server/thread-correspondence-store";
 import { execFile as execFileCallback } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import {
@@ -35491,6 +35492,89 @@ script = "printf setup"
     await registry.close();
   });
 
+  it("does not let correspondence status persistence failures alter the recipient FIFO", async () => {
+    const correspondenceStore = new ThreadCorrespondenceStore();
+    vi.spyOn(correspondenceStore, "update").mockImplementation(() => { throw new Error("Fixture disk failure"); });
+    const registry = new DesktopBackendRegistry({ codexClient: new MockBackendClient({}), correspondenceStore, overlayStore: createOverlayStoreMock(), threadTitleGenerationService: null });
+    onTestFinished(() => registry.close());
+    await expect(registry.submitHeldTurn({
+      backend: "codex", threadId: "recipient", queueEntryId: "held-durable", input: [{ type: "text", text: "Keep this message" }], holdReason: "Fixture hold",
+      messageOrigin: { kind: "agent", sourceThread: { backend: "codex", threadId: "sender", messageId: "correspondence:fixture" } },
+    })).resolves.toMatchObject({ status: "queued" });
+    expect(registry.getQueuedTurnsSnapshot()[buildThreadIdentityKey("codex", "recipient")]).toHaveLength(1);
+    expect(registry.cancelQueuedTurnWithDisposition("held-durable").cancelled).toBe(true);
+  });
+
+  it.each(["codex", "acp:grok"] as const)("reads the authoritative %s FIFO without changing ownership or order", async (backend) => {
+    const registry = new DesktopBackendRegistry({ codexClient: new MockBackendClient({}), overlayStore: createOverlayStoreMock(), threadTitleGenerationService: null });
+    onTestFinished(() => registry.close());
+    const input: AppServerTurnInputItem[] = [{ type: "text", text: "First paragraph Ω\n\n" + "long ".repeat(200) }, { type: "file", name: "notes.txt", mimeType: "text/plain", data: "AQID" }];
+    await registry.submitHeldTurn({ backend, threadId: "recipient", queueEntryId: "held-one", input, holdReason: "Fixture hold" });
+    await registry.submitTurn({ backend, threadId: "recipient", queueEntryId: "held-two", input: [{ type: "text", text: "Next" }] });
+    const content = await registry.readQueuedTurn({ backend, threadId: "recipient", queueEntryId: "held-one" });
+    expect(content.input).toEqual(input);
+    content.input.splice(0);
+    expect((await registry.readQueuedTurn({ backend, threadId: "recipient", queueEntryId: "held-one" })).input).toEqual(input);
+    expect(registry.getQueuedTurnsSnapshot()[buildThreadIdentityKey(backend, "recipient")]?.map((entry) => entry.queueEntryId)).toEqual(["held-one", "held-two"]);
+  });
+
+  it("keeps cross-thread queue content lossless and persists sender correspondence through cancellation and reload", async () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "correspondence-test-"));
+    onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+    const correspondenceStore = new ThreadCorrespondenceStore(directory);
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["turn/start"] },
+      threads: ["sender", "recipient"].map((id) => ({
+        id, title: id, titleSource: "explicit" as const, source: "codex" as const, linkedDirectories: [],
+      })),
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, correspondenceStore, overlayStore: createOverlayStoreMock(), threadTitleGenerationService: null });
+    onTestFinished(() => registry.close());
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => { events.push(event); });
+    for (const threadId of ["sender", "recipient"]) {
+      await registry.publishLocalEvent({ backend: "codex", notification: {
+        method: "turn/started", params: { threadId, turnId: `active:${threadId}`, turn: { id: `active:${threadId}` } },
+      } });
+    }
+    const prompt = `# Coordination 漢字 🛰️\n\n${"A long **markdown** paragraph. ".repeat(100)}\n\nFinal paragraph: Ω preserved.  `;
+    const response = await codexClient.emitRequest({ method: "item/tool/call", params: {
+      threadId: "sender", turnId: "active:sender", callId: "correspondence-call", requestId: "correspondence-call",
+      namespace: "pwragent", tool: "send_message_to_thread", arguments: { backend: "codex", threadId: "recipient", prompt },
+    } } as AppServerPendingRequestNotification);
+    expect(response).toMatchObject({ success: true });
+    const payload = JSON.parse((response as { contentItems: Array<{ text: string }> }).contentItems[0]!.text);
+    expect(payload.queueStatus).toBe("queued");
+    const summary = registry.getQueuedTurnsSnapshot()[buildThreadIdentityKey("codex", "recipient")]![0]!;
+    expect(summary.displayText.length).toBeLessThan(prompt.length);
+    const request = { backend: "codex" as const, threadId: "recipient", queueEntryId: payload.queueEntryId };
+    const content = await registry.readQueuedTurn(request);
+    expect(content.input).toEqual([{ type: "text", text: prompt }]);
+    expect(events).toContainEqual(expect.objectContaining({ notification: expect.objectContaining({
+      method: "item/completed", params: expect.objectContaining({ threadId: "sender", item: expect.objectContaining({ text: expect.stringContaining(prompt) }) }),
+    }) }));
+    expect(content.messageOrigin?.sourceThread).toMatchObject({ threadId: "sender", messageId: expect.stringMatching(/^correspondence:/) });
+    await expect(registry.readQueuedTurn({ ...request, threadId: "sender" })).rejects.toThrow("no longer waiting");
+    const image = { type: "image" as const, name: "diagram.png", url: "data:image/png;base64,AQID" };
+    registry.updateQueuedTurnInput(payload.queueEntryId, [...content.input, image]);
+    expect(registry.cancelQueuedTurnWithDisposition(payload.queueEntryId, "Edit", content.contentHash).disposition).toBe("content_changed");
+    expect(registry.getQueuedTurnsSnapshot()[buildThreadIdentityKey("codex", "recipient")]).toHaveLength(1);
+    const updated = await registry.readQueuedTurn(request);
+    expect(updated.input.at(-1)).toEqual(image);
+    const replay = await registry.readThread({ backend: "codex", threadId: "sender", viewOnly: true });
+    const breadcrumb = replay.replay.messages.find((message) => message.id === content.messageOrigin?.sourceThread?.messageId);
+    expect(breadcrumb?.text).toContain(prompt);
+    expect(breadcrumb?.text).toContain("Queued (last confirmed)");
+    expect(breadcrumb?.text).toContain("pwragent://thread/recipient");
+    expect(registry.cancelQueuedTurnWithDisposition(payload.queueEntryId, "Operator cancellation", updated.contentHash).cancelled).toBe(true);
+    const emptyReplay = { entries: [], messages: [], pagination: { supportsPagination: false, hasPreviousPage: false } };
+    const restored = new ThreadCorrespondenceStore(directory).appendToReplay({ backend: "codex", threadId: "sender" }, emptyReplay);
+    expect(restored.messages[0]?.text).toContain("**Cancelled**");
+    expect(restored.messages[0]?.text).toContain(prompt);
+    expect(restored.entries).toHaveLength(1);
+    await expect(registry.readQueuedTurn(request)).rejects.toThrow("no longer waiting");
+  });
+
   it("sends a follow-up prompt to another thread from an active turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["turn/start"] },
@@ -35622,6 +35706,7 @@ script = "printf setup"
                 backend: "codex",
                 threadId: "parent-thread",
                 title: "M4 runner-host conversion preflight",
+          messageId: expect.stringMatching(/^correspondence:/),
               },
             },
           },
@@ -35638,6 +35723,7 @@ script = "printf setup"
           backend: "codex",
           threadId: "parent-thread",
           title: "M4 runner-host conversion preflight",
+          messageId: expect.stringMatching(/^correspondence:/),
         },
       },
     });
@@ -36960,6 +37046,7 @@ script = "printf setup"
           backend: "codex",
           threadId: "parent-thread",
           title: "M4 runner-host conversion preflight",
+          messageId: expect.stringMatching(/^correspondence:/),
         },
       },
       executionMode: undefined,

--- a/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-backend-bridge.test.ts
@@ -1109,6 +1109,7 @@ describe("federation backend bridge", () => {
         },
       })),
       startTurn: vi.fn(),
+      readQueuedTurn: vi.fn(),
       cancelQueuedTurn: vi.fn(async ({ queueEntryId }) => ({
         queueEntryId,
         cancelled: true,
@@ -3305,6 +3306,7 @@ describe("federation backend bridge", () => {
       startThread: vi.fn(),
       forkThread: vi.fn(),
       startTurn: vi.fn(),
+      readQueuedTurn: vi.fn(async () => ({ queueEntryId: "queue-full", contentHash: "hash", input: [{ type: "text" as const, text: "# Full Ω\n\n" + "rich content ".repeat(100) }] })),
       cancelQueuedTurn: vi.fn(),
       releaseQueuedTurn: vi.fn(),
       startReview: vi.fn(),
@@ -3423,6 +3425,18 @@ describe("federation backend bridge", () => {
         celestialIcon: "moon",
       }),
     });
+
+    await router.routeEnvelope({
+      sourcePeerId: "gateway_one",
+      envelope: {
+        id: "read-queued-request", kind: "request", method: FEDERATION_BACKEND_METHODS.readQueuedTurn,
+        params: { backend: "codex", threadId: "thread-1", queueEntryId: "queue-full", forEdit: true },
+        protocolVersion: 1, sourceInstanceId: "gateway_one", targetInstanceId: "client_one", createdAt: 1_000,
+      },
+    });
+    expect(backend.readQueuedTurn).toHaveBeenCalledWith({ backend: "codex", threadId: "thread-1", queueEntryId: "queue-full", forEdit: true });
+    const queuedReply = replies.pop();
+    expect(JSON.stringify(queuedReply)).toContain("rich content ".repeat(100));
 
     await router.routeEnvelope({
       sourcePeerId: "gateway_one",
@@ -3693,6 +3707,7 @@ describe("federation backend bridge", () => {
         startThread: vi.fn(),
         forkThread: vi.fn(),
         startTurn: vi.fn(),
+        readQueuedTurn: vi.fn(),
         cancelQueuedTurn: vi.fn(),
         releaseQueuedTurn: vi.fn(),
         startReview: vi.fn(),

--- a/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-turn-input-attachments.test.ts
@@ -18,6 +18,8 @@ import type {
 import { imageInputFileRoot } from "../app-server/image-input-files";
 import {
   stageTurnInputAttachment,
+  portableTurnInputAttachments,
+  stageQueuedFileInputs,
   TURN_INPUT_ATTACHMENT_MAX_AGE_MS,
   turnInputAttachmentRoot,
 } from "../app-server/turn-input-attachment-files";
@@ -42,6 +44,36 @@ afterEach(async () => {
 });
 
 describe("federation turn input attachments", () => {
+  it("stages recovered file bytes before draft persistence and preserves empty files", async () => {
+    await createTestRoot();
+    const input = await stageQueuedFileInputs([
+      { type: "file", name: "notes.txt", mimeType: "text/plain", data: "AQID" },
+      { type: "file", name: "empty.txt", mimeType: "text/plain", data: "" },
+    ]);
+    expect(input.every((item) => item.type === "localFile")).toBe(true);
+    expect(JSON.stringify(input)).not.toContain('"data"');
+    for (const [index, item] of input.entries()) {
+      if (item.type !== "localFile") throw new Error("Expected staged file");
+      expect(await readFile(item.path)).toEqual(index === 0 ? Buffer.from([1, 2, 3]) : Buffer.alloc(0));
+    }
+  });
+
+  it("recovers owner-local queued attachments and round-trips their bytes through the existing upload seam", async () => {
+    await createTestRoot();
+    const image = await stageTurnInputAttachment({ type: "localImage", name: "diagram.png", data: Buffer.from([1, 2, 3]) });
+    const file = await stageTurnInputAttachment({ type: "localFile", name: "notes.txt", mimeType: "text/plain", data: Buffer.from("Unicode Ω\n\nsecond paragraph") });
+    const portable = await portableTurnInputAttachments([{ type: "text", text: "# Full prompt" }, image, file]);
+    expect(portable).toEqual([
+      { type: "text", text: "# Full prompt" },
+      { type: "image", name: "diagram.png", url: "data:image/png;base64,AQID" },
+      expect.objectContaining({ type: "file", name: "notes.txt", data: Buffer.from("Unicode Ω\n\nsecond paragraph").toString("base64") }),
+    ]);
+    const envelopes: FederationBlobChunkEnvelope[] = [];
+    await prepareOutgoingFederationTurnInput({ input: portable, localInstanceId: "viewer", targetInstanceId: "owner", sendEnvelope: collectBlobChunks(envelopes) });
+    expect(envelopes.map((envelope) => envelope.data)).toEqual([Buffer.from([1, 2, 3]), Buffer.from("Unicode Ω\n\nsecond paragraph")]);
+    await expect(portableTurnInputAttachments([{ type: "localFile", path: "/missing/queued-attachment.txt" }])).rejects.toThrow();
+  });
+
   it("stages data URLs and existing PwrAgent image inputs before binary upload", async () => {
     const root = await createTestRoot();
     const existingBytes = Buffer.from([9, 8, 7, 6]);

--- a/apps/desktop/src/main/__tests__/thread-correspondence-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-correspondence-store.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, onTestFinished } from "vitest";
-import type { AppServerThreadReplay } from "@pwragent/shared";
+import type { AppServerThreadMessageEntry, AppServerThreadReplay } from "@pwragent/shared";
 import { ThreadCorrespondenceStore, type CorrespondenceRecord } from "../app-server/thread-correspondence-store";
 
 const emptyReplay: AppServerThreadReplay = {
@@ -44,6 +44,43 @@ describe("PwrAgent correspondence persistence", () => {
     expect(replay.messages[0]?.text).toContain("Tail.");
     expect(replay.messages[0]?.parts).toContainEqual({ type: "image", url: "data:image/png;base64,AQID", alt: "diagram.png" });
     expect(store.appendToReplay(message.source, replay).entries).toHaveLength(1);
+  });
+
+  it("merges historical correspondence chronologically after reload without reordering provider entries", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "pwragent-correspondence-"));
+    onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+    const store = new ThreadCorrespondenceStore(directory);
+    const message = record();
+    // Arrival order need not match creation order.
+    store.record({ ...message, id: "later-send", createdAt: 3_000 });
+    store.record(message);
+    store.update(message.source, message.id, { state: "cancelled" });
+    const providerMessages: AppServerThreadMessageEntry[] = [
+      { type: "message", id: "first-user", role: "user", text: "First", createdAt: 500 },
+      { type: "message", id: "first-response", role: "assistant", text: "Response", createdAt: 1_000 },
+      { type: "message", id: "next-user", role: "user", text: "Next", turn: { id: "next-turn", startedAt: 2_000 } },
+      { type: "message", id: "next-response", role: "assistant", text: "Response", createdAt: 4_000 },
+    ];
+    const replay: AppServerThreadReplay = {
+      ...emptyReplay,
+      entries: [
+        ...providerMessages.slice(0, 2),
+        { type: "activity", id: "undated-activity", summary: "Work", details: [] },
+        ...providerMessages.slice(2),
+      ],
+      messages: providerMessages.map(({ turn: _turn, ...entry }) => entry),
+    };
+    const restored = new ThreadCorrespondenceStore(directory);
+    const merged = restored.appendToReplay(message.source, replay);
+    expect(merged.entries.map((entry) => entry.id)).toEqual([
+      "first-user", "first-response", "undated-activity", message.id,
+      "next-user", "later-send", "next-response",
+    ]);
+    expect(merged.messages.map((entry) => entry.id)).toEqual([
+      "first-user", "first-response", message.id, "next-user", "later-send", "next-response",
+    ]);
+    expect(merged.messages.find((entry) => entry.id === message.id)?.text).toContain("**Cancelled**");
+    expect(restored.appendToReplay(message.source, merged)).toEqual(merged);
   });
 
   it("does not let a peer with the same thread id update local correspondence", () => {

--- a/apps/desktop/src/main/__tests__/thread-correspondence-store.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-correspondence-store.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it, onTestFinished } from "vitest";
+import type { AppServerThreadReplay } from "@pwragent/shared";
+import { ThreadCorrespondenceStore, type CorrespondenceRecord } from "../app-server/thread-correspondence-store";
+
+const emptyReplay: AppServerThreadReplay = {
+  entries: [], messages: [], pagination: { supportsPagination: false, hasPreviousPage: false },
+};
+
+function record(): CorrespondenceRecord {
+  return {
+    id: "correspondence:fixture",
+    source: { backend: "acp:grok", threadId: "sender" },
+    destination: { backend: "codex", threadId: "recipient", title: "Recipient" },
+    input: [
+      { type: "text", text: `# Unicode Ω\n\n${"full paragraph ".repeat(200)}\n\nTail.` },
+      { type: "image", name: "diagram.png", url: "data:image/png;base64,AQID" },
+      { type: "file", name: "notes.txt", mimeType: "text/plain", data: "AQID" },
+    ],
+    createdAt: 1_000,
+    state: "sending",
+  };
+}
+
+describe("PwrAgent correspondence persistence", () => {
+  it("writes the body once, retains terminal evidence over a late queued receipt, and reloads after rollup", () => {
+    const directory = mkdtempSync(path.join(os.tmpdir(), "pwragent-correspondence-"));
+    onTestFinished(() => rmSync(directory, { recursive: true, force: true }));
+    const store = new ThreadCorrespondenceStore(directory);
+    const message = record();
+    store.record(message);
+    store.update(message.source, message.id, { state: "queued", queueEntryId: "queue-one" });
+    store.update(message.source, message.id, { state: "cancelled" });
+    store.update(message.source, message.id, { state: "queued" }, true);
+    const files = readdirSync(directory);
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatch(/^[a-f0-9]+\.jsonl$/);
+    const lines = readFileSync(path.join(directory, files[0]!), "utf8").trim().split("\n").map((line) => JSON.parse(line));
+    expect(lines.filter((event) => event.record?.input)).toHaveLength(1);
+    const replay = new ThreadCorrespondenceStore(directory).appendToReplay(message.source, emptyReplay);
+    expect(replay.messages[0]?.text).toContain("**Cancelled**");
+    expect(replay.messages[0]?.text).toContain("Tail.");
+    expect(replay.messages[0]?.parts).toContainEqual({ type: "image", url: "data:image/png;base64,AQID", alt: "diagram.png" });
+    expect(store.appendToReplay(message.source, replay).entries).toHaveLength(1);
+  });
+
+  it("does not let a peer with the same thread id update local correspondence", () => {
+    const store = new ThreadCorrespondenceStore();
+    const message = record();
+    store.record(message);
+    store.update({ ...message.source, instanceId: "peer-instance" }, message.id, { state: "cancelled" });
+    expect(store.message(message.source, message.id)?.text).toContain("Send outcome unknown");
+    expect(store.message({ ...message.source, instanceId: "peer-instance" }, message.id)).toBeUndefined();
+  });
+
+  it("reports unknown send outcomes, held and failed states without calling a queue delivered", () => {
+    const store = new ThreadCorrespondenceStore();
+    const message = record();
+    store.record(message);
+    expect(store.appendToReplay(message.source, emptyReplay).messages[0]?.text).toContain("Send outcome unknown");
+    store.update(message.source, message.id, { state: "held" });
+    expect(store.appendToReplay(message.source, emptyReplay).messages[0]?.text).toContain("Held for retry");
+    store.update(message.source, message.id, { state: "failed" });
+    expect(store.appendToReplay(message.source, emptyReplay).messages[0]?.text).toContain("Failed to send");
+  });
+});

--- a/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
+++ b/apps/desktop/src/main/agent-tools/__tests__/pwragent-thread-orchestration-agent-tools.test.ts
@@ -545,7 +545,7 @@ describe("pwragent thread orchestration agent tools", () => {
     });
   });
 
-  it("normalizes send_message_to_thread args and dispatches with caller context", async () => {
+  it("normalizes send_message_to_thread identifiers while preserving prompt content and caller context", async () => {
     const handler = vi.fn(async () => ({
       ok: true as const,
       data: {
@@ -596,7 +596,7 @@ describe("pwragent thread orchestration agent tools", () => {
         threadId: "target-thread",
         instanceId: "pwr_studio",
         includeRemote: true,
-        prompt: "Check CI",
+        prompt: " Check CI ",
         model: "gpt-5.5",
         fastMode: true,
       },

--- a/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/pwragent-thread-orchestration-agent-tools.ts
@@ -695,7 +695,7 @@ function normalizeSendMessageToThreadArgs(
   const backend = readTrimmedString(args.backend);
   const threadId = readTrimmedString(args.threadId);
   const instanceId = readTrimmedString(args.instanceId);
-  const prompt = readTrimmedString(args.prompt);
+  const prompt = typeof args.prompt === "string" && args.prompt.trim() ? args.prompt : undefined;
   if (!backend || !threadId || !prompt) {
     return undefined;
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1,3 +1,5 @@
+import type { ReadQueuedTurnRequest, ReadQueuedTurnResponse } from "@pwragent/shared";
+import { ThreadCorrespondenceStore } from "./thread-correspondence-store";
 import { rememberBoundedMap } from "../bounded-map";
 import { app } from "electron";
 import { AsyncLocalStorage } from "node:async_hooks";
@@ -611,7 +613,11 @@ import {
 } from "./thread-turn-queue";
 import { materializeLocalImageInputs } from "./image-input-files";
 import { enrichLocalFileInputs } from "./local-file-input";
-import { stageTurnInputAttachmentsForRetention } from "./turn-input-attachment-files";
+import {
+  portableTurnInputAttachments,
+  stageQueuedFileInputs,
+  stageTurnInputAttachmentsForRetention,
+} from "./turn-input-attachment-files";
 import type { MessagingStoreLike } from "../state/messaging-store-sqlite";
 import {
   PdfAttachmentStore,
@@ -8041,6 +8047,7 @@ export class DesktopBackendRegistry {
   private codexRateLimitsNotificationVersion = 0;
   private providerRuntimeFingerprints?: Readonly<Record<ProviderId, string>>;
   private providerRuntimeInvalidationPromise?: Promise<void>;
+  private readonly correspondenceStore: ThreadCorrespondenceStore;
   private readonly overlayStore: BackendRegistryOverlayStoreLike;
   private readonly gitDirectoryService: GitDirectoryService;
   private readonly gitWorkingStateService: GitWorkingStateService;
@@ -8712,6 +8719,7 @@ export class DesktopBackendRegistry {
   constructor(options?: {
     codexClient?: BackendClient;
     overlayStore?: BackendRegistryOverlayStoreLike;
+    correspondenceStore?: ThreadCorrespondenceStore;
     gitDirectoryService?: GitDirectoryService;
     gitWorkingStateService?: GitWorkingStateService;
     gitWorkspaceHandoffService?: GitWorkspaceHandoffService;
@@ -8840,6 +8848,10 @@ export class DesktopBackendRegistry {
     const settingsService = createsLiveCodexClient
       ? getDesktopSettingsService()
       : undefined;
+    this.correspondenceStore = options?.correspondenceStore
+      ?? new ThreadCorrespondenceStore(isAppStateInitialized()
+        ? resolveActiveProfilePath("state/thread-correspondence")
+        : undefined);
     const tokenMiserStateDir =
       createsLiveCodexClient && isAppStateInitialized()
         ? resolveActiveProfilePath("state/token-miser")
@@ -10036,9 +10048,58 @@ export class DesktopBackendRegistry {
     };
   }
 
+  private updateCorrespondenceStatus(
+    ...args: Parameters<ThreadCorrespondenceStore["update"]>
+  ): void {
+    try {
+      this.correspondenceStore.update(...args);
+      const [source, id] = args;
+      const message = this.correspondenceStore.message(source, id);
+      if (message) {
+        void this.emit({
+          backend: source.backend,
+          notification: {
+            method: "item/completed",
+            params: {
+              threadId: source.threadId,
+              item: {
+                id: message.id,
+                type: "agentMessage",
+                text: message.text,
+                content: message.parts,
+                origin: message.origin,
+              },
+            },
+          },
+        }).catch((error) => {
+          backendRegistryLog.error("Could not publish cross-thread delivery state", {
+            error: error instanceof Error ? error.message : String(error),
+          });
+        });
+      }
+    } catch (error) {
+      // Status persistence must not turn an already-admitted backend turn into
+      // a failed submission or prevent the recipient FIFO from advancing.
+      backendRegistryLog.error("Could not persist cross-thread delivery state", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   private async emitTurnQueueLifecycle(
     event: ThreadTurnQueueLifecycleEvent,
   ): Promise<void> {
+    const source = event.entry.messageOrigin?.sourceThread;
+    if (
+      source?.messageId
+      && event.type !== "terminal"
+    ) {
+      this.updateCorrespondenceStatus(source, source.messageId, {
+        state: event.type === "blocked" ? "held" : event.type,
+        queueEntryId: event.entry.id,
+        ...(event.type === "started" ? { turnId: event.turnId } : {}),
+      });
+    }
     const baseParams = {
       threadId: event.entry.threadId,
       queueEntryId: event.entry.id,
@@ -13481,6 +13542,12 @@ export class DesktopBackendRegistry {
       const response = await this.readAcpThread(request, backend);
       return {
         ...response,
+        replay: request.includeTurns === false || request.before
+          ? response.replay
+          : this.correspondenceStore.appendToReplay(
+              { backend, threadId: request.threadId },
+              response.replay,
+            ),
         readDurationMs: Math.max(0, Math.round(performance.now() - readStartedAt)),
       };
     }
@@ -13668,7 +13735,12 @@ export class DesktopBackendRegistry {
       ...(replayWithReviewMetadata.threadStatus
         ? { threadStatus: replayWithReviewMetadata.threadStatus }
         : {}),
-      replay: replayWithReviewMetadata,
+      replay: request.includeTurns === false || request.before
+        ? replayWithReviewMetadata
+        : this.correspondenceStore.appendToReplay(
+            { backend, threadId: request.threadId },
+            replayWithReviewMetadata,
+          ),
     };
   }
 
@@ -15089,6 +15161,40 @@ export class DesktopBackendRegistry {
     });
   }
 
+  async readQueuedTurn(
+    request: ReadQueuedTurnRequest,
+    portable = false,
+  ): Promise<ReadQueuedTurnResponse> {
+    const entry = this.threadTurnQueue.getQueuedEntries(request)
+      .find((candidate) => candidate.id === request.queueEntryId);
+    if (!entry) throw new Error("The queued message is no longer waiting.");
+    return {
+      queueEntryId: entry.id,
+      contentHash: createHash("sha256").update(JSON.stringify(entry.input)).digest("hex"),
+      input: portable
+        ? await portableTurnInputAttachments(structuredClone(entry.input), {
+            privateStorageRoots: this.localFilePrivateStorageRoots,
+          })
+        : request.forEdit
+        ? await stageQueuedFileInputs(structuredClone(entry.input))
+        : structuredClone(entry.input),
+      imageParts: entry.input.flatMap((item): AppServerThreadImagePart[] => {
+        if (item.type === "image") {
+          return [{ type: "image", url: item.url, alt: item.name }];
+        }
+        if (item.type === "localImage") {
+          return [{
+            type: "image",
+            url: toTranscriptImageProtocolUrl(pathToFileURL(item.path).toString()),
+            alt: item.name,
+          }];
+        }
+        return [];
+      }),
+      ...(entry.messageOrigin ? { messageOrigin: structuredClone(entry.messageOrigin) } : {}),
+    };
+  }
+
   cancelQueuedTurn(entryId: string, reason?: string): boolean {
     return Boolean(this.threadTurnQueue.cancelEntry(entryId, reason));
   }
@@ -15096,7 +15202,14 @@ export class DesktopBackendRegistry {
   cancelQueuedTurnWithDisposition(
     entryId: string,
     reason?: string,
+    expectedContentHash?: string,
   ): CancelQueuedTurnResponse {
+    if (expectedContentHash) {
+      const entry = this.threadTurnQueue.getAllQueuedEntries().find((entry) => entry.id === entryId);
+      if (entry && createHash("sha256").update(JSON.stringify(entry.input)).digest("hex") !== expectedContentHash) {
+        return { queueEntryId: entryId, cancelled: false, disposition: "content_changed" };
+      }
+    }
     const result = this.threadTurnQueue.cancelEntryWithDisposition(
       entryId,
       reason,
@@ -32241,8 +32354,8 @@ export class DesktopBackendRegistry {
     const threadId = request.args.threadId.trim();
     const instanceId = request.args.instanceId?.trim();
     const includeRemote = request.args.includeRemote !== false;
-    const prompt = request.args.prompt.trim();
-    if (!threadId || !prompt) {
+    const prompt = request.args.prompt;
+    if (!threadId || !prompt.trim()) {
       return threadOrchestrationFailure(
         "invalid_arguments",
         "send_message_to_thread requires non-empty threadId and prompt strings.",
@@ -32265,6 +32378,8 @@ export class DesktopBackendRegistry {
       );
     }
 
+    const correspondenceId = `correspondence:${randomUUID()}`;
+    const source = { backend: request.context.backend, threadId: request.context.threadId };
     try {
       const settings = {
         ...(request.args.executionMode
@@ -32296,6 +32411,17 @@ export class DesktopBackendRegistry {
       const messageOrigin = await this.buildAgentMessageOrigin({
         backend: request.context.backend,
         threadId: request.context.threadId,
+      });
+      if (messageOrigin.sourceThread) {
+        messageOrigin.sourceThread = { ...messageOrigin.sourceThread, messageId: correspondenceId };
+      }
+      this.correspondenceStore.record({
+        id: correspondenceId,
+        source,
+        destination: { backend, threadId, ...(instanceId ? { instanceId } : {}) },
+        input,
+        createdAt: Date.now(),
+        state: "sending",
       });
       let targetTitle: string | undefined;
       let targetInstanceId: string | undefined;
@@ -32405,6 +32531,12 @@ export class DesktopBackendRegistry {
         ...(targetInstanceId ? { instanceId: targetInstanceId } : {}),
         threadId: turn.threadId,
       };
+      this.updateCorrespondenceStatus(source, correspondenceId, {
+        state: turn.queueStatus === "queued" ? "queued" : "started",
+        destination: { ...threadLinkRef, title: targetTitle },
+        queueEntryId: turn.queueEntryId,
+        ...(turn.queueStatus === "queued" ? {} : { turnId: turn.turnId }),
+      }, true);
       const messageId = turn.queueStatus === "queued"
         ? undefined
         : buildTurnUserMessageOriginId(turn.turnId);

--- a/apps/desktop/src/main/app-server/thread-correspondence-store.ts
+++ b/apps/desktop/src/main/app-server/thread-correspondence-store.ts
@@ -1,0 +1,139 @@
+import { pathToFileURL } from "node:url";
+import { toTranscriptImageProtocolUrl } from "../transcript-image-protocol";
+import { createHash } from "node:crypto";
+import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import type {
+  AppServerBackendKind,
+  AppServerThreadMessageEntry,
+  AppServerThreadReplay,
+  AppServerTurnInputItem,
+} from "@pwragent/shared";
+import { buildThreadMarkdownLink } from "@pwragent/shared";
+
+type ThreadRef = { backend: AppServerBackendKind; threadId: string; instanceId?: string; title?: string };
+export type CorrespondenceRecord = {
+  id: string;
+  source: ThreadRef;
+  destination: ThreadRef;
+  input: AppServerTurnInputItem[];
+  createdAt: number;
+  state: "sending" | "queued" | "started" | "failed" | "cancelled" | "held";
+  queueEntryId?: string;
+  turnId?: string;
+};
+type Status = Pick<CorrespondenceRecord, "state"> & Partial<Pick<CorrespondenceRecord, "destination" | "queueEntryId" | "turnId">>;
+type Event = { type: "message"; record: CorrespondenceRecord } | { type: "status"; id: string; status: Status };
+
+/** PwrAgent-owned supplemental correspondence, never provider history or SQLite. */
+export class ThreadCorrespondenceStore {
+  private readonly records = new Map<string, Map<string, CorrespondenceRecord>>();
+  constructor(private readonly directory?: string) {}
+
+  private key(source: ThreadRef): string {
+    return createHash("sha256").update(JSON.stringify([source.backend, source.instanceId ?? null, source.threadId])).digest("hex");
+  }
+
+  private load(source: ThreadRef): Map<string, CorrespondenceRecord> {
+    const key = this.key(source);
+    const cached = this.records.get(key);
+    if (cached) return cached;
+    const records = new Map<string, CorrespondenceRecord>();
+    if (this.directory) {
+      const file = path.join(this.directory, `${key}.jsonl`);
+      let data: string;
+      try { data = readFileSync(file, "utf8"); }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+        data = "";
+      }
+      for (const [index, line] of data.split("\n").entries()) {
+        if (!line) continue;
+        let event: Event;
+        try { event = JSON.parse(line) as Event; }
+        catch { throw new Error(`Invalid PwrAgent correspondence record at ${file}:${index + 1}`); }
+        if (event.type === "message") records.set(event.record.id, event.record);
+        else if (event.type === "status") {
+          const record = records.get(event.id);
+          if (record) records.set(event.id, { ...record, ...event.status });
+        } else throw new Error(`Invalid PwrAgent correspondence event at ${file}:${index + 1}`);
+      }
+    }
+    this.records.set(key, records);
+    return records;
+  }
+
+  private append(source: ThreadRef, event: Event): void {
+    if (!this.directory) return;
+    mkdirSync(this.directory, { recursive: true, mode: 0o700 });
+    appendFileSync(path.join(this.directory, `${this.key(source)}.jsonl`), `${JSON.stringify(event)}\n`, { mode: 0o600 });
+  }
+
+  record(record: CorrespondenceRecord): void {
+    const records = this.load(record.source);
+    this.append(record.source, { type: "message", record });
+    records.set(record.id, structuredClone(record));
+  }
+
+  update(source: ThreadRef, id: string, status: Status, receipt = false): void {
+    const records = this.load(source);
+    const record = records.get(id);
+    // A peer owns the recipient queue, not the sender's correspondence file.
+    if (!record) return;
+    // A cancellation or dispatch can beat the submission response back to the
+    // sender. Its lifecycle evidence is newer than that response's queue state.
+    if (receipt && record.state !== "sending") status = { ...status, state: record.state };
+    this.append(source, { type: "status", id, status });
+    records.set(id, { ...record, ...status });
+  }
+
+  message(source: ThreadRef, id: string): AppServerThreadMessageEntry | undefined {
+    return this.appendToReplay(source, {
+      entries: [], messages: [], pagination: { supportsPagination: false, hasPreviousPage: false },
+    }, id).entries[0] as AppServerThreadMessageEntry | undefined;
+  }
+
+  appendToReplay(source: ThreadRef, replay: AppServerThreadReplay, onlyId?: string): AppServerThreadReplay {
+    const stored = this.load(source);
+    const selected = onlyId ? stored.get(onlyId) : undefined;
+    const records = onlyId ? (selected ? [selected] : []) : [...stored.values()];
+    const messages: AppServerThreadMessageEntry[] = records.map((record) => {
+      const destination = buildThreadMarkdownLink({ ...record.destination, ...(record.turnId ? { messageId: `user:${record.turnId}` } : {}) });
+      const state = {
+        sending: "Send outcome unknown",
+        queued: "Queued (last confirmed)",
+        started: "Accepted for execution",
+        failed: "Failed to send",
+        cancelled: "Cancelled",
+        held: "Held for retry",
+      }[record.state];
+      const heading = `**${state}** · To ${destination}`;
+      const body = record.input.flatMap((item) => item.type === "text" ? [item.text] : []).join("\n");
+      return {
+        type: "message",
+        id: record.id,
+        role: "assistant",
+        createdAt: record.createdAt,
+        origin: { kind: "pwragent" },
+        text: `${heading}\n\n${body}`,
+        parts: [
+          { type: "text", text: `${heading}\n\n${body}` },
+          ...record.input.flatMap((item) => {
+            if (item.type === "localImage") return [{ type: "image" as const, url: toTranscriptImageProtocolUrl(pathToFileURL(item.path).toString()), alt: item.name }];
+            if (item.type === "image") return [{ type: "image" as const, url: item.url, alt: item.name }];
+            return [];
+          }),
+          ...record.input.flatMap((item) => item.type === "file" || item.type === "localFile"
+            ? [{ type: "file" as const, name: item.name ?? (item.type === "file" ? "Attachment" : item.path) }]
+            : []),
+        ],
+      };
+    });
+    const ids = new Set(messages.map((message) => message.id));
+    return {
+      ...replay,
+      entries: [...replay.entries.filter((entry) => !ids.has(entry.id)), ...messages],
+      messages: [...replay.messages.filter((message) => !ids.has(message.id)), ...messages],
+    };
+  }
+}

--- a/apps/desktop/src/main/app-server/thread-correspondence-store.ts
+++ b/apps/desktop/src/main/app-server/thread-correspondence-store.ts
@@ -5,6 +5,8 @@ import { appendFileSync, mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import type {
   AppServerBackendKind,
+  AppServerThreadMessage,
+  AppServerThreadEntry,
   AppServerThreadMessageEntry,
   AppServerThreadReplay,
   AppServerTurnInputItem,
@@ -24,6 +26,28 @@ export type CorrespondenceRecord = {
 };
 type Status = Pick<CorrespondenceRecord, "state"> & Partial<Pick<CorrespondenceRecord, "destination" | "queueEntryId" | "turnId">>;
 type Event = { type: "message"; record: CorrespondenceRecord } | { type: "status"; id: string; status: Status };
+
+/** Keep provider order, including undated activities; insert before the next
+ * strictly newer timestamp. Ties retain provider order before correspondence. */
+function mergeCorrespondence<T extends { id: string }>(
+  entries: T[],
+  messages: AppServerThreadMessageEntry[],
+  timestamp: (entry: T) => number | undefined,
+): (T | AppServerThreadMessageEntry)[] {
+  const ids = new Set(messages.map((message) => message.id));
+  const merged: (T | AppServerThreadMessageEntry)[] = [];
+  let index = 0;
+  for (const entry of entries) {
+    if (ids.has(entry.id)) continue;
+    const createdAt = timestamp(entry);
+    while (index < messages.length && createdAt !== undefined && messages[index]!.createdAt! < createdAt) {
+      merged.push(messages[index++]!);
+    }
+    merged.push(entry);
+  }
+  merged.push(...messages.slice(index));
+  return merged;
+}
 
 /** PwrAgent-owned supplemental correspondence, never provider history or SQLite. */
 export class ThreadCorrespondenceStore {
@@ -97,6 +121,7 @@ export class ThreadCorrespondenceStore {
     const stored = this.load(source);
     const selected = onlyId ? stored.get(onlyId) : undefined;
     const records = onlyId ? (selected ? [selected] : []) : [...stored.values()];
+    records.sort((left, right) => left.createdAt - right.createdAt);
     const messages: AppServerThreadMessageEntry[] = records.map((record) => {
       const destination = buildThreadMarkdownLink({ ...record.destination, ...(record.turnId ? { messageId: `user:${record.turnId}` } : {}) });
       const state = {
@@ -129,11 +154,15 @@ export class ThreadCorrespondenceStore {
         ],
       };
     });
-    const ids = new Set(messages.map((message) => message.id));
+    const timestamp = (entry: AppServerThreadEntry) => entry.createdAt ?? entry.turn?.startedAt;
+    // The compact message list omits turn metadata; use the corresponding
+    // replay entry's timestamp so both views place messages consistently.
+    const entryTimestamps = new Map(replay.entries.map((entry) => [entry.id, timestamp(entry)]));
     return {
       ...replay,
-      entries: [...replay.entries.filter((entry) => !ids.has(entry.id)), ...messages],
-      messages: [...replay.messages.filter((message) => !ids.has(message.id)), ...messages],
+      entries: mergeCorrespondence(replay.entries, messages, timestamp),
+      messages: mergeCorrespondence<AppServerThreadMessage>(replay.messages, messages,
+        (message) => message.createdAt ?? entryTimestamps.get(message.id)),
     };
   }
 }

--- a/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
+++ b/apps/desktop/src/main/app-server/turn-input-attachment-files.ts
@@ -225,6 +225,42 @@ function filePathFromUrl(value: string): string | undefined {
   }
 }
 
+/** Keep recovered file bytes in the existing PwrAgent attachment store, not draft SQLite. */
+export async function stageQueuedFileInputs(
+  input: AppServerTurnInputItem[],
+): Promise<AppServerTurnInputItem[]> {
+  return await Promise.all(input.map(async (item): Promise<AppServerTurnInputItem> => {
+    if (item.type !== "file") return item;
+    const data = item.data === "" ? Buffer.alloc(0) : decodeBase64(item.data);
+    if (!data) throw new Error("The queued file attachment could not be decoded. The message remains queued.");
+    const staged = await stageTurnInputAttachment({ type: "localFile", data, name: item.name, mimeType: item.mimeType });
+    return { ...staged, ...(item.pdfRenderProfile ? { pdfRenderProfile: item.pdfRenderProfile } : {}) };
+  }));
+}
+
+/** Recover attachment bytes on their owner before a federated viewer edits them. */
+export async function portableTurnInputAttachments(
+  input: AppServerTurnInputItem[],
+  options?: { privateStorageRoots?: readonly string[] },
+): Promise<AppServerTurnInputItem[]> {
+  return await Promise.all(input.map(async (item): Promise<AppServerTurnInputItem> => {
+    if (item.type !== "localImage" && item.type !== "localFile") return item;
+    const staged = await stageLocalTurnInputAttachment(item, options);
+    const data = await readFile(staged.path);
+    const name = item.name ?? path.basename(item.path);
+    if (item.type === "localFile") {
+      return { type: "file", name, mimeType: item.mimeType ?? "application/octet-stream", data: data.toString("base64"), sizeBytes: data.length, ...(item.pdfRenderProfile ? { pdfRenderProfile: item.pdfRenderProfile } : {}) };
+    }
+    const imageMimeTypes: Record<string, string> = {
+      ".png": "image/png", ".jpg": "image/jpeg", ".jpeg": "image/jpeg",
+      ".gif": "image/gif", ".webp": "image/webp", ".avif": "image/avif",
+    };
+    const mimeType = imageMimeTypes[path.extname(item.path).toLowerCase()];
+    if (!mimeType) throw new Error("The queued image cannot be transferred in this format. The message remains queued.");
+    return { type: "image", name, url: `data:${mimeType};base64,${data.toString("base64")}` };
+  }));
+}
+
 export function isStagedTurnInputAttachmentPath(filePath: string): boolean {
   const relative = path.relative(
     path.resolve(turnInputAttachmentRoot()),

--- a/apps/desktop/src/main/federation/federation-backend-bridge.ts
+++ b/apps/desktop/src/main/federation/federation-backend-bridge.ts
@@ -15,6 +15,8 @@ import type {
   AgentEvent,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
+  ReadQueuedTurnRequest,
+  ReadQueuedTurnResponse,
   CancelQueuedTurnRequest,
   CancelQueuedTurnResponse,
   ReleaseQueuedTurnRequest,
@@ -323,6 +325,7 @@ function authenticateMessageOrigin(params: {
         ? { celestialIcon: sourceInstance.celestialIcon }
         : {}),
       threadId: sourceThread.threadId,
+      ...(sourceThread.messageId ? { messageId: sourceThread.messageId } : {}),
       ...(sourceThread.title ? { title: sourceThread.title } : {}),
     },
   };
@@ -383,6 +386,7 @@ export const FEDERATION_BACKEND_METHODS = {
   startThread: "backend.startThread",
   forkThread: "backend.forkThread",
   startTurn: "backend.startTurn",
+  readQueuedTurn: "backend.readQueuedTurn",
   cancelQueuedTurn: "backend.cancelQueuedTurn",
   releaseQueuedTurn: "backend.releaseQueuedTurn",
   startReview: "backend.startReview",
@@ -485,6 +489,7 @@ export const FEDERATION_BACKEND_METHOD_CAPABILITIES: Record<
   [FEDERATION_BACKEND_METHODS.startThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.forkThread]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startTurn]: "turn_control",
+  [FEDERATION_BACKEND_METHODS.readQueuedTurn]: "thread_detail",
   [FEDERATION_BACKEND_METHODS.cancelQueuedTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.releaseQueuedTurn]: "turn_control",
   [FEDERATION_BACKEND_METHODS.startReview]: "turn_control",
@@ -641,6 +646,9 @@ export type FederationBackendOperations = {
     >,
   ): Promise<ForkThreadResponse>;
   startTurn(request: FederationStartTurnRequest): Promise<StartTurnResponse>;
+  readQueuedTurn(
+    request: ReadQueuedTurnRequest,
+  ): Promise<ReadQueuedTurnResponse>;
   cancelQueuedTurn(
     request: CancelQueuedTurnRequest,
   ): Promise<CancelQueuedTurnResponse>;
@@ -1106,6 +1114,13 @@ export function registerFederationBackendHandlers(params: {
         ...(messageOrigin ? { messageOrigin } : {}),
       });
     },
+  );
+  params.router.registerHandler(
+    FEDERATION_BACKEND_METHODS.readQueuedTurn,
+    async (envelope) =>
+      await params.backend.readQueuedTurn(
+        envelope.params as ReadQueuedTurnRequest,
+      ),
   );
   params.router.registerHandler(
     FEDERATION_BACKEND_METHODS.cancelQueuedTurn,
@@ -1803,6 +1818,15 @@ export class FederationRemoteBackendClient implements FederationBackendOperation
   async startReview(request: StartReviewRequest): Promise<StartReviewResponse> {
     return await this.rpc.request<StartReviewResponse>({
       method: FEDERATION_BACKEND_METHODS.startReview,
+      params: request,
+    });
+  }
+
+  async readQueuedTurn(
+    request: ReadQueuedTurnRequest,
+  ): Promise<ReadQueuedTurnResponse> {
+    return await this.rpc.request<ReadQueuedTurnResponse>({
+      method: FEDERATION_BACKEND_METHODS.readQueuedTurn,
       params: request,
     });
   }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -1,3 +1,4 @@
+import type { ReadQueuedTurnRequest, ReadQueuedTurnResponse } from "@pwragent/shared";
 import { randomBytes, randomUUID } from "node:crypto";
 import { hostname } from "node:os";
 import path from "node:path";
@@ -5313,12 +5314,16 @@ function localBackendOperations(): FederationBackendOperations {
     ): Promise<StartReviewResponse> {
       return await getDesktopBackendRegistry().startReview(request);
     },
+    async readQueuedTurn(request: ReadQueuedTurnRequest): Promise<ReadQueuedTurnResponse> {
+      return getDesktopBackendRegistry().readQueuedTurn(request, request.forEdit === true);
+    },
     async cancelQueuedTurn(
       request: CancelQueuedTurnRequest,
     ): Promise<CancelQueuedTurnResponse> {
       return getDesktopBackendRegistry().cancelQueuedTurnWithDisposition(
         request.queueEntryId,
         "Cancelled from a federated desktop composer.",
+        request.expectedContentHash,
       );
     },
     async releaseQueuedTurn(

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -1,5 +1,5 @@
 import { stageQueuedFileInputs } from "../app-server/turn-input-attachment-files";
-import { toFederatedTranscriptImageProtocolUrl } from "../transcript-image-protocol";
+import { rewriteFederatedTranscriptImageUrlForRenderer } from "../transcript-image-protocol";
 import type { ReadQueuedTurnRequest, ReadQueuedTurnResponse } from "@pwragent/shared";
 import { ipcMain, type IpcMainInvokeEvent } from "electron";
 import { issueProviderDiscoveryPermit } from "../settings/provider-discovery-permit";
@@ -654,7 +654,7 @@ export function registerAgentIpcHandlers(): void {
           input: request.forEdit ? await stageQueuedFileInputs(response.input) : response.input,
           imageParts: response.imageParts?.map((image) => ({
             ...image,
-            url: toFederatedTranscriptImageProtocolUrl(federationTarget.instanceId, image.url),
+            url: rewriteFederatedTranscriptImageUrlForRenderer(image.url, federationTarget.instanceId),
           })),
         };
       }

--- a/apps/desktop/src/main/ipc/agent-ipc.ts
+++ b/apps/desktop/src/main/ipc/agent-ipc.ts
@@ -1,3 +1,6 @@
+import { stageQueuedFileInputs } from "../app-server/turn-input-attachment-files";
+import { toFederatedTranscriptImageProtocolUrl } from "../transcript-image-protocol";
+import type { ReadQueuedTurnRequest, ReadQueuedTurnResponse } from "@pwragent/shared";
 import { ipcMain, type IpcMainInvokeEvent } from "electron";
 import { issueProviderDiscoveryPermit } from "../settings/provider-discovery-permit";
 import {
@@ -96,6 +99,7 @@ import { getDesktopBackendRegistry } from "../app-server/backend-registry";
 import { buildLiveDiffActivityEntry } from "../app-server/live-diff-activity";
 import { timeStartupProfileOperation } from "../diagnostics/startup-profile-events";
 import {
+  AGENT_READ_QUEUED_TURN_CHANNEL,
   AGENT_CANCEL_QUEUED_TURN_CHANNEL,
   AGENT_RELEASE_QUEUED_TURN_CHANNEL,
   AGENT_CANCEL_THREAD_EXECUTION_MODE_QUEUE_CHANNEL,
@@ -630,6 +634,34 @@ export function registerAgentIpcHandlers(): void {
     },
   );
 
+  ipcMain.removeHandler(AGENT_READ_QUEUED_TURN_CHANNEL);
+  ipcMain.handle(
+    AGENT_READ_QUEUED_TURN_CHANNEL,
+    async (
+      _event,
+      request: ReadQueuedTurnRequest,
+    ): Promise<ReadQueuedTurnResponse> => {
+      if (
+        request.federationTarget
+        && isRemoteFederationTarget(request.federationTarget)
+      ) {
+        const { federationTarget, ...remoteRequest } = request;
+        const response = await getDesktopFederationRuntime()
+          .remoteBackend(federationTarget)
+          .readQueuedTurn(remoteRequest);
+        return {
+          ...response,
+          input: request.forEdit ? await stageQueuedFileInputs(response.input) : response.input,
+          imageParts: response.imageParts?.map((image) => ({
+            ...image,
+            url: toFederatedTranscriptImageProtocolUrl(federationTarget.instanceId, image.url),
+          })),
+        };
+      }
+      return registry.readQueuedTurn(request);
+    },
+  );
+
   ipcMain.removeHandler(AGENT_CANCEL_QUEUED_TURN_CHANNEL);
   ipcMain.handle(
     AGENT_CANCEL_QUEUED_TURN_CHANNEL,
@@ -649,6 +681,7 @@ export function registerAgentIpcHandlers(): void {
       return registry.cancelQueuedTurnWithDisposition(
         request.queueEntryId,
         "Cancelled from the desktop composer.",
+        request.expectedContentHash,
       );
     },
   );

--- a/apps/desktop/src/main/transcript-image-protocol.ts
+++ b/apps/desktop/src/main/transcript-image-protocol.ts
@@ -181,14 +181,22 @@ export function rewriteTranscriptImageUrlsForRenderer(
   );
 }
 
+/** Only owner-local and signed media need routing through the owning peer. */
+export function rewriteFederatedTranscriptImageUrlForRenderer(
+  url: string,
+  instanceId: FederationInstanceId,
+): string {
+  return isFederationOwnerImageUrl(url)
+    ? toFederatedTranscriptImageProtocolUrl(instanceId, url)
+    : url;
+}
+
 export function rewriteFederatedTranscriptImageUrlsForRenderer(
   response: AppServerReadThreadResponse,
   instanceId: FederationInstanceId,
 ): AppServerReadThreadResponse {
   return rewriteTranscriptImageUrls(response, (url) =>
-    isFederationOwnerImageUrl(url)
-      ? toFederatedTranscriptImageProtocolUrl(instanceId, url)
-      : undefined,
+    rewriteFederatedTranscriptImageUrlForRenderer(url, instanceId),
   );
 }
 
@@ -1051,7 +1059,7 @@ function rewriteTranscriptMessageImageUrls<T extends AppServerThreadMessage>(
       return part;
     }
     const url = rewriteUrl(part.url);
-    if (!url) {
+    if (!url || url === part.url) {
       return part;
     }
     changed = true;

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -18,6 +18,8 @@ import type {
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
+  ReadQueuedTurnRequest,
+  ReadQueuedTurnResponse,
   CancelQueuedTurnRequest,
   CancelQueuedTurnResponse,
   ReleaseQueuedTurnRequest,
@@ -459,6 +461,7 @@ import type {
   RevealQuitBlockerResponse,
 } from "../shared/quit-blockers";
 import {
+  AGENT_READ_QUEUED_TURN_CHANNEL,
   AGENT_CANCEL_QUEUED_TURN_CHANNEL,
   AGENT_RELEASE_QUEUED_TURN_CHANNEL,
   SCHEDULED_ACTIONS_CANCEL_CHANNEL,
@@ -1610,6 +1613,10 @@ const desktopApi = Object.freeze({
     request: StartTurnRequest
   ): Promise<StartTurnResponse> =>
     await ipcRenderer.invoke(AGENT_START_TURN_CHANNEL, request),
+  readQueuedTurn: async (
+    request: ReadQueuedTurnRequest,
+  ): Promise<ReadQueuedTurnResponse> =>
+    await ipcRenderer.invoke(AGENT_READ_QUEUED_TURN_CHANNEL, request),
   cancelQueuedTurn: async (
     request: CancelQueuedTurnRequest,
   ): Promise<CancelQueuedTurnResponse> =>

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,3 +1,5 @@
+import { QueuedMessageInspector } from "./QueuedMessageInspector";
+import { restoreQueuedMessage } from "./queued-message-content";
 import {
   Fragment,
   type ReactNode,
@@ -1408,7 +1410,7 @@ function appendFileReferenceMarkdown(
   if (fileRefs.length === 0) {
     return text;
   }
-  const referenceBlock = fileRefs
+  const referenceBlock = fileRefs.filter((fileRef) => !fileRef.originalInput)
     .map((fileRef) =>
       buildDirectoryReferenceMarkdown({
         label: fileRef.label,
@@ -1416,7 +1418,7 @@ function appendFileReferenceMarkdown(
       }),
     )
     .join("\n");
-  return text ? `${text}\n\n${referenceBlock}` : referenceBlock;
+  return referenceBlock ? (text ? `${text}\n\n${referenceBlock}` : referenceBlock) : text;
 }
 
 /**
@@ -1514,7 +1516,7 @@ function buildLocalFileInputs(
   };
 
   for (const fileRef of fileRefs) {
-    add(fileRef.label, fileRef.path);
+    if (!fileRef.originalInput) add(fileRef.label, fileRef.path);
   }
   for (const token of skillTokens) {
     if (
@@ -4178,9 +4180,27 @@ export function Composer(props: ComposerProps) {
       setQueuedTurnsState(nextQueuedTurns);
     }
   };
+  const readQueuedMessage = async (queued: QueuedTurnDraft, forEdit = false) => {
+    if (queued.queueEntryId) {
+      if (!props.desktopApi?.readQueuedTurn || !props.thread) {
+        throw new Error("Full queued message content is unavailable. The message remains queued.");
+      }
+      return await props.desktopApi.readQueuedTurn({
+        backend: props.thread.source,
+        threadId: props.thread.id,
+        queueEntryId: queued.queueEntryId,
+        forEdit,
+        federationTarget: props.thread.federation?.ref.target ?? readRendererFederationTarget(),
+      });
+    }
+    const payload = await buildQueuedTurnPayload(queued);
+    return { queueEntryId: queued.id, contentHash: "", input: payload.input };
+  };
+
   const cancelServerManagedQueuedTurn = async (
     queued: QueuedTurnDraft,
     scopeKey = composerScopeKey,
+    expectedContentHash?: string,
   ): Promise<"cancelled" | "already_admitted" | "failed"> => {
     const reportError = (message: string): void => {
       if (activeComposerScopeKeyRef.current === scopeKey) {
@@ -4218,6 +4238,7 @@ export function Composer(props: ComposerProps) {
       const response = await props.desktopApi.cancelQueuedTurn({
         ...(federationTarget ? { federationTarget } : {}),
         queueEntryId: queued.queueEntryId,
+        expectedContentHash,
       });
       if (!response.cancelled) {
         if (response.disposition === "already_admitted") {
@@ -4234,7 +4255,9 @@ export function Composer(props: ComposerProps) {
           }
           return "already_admitted";
         }
-        reportError("The queued turn is no longer waiting.");
+        reportError(response.disposition === "content_changed"
+          ? "The queued message changed. Open it again before editing."
+          : "The queued turn is no longer waiting.");
         return "failed";
       }
       return "cancelled";
@@ -6176,11 +6199,12 @@ export function Composer(props: ComposerProps) {
       }));
       const input: AppServerTurnInputItem[] = [
         ...(displayText ? [{ type: "text" as const, text: displayText }] : []),
-        ...attachments.map((attachment) => ({
+        ...attachments.map((attachment) => attachment.originalInput ?? ({
           type: "image" as const,
           name: attachment.name,
           url: attachment.url,
         })),
+        ...fileRefs.flatMap((attachment) => attachment.originalInput ? [attachment.originalInput] : []),
         ...buildLocalFileInputs(
           fileRefs,
           localReferenceTokens,
@@ -7433,9 +7457,21 @@ export function Composer(props: ComposerProps) {
     if (!expectedTurnId) {
       return;
     }
+    let contentHash: string | undefined;
+    if (queued.queueEntryId && !queued.input) {
+      try {
+        const content = await readQueuedMessage(queued, true);
+        queued = restoreQueuedMessage(queued, content);
+        contentHash = content.contentHash;
+      } catch (error) {
+        setSendError(error instanceof Error ? error.message : String(error));
+        return;
+      }
+    }
     const cancellation = await cancelServerManagedQueuedTurn(
       queued,
       expectedScopeKey,
+      contentHash,
     );
     if (cancellation !== "cancelled") {
       return;
@@ -10424,6 +10460,7 @@ export function Composer(props: ComposerProps) {
               <span className="composer__queued-text">
                 {formatDraftPreview(queued)}
               </span>
+              <QueuedMessageInspector load={() => readQueuedMessage(queued)} desktopApi={props.desktopApi} />
               {queued.errorMessage ? (
                 <span className="composer__queued-error">
                   {queued.errorMessage}
@@ -10496,7 +10533,7 @@ export function Composer(props: ComposerProps) {
                 disabled={queued.backendQueuePending}
                 type="button"
                 onClick={() => {
-                  const editQueuedTurn = (): void => {
+                  const editQueuedTurn = (editable = queued): void => {
                     removeQueuedTurnInScope(queuedScopeKey, queued);
                     if (activeComposerScopeKeyRef.current !== queuedScopeKey) {
                       const currentDraft = draftStore.get(queuedScopeKey);
@@ -10507,17 +10544,21 @@ export function Composer(props: ComposerProps) {
                         draftStore.pushDraft(queuedScopeKey, currentDraft);
                       }
                       saveComposerDraftSnapshot(queuedScopeKey, {
-                        draft: queued.text,
+                        draft: editable.text,
                         editorDocument: undefined,
-                        imageAttachments: queued.imageAttachments,
-                        fileAttachments: queued.fileAttachments,
+                        imageAttachments: editable.imageAttachments,
+                        fileAttachments: editable.fileAttachments,
                         skillTokens: [],
                       });
                       return;
                     }
-                    setComposerDraftFromCanonical(queued.text);
-                    setImageAttachments(queued.imageAttachments);
-                    setFileAttachments(queued.fileAttachments);
+                    const currentDraft = latestDraftSnapshotRef.current.snapshot;
+                    if (hasComposerDraftSnapshotContent(currentDraft)) {
+                      draftStore.pushDraft(queuedScopeKey, currentDraft);
+                    }
+                    setComposerDraftFromCanonical(editable.text);
+                    setImageAttachments(editable.imageAttachments);
+                    setFileAttachments(editable.fileAttachments);
                     setScheduledDraftSendAt(scheduledSendAt);
                     setScheduleArmed(true);
                     requestAnimationFrame(() => inputRef.current?.focus());
@@ -10527,14 +10568,25 @@ export function Composer(props: ComposerProps) {
                     return;
                   }
                   void (async () => {
+                    let editable: QueuedTurnDraft;
+                    let contentHash: string;
+                    try {
+                      const content = await readQueuedMessage(queued, true);
+                      contentHash = content.contentHash;
+                      editable = restoreQueuedMessage(queued, content);
+                    } catch (error) {
+                      setSendError(error instanceof Error ? error.message : String(error));
+                      return;
+                    }
                     const cancellation = await cancelServerManagedQueuedTurn(
                       queued,
                       queuedScopeKey,
+                      contentHash,
                     );
                     if (cancellation !== "cancelled") {
                       return;
                     }
-                    editQueuedTurn();
+                    editQueuedTurn(editable);
                   })();
                 }}
               >

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -6197,7 +6197,7 @@ export function Composer(props: ComposerProps) {
         url: attachment.url,
         alt: formatPastedImageAlt(attachment, index),
       }));
-      const input: AppServerTurnInputItem[] = [
+      const input = mergeDerivedLocalFileInputs([
         ...(displayText ? [{ type: "text" as const, text: displayText }] : []),
         ...attachments.map((attachment) => attachment.originalInput ?? ({
           type: "image" as const,
@@ -6205,12 +6205,11 @@ export function Composer(props: ComposerProps) {
           url: attachment.url,
         })),
         ...fileRefs.flatMap((attachment) => attachment.originalInput ? [attachment.originalInput] : []),
-        ...buildLocalFileInputs(
-          fileRefs,
-          localReferenceTokens,
-          resolvedInspection.filePaths,
-        ),
-      ];
+      ], buildLocalFileInputs(
+        fileRefs,
+        localReferenceTokens,
+        resolvedInspection.filePaths,
+      ));
 
       return { displayText, imageParts, input };
     };

--- a/apps/desktop/src/renderer/src/features/composer/QueuedMessageInspector.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/QueuedMessageInspector.tsx
@@ -1,0 +1,68 @@
+import { useId, useState } from "react";
+import type { ReadQueuedTurnResponse } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { TurnInputContent } from "../thread-detail/TurnInputContent";
+
+export function QueuedMessageInspector(props: {
+  load: () => Promise<ReadQueuedTurnResponse>;
+  desktopApi?: DesktopApi;
+}) {
+  const regionId = useId();
+  const [content, setContent] = useState<ReadQueuedTurnResponse>();
+  const [error, setError] = useState<string>();
+  const [loading, setLoading] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+  const open = async () => {
+    setExpanded(true);
+    setLoading(true);
+    setError(undefined);
+    setContent(undefined);
+    try {
+      setContent(await props.load());
+    } catch (error) {
+      setError(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  };
+  return (
+    <div>
+      <button
+        className="composer__secondary-action"
+        type="button"
+        aria-expanded={expanded}
+        aria-controls={regionId}
+        onClick={() => expanded ? setExpanded(false) : void open()}
+      >
+        {expanded ? "Hide message" : "View full message"}
+      </button>
+      {expanded ? (
+        <div
+          id={regionId}
+          className="queued-message-inspector"
+          role="region"
+          aria-label="Full queued message"
+          tabIndex={0}
+        >
+          {loading ? <span role="status">Loading message…</span> : null}
+          {error ? (
+            <div role="alert">
+              {error}
+              <button className="composer__secondary-action" type="button" onClick={() => void open()}>
+                Retry
+              </button>
+            </div>
+          ) : null}
+          {content ? (
+            <TurnInputContent
+              input={content.input}
+              imageParts={content.imageParts}
+              origin={content.messageOrigin}
+              desktopApi={props.desktopApi}
+            />
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -6981,6 +6981,7 @@ describe("Composer", () => {
     const baseProps = {
       backends: [backendSummary("codex")],
       desktopApi: {
+        readQueuedTurn: async () => ({ queueEntryId: "queue-entry-1", contentHash: "hash", input: [{ type: "text" as const, text: "First queued reply" }] }),
         cancelQueuedTurn,
         onAgentEvent: () => () => undefined,
         startTurn,
@@ -7028,12 +7029,58 @@ describe("Composer", () => {
     await waitFor(() => {
       expect(cancelQueuedTurn).toHaveBeenCalledWith({
         queueEntryId: "queue-entry-1",
+        expectedContentHash: "hash",
       });
       expect(screen.getByLabelText("Reply")).toHaveValue("First queued reply");
       expect(screen.getByLabelText("Queued message")).toHaveTextContent(
         "Second queued reply",
       );
     });
+  });
+
+  it("inspects and edits mirrored long markdown from authoritative queue input", async () => {
+    const draftStore = createComposerDraftStore();
+    const prompt = `# Full message 漢字\n\n${"Paragraph **bold** Ω. ".repeat(80)}\n\nTail beyond preview.`;
+    const input = [
+      { type: "text" as const, text: prompt },
+      { type: "image" as const, name: "diagram.png", url: "data:image/png;base64,AQID" },
+      { type: "file" as const, name: "notes.txt", mimeType: "text/plain", data: "aGVsbG8=" },
+    ];
+    draftStore.setQueuedTurns("thread:codex:thread-1", [{ id: "mirror", queueEntryId: "owner-entry", text: "tiny preview…", imageAttachments: [], fileAttachments: [] }]);
+    const readQueuedTurn = vi.fn().mockRejectedValueOnce(new Error("Owner unavailable"))
+      .mockResolvedValue({ queueEntryId: "owner-entry", contentHash: "content-hash", input });
+    const cancelQueuedTurn = vi.fn().mockResolvedValue({ queueEntryId: "owner-entry", cancelled: true, disposition: "cancelled" });
+    const startTurn = vi.fn().mockResolvedValue({ backend: "codex", threadId: "thread-1", turnId: "new-queue", queueStatus: "queued", queueEntryId: "new-queue" });
+    render(<Composer activeTurnId="active" backends={[backendSummary("codex")]} draftStore={draftStore}
+      desktopApi={{ readQueuedTurn, cancelQueuedTurn, startTurn, onAgentEvent: () => () => undefined }} disabled={false} skills={[]}
+      thread={{ id: "thread-1", title: "Recipient", titleSource: "explicit", source: "codex", linkedDirectories: [], inbox: { inInbox: false } }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await screen.findByText("Owner unavailable");
+    expect(cancelQueuedTurn).not.toHaveBeenCalled();
+    expect(draftStore.getQueuedTurns("thread:codex:thread-1")).toHaveLength(1);
+    const inspect = screen.getByRole("button", { name: "View full message" });
+    expect(inspect).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(inspect);
+    await screen.findByRole("heading", { name: "Full message 漢字" });
+    expect(screen.getByRole("region", { name: "Full queued message" })).toHaveAttribute("tabindex", "0");
+    expect(screen.getByText("Tail beyond preview.")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "diagram.png" })).toBeInTheDocument();
+    expect(screen.getByText("notes.txt")).toBeInTheDocument();
+    const expandImage = screen.getByRole("button", { name: /Expand transcript image/ });
+    expandImage.focus();
+    expect(expandImage).toHaveFocus();
+    fireEvent.click(expandImage);
+    expect(screen.getByRole("dialog", { name: "Expanded image" })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Expanded image" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await waitFor(() => expect(screen.getByLabelText("Reply")).toHaveValue(prompt));
+    expect(cancelQueuedTurn).toHaveBeenCalledWith(expect.objectContaining({ queueEntryId: "owner-entry", expectedContentHash: "content-hash" }));
+    expect(readQueuedTurn).toHaveBeenCalledWith(expect.objectContaining({ backend: "codex", threadId: "thread-1" }));
+    expect(draftStore.getQueuedTurns("thread:codex:thread-1")).toHaveLength(0);
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+    await waitFor(() => expect(startTurn).toHaveBeenCalled());
+    expect(startTurn.mock.calls[0]?.[0].input).toEqual(input);
   });
 
   it("cancels the owning peer's queued turn before remote steering", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -7083,6 +7083,29 @@ describe("Composer", () => {
     expect(startTurn.mock.calls[0]?.[0].input).toEqual(input);
   });
 
+  it("deduplicates restored queue attachments against hydrated file references", async () => {
+    const draftStore = createComposerDraftStore();
+    const prompt = "Review [@report.pdf](/tmp/report.pdf) and [@notes.txt](/tmp/notes.txt)";
+    const input = [
+      { type: "text" as const, text: prompt },
+      { type: "localFile" as const, name: "Authoritative report", path: "/tmp/report.pdf", mimeType: "application/pdf", sizeBytes: 42 },
+      { type: "localFile" as const, name: "Authoritative notes", path: "/tmp/notes.txt", mimeType: "text/plain", sizeBytes: 12 },
+    ];
+    draftStore.setQueuedTurns("thread:codex:thread-1", [{ id: "mirror", queueEntryId: "owner-entry", text: "preview…", imageAttachments: [], fileAttachments: [] }]);
+    const readQueuedTurn = vi.fn().mockResolvedValue({ queueEntryId: "owner-entry", contentHash: "hash", input });
+    const cancelQueuedTurn = vi.fn().mockResolvedValue({ queueEntryId: "owner-entry", cancelled: true, disposition: "cancelled" });
+    const startTurn = vi.fn().mockResolvedValue({ backend: "codex", threadId: "thread-1", turnId: "new-queue", queueStatus: "queued", queueEntryId: "new-queue" });
+    const inspectPdfReferencePaths = vi.fn(async () => ({ filePaths: ["/tmp/report.pdf", "/tmp/notes.txt"], pdfPaths: [] }));
+    render(<Composer activeTurnId="active" backends={[backendSummary("codex")]} draftStore={draftStore}
+      desktopApi={{ readQueuedTurn, cancelQueuedTurn, startTurn, inspectPdfReferencePaths, onAgentEvent: () => () => undefined }} disabled={false} skills={[]}
+      thread={{ id: "thread-1", title: "Recipient", titleSource: "explicit", source: "codex", linkedDirectories: [], inbox: { inInbox: false } }} />);
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    await waitFor(() => expect(screen.getByLabelText("Reply")).toHaveValue("Review  and "));
+    fireEvent.keyDown(screen.getByLabelText("Reply"), { key: "Enter" });
+    await waitFor(() => expect(startTurn).toHaveBeenCalled());
+    expect(startTurn.mock.calls[0]?.[0].input).toEqual(input);
+  });
+
   it("cancels the owning peer's queued turn before remote steering", async () => {
     const federationTarget = {
       scope: "remote" as const,

--- a/apps/desktop/src/renderer/src/features/composer/queued-message-content.ts
+++ b/apps/desktop/src/renderer/src/features/composer/queued-message-content.ts
@@ -1,0 +1,39 @@
+import type { ReadQueuedTurnResponse } from "@pwragent/shared";
+import type { ComposerQueuedTurnSnapshot } from "./useComposerDraftStore";
+
+/** Convert only authoritative input. Display previews are never editable content. */
+export function restoreQueuedMessage(
+  queued: ComposerQueuedTurnSnapshot,
+  content: ReadQueuedTurnResponse,
+): ComposerQueuedTurnSnapshot {
+  let imageIndex = 0;
+  return {
+    ...queued,
+    input: content.input,
+    text: content.input
+      .flatMap((item) => item.type === "text" ? [item.text] : [])
+      .join("\n"),
+    imageAttachments: content.input.flatMap((item, index) => {
+      if (item.type !== "image" && item.type !== "localImage") return [];
+      const preview = content.imageParts?.[imageIndex++];
+      return [{
+        id: `${queued.id}:image:${index}`,
+        name: item.name ?? "Image",
+        size: 0,
+        type: "image/*",
+        url: item.type === "image" ? item.url : preview?.url ?? item.path,
+        ...(item.type === "localImage" ? { originalInput: item } : {}),
+      }];
+    }),
+    fileAttachments: content.input.flatMap((item, index) =>
+      item.type === "file" || item.type === "localFile"
+        ? [{
+            id: `${queued.id}:file:${index}`,
+            label: item.name ?? "File",
+            path: item.type === "localFile" ? item.path : "",
+            originalInput: item,
+          }]
+        : [],
+    ),
+  };
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -685,7 +685,7 @@ function renderMessageSegment(params: {
   );
 }
 
-function TranscriptImageTile(props: {
+export function TranscriptImageTile(props: {
   desktopApi?: Pick<DesktopApi, "copyText">;
   imagePart: AppServerThreadImagePart;
   imageNumber: number;

--- a/apps/desktop/src/renderer/src/features/thread-detail/TurnInputContent.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TurnInputContent.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import type {
+  AppServerThreadImagePart,
+  AppServerThreadMessageOrigin,
+  AppServerTurnInputItem,
+} from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { useThreadLinks } from "../../lib/thread-links";
+import { ThreadChip } from "./ThreadChip";
+import { ThreadMarkdown } from "./ThreadMarkdown";
+import { TranscriptImageTile } from "./TranscriptMessage";
+import { ImageLightbox } from "./ImageLightbox";
+
+/** Rich input inspection uses the same Markdown, image and navigation primitives as history. */
+export function TurnInputContent(props: {
+  input: AppServerTurnInputItem[];
+  imageParts?: AppServerThreadImagePart[];
+  origin?: AppServerThreadMessageOrigin;
+  desktopApi?: DesktopApi;
+}) {
+  const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
+  const links = useThreadLinks();
+  const source = props.origin?.sourceThread;
+  const link = source
+    ? links?.resolve(source) ?? { ...source, title: source.title ?? "Source thread" }
+    : undefined;
+  return (
+    <div className="turn-input-content">
+      {link && links ? (
+        <ThreadChip link={link} onOpen={links.show} fallbackLabel={source?.title} />
+      ) : null}
+      {props.input.map((item, index) => {
+        if (item.type === "text") {
+          return <ThreadMarkdown key={index} text={item.text} desktopApi={props.desktopApi} />;
+        }
+        if (props.imageParts && (item.type === "image" || item.type === "localImage")) {
+          return null;
+        }
+        if (item.type === "image") {
+          return <TranscriptImageTile
+            key={index}
+            imagePart={{ type: "image", url: item.url, alt: item.name ?? "Attached image" }}
+            imageNumber={index + 1}
+            onOpenImage={setExpandedImage}
+            desktopApi={props.desktopApi}
+          />;
+        }
+        return <div key={index}>{item.name ?? (item.type === "file" ? "Attached file" : item.path)}</div>;
+      })}
+      {props.imageParts?.map((image, index) => (
+        <TranscriptImageTile
+          key={`image:${index}`}
+          imagePart={image}
+          imageNumber={index + 1}
+          onOpenImage={setExpandedImage}
+          desktopApi={props.desktopApi}
+        />
+      ))}
+      {expandedImage ? (
+        <ImageLightbox
+          src={expandedImage.url}
+          alt={expandedImage.alt ?? "Attached image"}
+          onClose={() => setExpandedImage(undefined)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/turn-input-content.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/turn-input-content.test.tsx
@@ -1,0 +1,35 @@
+import "@testing-library/jest-dom/vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
+import { TurnInputContent } from "../TurnInputContent";
+import { TranscriptMessage } from "../TranscriptMessage";
+
+const sender = "019f5d79-a595-73f2-84d9-a0976762c303";
+const recipient = "019f5d79-a595-73f2-84d9-a0976762c304";
+
+describe("correspondence navigation", () => {
+  it("opens a queued message's source anchor even before its navigation row is loaded", () => {
+    const onShowThread = vi.fn();
+    render(<ThreadLinkProvider onShowThread={onShowThread} threads={[]}>
+      <TurnInputContent input={[{ type: "text", text: "# Queue content" }]}
+        origin={{ kind: "agent", sourceThread: { backend: "codex", threadId: sender, messageId: "correspondence:one", title: "Source thread" } }} />
+    </ThreadLinkProvider>);
+    const link = screen.getByRole("button", { name: /Source thread/ });
+    link.focus();
+    expect(link).toHaveFocus();
+    fireEvent.click(link);
+    expect(onShowThread).toHaveBeenCalledWith(expect.objectContaining({ threadId: sender, messageId: "correspondence:one" }));
+  });
+
+  it("opens a sender breadcrumb's destination message through the common transcript renderer", () => {
+    const onShowThread = vi.fn();
+    render(<ThreadLinkProvider onShowThread={onShowThread} threads={[{
+      id: recipient, source: "codex", title: "Destination", titleSource: "explicit", linkedDirectories: [], inbox: { inInbox: false },
+    }]}>
+      <TranscriptMessage parentThreadId={sender} skills={[]} message={{ type: "message", id: "correspondence:one", role: "assistant", origin: { kind: "pwragent" }, text: `**Accepted for execution** · To [Destination](pwragent://thread/${recipient}?backend=codex&messageId=user%3Aturn-1)\n\nFull outgoing content.` }} />
+    </ThreadLinkProvider>);
+    fireEvent.click(screen.getByRole("button", { name: /Destination/ }));
+    expect(onShowThread).toHaveBeenCalledWith(expect.objectContaining({ threadId: recipient, messageId: "user:turn-1" }));
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/desktop-api.ts
+++ b/apps/desktop/src/renderer/src/lib/desktop-api.ts
@@ -47,6 +47,8 @@ import type {
   ArchiveWorktreeResponse,
   ArchiveThreadRequest,
   ArchiveThreadResponse,
+  ReadQueuedTurnRequest,
+  ReadQueuedTurnResponse,
   CancelQueuedTurnRequest,
   CancelQueuedTurnResponse,
   ReleaseQueuedTurnRequest,
@@ -730,6 +732,9 @@ export type DesktopApi = {
     request: RemoveCodexMcpServerRequest,
   ) => Promise<RemoveCodexMcpServerResponse>;
   startTurn?: (request: StartTurnRequest) => Promise<StartTurnResponse>;
+  readQueuedTurn?: (
+    request: ReadQueuedTurnRequest,
+  ) => Promise<ReadQueuedTurnResponse>;
   cancelQueuedTurn?: (
     request: CancelQueuedTurnRequest,
   ) => Promise<CancelQueuedTurnResponse>;

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33809,3 +33809,21 @@ button.pricing-token-miser__folded:focus-visible {
 .star-map-satellite-card__body .context-rail {
   max-width: 100%;
 }
+
+.queued-message-inspector {
+  max-height: 320px;
+  overflow: auto;
+  padding: 8px;
+  color: var(--text-primary);
+  font-size: var(--transcript-text-size);
+}
+
+.queued-message-inspector:focus-visible {
+  outline: 1px solid var(--focus-ring);
+}
+
+.turn-input-content img {
+  max-width: 100%;
+  max-height: 240px;
+  object-fit: contain;
+}

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -88,6 +88,7 @@ export const ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL =
 export const AGENT_START_THREAD_CHANNEL = "agent:start-thread";
 export const AGENT_FORK_THREAD_CHANNEL = "agent:fork-thread";
 export const AGENT_START_TURN_CHANNEL = "agent:start-turn";
+export const AGENT_READ_QUEUED_TURN_CHANNEL = "agent:read-queued-turn";
 export const AGENT_CANCEL_QUEUED_TURN_CHANNEL = "agent:cancel-queued-turn";
 export const AGENT_RELEASE_QUEUED_TURN_CHANNEL = "agent:release-queued-turn";
 export const SCHEDULED_ACTIONS_LIST_CHANNEL = "scheduled-actions:list";

--- a/docs/thread-history-persistence.md
+++ b/docs/thread-history-persistence.md
@@ -37,3 +37,22 @@ An ACP fallback may use a narrowly scoped desktop-local append-only JSONL store
 for providers that do not implement usable history loading. Keep any such API
 provider-neutral and preserve append-only writes, provider continuity metadata,
 replay reconstruction, and path-specific errors for malformed rollout files.
+
+## Cross-thread correspondence
+
+PwrAgent stores supplemental outbound messages in the active profile's
+`state/thread-correspondence/<thread-identity-hash>.jsonl`. A message event holds
+its full input once; later status events contain only delivery metadata. These
+are PwrAgent's own correspondence records, not a copy of provider history.
+They are materialized as ordinary transcript messages on the sender's latest
+history page, so activity rollup and renderer reload do not discard them.
+
+The recipient FIFO remains owned by its main process. Navigation snapshots
+contain only previews. `readQueuedTurn` reads one entry through its owner;
+editing recovers content before cancellation and compares a content hash to
+reject concurrent input changes. Federated editing recovers attachment bytes
+on the owner before removing the entry. A failed read or transfer leaves the
+queue intact. Queued status records mean last confirmed queue admission,
+not delivery; peer cancellation and process restart can make that observation
+stale. Local queue lifecycle events record cancellation, failure, and holds.
+The existing in-memory FIFO is not made restart-persistent by this store.

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -5,6 +5,7 @@ import type {
   AppServerNotification,
   AppServerThreadActivityEntry,
   AppServerThreadMessageOrigin,
+  AppServerThreadImagePart,
   LinkedDirectorySummary,
   ThreadExecutionMode,
   AppServerReviewDelivery,
@@ -272,7 +273,26 @@ export type StartTurnResponse = {
   queueEntryCreatedAt?: number;
 };
 
+export type ReadQueuedTurnRequest = {
+  /** Recover portable attachment bytes before moving a peer-owned entry to a draft. */
+  forEdit?: boolean;
+  federationTarget?: FederationTarget;
+  backend: AppServerBackendKind;
+  threadId: ThreadIdentifier;
+  queueEntryId: string;
+};
+
+export type ReadQueuedTurnResponse = {
+  imageParts?: AppServerThreadImagePart[];
+  contentHash: string;
+  queueEntryId: string;
+  input: AppServerTurnInputItem[];
+  messageOrigin?: AppServerThreadMessageOrigin;
+};
+
 export type CancelQueuedTurnRequest = {
+  /** Refuse editing if the authoritative input changed since inspection. */
+  expectedContentHash?: string;
   federationTarget?: FederationTarget;
   queueEntryId: string;
 };
@@ -284,7 +304,7 @@ export type CancelQueuedTurnResponse = {
    * Owner-authoritative lifecycle result. Optional so a newer viewer remains
    * compatible with peers that only return the legacy boolean.
    */
-  disposition?: "cancelled" | "already_admitted" | "not_found";
+  disposition?: "cancelled" | "already_admitted" | "not_found" | "content_changed";
   turnId?: string;
 };
 

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -1,3 +1,4 @@
+import type { AppServerTurnInputItem } from "./normalized-app-server";
 import type {
   AcpBackendId,
   AppServerBackendScope,
@@ -886,6 +887,7 @@ export type NavigationLaunchpadDraft = NavigationLaunchpadDefaults & {
 };
 
 export type NavigationLaunchpadImageAttachment = {
+  originalInput?: Extract<AppServerTurnInputItem, { type: "image" | "localImage" }>;
   id: string;
   height?: number;
   name: string;
@@ -902,6 +904,7 @@ export type NavigationLaunchpadImageAttachment = {
  * `[@label](~/path)` reference the agent reads itself.
  */
 export type NavigationLaunchpadFileAttachment = {
+  originalInput?: Extract<AppServerTurnInputItem, { type: "file" | "localFile" }>;
   id: string;
   /** Display label, normally the file's basename. */
   label: string;

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -534,6 +534,8 @@ export type AppServerThreadMessageOriginKind =
 export type AppServerThreadMessageOrigin = {
   kind: AppServerThreadMessageOriginKind;
   sourceThread?: {
+    /** Sender correspondence message, when PwrAgent has a durable breadcrumb. */
+    messageId?: string;
     backend: AppServerBackendKind;
     /** Durable owner identity when the source thread belongs to another instance. */
     instanceId?: FederationInstanceId;


### PR DESCRIPTION
## Summary

A queued cross-thread message was mirrored from its 200-character `displayText` preview with empty attachment lists. Edit then canceled the authoritative FIFO entry and restored that preview, losing the remainder. The full input was intact before Edit. Local/federated viewers and Codex/ACP queues share this projection.

- Read full queue content from its owner on demand. Reuse transcript Markdown, thread links, image tiles, and the full-size lightbox. Recover content before Edit cancellation and compare a content hash to reject concurrent changes. Failed reads/transfers leave the entry queued; recovered file bytes use the existing PwrAgent attachment store.
- Add durable sender correspondence in PwrAgent-owned append-only JSONL, published during the active turn and reconstructed as ordinary transcript messages after reload/rollup. Recipient provenance opens the sender message; sender content links to its destination. Replay interleaves correspondence chronologically while retaining provider entry order.
- Distinguish last-confirmed queue admission, accepted execution, holds, cancellation, failure, and unknown outcomes. Late receipts cannot overwrite newer lifecycle evidence, and status-persistence failures cannot disrupt the recipient FIFO. No transcript/prompt history is newly stored in SQLite, and no Codex-owned storage is inspected.

## Verification

- 1,045 tests passed across 10 focused suites: registry, tool contracts, IPC/federation, attachment transfers, FIFO/projection, correspondence persistence, composer, and navigation.
- Coverage includes long Unicode/Markdown, multiple paragraphs, image/file/empty-file bytes, Edit/resend, failed loading, stale hashes, source/destination anchors, keyboard focus and Escape, sender restart/rollup, Codex and ACP FIFO ownership, peer identity isolation, and real federation router/attachment-transfer seams.
- Typecheck, ESLint, dependency boundaries, Codex storage boundary, theme-color checks, and `git diff --check` passed.

- Review regressions reproduced before the fixes: direct data/HTTPS images must bypass peer routing; Edit/resend must deduplicate hydrated file references while retaining authoritative metadata; reloaded correspondence must retain chronological placement. All 976 tests across the composer, IPC, image-protocol, correspondence, and backend-registry suites passed after the fixes.

## Notes

The existing recipient FIFO remains in-memory and does not survive an owner-process restart. Remote sender status remains the last confirmed result when later lifecycle information is unavailable. Oversized/unavailable remote attachment transfers fail before cancellation. Local attachment references retain the existing attachment-store lifetime.

All fixtures are contrived. No live queue or running user thread was modified. No headed visual pass or live federated/provider end-to-end test was run; ACP coverage exercises the shared queue implementation.
