### PR TITLE
fix(desktop): capture sustained main-process CPU usage

### DIFF
--- a/apps/desktop/src/main/__tests__/main-process-hot-cpu-target.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-hot-cpu-target.test.ts
@@ -1,0 +1,75 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ProcessMetric } from "electron";
+import { expect, it, vi } from "vitest";
+import { createTemporaryTestDirectory } from "../testing/test-harness";
+import { createMainProcessHotCpuTarget } from "../diagnostics/main-process-hot-cpu-target";
+import { HotCpuProfiler } from "../diagnostics/hot-cpu-profiler";
+import { createHotCpuProfileSession } from "../diagnostics/hot-cpu-profile-session";
+import { resolveHotCpuProfileConfig } from "../diagnostics/hot-cpu-profile-config";
+import type { HotCpuProfileCapturedEvent } from "../../shared/hot-cpu-profile";
+
+function metric(pid: number, cpuPercent: number, cumulativeCpu: number): ProcessMetric {
+  return {
+    pid,
+    type: pid === process.pid ? "Browser" : "Tab",
+    creationTime: 1,
+    cpu: {
+      percentCPUUsage: cpuPercent,
+      cumulativeCPUUsage: cumulativeCpu,
+      idleWakeupsPerSecond: 0,
+    },
+    memory: { workingSetSize: 2, peakWorkingSetSize: 2 },
+  };
+}
+
+it("captures main CPU and heap usage when only the main process is hot", async () => {
+  const workspace = await createTemporaryTestDirectory();
+  const target = createMainProcessHotCpuTarget();
+  let profiler: HotCpuProfiler | undefined;
+  try {
+    const resolved = resolveHotCpuProfileConfig({ enabled: true, repoRoot: workspace.path, env: {} });
+    if (!resolved.enabled) throw new Error("Expected enabled config");
+    const config = {
+      ...resolved, startDelayMs: 0, intervalMs: 1, profileDurationMs: 5,
+      thresholdPercent: 50, consecutiveSamples: 2, maxProfiles: 1,
+      captureHeapSnapshot: true,
+    };
+    const created = await createHotCpuProfileSession({
+      config, target: "main",
+      versions: { appVersion: "test", electronVersion: "test", chromeVersion: "test", nodeVersion: process.version },
+    });
+    if (!created.ok) throw new Error(created.message);
+    let resolveCapture!: (event: HotCpuProfileCapturedEvent) => void;
+    const capture = new Promise<HotCpuProfileCapturedEvent>((resolve) => { resolveCapture = resolve; });
+    let cpuSeconds = 0;
+    let nowMs = 0;
+    profiler = new HotCpuProfiler({
+      config, session: created.session, target,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      now: () => new Date(nowMs += 1000),
+      getAppMetrics: () => [
+        metric(1234, 0, 0),
+        metric(process.pid, 200, cpuSeconds += 4),
+      ],
+      onProfileWritten: resolveCapture,
+    });
+    await profiler.start();
+    const event = await capture;
+    await profiler.stop("test-complete");
+    expect(event).toMatchObject({ target: "main", profileFilename: "main-hot-0001.cpuprofile", heapSnapshotArtifacts: [] });
+    const profile = JSON.parse(await fs.readFile(event.profilePath, "utf8"));
+    expect(profile.nodes.length).toBeGreaterThan(0);
+    const samples = (await fs.readFile(created.session.samplesPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+    expect(samples.length).toBeGreaterThanOrEqual(2);
+    expect(samples[0]).toMatchObject({ pid: process.pid, heapUsed: expect.any(Number), heapTotal: expect.any(Number) });
+    expect(JSON.parse(await fs.readFile(path.join(created.session.directoryPath, "session.json"), "utf8"))).toMatchObject({ target: "main" });
+    expect(target.debugger.isAttached()).toBe(false);
+    expect(target.takeHeapSnapshot).toBeUndefined();
+    await expect(target.debugger.sendCommand("Profiler.stop")).rejects.toThrow("not attached");
+  } finally {
+    await profiler?.stop("test-cleanup");
+    target.debugger.detach();
+    await workspace.cleanup();
+  }
+});

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -4,7 +4,7 @@ import { createTemporaryTestDirectory } from "../testing/test-harness";
 import type { ProcessMetric } from "electron";
 import { resolveHotCpuProfileConfig } from "../diagnostics/hot-cpu-profile-config";
 import { createHotCpuProfileSession } from "../diagnostics/hot-cpu-profile-session";
-import { RendererHotCpuProfiler } from "../diagnostics/renderer-hot-cpu-profiler";
+import { HotCpuProfiler } from "../diagnostics/hot-cpu-profiler";
 
 function createEnabledConfig(
   repoRoot: string,
@@ -174,20 +174,20 @@ function createSampleTracker() {
   };
 }
 
-describe("RendererHotCpuProfiler", () => {
+describe("HotCpuProfiler", () => {
   const cleanups: Array<() => Promise<void>> = [];
-  const profilers: RendererHotCpuProfiler[] = [];
+  const profilers: HotCpuProfiler[] = [];
 
   const sampleTrackers = new WeakMap<
-    RendererHotCpuProfiler,
+    HotCpuProfiler,
     ReturnType<typeof createSampleTracker>
   >();
 
   function createProfiler(
-    options: ConstructorParameters<typeof RendererHotCpuProfiler>[0],
-  ): RendererHotCpuProfiler {
+    options: ConstructorParameters<typeof HotCpuProfiler>[0],
+  ): HotCpuProfiler {
     const tracker = createSampleTracker();
-    const profiler = new RendererHotCpuProfiler({
+    const profiler = new HotCpuProfiler({
       ...options,
       onSampleCaptured: () => {
         options.onSampleCaptured?.();
@@ -201,7 +201,7 @@ describe("RendererHotCpuProfiler", () => {
 
   /** Sampling-progress tracker for a profiler built by `createProfiler`. */
   function samplesOf(
-    profiler: RendererHotCpuProfiler,
+    profiler: HotCpuProfiler,
   ): ReturnType<typeof createSampleTracker> {
     const tracker = sampleTrackers.get(profiler);
     if (!tracker) {

--- a/apps/desktop/src/main/__tests__/shared-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/shared-hot-cpu-profiler.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { SharedHotCpuProfiler } from "../diagnostics/shared-hot-cpu-profiler";
+
+function monitor() {
+  return { start: vi.fn(async () => {}), stop: vi.fn(async (_reason: string) => {}) };
+}
+
+describe("SharedHotCpuProfiler", () => {
+  it("shares one main monitor and stops only when its last window closes", async () => {
+    const shared = new SharedHotCpuProfiler();
+    const profiler = monitor();
+    const create = vi.fn(async () => profiler);
+    const first = Symbol();
+    const second = Symbol();
+    await Promise.all([
+      shared.acquire(first, { key: "enabled", create }),
+      shared.acquire(second, { key: "enabled", create }),
+    ]);
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(profiler.start).toHaveBeenCalledTimes(1);
+    await shared.release(first, "window-closed");
+    expect(profiler.stop).not.toHaveBeenCalled();
+    await shared.release(second, "window-closed");
+    expect(profiler.stop).toHaveBeenCalledExactlyOnceWith("window-closed");
+  });
+
+  it("waits for an old capture to stop before starting changed settings", async () => {
+    const shared = new SharedHotCpuProfiler();
+    const old = monitor();
+    const next = monitor();
+    let finishStop!: () => void;
+    const stopping = new Promise<void>((resolve) => { finishStop = resolve; });
+    let signalStop!: () => void;
+    const stopEntered = new Promise<void>((resolve) => { signalStop = resolve; });
+    old.stop.mockImplementation(async () => { signalStop(); await stopping; });
+    const owner = Symbol();
+    await shared.acquire(owner, { key: "old", create: async () => old });
+    const changed = shared.acquire(owner, { key: "new", create: async () => next });
+    await stopEntered;
+    expect(next.start).not.toHaveBeenCalled();
+    const closing = shared.release(owner, "window-closed");
+    finishStop();
+    await Promise.all([changed, closing]);
+    expect(next.start).toHaveBeenCalledTimes(1);
+    expect(next.stop).toHaveBeenCalledExactlyOnceWith("window-closed");
+  });
+
+  it("cleans up a failed start and allows a subsequent capture", async () => {
+    const shared = new SharedHotCpuProfiler();
+    const failed = monitor();
+    failed.start.mockRejectedValueOnce(new Error("inspector unavailable"));
+    const owner = Symbol();
+    await expect(shared.acquire(owner, {
+      key: "enabled", create: async () => failed,
+    })).rejects.toThrow("inspector unavailable");
+    expect(failed.stop).toHaveBeenCalledExactlyOnceWith("start-failed");
+    const next = monitor();
+    await shared.acquire(owner, { key: "enabled", create: async () => next });
+    expect(next.start).toHaveBeenCalledTimes(1);
+    await shared.release(owner, "test-cleanup");
+  });
+});

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profile-session.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profile-session.ts
@@ -15,6 +15,10 @@ export type HotCpuProfileSample = {
   workingSetSize?: number;
   peakWorkingSetSize?: number;
   consecutiveHotSamples: number;
+  heapUsed?: number;
+  heapTotal?: number;
+  external?: number;
+  arrayBuffers?: number;
 };
 
 export type HotCpuProfileEvent = {
@@ -24,6 +28,7 @@ export type HotCpuProfileEvent = {
 };
 
 export type HotCpuProfileSession = {
+  target?: "main" | "renderer";
   id: string;
   directoryName: string;
   directoryPath: string;
@@ -41,6 +46,7 @@ export type HotCpuProfileSessionCreateResult =
   | { ok: false; code: "SESSION_CREATE_FAILED"; message: string; cause: unknown };
 
 type HotCpuProfileSessionManifest = {
+  target: "main" | "renderer";
   id: string;
   directoryName: string;
   createdAt: string;
@@ -89,10 +95,12 @@ async function writeManifest(
 
 export async function createHotCpuProfileSession(options: {
   config: Extract<HotCpuProfileConfig, { enabled: true }>;
+  target?: "main" | "renderer";
   createdAt?: Date;
   sessionId?: string;
   versions: HotCpuProfileSessionManifest["versions"];
 }): Promise<HotCpuProfileSessionCreateResult> {
+  const target = options.target ?? "renderer";
   const createdAt = options.createdAt ?? new Date();
   const sessionId = options.sessionId ?? randomBytes(3).toString("hex");
   const directoryName = `hot-cpu-${formatSessionPrefix(createdAt)}-${sessionId}`;
@@ -103,6 +111,7 @@ export async function createHotCpuProfileSession(options: {
   const artifacts: string[] = [];
 
   const manifest: HotCpuProfileSessionManifest = {
+    target,
     id: sessionId,
     directoryName,
     createdAt: createdAt.toISOString(),
@@ -153,6 +162,7 @@ export async function createHotCpuProfileSession(options: {
   return {
     ok: true,
     session: {
+      target,
       id: sessionId,
       directoryName,
       directoryPath,
@@ -161,11 +171,11 @@ export async function createHotCpuProfileSession(options: {
       appendSample: async (sample) => appendRecord(samplesPath, sample),
       appendEvent: async (event) => appendRecord(eventsPath, event),
       createProfilePath: (index) =>
-        path.join(directoryPath, `renderer-hot-${String(index).padStart(4, "0")}.cpuprofile`),
+        path.join(directoryPath, `${target}-hot-${String(index).padStart(4, "0")}.cpuprofile`),
       createHeapSnapshotPath: (index, phase) =>
         path.join(
           directoryPath,
-          `renderer-hot-${String(index).padStart(4, "0")}-${phase}.heapsnapshot`,
+          `${target}-hot-${String(index).padStart(4, "0")}-${phase}.heapsnapshot`,
         ),
       registerArtifact,
     },

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profiler.ts
@@ -13,7 +13,7 @@ const CHROME_DEBUGGER_PROTOCOL_VERSION = "1.3";
 
 type Logger = Pick<Console, "info" | "warn" | "error">;
 
-type RendererDebugger = {
+type HotCpuDebugger = {
   attach: (version: string) => void;
   detach: () => void;
   isAttached: () => boolean;
@@ -22,11 +22,17 @@ type RendererDebugger = {
   off?: (event: "detach", listener: (event: unknown, reason: string) => void) => void;
 };
 
-type RendererHotCpuTarget = {
-  debugger: RendererDebugger;
+export type HotCpuTarget = {
+  debugger: HotCpuDebugger;
   getOSProcessId: () => number;
   isDestroyed?: () => boolean;
   takeHeapSnapshot?: (filePath: string) => Promise<void>;
+  readHeapUsage?: () => {
+    heapUsed: number;
+    heapTotal: number;
+    external: number;
+    arrayBuffers: number;
+  };
 };
 
 type CpuUsageReading = {
@@ -52,7 +58,7 @@ function artifactFilename(filePath: string): string {
   return path.basename(filePath);
 }
 
-export class RendererHotCpuProfiler {
+export class HotCpuProfiler {
   private readonly detachListener = (_event: unknown, reason: string) => {
     this.debuggerAttached = false;
     void this.session.appendEvent({
@@ -60,8 +66,9 @@ export class RendererHotCpuProfiler {
       type: "debugger-detached",
       detail: { reason },
     });
-    this.logger.warn("[pwragent:hot-cpu] renderer debugger detached", {
+    this.logger.warn("[pwragent:hot-cpu] target debugger detached", {
       reason,
+      target: this.session.target ?? "renderer",
       sessionDirectory: this.session.directoryPath,
     });
   };
@@ -76,7 +83,7 @@ export class RendererHotCpuProfiler {
     event: HotCpuProfileCapturedEvent,
   ) => void | Promise<void>;
   private readonly session: HotCpuProfileSession;
-  private readonly target: RendererHotCpuTarget;
+  private readonly target: HotCpuTarget;
 
   private consecutiveHotSamples = 0;
   private debuggerAttached = false;
@@ -103,7 +110,7 @@ export class RendererHotCpuProfiler {
     config: Extract<HotCpuProfileConfig, { enabled: true }>;
     getAppMetrics: () => ProcessMetric[];
     session: HotCpuProfileSession;
-    target: RendererHotCpuTarget;
+    target: HotCpuTarget;
     logger?: Logger;
     now?: () => Date;
     onHeapSnapshotLimitReached?: () => void | Promise<void>;
@@ -152,6 +159,7 @@ export class RendererHotCpuProfiler {
       },
     });
     this.logger.info("[pwragent:hot-cpu] monitoring started", {
+      target: this.session.target ?? "renderer",
       sessionDirectory: this.session.directoryPath,
       startDelayMs: this.config.startDelayMs,
       triggerMode: this.config.triggerMode,
@@ -267,6 +275,7 @@ export class RendererHotCpuProfiler {
         capturedAt,
         pid,
         cpuPercent,
+        ...this.target.readHeapUsage?.(),
         electronCpuPercent: cpuUsage.electronCpuPercent,
         ...(cpuUsage.cumulativeCpuDeltaSeconds !== undefined
           ? { cumulativeCpuDeltaSeconds: cpuUsage.cumulativeCpuDeltaSeconds }
@@ -449,6 +458,7 @@ export class RendererHotCpuProfiler {
       this.logger.warn("[pwragent:hot-cpu] CPU profile started", {
         cpuPercent: options.cpuPercent,
         pid: options.pid,
+        target: this.session.target ?? "renderer",
         sessionDirectory: this.session.directoryPath,
       });
 
@@ -519,7 +529,7 @@ export class RendererHotCpuProfiler {
       };
       await fs.writeFile(
         profilePath,
-        `${JSON.stringify(result.profile ?? {}, null, 2)}\n`,
+        `${JSON.stringify(result.profile ?? {})}\n`,
         "utf8",
       );
       await this.session.registerArtifact(profileFilename);
@@ -546,6 +556,7 @@ export class RendererHotCpuProfiler {
         heapSnapshotArtifacts: [...this.activeProfileHeapSnapshots],
         profileFilename,
         profilePath,
+        target: this.session.target ?? "renderer",
         sessionDirectory: this.session.directoryPath,
         sessionDirectoryName: this.session.directoryName,
         ...activeProfileTrigger,
@@ -707,6 +718,7 @@ export class RendererHotCpuProfiler {
     } catch (error) {
       this.logger.warn("[pwragent:hot-cpu] heap snapshot auto-disable failed", {
         error: serializeError(error),
+        target: this.session.target ?? "renderer",
         sessionDirectory: this.session.directoryPath,
       });
     }
@@ -731,8 +743,9 @@ export class RendererHotCpuProfiler {
       this.debuggerAttached = false;
     } catch (error) {
       this.debuggerAttached = false;
-      this.logger.warn("[pwragent:hot-cpu] renderer debugger detach failed", {
+      this.logger.warn("[pwragent:hot-cpu] target debugger detach failed", {
         error: serializeError(error),
+        target: this.session.target ?? "renderer",
         sessionDirectory: this.session.directoryPath,
       });
     }

--- a/apps/desktop/src/main/diagnostics/main-process-hot-cpu-target.ts
+++ b/apps/desktop/src/main/diagnostics/main-process-hot-cpu-target.ts
@@ -1,0 +1,57 @@
+// HotCpuTarget adapter for the Electron main process itself.
+//
+// node:inspector speaks the same Chrome DevTools Protocol Profiler
+// domain the renderer path drives through webContents.debugger, so the
+// whole trigger/profile machinery in hot-cpu-profiler.ts works
+// unchanged: attach() connects an in-process inspector session,
+// sendCommand() posts CDP methods to it, and Profiler.stop returns a
+// .cpuprofile-shaped object for the main thread.
+
+import { Session } from "node:inspector";
+import type { HotCpuTarget } from "./hot-cpu-profiler";
+
+export function createMainProcessHotCpuTarget(): HotCpuTarget {
+  let session: Session | null = null;
+
+  return {
+    debugger: {
+      attach: () => {
+        if (session !== null) {
+          throw new Error("main-process inspector session already attached");
+        }
+        const next = new Session();
+        next.connect();
+        session = next;
+      },
+      detach: () => {
+        const current = session;
+        session = null;
+        current?.disconnect();
+      },
+      isAttached: () => session !== null,
+      sendCommand: (method, params) =>
+        new Promise((resolve, reject) => {
+          if (session === null) {
+            reject(new Error("main-process inspector session not attached"));
+            return;
+          }
+          session.post(method, params ?? {}, (error, result) => {
+            if (error) reject(error);
+            else resolve(result);
+          });
+        }),
+      // An in-process inspector session never detaches spontaneously
+      // (there is no remote peer to drop it), so the detach listener
+      // contract is a no-op here.
+      on: () => {},
+      off: () => {},
+    },
+    getOSProcessId: () => process.pid,
+    readHeapUsage: () => {
+      const { heapUsed, heapTotal, external, arrayBuffers } = process.memoryUsage();
+      return { heapUsed, heapTotal, external, arrayBuffers };
+    },
+    // Automatic main snapshots block all windows. Keep the hot-CPU path
+    // to cheap heap readings; explicit heap capture remains available.
+  };
+}

--- a/apps/desktop/src/main/diagnostics/shared-hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/shared-hot-cpu-profiler.ts
@@ -1,0 +1,57 @@
+type Profiler = {
+  start: () => Promise<void>;
+  stop: (reason: string) => Promise<void>;
+};
+
+type Owner = {
+  key: string;
+  create: () => Promise<Profiler | null>;
+};
+
+// Windows share the main V8 isolate. Serialize ownership changes, including
+// settings changes and window closure, before connecting another inspector.
+export class SharedHotCpuProfiler {
+  private readonly owners = new Map<symbol, Owner>();
+  private active: { key: string; profiler: Profiler } | null = null;
+  private queue: Promise<void> = Promise.resolve();
+
+  acquire(owner: symbol, request: Owner): Promise<void> {
+    return this.enqueue(async () => {
+      this.owners.set(owner, request);
+      await this.reconcile("settings-changed");
+    });
+  }
+
+  release(owner: symbol, reason: string): Promise<void> {
+    return this.enqueue(async () => {
+      this.owners.delete(owner);
+      await this.reconcile(reason);
+    });
+  }
+
+  private enqueue(action: () => Promise<void>): Promise<void> {
+    const result = this.queue.then(action, action);
+    this.queue = result.catch(() => {});
+    return result;
+  }
+
+  private async reconcile(reason: string): Promise<void> {
+    const desired = [...this.owners.values()].at(-1);
+    if (desired && desired.key === this.active?.key) return;
+    if (this.active) {
+      const previous = this.active;
+      this.active = null;
+      await previous.profiler.stop(reason);
+    }
+    if (!desired) return;
+    const profiler = await desired.create();
+    if (!profiler) return;
+    try {
+      await profiler.start();
+      this.active = { key: desired.key, profiler };
+    } catch (error) {
+      await profiler.stop("start-failed");
+      throw error;
+    }
+  }
+}

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -25,7 +25,9 @@ import { resolveHotCpuProfileConfig } from "./diagnostics/hot-cpu-profile-config
 import { createHotCpuProfileSession } from "./diagnostics/hot-cpu-profile-session";
 import { MainProcessHeapMonitor } from "./diagnostics/main-process-heap-monitor";
 import { RendererHeapMonitor } from "./diagnostics/renderer-heap-monitor";
-import { RendererHotCpuProfiler } from "./diagnostics/renderer-hot-cpu-profiler";
+import { createMainProcessHotCpuTarget } from "./diagnostics/main-process-hot-cpu-target";
+import { SharedHotCpuProfiler } from "./diagnostics/shared-hot-cpu-profiler";
+import { HotCpuProfiler } from "./diagnostics/hot-cpu-profiler";
 import { isSafeExternalOpenUrl } from "./external-url-policy";
 import { getMainLogger } from "./log";
 import { macosTitleBarChrome } from "./macos-window-chrome";
@@ -127,6 +129,9 @@ const MAIN_WINDOW_MIN_WIDTH = 960;
 const MAIN_WINDOW_MIN_HEIGHT = 640;
 const mainLog = getMainLogger("pwragent:main");
 const heapLog = getMainLogger("pwragent:heap");
+const sharedMainHotCpuProfiler = new SharedHotCpuProfiler();
+type HotCpuProfilerLifecycle = Pick<HotCpuProfiler, "start" | "stop">;
+
 const hotCpuLog = getMainLogger("pwragent:hot-cpu");
 const rendererConsoleLog = getMainLogger("pwragent:renderer:console");
 const hotCpuProfilerSyncHandlers = new Map<number, (reason: string) => void>();
@@ -505,15 +510,17 @@ export function createMainWindow(options?: {
   attachWindowFullscreenSync(window);
   let rendererLoaded = false;
   let hotCpuProfilerConfigKey: string | null = null;
-  let hotCpuProfilerPromise: Promise<RendererHotCpuProfiler | null> | null = null;
+  let hotCpuProfilerPromise: Promise<HotCpuProfilerLifecycle | null> | null = null;
   let hotCpuProfilerGeneration = 0;
   let hotCpuProfilerSyncQueue: Promise<void> = Promise.resolve();
 
-  const createHotCpuProfiler = async (
+  const createTargetHotCpuProfiler = async (
     hotCpuConfig: Extract<ReturnType<typeof resolveHotCpuProfileConfig>, { enabled: true }>,
-  ): Promise<RendererHotCpuProfiler | null> => {
+    target: "main" | "renderer",
+  ): Promise<HotCpuProfilerLifecycle | null> => {
     const created = await createHotCpuProfileSession({
       config: hotCpuConfig,
+      target,
       versions: {
         appVersion: app.getVersion(),
         electronVersion: process.versions.electron ?? "unknown",
@@ -530,10 +537,11 @@ export function createMainWindow(options?: {
     }
 
     hotCpuLog.info("session directory", {
+      target,
       sessionDirectory: created.session.directoryPath,
     });
 
-    return new RendererHotCpuProfiler({
+    return new HotCpuProfiler({
       config: hotCpuConfig,
       getAppMetrics: () => app.getAppMetrics(),
       onHeapSnapshotLimitReached: async () => {
@@ -549,8 +557,36 @@ export function createMainWindow(options?: {
         }
       },
       session: created.session,
-      target: webContents,
+      target: target === "main" ? createMainProcessHotCpuTarget() : webContents,
     });
+  };
+
+  const createHotCpuProfiler = async (
+    config: Extract<ReturnType<typeof resolveHotCpuProfileConfig>, { enabled: true }>,
+  ): Promise<HotCpuProfilerLifecycle | null> => {
+    const renderer = await createTargetHotCpuProfiler(config, "renderer");
+    const owner = Symbol("main-hot-cpu-window");
+    let stopped = false;
+    return {
+      start: async () => {
+        if (stopped) return;
+        await renderer?.start();
+        if (stopped) return;
+        await sharedMainHotCpuProfiler.acquire(owner, {
+          key: hotCpuConfigKey(config),
+          create: () => createTargetHotCpuProfiler(
+            { ...config, captureHeapSnapshot: false }, "main",
+          ),
+        });
+      },
+      stop: async (reason = "stopped") => {
+        stopped = true;
+        await Promise.all([
+          renderer?.stop(reason),
+          sharedMainHotCpuProfiler.release(owner, reason),
+        ]);
+      },
+    };
   };
 
   const stopHotCpuProfiler = async (reason: string): Promise<void> => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -740,7 +740,7 @@ function DesktopAppShell(props: {
         copyText: buildHotCpuProfileHandoffMessage(event),
         detail: `Session: ${event.sessionDirectoryName}`,
         id: `hot-cpu-profile:${event.capturedAt}:${event.profileFilename}`,
-        title: "CPU profile captured",
+        title: `${event.target === "main" ? "Main" : "Renderer"} CPU profile captured`,
         message: [
           `${formatHotCpuProfileTriggerSummary(event)} saved ${event.profileFilename}.`,
           heapSnapshotSummary,

--- a/apps/desktop/src/renderer/src/features/settings/TroubleshootingSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/TroubleshootingSettings.tsx
@@ -464,8 +464,8 @@ export function TroubleshootingSettings(props: {
       >
         <div className="settings-fields">
           <SettingsField
-            label="Hot renderer CPU profiling"
-            sub="Start an armed capture only after the presets below are ready."
+            label="Hot CPU profiling"
+            sub="Monitor main and renderer CPU independently using the presets below. Main-process samples also record heap usage."
             source={sourceBadge(hotCpuProfilingEnabled)}
             control={
               <div className="settings-hot-cpu-capture">
@@ -532,7 +532,7 @@ export function TroubleshootingSettings(props: {
             checked={hotCpuProfilingCaptureHeapSnapshot.value}
             disabled={props.saving}
             label="Smart heap snapshots"
-            sub="Capture bounded heap snapshots around the next hot CPU trigger, then turn this option back off."
+            sub="Capture bounded renderer heap snapshots around the next hot renderer CPU trigger, then turn this option back off."
             help="Arms heap snapshots for the next explicit CPU capture start."
             source={sourceBadge(hotCpuProfilingCaptureHeapSnapshot)}
             onChange={(next) => {

--- a/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
+++ b/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
@@ -2,6 +2,21 @@ import { describe, expect, it } from "vitest";
 import { buildHotCpuProfileHandoffMessage } from "../hot-cpu-profile";
 
 describe("hot CPU profile handoff message", () => {
+  it("identifies main-process captures", () => {
+    expect(buildHotCpuProfileHandoffMessage({
+      target: "main",
+      capturedAt: "2026-09-05T23:00:00.000Z",
+      profileFilename: "main-hot-0001.cpuprofile",
+      profilePath: "/tmp/hot-cpu/main-hot-0001.cpuprofile",
+      sessionDirectory: "/tmp/hot-cpu",
+      sessionDirectoryName: "hot-cpu",
+      triggerConsecutiveSamples: 2,
+      triggerCpuPercent: 206,
+      triggerMode: "sustained",
+      triggerThresholdPercent: 50,
+    })).toContain("PwrAgent captured a main CPU profile.");
+  });
+
   it("includes copyable basenames and absolute paths", () => {
     expect(
       buildHotCpuProfileHandoffMessage({

--- a/apps/desktop/src/shared/hot-cpu-profile.ts
+++ b/apps/desktop/src/shared/hot-cpu-profile.ts
@@ -7,6 +7,7 @@ export type HotCpuProfileHeapSnapshotArtifact = {
 };
 
 export type HotCpuProfileCapturedEvent = {
+  target?: "main" | "renderer";
   capturedAt: string;
   heapSnapshotArtifacts?: HotCpuProfileHeapSnapshotArtifact[];
   profileFilename: string;
@@ -72,7 +73,7 @@ export function buildHotCpuProfileHandoffMessage(
       : [];
 
   return [
-    "PwrAgent captured a renderer CPU profile.",
+    `PwrAgent captured a ${event.target ?? "renderer"} CPU profile.`,
     `Trigger: ${formatHotCpuProfileTriggerSummary(event)}`,
     `Session basename: ${event.sessionDirectoryName}`,
     `Session directory path: ${event.sessionDirectory}`,


### PR DESCRIPTION
The hot-CPU controls only watched the renderer, so sustained main-process CPU could exceed 200% while a renderer below 50% never triggered a capture. Monitor both processes independently using the existing presets, and record main heap usage alongside CPU samples.

Reuse the profiler with a Node inspector target for the main process. Share one main monitor across windows and serialize shutdown/settings changes before replacing it. Label session manifests, profile filenames, notifications, and copied diagnostics by process. Automatic hot-CPU heap snapshots remain renderer-only to avoid blocking every window; explicit heap capture already supports both processes.

Validation:
- Focused profiler, inspector, ownership, and handoff tests passed (21 tests across the focused runs).
- Desktop TypeScript check passed.
- `pnpm lint:eslint` passed with no errors.
- `pnpm lint:boundaries` passed.
- `git diff --check` passed.

This closes the monitoring gap; it does not establish or fix the underlying cause of the reported freezes.
