### PR TITLE
fix(desktop): quiet repeated PR auto-dispatch decisions

### DIFF
--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch-log.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch-log.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PrAutoDispatchOutcome } from "../pr-status/pr-auto-dispatch";
+import { logPrAutoDispatchOutcome } from "../pr-status/pr-auto-dispatch-log";
+
+describe("PR auto-dispatch logging", () => {
+  const levels = {
+    scheduled: "info",
+    dispatched: "info",
+    "gate-off": "debug",
+    "not-actionable": "debug",
+    deferred: "debug",
+    "missing-head": "debug",
+    disabled: "debug",
+    busy: "debug",
+    pending: "debug",
+    duplicate: "debug",
+    "attempt-limit": "debug",
+    cancelled: "debug",
+    stale: "debug",
+    failed: "warn",
+  } satisfies Record<PrAutoDispatchOutcome["status"], "debug" | "info" | "warn">;
+
+  it.each(Object.entries(levels))("logs %s at %s", (status, level) => {
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn() };
+    const outcome = {
+      threadKey: "codex:thread-1",
+      status: status as PrAutoDispatchOutcome["status"],
+      fingerprint: "same-head-and-failure",
+    };
+    for (let poll = 0; poll < 3; poll += 1) {
+      logPrAutoDispatchOutcome(logger, "github.com/org/repo#1", outcome);
+    }
+    expect(logger[level]).toHaveBeenCalledTimes(3);
+    expect(logger[level]).toHaveBeenLastCalledWith("pr auto dispatch", {
+      prKey: "github.com/org/repo#1",
+      ...outcome,
+    });
+    for (const other of ["debug", "info", "warn"] as const) {
+      if (other !== level) expect(logger[other]).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
+++ b/apps/desktop/src/main/__tests__/pr-auto-dispatch.test.ts
@@ -190,6 +190,22 @@ async function createReadyBudgetClaim(params: {
 }
 
 describe("PrAutoDispatchCoordinator", () => {
+  it("does not rearm completed duplicate claims on unchanged polls", async () => {
+    const { coordinator, submitTurnIfIdle } = createHarness();
+    await observe(coordinator);
+    await runCountdown();
+    expect(submitTurnIfIdle).toHaveBeenCalledTimes(1);
+    const timers = vi.getTimerCount();
+
+    for (let poll = 0; poll < 3; poll += 1) {
+      expect(await observe(coordinator)).toEqual([
+        expect.objectContaining({ status: "duplicate" }),
+      ]);
+      expect(vi.getTimerCount()).toBe(timers);
+    }
+    expect(submitTurnIfIdle).toHaveBeenCalledTimes(1);
+  });
+
   it("treats PRs from secondary repositories as informational", () => {
     const primaryRepoKey = buildPrRepositoryKey(
       "github.com",

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -325,6 +325,7 @@ import {
   buildPrRepositoryKey,
   pullRequestMatchesRepositoryKey,
 } from "../pr-status/pr-auto-dispatch";
+import { logPrAutoDispatchOutcome } from "../pr-status/pr-auto-dispatch-log";
 import {
   PrStatusWatchCoordinator,
   getPrStatusWatchOutcome,
@@ -5655,7 +5656,7 @@ class DesktopAppServerService {
           })
         : [];
       for (const outcome of outcomes) {
-        appServerLog.info("pr auto dispatch", { prKey, ...outcome });
+        logPrAutoDispatchOutcome(appServerLog, prKey, outcome);
       }
       if (this.backgroundPrPollingEnabled) {
         const failureCoveredThreadKeys = new Set(

--- a/apps/desktop/src/main/pr-status/pr-auto-dispatch-log.ts
+++ b/apps/desktop/src/main/pr-status/pr-auto-dispatch-log.ts
@@ -1,0 +1,22 @@
+import type { PrAutoDispatchOutcome } from "./pr-auto-dispatch";
+
+type DispatchLogger = {
+  debug(message: string, details: Record<string, unknown>): void;
+  info(message: string, details: Record<string, unknown>): void;
+  warn(message: string, details: Record<string, unknown>): void;
+};
+
+export function logPrAutoDispatchOutcome(
+  logger: DispatchLogger,
+  prKey: string,
+  outcome: PrAutoDispatchOutcome,
+): void {
+  // Snapshots are observed on every poll, including unchanged PRs. Keep
+  // routine eligibility/dedupe decisions out of the operator's INFO log.
+  const level = outcome.status === "failed"
+    ? "warn"
+    : outcome.status === "scheduled" || outcome.status === "dispatched"
+      ? "info"
+      : "debug";
+  logger[level]("pr auto dispatch", { prKey, ...outcome });
+}

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -4677,7 +4677,9 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
               sameThread && duplicate.status === "pending"
                 ? "pending"
                 : "duplicate",
-            ...(sameThread && record ? { pending: record.pending } : {}),
+            ...(sameThread && duplicate.status === "pending" && record
+              ? { pending: record.pending }
+              : {}),
           };
         }
       }


### PR DESCRIPTION
Routine PR status polls logged every auto-dispatch decision at INFO, producing the same duplicate/not-actionable lines every 150 seconds even when nothing changed. Log routine decisions at DEBUG, keep scheduling and dispatch at INFO, and report failures at WARN.

Completed duplicate claims also returned their historical pending payload. The coordinator used it to arm an immediate timer on every unchanged snapshot; that timer then read the store and exited. Return pending payloads only for pending claims, preserving duplicate suppression and avoiding these unnecessary callbacks. No SQLite writes or schema changes are added.

Investigation of the reported profile state found seven passing, mergeable PRs and one already-dispatched merge-conflict fingerprint (#1877, attempt 1 of 2). That repair turn declined to change its stacked parent; the repeated duplicate was not an exhausted-attempt or failed-submission condition.

Validation:
- Added regressions and observed them fail before fixing: completed duplicates rearmed timers; routine decisions logged at INFO.
- 42 coordinator/logging tests pass.
- 134 app-server IPC tests pass.
- ESLint, typecheck, and dependency boundaries pass.
