### PR TITLE
fix(desktop): price multi-request Astra turns from the context window

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26680,6 +26680,77 @@ command = "pnpm dev"
     },
   );
 
+  it("prices an Astra aggregate from its context window when a request snapshot was missed", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-6-astra",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    // Two requests land between observations: the cumulative total grows by
+    // more than the single `last` snapshot, so the observed request components
+    // can no longer reproduce the turn total. The 258,400-token window still
+    // proves no request entered the >272K band.
+    for (const [input, cached] of [
+      [200_000, 100_000],
+      [600_000, 300_000],
+    ]) {
+      await codexClient.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          tokenUsage: {
+            model_context_window: 258_400,
+            total_token_usage: {
+              input_tokens: input,
+              cached_input_tokens: cached,
+              output_tokens: input / 20,
+              reasoning_output_tokens: 0,
+              total_tokens: input * 1.05,
+            },
+            last_token_usage: {
+              input_tokens: 200_000,
+              cached_input_tokens: 100_000,
+              output_tokens: 10_000,
+              reasoning_output_tokens: 0,
+              total_tokens: 210_000,
+            },
+          },
+        },
+      });
+    }
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+    expect(pricing.lines[0]).toMatchObject({
+      cachedInputTokens: 300_000,
+      inputTokens: 600_000,
+      modelContextWindow: 258_400,
+      outputTokens: 30_000,
+      priceStatus: "priced",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      totalCostMicros: 4_800_000,
+    });
+    expect(pricing.lines[0]?.pricingBasis).toBeUndefined();
+    expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
+
+    await registry.close();
+  });
+
   it("prices each Astra request before aggregating a multi-request turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -910,6 +910,83 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     });
   });
 
+  it("prices an aggregate Astra turn when its context window keeps every request under 272K", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine(buildAstraAggregateOverrides({
+        modelContextWindow: 258_400,
+      })),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "priced",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      totalCostMicros: 3_269_538,
+    });
+    expect(pricing.lines[0]?.priceUnavailableReason).toBeUndefined();
+    expect(pricing.summaries).toEqual([
+      expect.objectContaining({
+        pricedUsageLineCount: 1,
+        totalCostMicros: 3_269_538,
+        unpricedUsageLineCount: 0,
+      }),
+    ]);
+  });
+
+  it("lazily reprices an older aggregate row behind a priced newer row from its turn context window", async () => {
+    // Persisted before the context-window ceiling existed: the aggregate row
+    // stayed unpriced while its turn record already carried the window.
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine(buildAstraAggregateOverrides({
+        createdAt: Date.UTC(2026, 8, 5, 20, 40),
+        turnId: "turn-old",
+        usageLineId: "line-old",
+      })),
+    });
+    stateDb.raw
+      .prepare(
+        `UPDATE thread_usage_turns
+         SET model_context_window = 258400
+         WHERE thread_id = 'thread-1'`,
+      )
+      .run();
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        createdAt: Date.UTC(2026, 8, 5, 21, 0),
+        model: "gpt-6-astra",
+        sourceItemId: "item-new",
+        turnId: "turn-new",
+        usageLineId: "line-new",
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines.map((line) => line.usageLineId)).toEqual([
+      "line-new",
+      "line-old",
+    ]);
+    expect(pricing.lines[0]?.priceStatus).toBe("priced");
+    expect(pricing.lines[1]).toMatchObject({
+      priceStatus: "priced",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      totalCostMicros: 3_269_538,
+    });
+    expect(pricing.summaries).toEqual([
+      expect.objectContaining({
+        pricedUsageLineCount: 2,
+        unpricedUsageLineCount: 0,
+      }),
+    ]);
+  });
+
   it("uses the usage timestamp when selecting effective pricing rates", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
@@ -1527,6 +1604,34 @@ function buildUsageLine(
     uncachedInputCostMicros: 4_000,
     uncachedInputTokens: 800,
     usageLineId: "line-1",
+    ...overrides,
+  };
+}
+
+function buildAstraAggregateOverrides(
+  overrides: Partial<ThreadUsageLineRecord> = {},
+): Partial<ThreadUsageLineRecord> {
+  // A GPT-6 Astra turn whose 19 requests summed to 1.6M input tokens while
+  // every request stayed under the 258,400-token context window.
+  return {
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 1_527_808,
+    createdAt: Date.UTC(2026, 8, 5),
+    inputTokens: 1_648_011,
+    model: "gpt-6-astra",
+    outputCostMicros: 0,
+    outputTokens: 9_663,
+    priceStatus: "unpriced",
+    priceUnavailableReason: "insufficient-token-breakdown",
+    pricingCatalogId: undefined,
+    pricingCatalogVersion: undefined,
+    pricingRateId: undefined,
+    reasoningOutputTokens: 1_131,
+    scope: "turn",
+    totalCostMicros: 0,
+    totalTokens: 1_658_805,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 120_203,
     ...overrides,
   };
 }

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -1742,6 +1742,147 @@ describe("StateDb", () => {
     });
   });
 
+  it("reprices Astra aggregate rows whose turn context window caps every request under 272K", () => {
+    stateDb.close();
+
+    const dbPath = path.join(
+      tempDir,
+      "astra-context-window-pricing-repair-state.db",
+    );
+    stateDb = StateDb.open(dbPath);
+    const createdAt = Date.UTC(2026, 8, 5, 20, 40);
+    stateDb.raw
+      .prepare(
+        `INSERT INTO thread_usage_turns (
+          usage_turn_id,
+          provider,
+          backend,
+          thread_id,
+          turn_id,
+          model,
+          observed_at,
+          model_context_window,
+          updated_at
+        ) VALUES (
+          'openai:codex:thread-astra:turn-astra',
+          'openai',
+          'codex',
+          'thread-astra',
+          'turn-astra',
+          'gpt-6-astra',
+          ?,
+          258400,
+          ?
+        )`,
+      )
+      .run(createdAt, createdAt);
+    stateDb.raw
+      .prepare(
+        `INSERT INTO thread_usage_lines (
+          usage_line_id,
+          usage_turn_id,
+          provider,
+          backend,
+          thread_id,
+          turn_id,
+          source,
+          scope,
+          status,
+          created_at,
+          model,
+          fast_mode,
+          input_tokens,
+          cached_input_tokens,
+          uncached_input_tokens,
+          output_tokens,
+          reasoning_output_tokens,
+          total_tokens,
+          price_status,
+          price_unavailable_reason,
+          currency,
+          uncached_input_cost_micros,
+          cached_input_cost_micros,
+          output_cost_micros,
+          total_cost_micros,
+          updated_at
+        ) VALUES (
+          'codex:thread-astra:turn-astra:live-token-usage',
+          'openai:codex:thread-astra:turn-astra',
+          'openai',
+          'codex',
+          'thread-astra',
+          'turn-astra',
+          'live',
+          'turn',
+          'pending',
+          ?,
+          'gpt-6-astra',
+          0,
+          1648011,
+          1527808,
+          120203,
+          9663,
+          1131,
+          1658805,
+          'unpriced',
+          'insufficient-token-breakdown',
+          'USD',
+          0,
+          0,
+          0,
+          0,
+          ?
+        )`,
+      )
+      .run(createdAt, createdAt);
+    stateDb.raw.pragma("user_version = 58");
+    stateDb.close();
+
+    stateDb = StateDb.open(dbPath);
+
+    const line = stateDb.raw
+      .prepare(
+        `SELECT price_status, price_unavailable_reason, pricing_rate_id, total_cost_micros
+         FROM thread_usage_lines
+         WHERE usage_line_id = 'codex:thread-astra:turn-astra:live-token-usage'`,
+      )
+      .get() as {
+        price_status: string;
+        price_unavailable_reason: string | null;
+        pricing_rate_id: string | null;
+        total_cost_micros: number;
+      };
+    const summary = stateDb.raw
+      .prepare(
+        `SELECT priced_usage_line_count, unpriced_usage_line_count, total_cost_micros
+         FROM thread_pricing_summaries
+         WHERE provider = 'openai'
+           AND backend = 'codex'
+           AND thread_id = 'thread-astra'
+           AND currency = 'USD'`,
+      )
+      .get() as {
+        priced_usage_line_count: number;
+        total_cost_micros: number;
+        unpriced_usage_line_count: number;
+      };
+
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(
+      CURRENT_STATE_DB_USER_VERSION,
+    );
+    expect(line).toEqual({
+      price_status: "priced",
+      price_unavailable_reason: null,
+      pricing_rate_id: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      total_cost_micros: 3_269_538,
+    });
+    expect(summary).toEqual({
+      priced_usage_line_count: 1,
+      total_cost_micros: 3_269_538,
+      unpriced_usage_line_count: 0,
+    });
+  });
+
   it("reprices existing GPT-5.6 usage rows after the July 30 price reduction", () => {
     stateDb.close();
 

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -5227,6 +5227,11 @@ function buildLiveThreadUsageLine(params: {
         turnTokenUsage: tokens,
       })
     : undefined;
+  // Without a request breakdown (a missed snapshot, or a re-emitted total after
+  // the per-request fold was dropped), the provider's context window still
+  // bounds every request, so a turn-wide sum can select a band whose ceiling
+  // no request could have crossed.
+  const requestInputTokenCeiling = params.contextWindow?.modelContextWindow;
   const cost = requestComponentsCost ?? estimateTokenUsageCost({
     at: createdAt,
     cacheWriteInputTokens,
@@ -5235,6 +5240,7 @@ function buildLiveThreadUsageLine(params: {
     model: params.model,
     outputTokens,
     reasoningOutputTokens,
+    requestInputTokenCeiling,
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
@@ -5245,6 +5251,7 @@ function buildLiveThreadUsageLine(params: {
           cachedInputTokens,
           fastMode: params.fastMode,
           model: params.model,
+          requestInputTokenCeiling,
           serviceTier: params.serviceTier,
           uncachedInputTokens,
         });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1791,34 +1791,46 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         params.threadId,
       ) as ThreadUsageLineRow[];
 
-    // Pricing catalogs can gain rates without changing sqlite's schema. When
-    // the newest card is unpriced, lazily retry this thread in ten-row groups.
-    // A group with no repairs stops the scan, so permanently unknown histories
-    // cost one bounded read rather than a full-ledger walk on every load.
-    if (lineRows[0]?.price_status === "unpriced") {
+    // Pricing catalogs and pricing rules can change without touching sqlite's
+    // schema, and an unpriced row can sit behind newer priced rows. When any
+    // displayed card is unpriced, lazily retry those rows in ten-row groups,
+    // newest first. A group with no repairs stops the scan, so permanently
+    // unknown histories cost one bounded read rather than a full-ledger walk
+    // on every load.
+    const unpricedRows = lineRows.filter(
+      (row) => row.price_status !== "priced",
+    );
+    if (unpricedRows.length > 0) {
+      const candidates = unpricedRows.map((row) => ({
+        existing: row,
+        line: threadUsageLineFromRow(row),
+      }));
+      // The context-window ceiling lives on the turn record, not the line row.
+      this.attachUsageTurnMetadataSync(
+        params.backend,
+        params.threadId,
+        candidates.map((candidate) => candidate.line),
+      );
       const repairs: Array<{
         existing: ThreadUsageLineRow;
         repaired: ThreadUsageLineRecord;
       }> = [];
       for (
         let offset = 0;
-        offset < lineRows.length;
+        offset < candidates.length;
         offset += THREAD_PRICING_LAZY_REPRICE_BATCH_SIZE
       ) {
-        const batch = lineRows.slice(
+        const batch = candidates.slice(
           offset,
           offset + THREAD_PRICING_LAZY_REPRICE_BATCH_SIZE,
         );
         let repairedInBatch = 0;
-        for (const row of batch) {
-          if (row.price_status === "priced") {
-            continue;
-          }
-          const repaired = repriceTokenUsageLine(threadUsageLineFromRow(row));
+        for (const candidate of batch) {
+          const repaired = repriceTokenUsageLine(candidate.line);
           if (repaired.priceStatus !== "priced") {
             continue;
           }
-          repairs.push({ existing: row, repaired });
+          repairs.push({ existing: candidate.existing, repaired });
           repairedInBatch += 1;
         }
         if (repairedInBatch === 0) {
@@ -7407,6 +7419,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     model: line.model,
     outputTokens: line.outputTokens,
     reasoningOutputTokens: line.reasoningOutputTokens,
+    requestInputTokenCeiling: line.modelContextWindow,
     serviceTier: line.serviceTier,
     uncachedInputTokens: line.uncachedInputTokens,
   });
@@ -7420,6 +7433,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
           inputTokenScope:
             line.scope === "latest-request" ? "request" : "aggregate",
           model: line.model,
+          requestInputTokenCeiling: line.modelContextWindow,
           serviceTier: line.serviceTier,
           uncachedInputTokens: line.uncachedInputTokens,
         });

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 58;
+export const CURRENT_STATE_DB_USER_VERSION = 59;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -1651,6 +1651,15 @@ export class StateDb {
       if ((db.pragma("user_version", { simple: true }) as number) < 58) {
         db.transaction(() => {
           ensureThreadUsageRequestPricingColumns(db);
+          db.pragma("user_version = 58");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 59) {
+        db.transaction(() => {
+          // Multi-request aggregates above a request-scoped band boundary now
+          // price from the turn's context-window ceiling. Reprice rows that
+          // were persisted as "insufficient-token-breakdown" before that rule.
+          repairTokenUsagePricing(db);
           db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
         })();
       }
@@ -2991,28 +3000,42 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   }
   ensureThreadUsageRequestPricingColumns(db);
 
+  // The turn record carries the provider-reported context window that lets a
+  // multi-request aggregate price inside a request-scoped band. Older
+  // databases reach this repair before that column exists.
+  const hasTurnContextWindow =
+    tableColumnExists(db, "thread_usage_lines", "usage_turn_id")
+    && tableExists(db, "thread_usage_turns")
+    && tableColumnExists(db, "thread_usage_turns", "model_context_window");
   const now = Date.now();
   const rows = db
     .prepare(
       `SELECT
-         usage_line_id,
-         cache_write_input_tokens,
-         cached_input_tokens,
-         created_at,
-         currency,
-         fast_mode,
-         model,
-         output_tokens,
-         price_status,
-         pricing_basis,
-         provider,
-         reasoning_output_tokens,
-         service_tier,
-         scope,
-         uncached_input_tokens
-       FROM thread_usage_lines
-       WHERE provider IN ('openai', 'qwen', 'xai')
-         AND scope != 'fork-baseline'`,
+         lines.usage_line_id,
+         lines.cache_write_input_tokens,
+         lines.cached_input_tokens,
+         lines.created_at,
+         lines.currency,
+         lines.fast_mode,
+         lines.model,
+         lines.output_tokens,
+         lines.price_status,
+         lines.pricing_basis,
+         lines.provider,
+         lines.reasoning_output_tokens,
+         lines.service_tier,
+         lines.scope,
+         lines.uncached_input_tokens,
+         ${hasTurnContextWindow ? "turns.model_context_window" : "NULL"}
+           AS model_context_window
+       FROM thread_usage_lines AS lines
+       ${
+         hasTurnContextWindow
+           ? "LEFT JOIN thread_usage_turns AS turns ON turns.usage_turn_id = lines.usage_turn_id"
+           : ""
+       }
+       WHERE lines.provider IN ('openai', 'qwen', 'xai')
+         AND lines.scope != 'fork-baseline'`,
     )
     .all() as Array<{
       cache_write_input_tokens: number;
@@ -3021,6 +3044,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       currency: string;
       fast_mode: number | null;
       model: string | null;
+      model_context_window: number | null;
       output_tokens: number;
       price_status: string;
       pricing_basis: ThreadUsageLineRecord["pricingBasis"] | null;
@@ -3063,6 +3087,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       model: row.model ?? undefined,
       outputTokens: row.output_tokens,
       reasoningOutputTokens: row.reasoning_output_tokens,
+      requestInputTokenCeiling: row.model_context_window ?? undefined,
       serviceTier: row.service_tier ?? undefined,
       uncachedInputTokens: row.uncached_input_tokens,
     });

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -3008,9 +3008,8 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
     && tableExists(db, "thread_usage_turns")
     && tableColumnExists(db, "thread_usage_turns", "model_context_window");
   const now = Date.now();
-  const rows = db
-    .prepare(
-      `SELECT
+  const selectRows = hasTurnContextWindow
+    ? `SELECT
          lines.usage_line_id,
          lines.cache_write_input_tokens,
          lines.cached_input_tokens,
@@ -3026,17 +3025,35 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          lines.service_tier,
          lines.scope,
          lines.uncached_input_tokens,
-         ${hasTurnContextWindow ? "turns.model_context_window" : "NULL"}
+         turns.model_context_window
            AS model_context_window
        FROM thread_usage_lines AS lines
-       ${
-         hasTurnContextWindow
-           ? "LEFT JOIN thread_usage_turns AS turns ON turns.usage_turn_id = lines.usage_turn_id"
-           : ""
-       }
+       LEFT JOIN thread_usage_turns AS turns ON turns.usage_turn_id = lines.usage_turn_id
        WHERE lines.provider IN ('openai', 'qwen', 'xai')
-         AND lines.scope != 'fork-baseline'`,
-    )
+         AND lines.scope != 'fork-baseline'`
+    : `SELECT
+         lines.usage_line_id,
+         lines.cache_write_input_tokens,
+         lines.cached_input_tokens,
+         lines.created_at,
+         lines.currency,
+         lines.fast_mode,
+         lines.model,
+         lines.output_tokens,
+         lines.price_status,
+         lines.pricing_basis,
+         lines.provider,
+         lines.reasoning_output_tokens,
+         lines.service_tier,
+         lines.scope,
+         lines.uncached_input_tokens,
+         NULL
+           AS model_context_window
+       FROM thread_usage_lines AS lines
+       WHERE lines.provider IN ('openai', 'qwen', 'xai')
+         AND lines.scope != 'fork-baseline'`;
+  const rows = db
+    .prepare(selectRows)
     .all() as Array<{
       cache_write_input_tokens: number;
       cached_input_tokens: number;

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -482,6 +482,50 @@ describe("token usage pricing", () => {
     ).toBe("insufficient-token-breakdown");
   });
 
+  it("prices a multi-request Astra aggregate when the context window caps every request under 272K", () => {
+    // Codex reports a 258,400-token window for GPT-6 Astra (272K at its 95%
+    // effective width). No single request can enter the >272K band, so the
+    // turn-wide sum is priceable at the short-context rate even without the
+    // per-request breakdown.
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 5),
+      cachedInputTokens: 1_527_808,
+      inputTokenScope: "aggregate",
+      model: "gpt-6-astra",
+      outputTokens: 9_663,
+      reasoningOutputTokens: 1_131,
+      requestInputTokenCeiling: 258_400,
+      serviceTier: "standard",
+      uncachedInputTokens: 120_203,
+    });
+
+    expect(cost).toMatchObject({
+      displayName: "GPT-6 Astra Standard (<=272K input)",
+      rateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      uncachedInputCostMicros: 1_202_030,
+      cachedInputCostMicros: 1_527_808,
+      outputCostMicros: 539_700,
+      totalCostMicros: 3_269_538,
+    });
+  });
+
+  it("keeps an Astra aggregate unpriced when the context window admits requests above 272K", () => {
+    const usage = {
+      at: Date.UTC(2026, 8, 5),
+      cachedInputTokens: 72_001,
+      inputTokenScope: "aggregate" as const,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      requestInputTokenCeiling: 400_000,
+      uncachedInputTokens: 200_000,
+    };
+
+    expect(estimateOpenAiTokenUsageCost(usage)).toBeUndefined();
+    expect(resolveTokenUsagePriceUnavailableReason(usage)).toBe(
+      "insufficient-token-breakdown",
+    );
+  });
+
   it("keeps unsupported GPT-6 Astra billing modes unpriced", () => {
     const usage = {
       cachedInputTokens: 1_000,

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -879,6 +879,7 @@ export function estimateOpenAiTokenUsageCost(params: {
   model?: string;
   outputTokens: number;
   reasoningOutputTokens?: number;
+  requestInputTokenCeiling?: number;
   serviceTier?: string;
   uncachedInputTokens: number;
 }): TokenUsageCostEstimate | undefined {
@@ -895,6 +896,10 @@ export function estimateTokenUsageCost(params: {
   model?: string;
   outputTokens: number;
   reasoningOutputTokens?: number;
+  // Upper bound on any single request's input tokens, usually the provider's
+  // reported context window. Lets a multi-request aggregate select a band whose
+  // ceiling every request is known to respect.
+  requestInputTokenCeiling?: number;
   serviceTier?: string;
   uncachedInputTokens: number;
 }): TokenUsageCostEstimate | undefined {
@@ -912,6 +917,7 @@ function estimateTokenUsageCostFromCatalog(
     model?: string;
     outputTokens: number;
     reasoningOutputTokens?: number;
+    requestInputTokenCeiling?: number;
     serviceTier?: string;
     uncachedInputTokens: number;
   },
@@ -930,6 +936,7 @@ function estimateTokenUsageCostFromCatalog(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
         params.inputTokenScope,
+        params.requestInputTokenCeiling,
       ),
   );
   const provider = matchingEntries[0]?.provider;
@@ -969,6 +976,7 @@ function estimateTokenUsageCostFromCatalog(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
         params.inputTokenScope,
+        params.requestInputTokenCeiling,
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
@@ -1145,6 +1153,10 @@ export function resolveTokenUsagePriceUnavailableReason(params: {
   fastMode?: boolean;
   inputTokenScope?: TokenUsagePricingInputScope;
   model?: string;
+  // Accepted so callers can forward the same parameters they priced with. The
+  // band lookup below deliberately matches by request-scope count, so the
+  // ceiling never changes which entry explains the failure.
+  requestInputTokenCeiling?: number;
   serviceTier?: string;
   uncachedInputTokens: number;
 }): TokenUsagePriceUnavailableReason {
@@ -1315,17 +1327,30 @@ function pricingEntryMatchesInputTokens(
   entry: PricingCatalogEntry,
   inputTokens: number,
   inputTokenScope: TokenUsagePricingInputScope | undefined,
+  requestInputTokenCeiling?: number,
 ): boolean {
+  if (entry.requiresRequestInputTokens && inputTokenScope !== "request") {
+    return false;
+  }
+  if (
+    entry.minimumInputTokens !== undefined
+    && inputTokens < entry.minimumInputTokens
+  ) {
+    return false;
+  }
+  if (
+    entry.maximumInputTokens === undefined
+    || inputTokens <= entry.maximumInputTokens
+  ) {
+    return true;
+  }
+  // A turn-wide sum above the band ceiling still belongs to this band when the
+  // provider's context window proves that no single request could exceed it.
   return (
-    (!entry.requiresRequestInputTokens || inputTokenScope === "request")
-    && (
-      entry.minimumInputTokens === undefined
-      || inputTokens >= entry.minimumInputTokens
-    )
-    && (
-      entry.maximumInputTokens === undefined
-      || inputTokens <= entry.maximumInputTokens
-    )
+    inputTokenScope !== "request"
+    && requestInputTokenCeiling !== undefined
+    && requestInputTokenCeiling > 0
+    && requestInputTokenCeiling <= entry.maximumInputTokens
   );
 }
 


### PR DESCRIPTION
## Problem

Threads on GPT-6 Astra kept showing `Unpriced: insufficient token breakdown` on turns whose turn-wide input exceeded 272K tokens, even after #1983 and #1993. In the reported thread, 8 of 11 turns were unpriced while every one of them ran with a 258,400-token context window and a peak request context under 210K.

Astra bills a higher per-request rate above 272K input. The catalog's `>272K` bands are marked `requiresRequestInputTokens`, so an aggregate above the boundary refused to price unless the per-request breakdown (`pricingBasis: "request-components"`) was available. That breakdown only exists in memory, folded from live `thread/tokenUsage/updated` notifications. The log shows how it was lost for the 20:40 turn: the turn priced fine while it ran, then at 21:00:00 the next turn's first token-usage notification arrived before its own `turn/started`, was attributed to the just-finished turn, and re-persisted that turn's aggregate without a matching request fold. The row landed as unpriced and nothing retried it later.

## Fix

Codex reports `model_context_window` with every token-usage update, and no single request can carry more input than that window. When the window fits under a band's `maximumInputTokens`, every request in the turn belongs to that band, so the aggregate is priceable at the short-context rate without a breakdown. When the window admits requests above the boundary (a hypothetical 400K model), the aggregate stays ambiguous and still reports `insufficient-token-breakdown`.

- `estimateTokenUsageCost` gains `requestInputTokenCeiling`. An aggregate above a band maximum matches that band when the ceiling fits under it. Request-scope pricing is unchanged.
- The live usage builder passes the observed `modelContextWindow` as the ceiling on its aggregate fallback, so a missed snapshot or a re-emitted total still prices.
- `repriceTokenUsageLine` passes the line's `modelContextWindow`.
- Lazy read-time repricing previously ran only when the newest row was unpriced, so older unpriced rows behind a priced newer row were never retried. It now retries any unpriced row (still in bounded ten-row groups) and attaches the turn record first, since the context window lives on `thread_usage_turns`.
- Schema v59 reruns `repairTokenUsagePricing`, which now joins `thread_usage_turns` for the context window, so persisted rows heal on the next launch.

## Verification

Each new test failed before the fix for the expected reason and passes after:

- `packages/shared`: an Astra aggregate of 1.65M input with a 258,400 ceiling prices at `input-lte-272k`; a 400K ceiling stays unpriced with the same reason.
- `overlay-store-usage-pricing`: an aggregate line with the window prices on upsert; an older unpriced row behind a priced newer row is repaired on read from the turn record.
- `state-db`: a v58 database with an unpriced Astra aggregate and a turn record carrying the window migrates to priced with a rebuilt summary.
- `backend-registry`: a live turn where a request snapshot was missed prices from the window instead of persisting unpriced.

Against a backup copy of the reporting profile's `state.db`, opening the database migrated it to v59 and priced all 11 turns of the reported thread. The 20:40 turn priced at $3.27 list, and the thread summary shows 50 priced and 0 unpriced lines.

Full runs of the four touched test files pass (40, 39, 53, and 642 tests). `pnpm typecheck`, `pnpm lint:eslint`, and `pnpm lint:boundaries` pass.

## Residual

One row in that profile remains unpriced: a review-monitor line (`scope: monitor`) whose task-monitor snapshot never records a context window, so no ceiling is available. Threading the window through `TaskMonitorUsageSnapshot` is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
