### PR TITLE
fix(desktop): defer PDF runtime loading until requested

### DIFF
--- a/apps/desktop/src/main/__tests__/pdf-canvas-lazy-loading.test.ts
+++ b/apps/desktop/src/main/__tests__/pdf-canvas-lazy-loading.test.ts
@@ -3,6 +3,16 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 
 const canvasModuleLoaded = vi.hoisted(() => vi.fn());
+const pdfModuleLoaded = vi.hoisted(() => vi.fn());
+
+// PDF.js requires native canvas internally during module initialization. A
+// canvas import mock alone cannot observe that dependency's CommonJS require.
+vi.mock("pdfjs-dist/legacy/build/pdf.mjs", async () => {
+  pdfModuleLoaded();
+  return vi.importActual<typeof import("pdfjs-dist/legacy/build/pdf.mjs")>(
+    "pdfjs-dist/legacy/build/pdf.mjs",
+  );
+});
 
 vi.mock("@napi-rs/canvas", async () => {
   canvasModuleLoaded();
@@ -22,8 +32,9 @@ const jeepStickerPageFixture = fileURLToPath(
   new URL("./fixtures/pdf/jeep-sticker-page-size.pdf", import.meta.url),
 );
 
-describe("PDF canvas lazy loading", () => {
-  it("loads the native canvas module only when PDF pixels are requested", async () => {
+describe("PDF runtime lazy loading", () => {
+  it("loads PDF.js and native canvas only when PDF work is requested", async () => {
+    expect(pdfModuleLoaded).not.toHaveBeenCalled();
     expect(canvasModuleLoaded).not.toHaveBeenCalled();
 
     calculateComposerPdfPreviewDimensions({ height: 792, width: 1224 });
@@ -32,12 +43,15 @@ describe("PDF canvas lazy loading", () => {
     expect(canvasModuleLoaded).not.toHaveBeenCalled();
 
     const data = await readFile(jeepStickerPageFixture);
+    expect(pdfModuleLoaded).not.toHaveBeenCalled();
     await renderComposerPdfPreview({ data });
 
+    expect(pdfModuleLoaded).toHaveBeenCalledTimes(1);
     expect(canvasModuleLoaded).toHaveBeenCalledTimes(1);
 
     await renderPdfPages({ data, profile: "low" });
 
+    expect(pdfModuleLoaded).toHaveBeenCalledTimes(1);
     expect(canvasModuleLoaded).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/pdf/composer-pdf-preview.ts
+++ b/apps/desktop/src/main/pdf/composer-pdf-preview.ts
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
 
 /**
  * The Composer preview is deliberately much smaller than any image sent to a
@@ -19,9 +18,6 @@ export type ComposerPdfPreview = {
 };
 
 const require = createRequire(import.meta.url);
-const wasmUrl = pathToFileURL(
-  `${path.dirname(require.resolve("pdfjs-dist/wasm/openjpeg.wasm"))}${path.sep}`,
-).href;
 
 /**
  * Render page one for the Composer only. This module intentionally does not
@@ -31,6 +27,12 @@ const wasmUrl = pathToFileURL(
 export async function renderComposerPdfPreview(params: {
   data: Uint8Array;
 }): Promise<ComposerPdfPreview> {
+  // PDF.js loads native canvas and scans installed fonts during import.
+  // Keep that work deferred until a PDF operation actually needs the runtime.
+  const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+  const wasmUrl = pathToFileURL(
+    `${path.dirname(require.resolve("pdfjs-dist/wasm/openjpeg.wasm"))}${path.sep}`,
+  ).href;
   const loadingTask = pdfjs.getDocument({
     data: new Uint8Array(params.data),
     verbosity: pdfjs.VerbosityLevel.ERRORS,

--- a/apps/desktop/src/main/pdf/pdf-page-renderer.ts
+++ b/apps/desktop/src/main/pdf/pdf-page-renderer.ts
@@ -1,7 +1,6 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import * as pdfjs from "pdfjs-dist/legacy/build/pdf.mjs";
 import {
   IMAGE_UPLOAD_QUALITY_PROFILES,
   type ImageUploadQualityProfile,
@@ -58,9 +57,6 @@ export const MAX_PDF_TEXT_SEARCH_QUERY_CHARACTERS = 200;
 const PDF_PAGE_DATA_URL_PREFIX = "data:image/png;base64,";
 
 const require = createRequire(import.meta.url);
-const wasmUrl = pathToFileURL(
-  `${path.dirname(require.resolve("pdfjs-dist/wasm/openjpeg.wasm"))}${path.sep}`,
-).href;
 
 /**
  * PDFs describe a page in points, not pixels. Render into the selected
@@ -111,7 +107,7 @@ export async function inspectPdfDocument(params: {
   data: Uint8Array;
   profile: ImageUploadQualityProfile;
 }): Promise<PdfDocumentInspection> {
-  const loadingTask = loadPdfDocument(params.data);
+  const loadingTask = await loadPdfDocument(params.data);
   try {
     const document = await loadingTask.promise;
     if (document.numPages < 1) {
@@ -163,7 +159,7 @@ export async function searchPdfText(params: {
     );
   }
 
-  const loadingTask = loadPdfDocument(params.data);
+  const loadingTask = await loadPdfDocument(params.data);
   try {
     const document = await loadingTask.promise;
     const pageStart = normalizePageNumber(params.pageStart, 1);
@@ -224,7 +220,7 @@ export async function renderPdfPages(params: {
   profile: ImageUploadQualityProfile;
 }): Promise<RenderedPdfPage[]> {
   const limits = normalizePdfRenderLimits(params.limits);
-  const loadingTask = loadPdfDocument(params.data);
+  const loadingTask = await loadPdfDocument(params.data);
 
   try {
     const document = await loadingTask.promise;
@@ -327,7 +323,13 @@ export async function renderPdfPages(params: {
   }
 }
 
-function loadPdfDocument(data: Uint8Array) {
+async function loadPdfDocument(data: Uint8Array) {
+  // PDF.js loads native canvas and scans installed fonts during import.
+  // Keep that work deferred until a PDF operation actually needs the runtime.
+  const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+  const wasmUrl = pathToFileURL(
+    `${path.dirname(require.resolve("pdfjs-dist/wasm/openjpeg.wasm"))}${path.sep}`,
+  ).href;
   return pdfjs.getDocument({
     data: new Uint8Array(data),
     verbosity: pdfjs.VerbosityLevel.ERRORS,


### PR DESCRIPTION
## Summary

Starting PwrAgent eagerly imported PDF.js through the PDF preview and turn-rendering modules. PDF.js then loaded native canvas, which scanned installed system and user fonts even when no PDF was used. A standalone PDF.js import reproduced 442 mapped font files on macOS.

Dynamically import PDF.js and resolve its WASM assets only when a PDF operation runs. The runtime remains cached after first use, and PDF rendering retains its existing font support.

Extend the lazy-loading regression test to observe PDF.js itself: the previous canvas mock missed PDF.js's internal CommonJS require. The updated test failed before the fix and passes with it, including real preview and page rendering.

## Verification

- Five targeted PDF test files: 20 tests passed.
- `pnpm lint:eslint`: passed (47 existing warnings, no errors).
- `pnpm typecheck`: passed.
- `pnpm lint:boundaries`: passed.
- `pnpm --filter @pwragent/desktop build`: passed, including main bundle boundary check.
- Inspected the production main bundle: both PDF.js imports remain dynamic inside async PDF operations.
- `git diff --check`: passed.

## Notes

The first PDF operation now pays runtime initialization cost. Subsequent operations reuse the loaded module. System font discovery is preserved for PDF rendering.
