### PR TITLE
fix(desktop): give expanded queued messages the full width

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -10430,6 +10430,7 @@ export function Composer(props: ComposerProps) {
           <div
             className={[
               "composer__queued",
+              "composer__queued--message",
               scheduledSendAt ? "composer__queued--scheduled" : "",
               queued.errorMessage || queued.manualReleaseRequired
                 ? "composer__queued--failed"
@@ -10459,7 +10460,6 @@ export function Composer(props: ComposerProps) {
               <span className="composer__queued-text">
                 {formatDraftPreview(queued)}
               </span>
-              <QueuedMessageInspector load={() => readQueuedMessage(queued)} desktopApi={props.desktopApi} />
               {queued.errorMessage ? (
                 <span className="composer__queued-error">
                   {queued.errorMessage}
@@ -10472,7 +10472,10 @@ export function Composer(props: ComposerProps) {
               ) : null}
             </div>
             <QueuedImageAttachments attachments={queued.imageAttachments} />
-            <div className="composer__queued-actions">
+            <QueuedMessageInspector
+              load={() => readQueuedMessage(queued)}
+              desktopApi={props.desktopApi}
+            >
               {queued.manualReleaseRequired && index === 0 ? (
                 <button
                   className="composer__secondary-action"
@@ -10613,7 +10616,7 @@ export function Composer(props: ComposerProps) {
               >
                 Delete
               </button>
-            </div>
+            </QueuedMessageInspector>
           </div>
         );
       })}

--- a/apps/desktop/src/renderer/src/features/composer/QueuedMessageInspector.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/QueuedMessageInspector.tsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { type ReactNode, useId, useState } from "react";
 import type { ReadQueuedTurnResponse } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { TurnInputContent } from "../thread-detail/TurnInputContent";
@@ -6,6 +6,7 @@ import { TurnInputContent } from "../thread-detail/TurnInputContent";
 export function QueuedMessageInspector(props: {
   load: () => Promise<ReadQueuedTurnResponse>;
   desktopApi?: DesktopApi;
+  children?: ReactNode;
 }) {
   const regionId = useId();
   const [content, setContent] = useState<ReadQueuedTurnResponse>();
@@ -26,16 +27,19 @@ export function QueuedMessageInspector(props: {
     }
   };
   return (
-    <div>
-      <button
-        className="composer__secondary-action"
-        type="button"
-        aria-expanded={expanded}
-        aria-controls={regionId}
-        onClick={() => expanded ? setExpanded(false) : void open()}
-      >
-        {expanded ? "Hide message" : "View full message"}
-      </button>
+    <div className="queued-message-inspector-shell">
+      <div className="queued-message-inspector-toolbar">
+        <button
+          className="composer__secondary-action"
+          type="button"
+          aria-expanded={expanded}
+          aria-controls={regionId}
+          onClick={() => expanded ? setExpanded(false) : void open()}
+        >
+          {expanded ? "Hide message" : "View full message"}
+        </button>
+        <div className="composer__queued-actions">{props.children}</div>
+      </div>
       {expanded ? (
         <div
           id={regionId}

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -27106,6 +27106,10 @@ button.pricing-token-miser__folded:focus-visible {
   background: var(--bg-panel-elevated);
 }
 
+.composer__queued--message {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
 .composer__queued--steer {
   border-color: var(--accent-border);
   background: color-mix(in srgb, var(--accent-soft) 48%, var(--bg-panel-elevated));
@@ -33852,7 +33856,21 @@ button.pricing-token-miser__folded:focus-visible {
 
 .federation-activity__sizes { margin-top: 18px; }
 
+.queued-message-inspector-shell {
+  grid-column: 1 / -1;
+  min-width: 0;
+}
+
+.queued-message-inspector-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .queued-message-inspector {
+  margin-top: 8px;
   max-height: 320px;
   overflow: auto;
   padding: 8px;


### PR DESCRIPTION
Expanded queued messages kept Steer, Edit, and Delete centered in a separate column alongside the entire message. This wasted reading width: a 328px queue card left only 101px for content.

Move the controls into one wrapping row above the message and let the inspector span the card. The same card now provides 306px for the message. Queue actions, on-demand content loading, and the scrollable rich view retain their existing behavior.

Validation: all 306 composer tests passed; typecheck, ESLint, dependency boundaries, color-token lint, and diff checks passed. A headless Chromium harness rendered the actual Composer and stylesheet with entirely contrived text/image data at 760px and 400px viewport widths in light and dark themes. Geometry checks confirmed full-width content, controls above the content, and no horizontal overflow; keyboard order, focusable message region, and collapse passed. No live thread or queue was changed.

## Before

![Before: action column takes space from the expanded message](https://github.com/user-attachments/assets/013c0c93-d894-440f-838c-73000b78c5fb)

## After

![After: compact action row above full-width content](https://github.com/user-attachments/assets/5250ecb0-8781-45e7-88a2-46294c44971e)

## Narrow pane, dark theme

![After: narrow pane keeps the message readable](https://github.com/user-attachments/assets/ff3f8308-4856-4b76-a814-5236414d4059)
