### PR TITLE
fix(desktop): preserve observed pricing for failed turns

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26501,6 +26501,81 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it.each(["failed", "interrupted", "completed"])(
+    "keeps request pricing through a context estimate and %s terminal", async (status) => {
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/read"] },
+      });
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex", threadId: "thread-1", executionMode: "default",
+            extraLinkedDirectories: [], model: "gpt-6-astra", serviceTier: "standard",
+          },
+        },
+      });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const total = {
+        input_tokens: 400_000, cached_input_tokens: 200_000,
+        output_tokens: 20_000, reasoning_output_tokens: 0, total_tokens: 420_000,
+      };
+      for (const input of [200_000, 400_000]) {
+        await codexClient.emit({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1", turnId: "turn-1",
+            tokenUsage: {
+              total_token_usage: {
+                input_tokens: input, cached_input_tokens: input / 2,
+                output_tokens: input / 20, reasoning_output_tokens: 0,
+                total_tokens: input * 1.05,
+              },
+              last_token_usage: {
+                input_tokens: 200_000, cached_input_tokens: 100_000,
+                output_tokens: 10_000, reasoning_output_tokens: 0, total_tokens: 210_000,
+              },
+            },
+          },
+        });
+      }
+      const before = await overlayStore.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+      expect(before.lines[0]?.priceStatus).toBe("priced");
+      expect(before.lines[0]?.totalCostMicros).toBeGreaterThan(0);
+      // Codex recompute_token_usage publishes a context estimate in last,
+      // without changing the cumulative billed usage. Rate-limit updates
+      // may repeat that same snapshot.
+      for (let i = 0; i < 2; i += 1) {
+        await codexClient.emit({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1", turnId: "turn-1",
+            tokenUsage: {
+              total_token_usage: total,
+              last_token_usage: {
+                input_tokens: 0, cached_input_tokens: 0, output_tokens: 0,
+                reasoning_output_tokens: 0, total_tokens: 160_000,
+              },
+            },
+          },
+        });
+      }
+      await codexClient.emit({
+        method: status === "failed" ? "turn/failed" : "turn/completed",
+        params: {
+          threadId: "thread-1", turnId: "turn-1",
+          turn: { id: "turn-1", status, error: status === "failed" ? { message: "Usage limit reached" } : undefined },
+        },
+      } as AppServerNotification);
+      const after = await overlayStore.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+      expect(after.lines[0]).toMatchObject({
+        priceStatus: "priced", pricingBasis: "request-components",
+        inputTokens: 400_000, cachedInputTokens: 200_000, outputTokens: 20_000,
+        totalCostMicros: before.lines[0]!.totalCostMicros,
+      });
+      await registry.close();
+    },
+  );
+
   it("prices each Astra request before aggregating a multi-request turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -96,6 +96,53 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it.each(["unchanged", "tokens", "settings"])(
+    "preserves observed request prices only for equivalent aggregate refreshes (%s)",
+    async (change) => {
+      const unchanged = change === "unchanged";
+      const line = buildUsageLine({
+        source: "live", scope: "turn", status: "pending",
+        createdAt: Date.UTC(2026, 8, 5), model: "gpt-6-astra",
+        inputTokens: 400_000, uncachedInputTokens: 200_000,
+        cachedInputTokens: 200_000, outputTokens: 20_000,
+        reasoningOutputTokens: 0, totalTokens: 420_000,
+        totalCostMicros: 3_200_000, uncachedInputCostMicros: 2_000_000,
+        cachedInputCostMicros: 200_000, outputCostMicros: 1_000_000,
+        pricingBasis: "request-components", pricingCatalogVersion: "2026-09-04",
+        pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      });
+      await store.upsertThreadUsageLine({ line });
+      await store.upsertThreadUsageLine({ line: {
+        ...line,
+        completedAt: line.createdAt + 60_000,
+        status: "finalized",
+        pricingBasis: undefined, pricingRateId: undefined,
+        priceStatus: "unpriced", priceUnavailableReason: "insufficient-token-breakdown",
+        totalCostMicros: 0, cachedInputCostMicros: 0,
+        uncachedInputCostMicros: 0, outputCostMicros: 0,
+        ...(change === "tokens" ? { outputTokens: 21_000, totalTokens: 421_000 } : {}),
+        ...(change === "settings" ? { serviceTier: "unsupported" } : {}),
+      } });
+      const pricing = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+      expect(pricing.lines[0]).toMatchObject({
+        completedAt: line.createdAt + 60_000,
+        status: "finalized",
+        priceStatus: unchanged ? "priced" : "unpriced",
+        totalCostMicros: unchanged ? line.totalCostMicros : 0,
+      });
+      if (unchanged) {
+        expect(pricing.lines[0]).toMatchObject({
+          pricingBasis: "request-components",
+          cachedInputCostMicros: 200_000,
+          uncachedInputCostMicros: 2_000_000,
+          outputCostMicros: 1_000_000,
+        });
+        expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
+        expect(pricing.summaries[0]?.totalCostMicros).toBe(line.totalCostMicros);
+      }
+    },
+  );
+
   it("does not rewrite a finalized usage line model when thread settings change later", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4185,6 +4185,19 @@ function foldLiveThreadRequestUsage(params: {
     && normalizedCumulativeInputTokens === params.current.cumulativeInputTokens
   ) {
     const priorRequest = params.current.requests.at(-1);
+    const latestTokens = normalizeTaskMonitorPricingTokens(latestUsage);
+    // Codex recomputes context size using an empty last-request breakdown
+    // while retaining cumulative billed usage. Rate-limit notifications can
+    // repeat it. It is not a correction to the last measured model request.
+    if (
+      latestTokens.inputTokens === 0
+      && latestTokens.cachedInputTokens === 0
+      && latestTokens.cacheWriteInputTokens === 0
+      && latestTokens.outputTokens === 0
+      && latestTokens.reasoningOutputTokens === 0
+    ) {
+      return params.current;
+    }
     if (taskMonitorTokenUsageEqual(priorRequest, latestUsage)) {
       return params.current;
     }

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -7312,6 +7312,41 @@ function mergeThreadUsageLineForUpsert(
     ),
   };
 
+  // A refresh can retain all measured tokens but lack the request breakdown
+  // used to price them (for example after a restart). Do not erase that exact
+  // price with an unpriceable aggregate. Changed usage or settings must still
+  // be priced afresh; retaining the old cost there would hide unpriced work.
+  if (
+    merged.priceStatus === "unpriced"
+    && existing.priceStatus === "priced"
+    && existing.pricingBasis === "request-components"
+    && merged.provider === existing.provider
+    && merged.currency === existing.currency
+    && merged.model === existing.model
+    && merged.serviceTier === existing.serviceTier
+    && merged.fastMode === existing.fastMode
+    && merged.inputTokens === existing.inputTokens
+    && merged.uncachedInputTokens === existing.uncachedInputTokens
+    && merged.cachedInputTokens === existing.cachedInputTokens
+    && (merged.cacheWriteInputTokens ?? 0) === (existing.cacheWriteInputTokens ?? 0)
+    && merged.outputTokens === existing.outputTokens
+    && merged.reasoningOutputTokens === existing.reasoningOutputTokens
+  ) {
+    return {
+      ...merged,
+      cacheWriteInputCostMicros: existing.cacheWriteInputCostMicros,
+      cachedInputCostMicros: existing.cachedInputCostMicros,
+      outputCostMicros: existing.outputCostMicros,
+      priceStatus: existing.priceStatus,
+      priceUnavailableReason: undefined,
+      pricingBasis: existing.pricingBasis,
+      pricingCatalogId: existing.pricingCatalogId,
+      pricingCatalogVersion: existing.pricingCatalogVersion,
+      pricingRateId: existing.pricingRateId,
+      totalCostMicros: existing.totalCostMicros,
+      uncachedInputCostMicros: existing.uncachedInputCostMicros,
+    };
+  }
   return repriceTokenUsageLine(merged);
 }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -708,6 +708,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             subAgents={props.thread.subAgents}
             tokenMiserAccounting={props.toolAccounting?.tokenMiser}
             threadReasoningEffort={props.thread.reasoningEffort}
+            turnFailures={props.thread.turnFailureLog}
           />
         );
       case "tool-calls": {

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -1033,6 +1033,30 @@ describe("ThreadContextPanel", () => {
     expect(screen.getByRole("tab", { name: "Thread info" })).toBeInTheDocument();
   });
 
+  it("keeps a failed turn's price and shows its usage-limit error on the pricing card", () => {
+    const line = buildMonitorLine({
+      scope: "turn", source: "live", sourceItemId: undefined,
+      turnId: "failed-turn", usageLineId: "failed-turn-usage",
+      model: "gpt-6-astra", totalCostMicros: 3_200_000,
+      pricingBasis: "request-components",
+    });
+    renderPanel({
+      activeTab: "pricing", pinned: true, threadPricingSummaryEnabled: true,
+      thread: {
+        ...baseThread,
+        turnFailureLog: [{
+          id: "failure-1", turnId: "failed-turn",
+          error: "Usage limit reached. Try again later.", occurredAt: 1_800_000_001_000,
+        }],
+      },
+      pricing: { lines: [line], summaries: [] },
+    });
+    const card = screen.getByText("$3.20 list price this turn").closest(".pricing-usage-row")!;
+    expect(within(card as HTMLElement).getByText("Failed")).toBeInTheDocument();
+    expect(within(card as HTMLElement).getByText("Usage limit reached. Try again later.")).toBeInTheDocument();
+    expect(within(card as HTMLElement).queryByText(/Unpriced/)).not.toBeInTheDocument();
+  });
+
   it("renders cached pricing totals and per-turn model settings", () => {
     const summary: ThreadPricingSummary = {
       backend: "codex",

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -5,6 +5,7 @@ import type {
   ThreadSubAgentSummary,
   ThreadTokenMiserAccounting,
   ThreadTokenMiserInterceptionAccounting,
+  ThreadTurnFailure,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import {
@@ -72,6 +73,7 @@ type PricingPanelProps = {
   subAgents?: ThreadSubAgentSummary[];
   tokenMiserAccounting?: ThreadTokenMiserAccounting;
   threadReasoningEffort?: string;
+  turnFailures?: readonly ThreadTurnFailure[];
 };
 
 type PricingDisplayOptions = {
@@ -296,6 +298,9 @@ export function PricingPanel(props: PricingPanelProps) {
       ? (gateLinesByTurn.get(line.turnId) ?? [])
       : [];
     const isActive = isActiveUsageLine({ activeTurnId, line, subAgentsById });
+    const turnFailure = !isActive && line.scope === "turn"
+      ? props.turnFailures?.find((failure) => failure.turnId === line.turnId)
+      : undefined;
     const usageTitle = formatUsageLineTitle(line, subAgent);
     const showUsageTitle = usageTitle !== "Turn usage";
     const reasoningEffort =
@@ -333,6 +338,8 @@ export function PricingPanel(props: PricingPanelProps) {
           <div className="pricing-usage-row__controls">
             {isActive ? (
               <RailStatusChip tone="active">Running</RailStatusChip>
+            ) : turnFailure ? (
+              <RailStatusChip tone="error" alert>Failed</RailStatusChip>
             ) : null}
             <PricingUsageActions
               line={line}
@@ -357,6 +364,7 @@ export function PricingPanel(props: PricingPanelProps) {
         {usageLineEstimate ? (
           <p className="pricing-usage-row__cost">{usageLineEstimate}</p>
         ) : null}
+        {turnFailure ? <p className="rail-card__error">{turnFailure.error}</p> : null}
         <p className="rail-card__usage">
           {formatTokenCount(line.uncachedInputTokens)} uncached in ·{" "}
           {formatTokenCount(line.cachedInputTokens)} cached ·{" "}


### PR DESCRIPTION
Turns that had displayed a live price could later show “Unpriced: insufficient token breakdown” after an interruption or usage-limit failure. Preserve their observed request-level prices and show the failure separately on the pricing card.

Codex's `recompute_token_usage` can publish an empty last-request billing breakdown containing only a context-size estimate, without changing cumulative billed tokens. Rate-limit notifications can repeat that snapshot. Our request accumulator replaced its last measured request with the empty record, so request totals stopped matching the turn and pricing fell back to an unpriceable aggregate.

- Keep the measured request when cumulative input is unchanged and the incoming last-request billing breakdown is empty.
- Preserve persisted request-component prices when an aggregate-only refresh has exactly the same measured tokens and pricing settings. Changed usage or settings still require new pricing; an old amount is not presented as the full cost of different usage.
- Show a Failed badge and the recorded error beside the retained price, using the existing turn-failure log and rail styles.

No schema change, extra persistence, or new SQLite writes. Incremental write volume is 0 MB/day. This prevents loss going forward; it cannot reconstruct exact request-band prices for historical rows whose component pricing has already been erased.

Started from `origin/main` at `a5188145a`, containing the squash merge of #1988. Verified the empty-request/context-estimate and rate-limit notification behavior in the local Codex source (`codex-rs/core/src/session/mod.rs`).

### Validation

- Tests first: three backend cases, the equivalent-refresh storage case, and the failure-card UI case all failed before their fixes.
- 765 tests passed in the combined backend registry, SQLite pricing store, and context panel suites. The additional changed-settings guard subsequently passed in the focused storage run.
- Eight existing live-usage durability/write-budget cases passed, including the one-commit burst budget. No budgets changed.
- Typecheck, ESLint, and dependency boundaries passed (46 existing ESLint warnings, no errors).
- One initial isolated SQLite pricing-suite process exited 139 after reporting all 36 tests passed; the combined suites and subsequent focused SQLite/write-budget runs exited successfully. No runner settings or retries were added.
- Rendered and visually checked the actual PricingPanel in headless Chromium. Both screenshots use entirely contrived fixture data.

### Before: contrived reproduction

![Previously priced turn shown as unpriced](https://github.com/user-attachments/assets/e8482872-81f9-4d13-bb2c-8ccd1911c771)

### After

![Retained price beside the failed status and usage-limit message](https://github.com/user-attachments/assets/c654639d-85b1-4487-bdc1-391faa31372e)
