### PR TITLE
fix(desktop): avoid archived-thread sync and expose archive failures

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -51013,6 +51013,70 @@ describe("DesktopBackendRegistry — ACP worktree directory grouping", () => {
     }
   }
 
+  it("does not synchronize archived threads while collecting archive cleanup metadata", async () => {
+    vi.useFakeTimers();
+    const fixture = buildMissingThreadFixture({
+      missingThreadIds: ["already-archived"],
+      presentThreadIds: ["archive-target"],
+    });
+    const codexClient = new MissingThreadCodexClient(new Set(["already-archived"]), {
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: fixture.threads.filter((thread) => thread.id === "archive-target"),
+      archivedThreads: fixture.threads.filter((thread) => thread.id === "already-archived"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock({ overlays: fixture.overlays }),
+    });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => { events.push(event); });
+    try {
+      await registry.archiveThread({ backend: "codex", threadId: "archive-target" });
+      await settleMissingCodexThreadAudit(registry);
+      expect(codexClient.updateThreadWorkspaceCallCount).toBe(0);
+      expect(codexClient.archivedThreadIds).toEqual(["archive-target"]);
+      expect(events.filter((event) =>
+        event.notification.method === "codex/missingThreads/updated",
+      )).toEqual([]);
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
+  it("includes the thread and cleanup error when automatic missing-thread archive fails", async () => {
+    vi.useFakeTimers();
+    const fixture = buildMissingThreadFixture({
+      missingThreadIds: ["thread-missing"],
+      presentThreadIds: ["a", "b", "c", "d", "e"],
+    });
+    const codexClient = new MissingThreadCodexClient(new Set(["thread-missing"]), {
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+      threads: fixture.threads,
+      archivedThreads: [],
+    });
+    const overlayStore = createOverlayStoreMock({ overlays: fixture.overlays });
+    vi.spyOn(overlayStore, "setThreadArchiveTombstone").mockRejectedValue(
+      new Error("archive storage unavailable"),
+    );
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => { events.push(event); });
+    try {
+      await registry.listThreads({ backend: "codex", forceRefresh: true });
+      await settleMissingCodexThreadAudit(registry);
+      expect(events.find((event) =>
+        event.notification.method === "codex/missingThreads/updated",
+      )?.notification.params).toMatchObject({
+        failedCount: 1,
+        failures: [{ threadId: "thread-missing", error: "archive storage unavailable" }],
+      });
+    } finally {
+      await registry.close();
+      vi.useRealTimers();
+    }
+  });
+
   it("archives Codex threads reported missing when they are a small share of the profile", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/desktop/src/main/__tests__/git-directory-service.test.ts
+++ b/apps/desktop/src/main/__tests__/git-directory-service.test.ts
@@ -586,13 +586,27 @@ describe("GitDirectoryService", () => {
   it("reports at most the newest recent commits for the current branch", async () => {
     const repoDir = await createFixtureRepo();
     cleanupPaths.push(repoDir);
-    for (let index = 0; index < MAX_TRACKED_COMMITS + 5; index += 1) {
-      execFileSync(
-        "git",
-        ["-C", repoDir, "commit", "--allow-empty", "-m", `Commit ${index}`],
-        { stdio: "ignore" },
-      );
-    }
+    // Build the same linear history in one Git process. Starting a process
+    // for each empty commit can exhaust the test budget on Windows CI before
+    // the service under test gets to read the repository.
+    const seedSha = runGit(repoDir, ["rev-parse", "HEAD"]);
+    const commits = Array.from({ length: MAX_TRACKED_COMMITS + 5 }, (_, index) => {
+      const message = `Commit ${index}`;
+      return [
+        "commit refs/heads/main",
+        `mark :${index + 1}`,
+        `committer PwrAgent Tests <pwragent-tests@example.invalid> ${1_700_000_000 + index} +0000`,
+        `data ${Buffer.byteLength(message)}`,
+        message,
+        `from ${index === 0 ? seedSha : `:${index}`}`,
+        "",
+        "",
+      ].join("\n");
+    }).join("");
+    execFileSync("git", ["-C", repoDir, "fast-import", "--quiet"], {
+      input: commits,
+      stdio: ["pipe", "ignore", "pipe"],
+    });
     const service = new GitDirectoryService();
 
     const status = await service.readDirectoryStatus({ path: repoDir });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -23984,10 +23984,14 @@ export class DesktopBackendRegistry {
     ) {
       this.recordCodexVisibleThreadCount(visibleThreads.length);
     }
-    this.schedulePendingCodexWorkspaceCwdSyncs({
-      overlaysByThreadId,
-      threads: visibleThreads,
-    });
+    // Archive cleanup also lists archived threads. Reading that collection
+    // must not try to reopen their workspaces or classify them as missing.
+    if (!params.archived) {
+      this.schedulePendingCodexWorkspaceCwdSyncs({
+        overlaysByThreadId,
+        threads: visibleThreads,
+      });
+    }
     const reconciledOverlaysByThreadId =
       await this.reconcileCodexDirectoryRelationshipsFromSource({
         diagnostics,
@@ -28897,6 +28901,7 @@ export class DesktopBackendRegistry {
     await this.emitCodexMissingThreadsUpdate({
       archivedCount: result.archived.length,
       failedCount: result.failed.length,
+      failures: result.failures,
       missingCount: threadIds.length,
       profileName: this.resolveMissingCodexThreadProfileName(),
       status: "archived",
@@ -28908,9 +28913,11 @@ export class DesktopBackendRegistry {
   private async archiveMissingCodexThreads(threadIds: string[]): Promise<{
     archived: string[];
     failed: string[];
+    failures: { threadId: string; error: string }[];
   }> {
     const archived: string[] = [];
     const failed: string[] = [];
+    const failures: { threadId: string; error: string }[] = [];
     for (const threadId of threadIds) {
       this.unresolvedMissingCodexThreadIds.delete(threadId);
       try {
@@ -28921,10 +28928,12 @@ export class DesktopBackendRegistry {
         archived.push(threadId);
       } catch (error) {
         failed.push(threadId);
-        backendRegistryLog.warn("archiving a missing Codex thread failed", {
+        const failure = {
           error: error instanceof Error ? error.message : String(error),
           threadId,
-        });
+        };
+        failures.push(failure);
+        backendRegistryLog.warn("archiving a missing Codex thread failed", failure);
       }
     }
     if (archived.length > 0) {
@@ -28936,7 +28945,7 @@ export class DesktopBackendRegistry {
         failedCount: failed.length,
       });
     }
-    return { archived, failed };
+    return { archived, failed, failures };
   }
 
   /**

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/codex-missing-threads-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/codex-missing-threads-notice.test.ts
@@ -89,6 +89,27 @@ describe("buildCodexMissingThreadsNotice", () => {
     expect(notice?.detail).toContain("2 threads could not be archived");
   });
 
+  it("identifies affected threads on the notice and preserves errors when copied", () => {
+    const notice = buildCodexMissingThreadsNotice({
+      onArchive: vi.fn(),
+      onKeep: vi.fn(),
+      signal: {
+        archivedCount: 0,
+        failedCount: 1,
+        missingCount: 1,
+        profileName: "work",
+        status: "archived",
+        threadIds: ["thread-missing"],
+        totalCount: 10,
+        failures: [{ threadId: "thread-missing", error: "snapshot failed" }],
+      },
+    });
+    expect(notice?.detail).toContain("thread-missing");
+    expect(notice?.copyText).toContain("Missing threads not archived");
+    expect(notice?.copyText).toContain("work");
+    expect(notice?.copyText).toContain("thread-missing: snapshot failed");
+  });
+
   it("produces nothing when there is no thread to report", () => {
     expect(
       buildCodexMissingThreadsNotice({

--- a/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/codex-missing-threads-notice.ts
@@ -1,17 +1,13 @@
+import type { AppServerNotification } from "@pwragent/shared";
 import type { AppNoticeToastNotice } from "./AppNoticeToast";
 
 export const CODEX_MISSING_THREADS_CONFIRMATION_NOTICE_ID =
   "codex-missing-threads:confirmation";
 
-export type CodexMissingThreadsSignal = {
-  status: "archived" | "confirmationRequired";
-  threadIds: string[];
-  missingCount: number;
-  totalCount: number;
-  profileName: string;
-  archivedCount?: number;
-  failedCount?: number;
-};
+export type CodexMissingThreadsSignal = Extract<
+  AppServerNotification,
+  { method: "codex/missingThreads/updated" }
+>["params"];
 
 export function formatMissingThreadShare(params: {
   missingCount: number;
@@ -48,12 +44,34 @@ export function buildCodexMissingThreadsNotice(params: {
   const { signal } = params;
   if (signal.threadIds.length === 0) return undefined;
 
+  const threadDetail = signal.threadIds.length === 1
+    ? `Thread: ${signal.threadIds[0]}`
+    : `Threads: ${signal.threadIds.slice(0, 3).join(", ")}${signal.threadIds.length > 3 ? ` (+${signal.threadIds.length - 3} more; copy notice for all IDs)` : ""}`;
+  const withDiagnostics = (notice: AppNoticeToastNotice): AppNoticeToastNotice => ({
+    ...notice,
+    detail: `${notice.detail} ${threadDetail}`,
+    copyText: [
+      notice.title,
+      notice.message,
+      notice.detail,
+      `PwrAgent profile: ${signal.profileName}`,
+      `Threads reported missing: ${signal.missingCount} of ${signal.totalCount}`,
+      "Affected Codex thread IDs:",
+      ...signal.threadIds,
+      ...(signal.failures?.length
+        ? ["Archive failures:", ...signal.failures.map((failure) =>
+            `${failure.threadId}: ${failure.error}`,
+          )]
+        : []),
+    ].filter(Boolean).join("\n"),
+  });
+
   if (signal.status === "archived") {
     const archivedCount = signal.archivedCount ?? 0;
     const failedCount = signal.failedCount ?? 0;
     if (archivedCount === 0 && failedCount === 0) return undefined;
 
-    return {
+    return withDiagnostics({
       detail: failedCount > 0
         ? `${pluralizeThreads(failedCount)} could not be archived and stayed in the sidebar.`
         : "Restore them from the Archived lens if this was not what you wanted.",
@@ -66,7 +84,7 @@ export function buildCodexMissingThreadsNotice(params: {
         : "Missing threads not archived",
       tone: failedCount > 0 ? "warning" : "neutral",
       transientSlot: "codex-missing-threads",
-    };
+    });
   }
 
   const share = formatMissingThreadShare({
@@ -74,7 +92,7 @@ export function buildCodexMissingThreadsNotice(params: {
     totalCount: signal.totalCount,
   });
 
-  return {
+  return withDiagnostics({
     actions: [
       {
         label: "Leave Everything Alone",
@@ -95,5 +113,5 @@ export function buildCodexMissingThreadsNotice(params: {
     onDismiss: params.onKeep,
     title: "Threads missing from Codex",
     tone: "warning",
-  };
+  });
 }

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1600,6 +1600,7 @@ export type AppServerNotification =
         profileName: string;
         archivedCount?: number;
         failedCount?: number;
+        failures?: { threadId: string; error: string }[];
       };
     }
   | {


### PR DESCRIPTION
## Problem and fix

Archiving a thread reads both active and archived threads to collect cleanup metadata. The archived list also scheduled workspace CWD synchronization for old handoffs. A rejection could classify an already archived thread as missing and trigger another archive attempt. Skip workspace synchronization when listing archived threads.

Missing-thread notices also discarded affected IDs and cleanup errors. Show a bounded list of IDs in the notice and include all IDs, the profile, and per-thread archive errors in copied diagnostics. The renderer now uses the shared notification type.

The reported missing ID differed from the contemporaneously archived ID. The regression reproduces the archived-list side effect; the provided logs do not contain the final cleanup error, so they cannot establish the exact cause of that individual failure.

## Validation

- Three regression tests failed before the fixes and passed afterward.
- All 654 backend-registry and missing-thread notice tests passed.
- ESLint, workspace typecheck, dependency boundaries, Codex storage lint, and git diff checks passed.
