### PR TITLE
fix(desktop): bound Token Miser storage and scope accounting reads

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -5,6 +6,7 @@ import type {
   AgentEvent,
   NavigationSnapshot,
   ThreadSubAgentSummary,
+  ThreadToolAccounting,
   ThreadToolInvocationRecord,
   ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -41,6 +43,36 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     await registry.close();
     stateDb.close();
     rmSync(directory, { force: true, recursive: true });
+  });
+
+  it("reads thread metadata once for both accounting and savings", async () => {
+    const tokenMiserStore = new TokenMiserStore(path.join(directory, "token-miser-objects"));
+    for (const threadId of ["thread-parent", "thread-unrelated"]) {
+      await tokenMiserStore.store({
+        ...metadata(randomUUID(), `helper-${threadId}`),
+        threadId,
+        output: "fixture output",
+        parentModel: "gpt-5.6-terra",
+      });
+    }
+    const internals = registry as unknown as {
+      tokenMiserStore?: TokenMiserStore;
+      withTokenMiserAccounting(params: {
+        backend: "codex";
+        threadId: string;
+        accounting: ThreadToolAccounting;
+      }): Promise<ThreadToolAccounting>;
+    };
+    internals.tokenMiserStore = tokenMiserStore;
+    const listMetadata = vi.spyOn(tokenMiserStore, "listMetadata");
+    const accounting = await internals.withTokenMiserAccounting({
+      backend: "codex",
+      threadId: "thread-parent",
+      accounting: await store.readThreadToolAccounting({ backend: "codex", threadId: "thread-parent" }),
+    });
+    expect(accounting.tokenMiser?.interceptionCount).toBe(1);
+    expect(accounting.tokenMiser?.savings?.gateCount).toBe(1);
+    expect(listMetadata).toHaveBeenCalledExactlyOnceWith("thread-parent");
   });
 
   it("batches gate cards and Luna usage into the parent ledgers", async () => {

--- a/apps/desktop/src/main/__tests__/token-miser-storage-pressure.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-storage-pressure.test.ts
@@ -1,0 +1,205 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TokenMiserStore } from "../token-miser/token-miser-store";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-miser-pressure-"));
+  roots.push(root);
+  const writer = new TokenMiserStore(root);
+  const records = [];
+  for (const threadId of ["thread-a", "thread-b"]) {
+    const metadata = await addObject(writer, threadId);
+    const observation = await addObservation(writer, threadId);
+    records.push({ threadId, metadata, observation });
+  }
+  return { root, writer, records, reader: new TokenMiserStore(root) };
+}
+
+async function addObject(store: TokenMiserStore, threadId: string) {
+  return await store.store({
+    threadId,
+    turnId: "turn-1",
+    toolUseId: "tool-1",
+    toolName: "Bash",
+    output: "fixture output",
+    replacementCharacters: 10,
+    summary: { summary: "fixture summary", usefulDetails: [] },
+  });
+}
+
+async function addObservation(store: TokenMiserStore, threadId: string, callId = "call-1") {
+  return await store.recordCodeModeObservation({
+    threadId,
+    turnId: "turn-1",
+    callId,
+    cellId: callId,
+    outputCharacters: 100,
+    maxOutputTokens: 1_000,
+    scriptStatus: "completed",
+    retrieval: false,
+    capturedNestedInvocationCount: 1,
+  });
+}
+
+describe("Token Miser storage I/O budgets", () => {
+  it("reads only the requested thread's JSON after discovery", async () => {
+    const { reader, records } = await fixture();
+    await reader.summarizeThreadUsage("thread-a");
+    const other = records[1]!;
+    const readFile = fs.readFile.bind(fs);
+    const reads = vi.spyOn(fs, "readFile").mockImplementation(async (file, options) => {
+      const name = path.basename(String(file));
+      if ([`${other.metadata.objectId}.json`, `${other.observation.observationId}.json`].includes(name)) {
+        throw new Error("unrelated thread record must not be opened");
+      }
+      return await readFile(file, options);
+    });
+
+    const usage = await reader.summarizeThreadUsage("thread-a");
+    expect(usage.interceptionCount).toBe(1);
+    expect(usage.codeMode.callCount).toBe(1);
+    expect(reads).toHaveBeenCalledTimes(2);
+    reads.mockClear();
+    expect(await reader.readGroupBatch({
+      groupId: "missing-group",
+      threadId: "thread-a",
+      operations: [],
+    })).toBeUndefined();
+    expect(reads).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares cold discovery across overlapping thread queries", async () => {
+    const { reader, records } = await fixture();
+    const reads = vi.spyOn(fs, "readFile");
+    const summaries = await Promise.all([
+      reader.summarizeThreadUsage("thread-a"),
+      reader.summarizeThreadUsage("thread-b"),
+    ]);
+    expect(summaries.map((summary) => summary.interceptionCount)).toEqual([1, 1]);
+    const counts = new Map<string, number>();
+    for (const [file] of reads.mock.calls) {
+      const name = path.basename(String(file));
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+    for (const { metadata, observation } of records) {
+      expect(counts.get(`${metadata.objectId}.json`)).toBe(1);
+      expect(counts.get(`${observation.observationId}.json`)).toBe(1);
+    }
+  });
+
+  it("discovers external additions and removals and reads changed counters fresh", async () => {
+    const { root, writer, reader, records } = await fixture();
+    await reader.summarizeThreadUsage("thread-a");
+    const original = records[0]!.metadata;
+    await writer.recordParentModelRequest({ objectId: original.objectId, cumulativeInputTokens: 100 });
+    await writer.recordParentModelRequest({ objectId: original.objectId, cumulativeInputTokens: 200 });
+    await writer.recordParentModelRequest({ objectId: original.objectId, cumulativeInputTokens: 300 });
+    const added = await addObject(writer, "thread-a");
+    await addObservation(writer, "thread-a", "call-2");
+    expect(await reader.summarizeThreadUsage("thread-a")).toMatchObject({
+      interceptionCount: 2,
+      cachedReplayCount: 1,
+      codeMode: { callCount: 2 },
+    });
+    await fs.rm(path.join(root, `${added.objectId}.json`));
+    await fs.rm(path.join(root, "code-mode-observations", `${records[0]!.observation.observationId}.json`));
+    expect(await reader.summarizeThreadUsage("thread-a")).toMatchObject({
+      interceptionCount: 1,
+      cachedReplayCount: 1,
+      codeMode: { callCount: 1 },
+    });
+  });
+
+  it("bounds writes and reads together across stores", async () => {
+    const { reader, writer } = await fixture();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let active = 0;
+    let peak = 0;
+    const track = async <T>(run: () => Promise<T>): Promise<T> => {
+      active += 1;
+      peak = Math.max(peak, active);
+      try {
+        await gate;
+        return await run();
+      } finally {
+        active -= 1;
+      }
+    };
+    const readFile = fs.readFile.bind(fs);
+    const writeFile = fs.writeFile.bind(fs);
+    vi.spyOn(fs, "readFile").mockImplementation((file, options) => track(() => readFile(file, options)));
+    vi.spyOn(fs, "writeFile").mockImplementation((file, data, options) => track(() => writeFile(file, data, options)));
+    const work = Promise.all([
+      reader.summarizeThreadUsage("thread-a"),
+      ...Array.from({ length: 40 }, (_, index) => addObservation(writer, "thread-b", `burst-${index}`)),
+    ]);
+    try {
+      await vi.waitFor(() => expect(active).toBeGreaterThan(0));
+      release();
+      await work;
+      expect(peak).toBeLessThanOrEqual(16);
+      expect(active).toBe(0);
+    } finally {
+      release();
+      await work;
+    }
+  });
+
+  it.each(["local", "external"])("includes %s commits in a query started during an older discovery", async (owner) => {
+    const { root, reader, writer, records } = await fixture();
+    let release!: () => void;
+    let entered!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const started = new Promise<void>((resolve) => { entered = resolve; });
+    const readFile = fs.readFile.bind(fs);
+    let blocked = false;
+    vi.spyOn(fs, "readFile").mockImplementation(async (file, options) => {
+      if (!blocked && String(file) === path.join(root, `${records[0]!.metadata.objectId}.json`)) {
+        blocked = true;
+        entered();
+        await gate;
+      }
+      return await readFile(file, options);
+    });
+    const older = reader.listMetadata("thread-a");
+    try {
+      await started;
+      const added = await addObject(owner === "local" ? reader : writer, "thread-a");
+      const pending = reader.listMetadata("thread-a");
+      release();
+      const current = await pending;
+      expect(current.map((record) => record.objectId)).toContain(added.objectId);
+      expect(current).toHaveLength(2);
+    } finally {
+      release();
+      await older;
+    }
+  });
+
+  it("releases write slots and removes temporary files after failed renames", async () => {
+    const { root, writer } = await fixture();
+    const rename = vi.spyOn(fs, "rename").mockRejectedValue(
+      Object.assign(new Error("rename failed"), { code: "EIO" }),
+    );
+    const results = await Promise.allSettled(Array.from(
+      { length: 40 },
+      (_, index) => addObservation(writer, "thread-a", `failed-${index}`),
+    ));
+    expect(results.every((result) => result.status === "rejected")).toBe(true);
+    expect((await fs.readdir(path.join(root, "code-mode-observations")))
+      .some((name) => name.endsWith(".tmp"))).toBe(false);
+    rename.mockRestore();
+    await addObservation(writer, "thread-a", "successful");
+    expect(await writer.listCodeModeObservations("thread-a")).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/main/__tests__/token-miser-store.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-store.test.ts
@@ -15,6 +15,81 @@ afterEach(async () => {
 });
 
 describe("TokenMiserStore", () => {
+  it("bounds metadata reads across overlapping scans and store instances", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-token-miser-"));
+    temporaryDirectories.push(root);
+    const first = new TokenMiserStore(root);
+    const second = new TokenMiserStore(root);
+    for (let index = 0; index < 40; index += 1) {
+      await createObject(first, `output-${index}`, index);
+      await first.recordCodeModeObservation({
+        threadId: "thread-owner",
+        turnId: "turn-1",
+        callId: `call-${index}`,
+        cellId: `cell-${index}`,
+        outputCharacters: 100,
+        maxOutputTokens: 1_000,
+        scriptStatus: "completed",
+        retrieval: false,
+        capturedNestedInvocationCount: 1,
+      });
+    }
+
+    let releaseReads!: () => void;
+    const gate = new Promise<void>((resolve) => { releaseReads = resolve; });
+    let active = 0;
+    let peak = 0;
+    const readFile = fs.readFile.bind(fs);
+    const readSpy = vi.spyOn(fs, "readFile").mockImplementation(async (file, options) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      try {
+        await gate;
+        return await readFile(file, options);
+      } finally {
+        active -= 1;
+      }
+    });
+    const scans = Promise.all([
+      first.listMetadata(),
+      second.listMetadata(),
+      first.listCodeModeObservations("thread-owner"),
+      second.listCodeModeObservations("thread-owner"),
+    ]);
+    try {
+      await vi.waitFor(() => expect(active).toBe(16));
+      releaseReads();
+      const results = await scans;
+      expect(results.map((entries) => entries.length)).toEqual([40, 40, 40, 40]);
+      expect(readSpy).toHaveBeenCalledTimes(160);
+      expect(peak).toBeLessThanOrEqual(16);
+      expect(active).toBe(0);
+    } finally {
+      releaseReads();
+      await scans;
+      readSpy.mockRestore();
+    }
+  });
+
+  it("releases metadata read slots after filesystem failures", async () => {
+    const store = await createStore();
+    const entry = await createObject(store, "retained output", 1);
+    const readFile = fs.readFile.bind(fs);
+    const readSpy = vi.spyOn(fs, "readFile").mockRejectedValue(
+      Object.assign(new Error("read failed"), { code: "EIO" }),
+    );
+    try {
+      const results = await Promise.allSettled(
+        Array.from({ length: 40 }, () => store.readMetadata(entry.objectId)),
+      );
+      expect(results.every((result) => result.status === "rejected")).toBe(true);
+      readSpy.mockImplementation(readFile);
+      expect(await store.readMetadata(entry.objectId)).toEqual(entry);
+    } finally {
+      readSpy.mockRestore();
+    }
+  });
+
   it("counts all decisions separately from helper evaluations", async () => {
     const store = await createStore();
     const helperUsage = (ordinal: number) => ({

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14226,8 +14226,10 @@ export class DesktopBackendRegistry {
       return params.accounting;
     }
     try {
+      const metadata = await this.tokenMiserStore.listMetadata(params.threadId);
       const tokenMiser = await this.tokenMiserStore.summarizeThreadUsage(
         params.threadId,
+        metadata,
       );
       const withReplays = withLegacyTokenMiserReplayAccounting(
         tokenMiser,
@@ -14235,6 +14237,7 @@ export class DesktopBackendRegistry {
       );
       const savings = await this.buildTokenMiserThreadSavings({
         backend: params.backend,
+        entries: metadata,
         invocations: params.accounting.invocations,
         threadId: params.threadId,
       });
@@ -30043,14 +30046,14 @@ export class DesktopBackendRegistry {
    */
   private async buildTokenMiserThreadSavings(params: {
     backend: AppServerBackendKind;
+    entries: readonly TokenMiserObjectMetadata[];
     invocations: readonly ThreadToolInvocationRecord[];
     threadId: string;
   }): Promise<ThreadTokenMiserSavings | undefined> {
     if (!this.tokenMiserStore) {
       return undefined;
     }
-    const entries = (await this.tokenMiserStore.listMetadata())
-      .filter((entry) => entry.threadId === params.threadId);
+    const entries = params.entries;
     if (entries.length === 0) {
       return undefined;
     }

--- a/apps/desktop/src/main/token-miser/token-miser-file-io.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-file-io.ts
@@ -1,0 +1,50 @@
+// This budget belongs to the process, not a scan or store instance. On macOS,
+// child-process stdio descriptors above 10239 can make spawn fail with EBADF
+// even before the process reaches its open-file limit.
+const MAX_CONCURRENT_FILE_OPERATIONS = 16;
+const SCAN_WORKERS = 8;
+let activeOperations = 0;
+const waiters = new Set<() => void>();
+
+export async function withTokenMiserFileOperation<T>(run: () => Promise<T>): Promise<T> {
+  if (activeOperations >= MAX_CONCURRENT_FILE_OPERATIONS) {
+    await new Promise<void>((resolve) => { waiters.add(resolve); });
+  } else {
+    activeOperations += 1;
+  }
+  try {
+    return await run();
+  } finally {
+    const next = waiters.values().next().value;
+    if (next) {
+      // Transfer the slot; a new caller must not take it before next resumes.
+      waiters.delete(next);
+      next();
+    } else {
+      activeOperations -= 1;
+    }
+  }
+}
+
+export async function mapTokenMiserFiles<T>(
+  files: readonly string[],
+  read: (file: string) => Promise<T>,
+): Promise<T[]> {
+  const results = new Array<T>(files.length);
+  let nextIndex = 0;
+  // A worker owns one operation until it settles. Do not enqueue a promise
+  // for every retained file into the process-wide budget.
+  const workers = await Promise.allSettled(Array.from(
+    { length: Math.min(SCAN_WORKERS, files.length) },
+    async () => {
+      while (nextIndex < files.length) {
+        const index = nextIndex++;
+        results[index] = await read(files[index]!);
+      }
+    },
+  ));
+  for (const worker of workers) {
+    if (worker.status === "rejected") throw worker.reason;
+  }
+  return results;
+}

--- a/apps/desktop/src/main/token-miser/token-miser-record-index.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-record-index.ts
@@ -1,0 +1,98 @@
+import { promises as fs } from "node:fs";
+import { mapTokenMiserFiles, withTokenMiserFileOperation } from "./token-miser-file-io";
+
+type Discovery<T> = {
+  names: string[];
+  records: Map<string, T | undefined>;
+};
+
+/**
+ * The flat legacy store has no on-disk thread index. Retain only immutable
+ * filename ownership, never mutable counters or observation payloads. Listing
+ * names discovers other processes' additions/removals; known unrelated records
+ * need no content read. Each cold discovery is shared by overlapping queries.
+ */
+export class TokenMiserRecordIndex<T extends { threadId: string }> {
+  private readonly owners = new Map<string, string>();
+  private discovery?: { version: string; result: Promise<Discovery<T>> };
+
+  constructor(
+    private readonly directory: string,
+    private readonly read: (name: string) => Promise<T | undefined>,
+  ) {}
+
+  remember(name: string, threadId: string): void {
+    this.owners.set(name, threadId);
+    // A query started after this commit needs a new directory snapshot, even
+    // if an older discovery is still reading records.
+    this.discovery = undefined;
+  }
+
+  forget(name: string): void {
+    this.owners.delete(name);
+    this.discovery = undefined;
+  }
+
+  async list(threadId?: string): Promise<T[]> {
+    // Atomic record replacements change the parent directory's timestamps.
+    // A caller after another process's commit must not join an older discovery.
+    const version = await this.directoryVersion();
+    const discovery = this.discovery?.version === version
+      ? this.discovery
+      : { version, result: this.discover() };
+    this.discovery = discovery;
+    let snapshot: Discovery<T>;
+    try {
+      snapshot = await discovery.result;
+    } finally {
+      if (this.discovery === discovery) this.discovery = undefined;
+    }
+    const names = snapshot.names.filter((name) =>
+      !threadId || this.owners.get(name) === threadId
+    );
+    const values = await mapTokenMiserFiles(names, async (name) => {
+      const value = snapshot.records.has(name)
+        ? snapshot.records.get(name)
+        : await this.read(name);
+      if (value) this.owners.set(name, value.threadId);
+      return value;
+    });
+    return values
+      .filter((value): value is T => value !== undefined)
+      .filter((value) => !threadId || value.threadId === threadId);
+  }
+
+  private async directoryVersion(): Promise<string> {
+    try {
+      const stats = await withTokenMiserFileOperation(() =>
+        fs.stat(this.directory, { bigint: true })
+      );
+      return `${stats.dev}:${stats.ino}:${stats.mtimeNs}:${stats.ctimeNs}`;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return "missing";
+      throw error;
+    }
+  }
+
+  private async discover(): Promise<Discovery<T>> {
+    const entries = await withTokenMiserFileOperation(() => fs.readdir(this.directory))
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return [];
+        throw error;
+      });
+    const names = entries.filter((name) => name.endsWith(".json"));
+    const present = new Set(names);
+    for (const name of this.owners.keys()) {
+      if (!present.has(name)) this.owners.delete(name);
+    }
+    const unknown = names.filter((name) => !this.owners.has(name));
+    const values = await mapTokenMiserFiles(unknown, this.read);
+    const records = new Map<string, T | undefined>();
+    for (const [index, name] of unknown.entries()) {
+      const value = values[index];
+      records.set(name, value);
+      if (value) this.owners.set(name, value.threadId);
+    }
+    return { names, records };
+  }
+}

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -1,6 +1,8 @@
 import { createHash, randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { mapTokenMiserFiles, withTokenMiserFileOperation } from "./token-miser-file-io";
+import { TokenMiserRecordIndex } from "./token-miser-record-index";
 import {
   TOKEN_MISER_MODEL_VISIBLE_CAP_BYTES,
   estimateTokenCount,
@@ -25,6 +27,10 @@ const RETRIEVAL_DELIVERY_TTL_MS = 2 * 60_000;
 // fresh pending output owned by another PwrAgent process sharing the profile,
 // while still reclaiming raw files left by a crash before acceptance.
 const PENDING_OUTPUT_ORPHAN_GRACE_MS = 5 * 60_000;
+
+async function readStoredFile(filePath: string): Promise<string> {
+  return await withTokenMiserFileOperation(() => fs.readFile(filePath, "utf8"));
+}
 
 export type TokenMiserStoredObject = {
   metadata: TokenMiserObjectMetadata;
@@ -221,11 +227,21 @@ export class TokenMiserStore {
   private readonly updateLocks = new Map<string, Promise<void>>();
   private readonly pendingRetrievalDeliveries =
     new Map<string, PendingRetrievalDelivery>();
+  private readonly metadataIndex: TokenMiserRecordIndex<TokenMiserObjectMetadata>;
+  private readonly observationIndex: TokenMiserRecordIndex<TokenMiserCodeModeObservation>;
 
   constructor(
     private readonly rootDir: string,
     private readonly options: TokenMiserStoreOptions = {},
-  ) {}
+  ) {
+    this.metadataIndex = new TokenMiserRecordIndex(rootDir, (name) =>
+      this.readMetadata(name.slice(0, -METADATA_SUFFIX.length))
+    );
+    this.observationIndex = new TokenMiserRecordIndex(
+      this.observationRoot(),
+      (name) => this.readCodeModeObservation(name),
+    );
+  }
 
   async store(params: TokenMiserStoreParams): Promise<TokenMiserObjectMetadata> {
     const staged = await this.stage(params);
@@ -338,7 +354,7 @@ export class TokenMiserStore {
       return undefined;
     }
     try {
-      const raw = await fs.readFile(this.metadataPath(objectId), "utf8");
+      const raw = await readStoredFile(this.metadataPath(objectId));
       const value = JSON.parse(raw) as TokenMiserObjectMetadata;
       return value?.version === 1 && value.objectId === objectId
         ? value
@@ -439,8 +455,8 @@ export class TokenMiserStore {
     operations: TokenMiserGroupBatchOperation[];
     maxOutputChars?: number;
   }): Promise<TokenMiserGroupBatchResult | undefined> {
-    const metadata = (await this.listMetadata()).find((entry) =>
-      entry.threadId === params.threadId && entry.groupId === params.groupId
+    const metadata = (await this.listMetadata(params.threadId)).find((entry) =>
+      entry.groupId === params.groupId
     );
     if (!metadata || !metadata.groupMembers?.length) {
       return undefined;
@@ -553,20 +569,8 @@ export class TokenMiserStore {
     this.pendingRetrievalDeliveries.delete(deliveryId);
   }
 
-  async listMetadata(): Promise<TokenMiserObjectMetadata[]> {
-    const entries = await fs.readdir(this.rootDir).catch((error: unknown) => {
-      if (isMissingFileError(error)) {
-        return [];
-      }
-      throw error;
-    });
-    const metadata = await Promise.all(
-      entries
-        .filter((entry) => entry.endsWith(METADATA_SUFFIX))
-        .map((entry) => this.readMetadata(entry.slice(0, -METADATA_SUFFIX.length))),
-    );
-    return metadata
-      .filter((entry): entry is TokenMiserObjectMetadata => Boolean(entry))
+  async listMetadata(threadId?: string): Promise<TokenMiserObjectMetadata[]> {
+    return (await this.metadataIndex.list(threadId))
       .sort((left, right) => right.createdAt - left.createdAt);
   }
 
@@ -615,6 +619,7 @@ export class TokenMiserStore {
       this.observationPath(observationId),
       `${JSON.stringify(observation)}\n`,
     );
+    this.observationIndex.remember(`${observationId}${METADATA_SUFFIX}`, observation.threadId);
     await this.options.onCodeModeObservationUpdated?.(observation);
     return observation;
   }
@@ -622,51 +627,37 @@ export class TokenMiserStore {
   async listCodeModeObservations(
     threadId?: string,
   ): Promise<TokenMiserCodeModeObservation[]> {
-    const entries = await fs.readdir(this.observationRoot()).catch(
-      (error: unknown) => {
-        if (isMissingFileError(error)) return [];
-        throw error;
-      },
-    );
-    const observations = await Promise.all(entries
-      .filter((entry) => entry.endsWith(METADATA_SUFFIX))
-      .map(async (entry) => {
-        try {
-          const raw = await fs.readFile(
-            path.join(this.observationRoot(), entry),
-            "utf8",
-          );
-          const value = JSON.parse(raw) as TokenMiserCodeModeObservation;
-          return value?.version === 1
-            && value.observationId === entry.slice(0, -METADATA_SUFFIX.length)
-            ? value
-            : undefined;
-        } catch {
-          return undefined;
-        }
-      }));
-    return observations
-      .filter((entry): entry is TokenMiserCodeModeObservation => Boolean(entry))
-      .filter((entry) => !threadId || entry.threadId === threadId)
+    return (await this.observationIndex.list(threadId))
       .sort((left, right) => left.createdAt - right.createdAt);
+  }
+
+  private async readCodeModeObservation(name: string): Promise<TokenMiserCodeModeObservation | undefined> {
+    try {
+      const raw = await readStoredFile(path.join(this.observationRoot(), name));
+      const value = JSON.parse(raw) as TokenMiserCodeModeObservation;
+      return value?.version === 1
+        && value.observationId === name.slice(0, -METADATA_SUFFIX.length)
+        ? value
+        : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   async summarizeUsage(params?: {
     threadId?: string;
   }): Promise<TokenMiserUsageSummary> {
-    const allMetadata = await this.listMetadata();
-    const metadata = params?.threadId
-      ? allMetadata.filter((entry) => entry.threadId === params.threadId)
-      : allMetadata;
+    const metadata = await this.listMetadata(params?.threadId);
     return summarizeMetadata(metadata);
   }
 
   async summarizeThreadUsage(
     threadId: string,
+    metadataSnapshot?: TokenMiserObjectMetadata[],
   ): Promise<TokenMiserThreadUsageSummary> {
-    const metadata = (await this.listMetadata()).filter(
-      (entry) => entry.threadId === threadId,
-    );
+    // Accounting and savings can share the same current metadata snapshot.
+    const metadata = (metadataSnapshot ?? await this.listMetadata(threadId))
+      .filter((entry) => entry.threadId === threadId);
     const observations = await this.listCodeModeObservations(threadId);
     const metadataByToolUseId = new Map(
       metadata.map((entry) => [entry.toolUseId, entry]),
@@ -850,7 +841,7 @@ export class TokenMiserStore {
     ) {
       return undefined;
     }
-    const output = await fs.readFile(this.outputPath(objectId), "utf8").catch(
+    const output = await readStoredFile(this.outputPath(objectId)).catch(
       (error: unknown) => {
         if (isMissingFileError(error)) {
           return undefined;
@@ -871,7 +862,7 @@ export class TokenMiserStore {
       }
       throw error;
     });
-    await Promise.all(entries.map(async (entry) => {
+    await mapTokenMiserFiles(entries, async (entry) => {
       if (!entry.endsWith(OUTPUT_SUFFIX)) {
         return;
       }
@@ -887,7 +878,7 @@ export class TokenMiserStore {
       ) {
         await fs.rm(outputPath, { force: true });
       }
-    }));
+    });
   }
 
   private async recordRetrieval(objectId: string, characters: number): Promise<void> {
@@ -1004,6 +995,7 @@ export class TokenMiserStore {
       fs.rm(this.outputPath(objectId), { force: true }),
       fs.rm(this.metadataPath(objectId), { force: true }),
     ]);
+    this.metadataIndex.forget(`${objectId}${METADATA_SUFFIX}`);
   }
 
   private async ensureRoot(): Promise<void> {
@@ -1015,6 +1007,7 @@ export class TokenMiserStore {
       this.metadataPath(metadata.objectId),
       `${JSON.stringify(metadata)}\n`,
     );
+    this.metadataIndex.remember(`${metadata.objectId}${METADATA_SUFFIX}`, metadata.threadId);
   }
 
   private metadataPath(objectId: string): string {
@@ -1035,9 +1028,16 @@ export class TokenMiserStore {
 }
 
 async function writePrivateFileAtomic(filePath: string, contents: string): Promise<void> {
-  const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
-  await fs.writeFile(temporaryPath, contents, { encoding: "utf8", mode: 0o600 });
-  await fs.rename(temporaryPath, filePath);
+  await withTokenMiserFileOperation(async () => {
+    const temporaryPath = `${filePath}.${randomUUID()}.tmp`;
+    try {
+      await fs.writeFile(temporaryPath, contents, { encoding: "utf8", mode: 0o600 });
+      await fs.rename(temporaryPath, filePath);
+    } catch (error) {
+      await fs.rm(temporaryPath, { force: true }).catch(() => undefined);
+      throw error;
+    }
+  });
 }
 
 function summarizeMetadata(

--- a/docs/design/token-miser-storage-review.md
+++ b/docs/design/token-miser-storage-review.md
@@ -1,0 +1,128 @@
+# Token Miser storage and accounting review
+
+Reviewed September 5, 2026 after repeated `spawn EBADF` failures in the default
+profile. This review covers retained output, metadata, Code Mode observations,
+accounting reads, replay updates, and retention. It does not change the reducer's
+decision policy or the model used to summarize output.
+
+## What is stored
+
+The profile owns `state/token-miser/objects/`:
+
+| File | Purpose | Write trigger |
+| --- | --- | --- |
+| `<objectId>.txt` | Exact retained tool output, including grouped output, for authorized retrieval | Output staging |
+| `<objectId>.json` | Thread/turn/tool ownership, summary, byte/token estimates, helper usage, parent model, retrieval and replay counters | Accepted result; retrieval; observed model request; replay retirement |
+| `code-mode-observations/<observationId>.json` | Call identity, command/patch/poll counts, output size, up to 4,000 script characters and 5,000 preview characters | Code Mode observation, including direct and retrieval calls |
+
+These are PwrAgent-owned records, not Codex session files. Raw output supports
+retrieval after replacement by a summary. The other records support accounting,
+the Pricing rail, and the Token Miser explorer. Metadata and observations are
+therefore not merely filesystem paths or Git information. They contain text.
+
+The store originated in PR #1733; PR #1942 subsequently changed its model-boundary
+accounting. Current code, rather than earlier design records, was reviewed here.
+
+## Incident evidence
+
+At inspection the profile contained 3,257 retained outputs (36.0 MB), 3,257
+metadata records (5.0 MB), and 10,641 observations (41.3 MB). These counts are a
+point-in-time measurement, not a size limit. No operator content is included here.
+
+The live Electron main process reached 18,531 open descriptors; another sample
+contained descriptor numbers up to 25,945. Most of the observed file pressure
+came from Token Miser JSON reads. In an isolated local process, Git succeeded
+before opening 11,000 descriptors, failed with EBADF while they were open, and
+succeeded after they closed. macOS's spawn file actions can reject stdio
+descriptors above 10,239: <https://github.com/libuv/libuv/issues/5204>.
+
+## Findings
+
+1. `listMetadata` and `listCodeModeObservations` used `Promise.all` over every
+   JSON file. One observation scan could exceed the macOS spawn threshold.
+   Several scans could overlap in the same process.
+2. A thread accounting refresh read the entire profile's result and observation
+   record, then filtered for one thread. Savings calculation read all result
+   records again. Grouped retrieval also scanned all result records.
+3. Every Code Mode observation schedules accounting publication. Model-request
+   replay accounting also publishes it. These routine events made total
+   retained profile history part of the cost of each active thread update.
+4. Replay accounting rewrites each affected gate's JSON atomically. Per-object
+   update locks protect local updates, but do not impose an aggregate I/O bound.
+   Limiting reads alone leaves concurrent metadata writes outside that budget.
+5. Startup reconciliation and retention legitimately need profile-wide data.
+   Settings also requests a profile-wide usage summary. They need bounded scans
+   even after thread-specific callers stop reading unrelated records.
+6. Retention runs at startup, with a seven-day age and 512 MiB payload budget.
+   This is not a continuous disk quota. It currently counts output and
+   observation bytes, but omits result JSON bytes. Script/preview collection and
+   the boot-only retention schedule are existing product behavior; this repair
+   should not silently redefine them.
+
+## Selected design
+
+- Apply one process-wide budget to Token Miser file reads and atomic writes.
+  Hold a slot through completion, including rejection and rename. Do not retry
+  failed Git launches or increase file-descriptor limits to hide the pressure.
+- Use bounded scan workers, rather than allocating an active read for every
+  retained file. Share concurrent discovery within a store, guarded by directory identity and
+  timestamps so a query after an external atomic commit cannot join an older scan.
+- Maintain an in-memory index of immutable filename-to-thread ownership. Learn
+  existing ownership once, and register locally committed records immediately.
+  Keep the existing on-disk layout and retrieval identifiers.
+- Enumerate directory names to discover external additions and removals. Read
+  newly discovered records to learn their owners, then read only the requested
+  thread's known records. Do not cache mutable counters, scripts, or previews:
+  edits by another process must be visible on the next completed query.
+- Reuse newly discovered records within that query. Warm queries may enumerate
+  profile filenames, but must not reopen unrelated JSON files. Startup and
+  explicit global queries may read all records under the shared I/O budget.
+- Build accounting and savings from the same thread metadata snapshot, removing
+  the duplicate result-record read. Use the thread index for grouped retrieval.
+- Preserve direct-object authorization and accepted-write ordering. Do not add
+  SQLite writes, durable secondary indexes, watchers, background polling, or a
+  cache TTL that can silently hide another process's changes.
+
+The remaining filename enumeration is O(profile file count); content I/O after
+discovery is O(requested thread record count plus newly discovered records).
+The ownership index retains identifiers only, not the 41 MB observation payload.
+This deliberately avoids a file-format migration or another persistent database.
+
+## Validation requirements
+
+- Concurrent cold scans and writes across store instances stay within the
+  process-wide file-operation budget, including failed operations.
+- Overlapping discovery reads each unknown record once per store.
+- Warm thread accounting and grouped retrieval do not open another thread's
+  records, even if the unrelated record later becomes unreadable or malformed.
+- A second store's additions, counter updates, observations, and removals become
+  visible; rebuilding the store retains the same behavior for legacy files.
+- A local write during discovery is not omitted from a subsequent query.
+- Thread accounting reads result metadata once for both counts and savings.
+- Failed atomic writes release their slots and remove their temporary files.
+- Existing retention, retrieval authorization, replay, and accounting tests pass.
+
+## Write costs and remaining limits
+
+This design adds no persistent index, SQLite statement, commit, or periodic
+write: incremental SQLite cost is 0 MB/day. Existing gate counters still require
+one JSON replacement per affected gate at a new model-request boundary. That
+cost scales with active gates; this change bounds its concurrency without
+changing the counters' durability or arithmetic. Cross-process counter
+read/modify/write is not made transactional by a process-local queue. It must
+not be described as such; concurrent ownership of one gate would need a separate
+durability design.
+
+Accounting for a single exceptionally long thread still grows with that
+thread's retained records. A future queryable store or thread-level aggregates
+would need explicit persistence, consistency, and write-budget review. Neither
+that redesign nor a retention-policy change is required to stop this incident.
+
+## Regression evidence
+
+Five focused tests fail against the original implementation: unrelated-thread
+reads, duplicate cold discovery, the mixed read/write budget, duplicate
+accounting/savings reads, and failed-rename temporary-file cleanup. The original
+mixed workload reaches 42 simultaneous operations against a budget of 16.
+The corrected implementation also covers local/external commits during discovery
+and live cross-instance changes without a persistent content cache.


### PR DESCRIPTION
Token Miser accounting opened every retained result and Code Mode observation in the profile for each thread refresh, then reread all result metadata for savings. A profile with 10,641 observations could exceed macOS's spawn descriptor threshold in a single scan, causing unrelated Git operations—including branch loading—to fail with `spawn EBADF`.

This change scopes warm content reads to the requested thread and gives Token Miser reads and atomic writes one process-wide I/O budget. It preserves the existing files, retrieval IDs, counters, and cross-instance visibility.

## Design review

[Storage and accounting review](https://github.com/pwrdrvr/PwrAgent/blob/fix/token-miser-storage-pressure/docs/design/token-miser-storage-review.md) documents what is stored, write and read triggers, incident evidence, alternatives, consistency rules, and remaining limits.

- Use 16 shared file-operation slots and bounded scan workers, including failed operations.
- Keep an in-memory filename-to-thread ownership index. Discover external additions/removals by directory enumeration; read mutable records fresh. Share cold discovery only while directory identity/timestamps still match.
- Reuse one thread metadata snapshot for accounting and savings; scope grouped retrieval to its owning thread.
- Remove temporary files after failed atomic writes.
- Add no SQLite commits, durable secondary index, watcher, polling timer, or storage-format migration. Incremental SQLite write cost is 0 MB/day.

Warm queries still enumerate filenames. Per-gate replay JSON writes and boot-only retention remain explicit limits in the review; this PR does not redefine retention or script/preview collection.

## Validation

Five regression tests fail against the original implementation: unrelated-thread reads, duplicate cold discovery, mixed read/write concurrency (42 operations versus a budget of 16), duplicate accounting/savings reads, and abandoned temporary files. Additional tests cover concurrent store instances, local/external commits during discovery, external edits/removals, and slot release after failures.

- 728 tests pass across the Token Miser store, storage pressure, service, agent tools, registry Token Miser integration, and full backend registry suites.
- `pnpm typecheck`
- `pnpm lint:eslint` (no errors)
- `pnpm lint:boundaries`
- `pnpm lint:codex-storage`
- `git diff --check`

The macOS failure was also reproduced in an isolated process: Git succeeded normally, failed with 11,000 descriptors open, and succeeded after they closed. No live profile files were migrated or deleted, and the running default-profile app was not restarted.
