### PR TITLE
fix(desktop): show Luna Reserve and Codex credit balance

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6415,6 +6415,109 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("replaces a credits balance when a later snapshot omits the amount", async () => {
+    const creditsLimit: BackendRateLimitSummary = {
+      name: "Credits",
+      limitId: "credits",
+      windowKey: "credits",
+      hasCredits: true,
+      unlimited: false,
+      remaining: 100,
+    };
+    const fiveHourLimit: BackendRateLimitSummary = {
+      name: "5h limit",
+      limitId: "codex",
+      limitName: "Codex",
+      windowKey: "primary",
+      usedPercent: 77,
+      remaining: 23,
+      windowMinutes: 300,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: {
+        methods: ["thread/list", "thread/read", "thread/start", "turn/start"],
+      },
+      rateLimits: [fiveHourLimit, creditsLimit],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+
+    await codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: {
+            usedPercent: 77,
+            windowDurationMins: 300,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: null,
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+
+    expect(
+      (await registry.listBackends({ includeUnavailable: true })).backends[0]
+        ?.rateLimits,
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "Credits",
+          remaining: 100,
+          hasCredits: true,
+        }),
+      ]),
+    );
+
+    await codexClient.emit({
+      method: "account/rateLimits/updated",
+      params: {
+        rateLimits: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: {
+            usedPercent: 77,
+            windowDurationMins: 300,
+            resetsAt: null,
+          },
+          secondary: null,
+          individualLimit: null,
+          credits: {
+            hasCredits: true,
+            unlimited: false,
+            balance: null,
+          },
+          planType: null,
+          rateLimitReachedType: null,
+        },
+      },
+    });
+
+    const credits = (
+      await registry.listBackends({ includeUnavailable: true })
+    ).backends[0]?.rateLimits?.find((limit) => limit.name === "Credits");
+    expect(credits).toMatchObject({
+      name: "Credits",
+      hasCredits: true,
+      unlimited: false,
+    });
+    expect(credits?.remaining).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("coalesces changed Codex rate-limit broadcasts into a 20-second window", async () => {
     vi.useFakeTimers();
     const codexClient = new MockBackendClient({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2709,6 +2709,66 @@ describe("CodexAppServerClient", () => {
     ]);
   });
 
+  it("normalizes the Codex account credits snapshot as a Credits row", async () => {
+    MockTransport.rateLimitsResult = {
+      rateLimits: {
+        limitId: "codex",
+        primary: {
+          usedPercent: 100,
+          windowDurationMins: 300,
+        },
+        secondary: {
+          usedPercent: 100,
+          windowDurationMins: 10_080,
+        },
+        credits: {
+          hasCredits: true,
+          unlimited: false,
+          balance: "100.00",
+        },
+      },
+      rateLimitResetCredits: {
+        availableCount: 1,
+        credits: [
+          {
+            id: "reset-1",
+            resetType: "codexRateLimits",
+            status: "available",
+          },
+        ],
+      },
+    };
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex" });
+
+    await expect(client.readRateLimits()).resolves.toEqual([
+      expect.objectContaining({
+        name: "5h limit",
+        limitId: "codex",
+        windowKey: "primary",
+        usedPercent: 100,
+        remaining: 0,
+        windowMinutes: 300,
+      }),
+      expect.objectContaining({
+        name: "Credits",
+        limitId: "credits",
+        windowKey: "credits",
+        hasCredits: true,
+        unlimited: false,
+        remaining: 100,
+      }),
+      expect.objectContaining({
+        name: "Weekly limit",
+        limitId: "codex",
+        windowKey: "secondary",
+        usedPercent: 100,
+        remaining: 0,
+        windowMinutes: 10_080,
+      }),
+    ]);
+  });
+
   it("reads account-wide token usage through the app-server protocol", async () => {
     MockTransport.accountUsageResult = {
       summary: { lifetimeTokens: 1234 },

--- a/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-status-card.test.ts
@@ -442,6 +442,13 @@ describe("buildBindingStatusIntent", () => {
             used: 3500.4,
             usedPercent: 4,
           },
+          {
+            name: "Credits",
+            limitId: "credits",
+            windowKey: "credits",
+            hasCredits: true,
+            remaining: 100,
+          },
         ],
       },
       createdAt: 1000,
@@ -450,7 +457,7 @@ describe("buildBindingStatusIntent", () => {
     });
 
     expect(intent.text).toContain(
-      "Rate limits: 5h limit: 95% left, resets 6:02 PM; Weekly limit: 73% left, resets Jun 10; Individual limit: 3,500/100,000 used, 96% left; Spark 5h limit: 100% left, resets 7:20 PM; Spark Weekly limit: 100% left, resets Jun 12",
+      "Rate limits: Credits: $100; 5h limit: 95% left, resets 6:02 PM; Weekly limit: 73% left, resets Jun 10; Individual limit: 3,500/100,000 used, 96% left; Spark 5h limit: 100% left, resets 7:20 PM; Spark Weekly limit: 100% left, resets Jun 12",
     );
     expect(intent.text).not.toContain("GPT-5.3-Codex-Spark");
     expect(intent.text).not.toContain("95 remaining");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5834,6 +5834,15 @@ function mergeRateLimitSummary(
       ? { windowMinutes: update.windowMinutes }
       : {}),
   };
+  if (update.windowKey === "credits") {
+    // A present CreditsSnapshot replaces its balance. Sparse updates omit the
+    // entire credits row when they have no new observation, not remaining.
+    if (update.remaining === undefined) {
+      delete merged.remaining;
+    } else {
+      merged.remaining = update.remaining;
+    }
+  }
   if (merged.windowKey === "primary" || merged.windowKey === "secondary") {
     merged.name = formatRateLimitWindowName({
       limitId: merged.limitId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5824,6 +5824,8 @@ function mergeRateLimitSummary(
     ...(update.limit !== undefined ? { limit: update.limit } : {}),
     ...(update.used !== undefined ? { used: update.used } : {}),
     ...(update.usedPercent !== undefined ? { usedPercent: update.usedPercent } : {}),
+    ...(update.hasCredits !== undefined ? { hasCredits: update.hasCredits } : {}),
+    ...(update.unlimited !== undefined ? { unlimited: update.unlimited } : {}),
     ...(update.resetAt !== undefined ? { resetAt: update.resetAt } : {}),
     ...(update.windowSeconds !== undefined
       ? { windowSeconds: update.windowSeconds }

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1485,10 +1485,24 @@ export function formatRateLimitWindowName(params: {
   return `${rawName ?? rawId} ${windowLabel}`.trim();
 }
 
+const CREDITS_RATE_LIMIT_NAME = "Credits";
+const CREDITS_RATE_LIMIT_ID = "credits";
+
 export function extractRateLimitSummaries(
   value: unknown,
 ): BackendRateLimitSummary[] {
   const out = new Map<string, BackendRateLimitSummary>();
+  const addCredits = (snapshot: Record<string, unknown>): void => {
+    const credits = extractCreditsRateLimit(snapshot);
+    if (!credits) {
+      return;
+    }
+    const existing = out.get(CREDITS_RATE_LIMIT_NAME);
+    out.set(
+      CREDITS_RATE_LIMIT_NAME,
+      existing ? preferCreditsRateLimit(existing, credits) : credits,
+    );
+  };
   const addWindow = (
     windowValue: unknown,
     params: { limitId?: string; limitName?: string; windowKey: "primary" | "secondary" }
@@ -1575,7 +1589,7 @@ export function extractRateLimitSummaries(
     if (!record) {
       return;
     }
-    if ("primary" in record || "secondary" in record) {
+    if ("primary" in record || "secondary" in record || "credits" in record) {
       const limitId = pickString(record, ["limitId", "limit_id", "id"]);
       const limitName = pickString(record, ["limitName", "limit_name", "name", "label"]);
       addWindow(record.primary, { limitId, limitName, windowKey: "primary" });
@@ -1584,6 +1598,7 @@ export function extractRateLimitSummaries(
         limitId,
         limitName,
       });
+      addCredits(record);
     }
     const byLimitId = asRecord(record.rateLimitsByLimitId ?? record.rate_limits_by_limit_id);
     if (byLimitId) {
@@ -1599,6 +1614,7 @@ export function extractRateLimitSummaries(
           snapshotRecord.individualLimit ?? snapshotRecord.individual_limit,
           { limitId, limitName },
         );
+        addCredits(snapshotRecord);
       }
     }
     const remaining = pickFiniteNumber(record, [
@@ -1663,6 +1679,66 @@ export function extractRateLimitSummaries(
   };
   visit(value);
   return [...out.values()].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+function extractCreditsRateLimit(
+  snapshot: Record<string, unknown>,
+): BackendRateLimitSummary | undefined {
+  const credits = asRecord(snapshot.credits);
+  if (!credits) {
+    return undefined;
+  }
+  const hasCredits = pickBoolean(credits, ["hasCredits", "has_credits"]);
+  const unlimited = pickBoolean(credits, ["unlimited"]);
+  if (hasCredits === undefined && unlimited === undefined) {
+    // Reset-credit ledgers also use a `credits` array/object. Account balance
+    // snapshots always carry the boolean flags from CreditsSnapshot.
+    return undefined;
+  }
+  return {
+    name: CREDITS_RATE_LIMIT_NAME,
+    limitId: CREDITS_RATE_LIMIT_ID,
+    windowKey: "credits",
+    hasCredits: hasCredits === true,
+    unlimited: unlimited === true,
+    remaining: parseCreditBalance(pickString(credits, ["balance"])),
+  };
+}
+
+function preferCreditsRateLimit(
+  current: BackendRateLimitSummary,
+  next: BackendRateLimitSummary,
+): BackendRateLimitSummary {
+  if (next.unlimited && !current.unlimited) {
+    return next;
+  }
+  if (current.unlimited && !next.unlimited) {
+    return current;
+  }
+  const currentRemaining = current.remaining ?? Number.NEGATIVE_INFINITY;
+  const nextRemaining = next.remaining ?? Number.NEGATIVE_INFINITY;
+  if (nextRemaining !== currentRemaining) {
+    return nextRemaining > currentRemaining ? next : current;
+  }
+  if (next.hasCredits && !current.hasCredits) {
+    return next;
+  }
+  return current;
+}
+
+function parseCreditBalance(raw: string | undefined): number | undefined {
+  if (!raw) {
+    return undefined;
+  }
+  const trimmed = raw.replace(/^\$/, "").replace(/,/g, "").trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  const value = Number(trimmed);
+  if (!Number.isFinite(value) || value <= 0) {
+    return undefined;
+  }
+  return value;
 }
 
 function extractAccountSummary(value: unknown): BackendAccountSummary {

--- a/apps/desktop/src/main/messaging/core/messaging-status-card.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-status-card.ts
@@ -387,24 +387,29 @@ function selectStatusRateLimits(
   if (!limits || limits.length === 0) {
     return undefined;
   }
-  return [...limits].sort((left, right) => {
-    const leftName = splitRateLimitName(left.name);
-    const rightName = splitRateLimitName(right.name);
-    const leftFamilyOrder = isSparkRateLimit(left) ? 1 : 0;
-    const rightFamilyOrder = isSparkRateLimit(right) ? 1 : 0;
-    if (leftFamilyOrder !== rightFamilyOrder) {
-      return leftFamilyOrder - rightFamilyOrder;
-    }
-    if (leftName.labelOrder !== rightName.labelOrder) {
-      return leftName.labelOrder - rightName.labelOrder;
-    }
-    return left.name.localeCompare(right.name);
-  });
+  return [...limits]
+    .filter((limit) => !isCreditsRateLimit(limit) || isVisibleCreditsLimit(limit))
+    .sort((left, right) => {
+      const leftName = splitRateLimitName(left.name);
+      const rightName = splitRateLimitName(right.name);
+      const leftFamilyOrder = rateLimitFamilyOrder(left);
+      const rightFamilyOrder = rateLimitFamilyOrder(right);
+      if (leftFamilyOrder !== rightFamilyOrder) {
+        return leftFamilyOrder - rightFamilyOrder;
+      }
+      if (leftName.labelOrder !== rightName.labelOrder) {
+        return leftName.labelOrder - rightName.labelOrder;
+      }
+      return left.name.localeCompare(right.name);
+    });
 }
 
 function formatBackendRateLimit(
   rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
 ): string | undefined {
+  if (isCreditsRateLimit(rateLimit)) {
+    return formatCreditsLine(rateLimit);
+  }
   const { label } = splitRateLimitName(rateLimit.name);
   const displayLabel = isSparkRateLimit(rateLimit) ? `Spark ${label}` : label;
   const resetText = formatRateLimitReset(rateLimit.resetAt);
@@ -479,6 +484,56 @@ function isSparkRateLimit(
 ): boolean {
   return isSparkRateLimitName(rateLimit.limitId) ||
     isSparkRateLimitName(rateLimit.name);
+}
+
+function isCreditsRateLimit(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+): boolean {
+  return rateLimit.windowKey === "credits"
+    || rateLimit.limitId?.toLowerCase() === "credits"
+    || rateLimit.name === "Credits";
+}
+
+function isVisibleCreditsLimit(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+): boolean {
+  return rateLimit.unlimited === true || rateLimit.hasCredits === true;
+}
+
+function rateLimitFamilyOrder(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+): number {
+  if (isCreditsRateLimit(rateLimit)) {
+    return 0;
+  }
+  return isSparkRateLimit(rateLimit) ? 2 : 1;
+}
+
+function formatCreditsLine(
+  rateLimit: NonNullable<BackendSummary["rateLimits"]>[number],
+): string {
+  if (rateLimit.unlimited) {
+    return "Credits: unlimited";
+  }
+  if (typeof rateLimit.remaining === "number" && rateLimit.remaining > 0) {
+    return `Credits: ${formatUsdBalance(rateLimit.remaining)}`;
+  }
+  if (rateLimit.hasCredits) {
+    return "Credits: available";
+  }
+  return "Credits: $0";
+}
+
+function formatUsdBalance(value: number): string {
+  const cents = Math.round(value * 100);
+  const dollars = cents / 100;
+  if (cents % 100 === 0) {
+    return `$${dollars.toLocaleString()}`;
+  }
+  return `$${dollars.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
 }
 
 function isSparkRateLimitName(value: string | undefined): boolean {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2071,6 +2071,13 @@ describe("Sidebar", () => {
             },
             rateLimits: [
               {
+                name: "Credits",
+                limitId: "credits",
+                windowKey: "credits",
+                hasCredits: true,
+                remaining: 100,
+              },
+              {
                 name: "5h limit",
                 remaining: 85,
                 limit: 100,
@@ -2136,6 +2143,7 @@ describe("Sidebar", () => {
     expect(tooltip).toHaveTextContent("Codex profile: work3");
     expect(tooltip).toHaveTextContent("Codex account: work@example.com");
     expect(tooltip).toHaveTextContent("Plan: pro");
+    expect(tooltip).toHaveTextContent("Credits: $100");
     expect(tooltip).toHaveTextContent("5h limit");
     expect(tooltip).toHaveTextContent("85% left");
     expect(tooltip).toHaveTextContent("Weekly limit: 60% left");

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
@@ -40,6 +40,13 @@ const codexBackend: BackendSummary = {
   rateLimits: [
     { name: "5h limit", usedPercent: 15, windowMinutes: 300 },
     { name: "Weekly limit", usedPercent: 9, windowMinutes: 10_080 },
+    {
+      name: "Credits",
+      limitId: "credits",
+      windowKey: "credits",
+      hasCredits: true,
+      remaining: 100,
+    },
   ],
 };
 
@@ -164,6 +171,7 @@ describe("ProviderStatusPanel", () => {
     expect(screen.getByText("Available")).toBeInTheDocument();
     expect(screen.getByText("user@example.com")).toBeInTheDocument();
     expect(screen.getByText("pro")).toBeInTheDocument();
+    expect(screen.getByText(/Credits: \$100/)).toBeInTheDocument();
     expect(screen.getByText(/5h limit: 85% left/)).toBeInTheDocument();
     expect(screen.getByText(/Weekly limit: 91% left/)).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
@@ -38,6 +38,75 @@ describe("backend status formatting", () => {
     ]);
   });
 
+  it("shows Luna Reserve after the included 5h window is exhausted", () => {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
+      kind: "codex",
+      rateLimits: [
+        { name: "5h limit", usedPercent: 100 },
+        { name: "Weekly limit", usedPercent: 39 },
+        {
+          name: "gpt-reserve Weekly limit",
+          limitId: "base_model_inference",
+          limitName: "gpt-reserve",
+          usedPercent: 0,
+        },
+        { name: "GPT-5.3-Codex-Spark 5h limit", usedPercent: 2 },
+      ],
+    };
+
+    expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
+      "5h limit",
+      "Weekly limit",
+      "gpt-reserve Weekly limit",
+      "GPT-5.3-Codex-Spark 5h limit",
+    ]);
+  });
+
+  it("shows Luna Reserve after the included weekly window is exhausted", () => {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
+      kind: "codex",
+      rateLimits: [
+        { name: "5h limit", usedPercent: 26 },
+        { name: "Weekly limit", remaining: 0 },
+        {
+          name: "gpt-reserve Weekly limit",
+          limitId: "base_model_inference",
+          limitName: "gpt-reserve",
+          usedPercent: 12,
+        },
+      ],
+    };
+
+    expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
+      "5h limit",
+      "Weekly limit",
+      "gpt-reserve Weekly limit",
+    ]);
+  });
+
+  it("does not treat an exhausted Spark window as primary-plan exhaustion", () => {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
+      kind: "codex",
+      rateLimits: [
+        { name: "5h limit", usedPercent: 26 },
+        { name: "Weekly limit", usedPercent: 39 },
+        { name: "GPT-5.3-Codex-Spark 5h limit", usedPercent: 100 },
+        {
+          name: "gpt-reserve Weekly limit",
+          limitId: "base_model_inference",
+          limitName: "gpt-reserve",
+          usedPercent: 0,
+        },
+      ],
+    };
+
+    expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
+      "5h limit",
+      "Weekly limit",
+      "GPT-5.3-Codex-Spark 5h limit",
+    ]);
+  });
+
   it("keeps provider-defined Grok rate limits visible", () => {
     const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
       kind: "acp:grok",
@@ -88,5 +157,91 @@ describe("backend status formatting", () => {
         usedPercent: 4,
       }),
     ).toBe("Individual limit: 3,500/100,000 used, 96% left");
+  });
+
+  it("labels the gpt-reserve bucket as Luna Reserve", () => {
+    expect(
+      formatRateLimitLine({
+        name: "gpt-reserve Weekly limit",
+        limitId: "base_model_inference",
+        limitName: "gpt-reserve",
+        usedPercent: 0,
+      }),
+    ).toBe("Luna Reserve: 100% left");
+  });
+
+  it("shows the Codex account credits balance ahead of plan windows", () => {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
+      kind: "codex",
+      rateLimits: [
+        { name: "5h limit", usedPercent: 100 },
+        { name: "Weekly limit", usedPercent: 100 },
+        {
+          name: "Credits",
+          limitId: "credits",
+          windowKey: "credits",
+          hasCredits: true,
+          remaining: 100,
+        },
+        {
+          name: "gpt-reserve Weekly limit",
+          limitId: "base_model_inference",
+          limitName: "gpt-reserve",
+          usedPercent: 0,
+        },
+      ],
+    };
+
+    expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
+      "Credits",
+      "5h limit",
+      "Weekly limit",
+      "gpt-reserve Weekly limit",
+    ]);
+  });
+
+  it("hides a credits row that the protocol marked as empty", () => {
+    const backend: Pick<BackendSummary, "kind" | "rateLimits"> = {
+      kind: "codex",
+      rateLimits: [
+        { name: "5h limit", usedPercent: 26 },
+        {
+          name: "Credits",
+          limitId: "credits",
+          windowKey: "credits",
+          hasCredits: false,
+          unlimited: false,
+        },
+      ],
+    };
+
+    expect(selectVisibleRateLimits(backend).map((limit) => limit.name)).toEqual([
+      "5h limit",
+    ]);
+  });
+
+  it("formats a dollar credits balance, unlimited credits, and a hidden amount", () => {
+    expect(
+      formatRateLimitLine({
+        name: "Credits",
+        windowKey: "credits",
+        hasCredits: true,
+        remaining: 100,
+      }),
+    ).toBe("Credits: $100");
+    expect(
+      formatRateLimitLine({
+        name: "Credits",
+        windowKey: "credits",
+        unlimited: true,
+      }),
+    ).toBe("Credits: unlimited");
+    expect(
+      formatRateLimitLine({
+        name: "Credits",
+        windowKey: "credits",
+        hasCredits: true,
+      }),
+    ).toBe("Credits: available");
   });
 });

--- a/apps/desktop/src/renderer/src/lib/backend-status-format.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-status-format.ts
@@ -29,13 +29,21 @@ export function formatBackendAccountText(
 export function selectVisibleRateLimits(
   backend: Pick<BackendSummary, "kind" | "rateLimits">,
 ): BackendRateLimitSummary[] {
-  return [...(backend.rateLimits ?? [])]
+  const limits = backend.rateLimits ?? [];
+  const showLunaReserve = backend.kind === "codex"
+    && isPrimaryCodexPlanExhausted(limits);
+  return [...limits]
     .filter((limit) => {
       if (backend.kind !== "codex") {
         return true;
       }
-      if (isHiddenCodexRateLimit(limit)) {
-        return false;
+      if (isReserveRateLimit(limit)) {
+        // Luna Reserve is a post-limit fallback. Hide it until the included
+        // Codex 5h or weekly window is exhausted.
+        return showLunaReserve;
+      }
+      if (isCreditsRateLimit(limit)) {
+        return isVisibleCreditsLimit(limit);
       }
       const { label } = splitRateLimitName(limit.name);
       return label === "5h limit"
@@ -58,8 +66,15 @@ export function selectVisibleRateLimits(
 }
 
 export function formatRateLimitLine(limit: BackendRateLimitSummary): string {
+  if (isCreditsRateLimit(limit)) {
+    return formatCreditsLine(limit);
+  }
   const { label } = splitRateLimitName(limit.name);
-  const displayLabel = isSparkRateLimit(limit) ? `Spark ${label}` : label;
+  const displayLabel = isReserveRateLimit(limit)
+    ? "Luna Reserve"
+    : isSparkRateLimit(limit)
+      ? `Spark ${label}`
+      : label;
   const resetText = formatRateLimitReset(limit.resetAt);
   const suffix = resetText ? `, resets ${resetText}` : "";
   if (
@@ -116,10 +131,71 @@ function isSparkRateLimit(limit: BackendRateLimitSummary): boolean {
   return isSparkName(limit.limitId) || isSparkName(limit.name);
 }
 
-function isHiddenCodexRateLimit(limit: BackendRateLimitSummary): boolean {
+function isCreditsRateLimit(limit: BackendRateLimitSummary): boolean {
+  return limit.windowKey === "credits"
+    || limit.limitId?.toLowerCase() === "credits"
+    || limit.name === "Credits";
+}
+
+function isVisibleCreditsLimit(limit: BackendRateLimitSummary): boolean {
+  return limit.unlimited === true || limit.hasCredits === true;
+}
+
+function formatCreditsLine(limit: BackendRateLimitSummary): string {
+  if (limit.unlimited) {
+    return "Credits: unlimited";
+  }
+  if (typeof limit.remaining === "number" && limit.remaining > 0) {
+    return `Credits: ${formatUsdBalance(limit.remaining)}`;
+  }
+  if (limit.hasCredits) {
+    return "Credits: available";
+  }
+  return "Credits: $0";
+}
+
+function formatUsdBalance(value: number): string {
+  const cents = Math.round(value * 100);
+  const dollars = cents / 100;
+  if (cents % 100 === 0) {
+    return `$${dollars.toLocaleString()}`;
+  }
+  return `$${dollars.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
+
+function isReserveRateLimit(limit: BackendRateLimitSummary): boolean {
   return limit.limitId?.toLowerCase() === "base_model_inference"
     || limit.limitName?.toLowerCase() === "gpt-reserve"
     || limit.name.toLowerCase().startsWith("gpt-reserve ");
+}
+
+function isPrimaryCodexPlanWindow(limit: BackendRateLimitSummary): boolean {
+  if (isSparkRateLimit(limit) || isReserveRateLimit(limit)) {
+    return false;
+  }
+  const { label } = splitRateLimitName(limit.name);
+  return label === "5h limit" || label === "Weekly limit";
+}
+
+function isRateLimitExhausted(limit: BackendRateLimitSummary): boolean {
+  if (typeof limit.usedPercent === "number" && Number.isFinite(limit.usedPercent)) {
+    return limit.usedPercent >= 100;
+  }
+  if (typeof limit.remaining === "number" && Number.isFinite(limit.remaining)) {
+    return limit.remaining <= 0;
+  }
+  return false;
+}
+
+function isPrimaryCodexPlanExhausted(
+  limits: readonly BackendRateLimitSummary[],
+): boolean {
+  return limits.some(
+    (limit) => isPrimaryCodexPlanWindow(limit) && isRateLimitExhausted(limit),
+  );
 }
 
 function isSparkName(value: string | undefined): boolean {
@@ -127,7 +203,13 @@ function isSparkName(value: string | undefined): boolean {
 }
 
 function rateLimitFamilyOrder(limit: BackendRateLimitSummary): number {
-  return isSparkRateLimit(limit) ? 1 : 0;
+  if (isCreditsRateLimit(limit)) {
+    return 0;
+  }
+  if (isReserveRateLimit(limit)) {
+    return 2;
+  }
+  return isSparkRateLimit(limit) ? 3 : 1;
 }
 
 function formatRateLimitReset(resetAt: number | undefined): string | undefined {

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -206,7 +206,7 @@ export type BackendRateLimitSummary = {
   /** Provider label retained so a sparse update cannot erase it. */
   limitName?: string;
   /** Provider slot used to merge sparse rolling updates with a full snapshot. */
-  windowKey?: "primary" | "secondary" | "individual";
+  windowKey?: "primary" | "secondary" | "individual" | "credits";
   remaining?: number;
   limit?: number;
   used?: number;
@@ -214,6 +214,16 @@ export type BackendRateLimitSummary = {
   resetAt?: number;
   windowSeconds?: number;
   windowMinutes?: number;
+  /**
+   * Codex CreditsSnapshot.hasCredits. Set only on the account credits row.
+   * Sparse updates omit this object rather than clearing a previously observed
+   * balance, so a false value is an explicit "no credits" observation.
+   */
+  hasCredits?: boolean;
+  /**
+   * Codex CreditsSnapshot.unlimited. Set only on the account credits row.
+   */
+  unlimited?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Show the Codex `gpt-reserve` bucket as **Luna Reserve** once the included 5h or weekly plan window is exhausted, matching ChatGPT's fallback meter.
- Parse the account `CreditsSnapshot` (`hasCredits`, `unlimited`, `balance`) from `account/rateLimits/read` and rolling updates, and show it as **Credits: $100** (or `unlimited` / `available`) on the profile tooltip, AI provider status, and messaging status cards.
- Keep Luna Reserve hidden while the included plan still has remaining usage, and keep banked rate-limit reset credits (`rateLimitResetCredits`) out of this display.

## Verification

- `pnpm test apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts`
- `pnpm test apps/desktop/src/main/__tests__/codex-client.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx apps/desktop/src/main/__tests__/messaging-status-card.test.ts`
- `pnpm test apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx apps/desktop/src/main/__tests__/backend-registry.test.ts`

## Notes

- Luna Reserve is labeled instead of reusing "Weekly limit", which is why that internal bucket was hidden previously.
- Credit balance uses the ChatGPT Usage & billing dollar display. Thread Codex-credit spend is unchanged.