### PR TITLE
fix(desktop): center pane resize seams on their borders

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -39,6 +39,7 @@ import {
   toolOutputWarningChars,
 } from "@pwragent/shared";
 import { Sidebar } from "./features/navigation/Sidebar";
+import { SidebarResizeHandle } from "./features/navigation/SidebarResizeHandle";
 import { useThreadJump } from "./features/navigation/useThreadJump";
 import { AppTitleBar } from "./features/chrome/AppTitleBar";
 import { buildFederationThreadTargets } from "./features/chrome/federation-thread-targets";
@@ -2810,12 +2811,18 @@ function DesktopAppShell(props: {
             await desktopApi.unbindMessagingThread({ bindingId: binding.bindingId });
             await navigation.refresh?.();
           }}
-          onResizeStart={startSidebarResize}
-          onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidthRef.current + delta)}
-          sidebarWidth={sidebarWidth}
-          sidebarMinWidth={sidebarMinWidth}
-          sidebarMaxWidth={sidebarMaxWidth}
         />
+        {/* Sibling of the sidebar, not a child: the seam straddles the
+            sidebar's border, which the aside's overflow clip would cut off. */}
+        {sidebarHidden ? null : (
+          <SidebarResizeHandle
+            onResizeStart={startSidebarResize}
+            onResizeByKeyboard={(delta) => resizeSidebar(sidebarWidthRef.current + delta)}
+            sidebarWidth={sidebarWidth}
+            sidebarMinWidth={sidebarMinWidth}
+            sidebarMaxWidth={sidebarMaxWidth}
+          />
+        )}
 
         <main
           className={`app-main${

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
-  KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
   ReactElement,
   ReactNode,
-  PointerEvent,
 } from "react";
 import type {
   AppServerBackendKind,
@@ -368,19 +366,6 @@ type SidebarProps = {
     thread: NavigationThreadSummary,
     binding: MessagingThreadBindingSummary,
   ) => Promise<void>;
-  onResizeStart?: (event: PointerEvent<HTMLElement>) => void;
-  onResizeByKeyboard?: (delta: number) => void;
-  /**
-   * Current sidebar width and clamp range, plumbed in so the resize
-   * handle can expose aria-valuenow / aria-valuemin / aria-valuemax —
-   * required by axe-core for focusable role="separator". All three are
-   * optional so older callers (and unit tests that mount Sidebar in
-   * isolation) keep compiling; the handle silently omits the aria-value*
-   * attributes when they're absent.
-   */
-  sidebarWidth?: number;
-  sidebarMinWidth?: number;
-  sidebarMaxWidth?: number;
 };
 
 /**
@@ -1876,26 +1861,9 @@ export function Sidebar(props: SidebarProps) {
           onClose={() => props.onThreadJumpOpenChange?.(false)}
         />
       ) : null}
-      <div
-        aria-label="Resize thread sidebar"
-        aria-orientation="vertical"
-        aria-valuenow={props.sidebarWidth}
-        aria-valuemin={props.sidebarMinWidth}
-        aria-valuemax={props.sidebarMaxWidth}
-        className="sidebar__resize-handle"
-        role="separator"
-        tabIndex={0}
-        onKeyDown={(event: ReactKeyboardEvent<HTMLElement>) => {
-          if (event.key === "ArrowLeft") {
-            event.preventDefault();
-            props.onResizeByKeyboard?.(-16);
-          } else if (event.key === "ArrowRight") {
-            event.preventDefault();
-            props.onResizeByKeyboard?.(16);
-          }
-        }}
-        onPointerDown={props.onResizeStart}
-      />
+      {/* The resize seam is NOT here — see SidebarResizeHandle, rendered by
+          the shell as this aside's sibling so it can straddle the border
+          that `overflow: hidden` keeps every child from reaching. */}
       <header className="sidebar__masthead">
         <p className="sidebar__brand">
           Pwr<span className="sidebar__brand-accent">Agent</span>

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarResizeHandle.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarResizeHandle.tsx
@@ -1,0 +1,55 @@
+import type {
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent,
+  ReactElement,
+} from "react";
+
+type SidebarResizeHandleProps = {
+  onResizeStart?: (event: PointerEvent<HTMLElement>) => void;
+  onResizeByKeyboard?: (delta: number) => void;
+  /**
+   * Current sidebar width and clamp range, exposed as aria-valuenow /
+   * aria-valuemin / aria-valuemax — required by axe-core for a focusable
+   * role="separator".
+   */
+  sidebarWidth: number;
+  sidebarMinWidth: number;
+  sidebarMaxWidth: number;
+};
+
+/**
+ * The drag seam between the sidebar and the main pane.
+ *
+ * Rendered as a sibling of `.sidebar` inside `.app-shell`, NOT inside the
+ * sidebar: `.sidebar` is `overflow: hidden`, which clips at its padding box,
+ * so a child can never paint on the sidebar's own border-right pixel, let
+ * alone straddle it. Living in the shell lets the handle sit centered on the
+ * seam (see `.sidebar__resize-handle` in app.css), which keeps its hit area
+ * off the thread lane's scrollbar and lights up the border itself on hover.
+ */
+export function SidebarResizeHandle(
+  props: SidebarResizeHandleProps,
+): ReactElement {
+  return (
+    <div
+      aria-label="Resize thread sidebar"
+      aria-orientation="vertical"
+      aria-valuenow={props.sidebarWidth}
+      aria-valuemin={props.sidebarMinWidth}
+      aria-valuemax={props.sidebarMaxWidth}
+      className="sidebar__resize-handle"
+      role="separator"
+      tabIndex={0}
+      onKeyDown={(event: ReactKeyboardEvent<HTMLElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          props.onResizeByKeyboard?.(-16);
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          props.onResizeByKeyboard?.(16);
+        }
+      }}
+      onPointerDown={props.onResizeStart}
+    />
+  );
+}

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -383,6 +383,10 @@ describe("Tangerine Terminal theme contract", () => {
       "sidebar-rail-inset",
       "sidebar-lane-inset",
       "sidebar-masthead-pull",
+      // Pane resize seams — defined on the two resize handles, not `:root`.
+      // How far the 11px hit band reaches over the scrolling neighbour's
+      // edge; both seams read it so their geometry cannot drift apart.
+      "pane-seam-scroll-side",
       // Live run strip row height — defined on `.live-strip`, not `:root`.
       // The four-row scroll cap is derived from it, so the two cannot drift.
       "live-strip-row-h",

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -1478,30 +1478,52 @@ textarea,
   color: var(--text-secondary);
 }
 
+/* Pane resize seams (sidebar | main, and transcript | pinned context rail).
+
+   Each handle straddles the 1px border between its two panes, and its
+   hover / focus indicator IS that border pixel lit in accent — one seam,
+   not a second line running beside the real one. The 11px hit band is
+   deliberately lopsided: `--pane-seam-scroll-side` (2px) on the side that
+   scrolls, the seam itself, then the rest on the side whose edge holds no
+   scrollbar. Both scrolling neighbours park their thumb flush against
+   this border (`.sidebar-list--dense` at the sidebar wall,
+   `.transcript-list__items` at the rail), and the earlier 11px band that
+   sat entirely inside the sidebar covered that thumb end to end — a
+   classic-mode (mouse attached) scrollbar is exactly 11px wide, so every
+   grab of it started a resize instead. 2px is the sliver a thumb can
+   afford to lose; the panel / main side pays the remaining 8px because
+   nothing interactive lives in its first 8px (the transcript's left pad
+   is 16px, the rail sections' is 12px). */
 .sidebar__resize-handle,
 .context-rail__resize-handle {
+  --pane-seam-scroll-side: 2px;
   position: absolute;
+  top: 0;
+  bottom: 0;
   z-index: 12;
   width: 11px;
   cursor: col-resize;
   touch-action: none;
 }
 
+/* A sibling of `.sidebar` inside `.app-shell` (see SidebarResizeHandle):
+   the aside is `overflow: hidden`, which clips at its padding box, so a
+   child could never reach the border pixel. `--sidebar-reserve` tracks the
+   live `--sidebar-width` during a drag, so the seam follows the wall. */
 .sidebar__resize-handle {
-  top: 0;
-  right: 0;
-  bottom: 0;
+  left: calc(
+    var(--sidebar-reserve, 408px) - 1px - var(--pane-seam-scroll-side)
+  );
 }
 
 .sidebar__resize-handle::after,
 .context-rail__resize-handle::after {
   content: "";
   position: absolute;
-  top: 12px;
-  bottom: 12px;
-  left: 5px;
+  top: 0;
+  bottom: 0;
+  left: var(--pane-seam-scroll-side);
   width: 1px;
-  border-radius: 999px;
   background: transparent;
   transition:
     background 140ms ease,
@@ -1514,6 +1536,14 @@ textarea,
 .context-rail__resize-handle:focus-visible::after {
   background: var(--accent);
   box-shadow: 0 0 0 1px var(--accent-bg-medium);
+}
+
+/* A pointer crossing the seam on its way somewhere else should not flash
+   it; hold the hover lit-up a beat. Keyboard focus is deliberate, so it
+   lights immediately (the rule above, no delay). */
+.sidebar__resize-handle:hover:not(:focus-visible)::after,
+.context-rail__resize-handle:hover:not(:focus-visible)::after {
+  transition-delay: 120ms;
 }
 
 .sidebar__resize-handle:focus-visible,
@@ -23345,10 +23375,11 @@ a.transcript-message__messaging-origin:focus-visible {
   flex: 1 1 auto;
 }
 
+/* Straddles the panel's border-left: 2px over the transcript (whose
+   scrollbar parks against this edge), the seam, 8px into the panel. The
+   rail is `overflow: visible`, so the negative offset is not clipped. */
 .context-rail__resize-handle {
-  top: 0;
-  bottom: 0;
-  left: 0;
+  left: calc(-1 * var(--pane-seam-scroll-side));
   z-index: 3;
 }
 


### PR DESCRIPTION
## Summary

Both pane resize grips drew their hover line next to the border instead of on it, and the sidebar's grip sat on top of the thread lane's scrollbar.

- **Sidebar seam:** the handle lived inside `.sidebar`, which is `overflow: hidden` and clips at its padding box, so it could never reach the border pixel. It was parked at `right: 0` with an 11px hit band at `[wall-12, wall-1)` and its line at `wall-7`. That band is exactly the footprint of the lane's classic-mode (mouse attached) scrollbar, so grabbing the thumb started a resize, and the accent line ran down the middle of the thumb.
- **Rail seam:** the handle sat at `left: 0` with its line at `seam+5`, so hovering showed two parallel lines 5px apart, the panel border and the accent line.

## Change

- The sidebar handle moves out to `.app-shell` as the aside's sibling (`SidebarResizeHandle`), placed from `--sidebar-reserve` so it follows the live width during a drag. `Sidebar` drops the five pass-through props.
- Both handles now straddle their border: 2px over the scrolling neighbour, the 1px seam, 8px into the other pane. The `::after` line sits on the border pixel, full height, so hover lights the seam itself.
- One shared `--pane-seam-scroll-side` token carries the asymmetry for both seams (allowlisted as a local token in `theme-contract.test.tsx`).
- Hover lights after a 120ms hold so a pointer crossing the seam on its way somewhere else does not flash it. Keyboard focus lights immediately.

## Before / After

Headless render of `app.css` (dark theme, contrived rows only), each seam hovered. Left of each pair is sidebar | main, right is transcript | pinned rail.

![resize seams before and after](https://github.com/user-attachments/assets/9ae40f3e-9b16-466c-9375-a4c04ef99e07)

Measured at 1400x800 with the sidebar at 408px and the rail at 380px:

| | Before | After |
|---|---|---|
| Sidebar hit band | `[wall-12, wall-1)` | `[wall-3, wall+8)` |
| Sidebar line | `wall-7` | on the border pixel |
| Rail hit band | `[seam, seam+11)` | `[seam-2, seam+9)` |
| Rail line | `seam+5` | on the border pixel |
| Lane scrollbar hit-tests to the lane | 0 of 11px | 9 of 11px |

Design review with cross-sections and findings: [Pane Resize Seams UX Review](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Pane+Resize+Seams+UX+Review.dc.html) in the PwrAgent Claude Design project.

## Verification

- `pnpm --filter @pwragent/desktop typecheck` clean.
- ESLint clean on the three changed TSX files.
- Vitest: `features/navigation`, `styles/__tests__/theme-contract.test.tsx`, and `renderer/src/__tests__` pass (409 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
