### PR TITLE
fix(desktop): make Token Miser original retention temporary

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -43,6 +43,44 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     await registry.close();
     stateDb.close();
     rmSync(directory, { force: true, recursive: true });
+  });
+
+  it.each([true, false])("migrates history before reconciliation and accounting reads (enabled=%s)", async (enabled) => {
+    const root = path.join(directory, "legacy-objects");
+    await fs.mkdir(root);
+    const legacy = { ...metadata(randomUUID(), "helper-legacy"), replayTrackingVersion: 2 as const };
+    await fs.writeFile(path.join(root, `${legacy.objectId}.json`), JSON.stringify(legacy));
+    await fs.writeFile(path.join(root, `${legacy.objectId}.txt`), "contrived private output");
+    const tokenMiserStore = new TokenMiserStore(root);
+    const internals = registry as unknown as {
+      initializeTokenMiserLedger(): Promise<void>;
+      recordTokenMiserParentModelRequest(event: AgentEvent): Promise<void>;
+      activeTokenMiserReplayEntries: Map<string, Map<string, unknown>>;
+      withTokenMiserAccounting(params: { backend: "codex"; threadId: string; accounting: ThreadToolAccounting }): Promise<ThreadToolAccounting>;
+    };
+    const prepareRuntime = vi.fn();
+    Object.assign(registry, {
+      tokenMiserStore, resolveTokenMiserEnabledFn: () => enabled,
+      prepareTokenMiserRuntime: prepareRuntime,
+    });
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    const prune = tokenMiserStore.prune.bind(tokenMiserStore);
+    vi.spyOn(tokenMiserStore, "prune").mockImplementation(async (options) => {
+      await barrier;
+      await prune(options);
+    });
+    const initialized = internals.initializeTokenMiserLedger();
+    const startup = registry.prepareTokenMiserRuntimeAtStartup();
+    const read = internals.withTokenMiserAccounting({ backend: "codex", threadId: legacy.threadId, accounting: await store.readThreadToolAccounting({ backend: "codex", threadId: legacy.threadId }) });
+    release();
+    await Promise.all([initialized, startup]);
+    expect((await read).tokenMiser?.interceptionCount).toBe(1);
+    expect(internals.activeTokenMiserReplayEntries.get(legacy.threadId)?.has(legacy.objectId)).toBe(true);
+    expect(prepareRuntime).toHaveBeenCalledTimes(enabled ? 1 : 0);
+    for (const tokens of [100, 200, 300]) await internals.recordTokenMiserParentModelRequest(parentUsageEvent(tokens));
+    expect((await tokenMiserStore.readMetadata(legacy.objectId))?.cachedReplayCount).toBe(1);
+    await expect(fs.stat(path.join(root, `${legacy.objectId}.txt`))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("reads thread metadata once for both accounting and savings", async () => {

--- a/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry-token-miser.test.ts
@@ -83,6 +83,28 @@ describe("DesktopBackendRegistry Token Miser ledger", () => {
     await expect(fs.stat(path.join(root, `${legacy.objectId}.txt`))).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.each([false, true])("drains active-turn replay estimates even if another shutdown resource fails (%s)", async (failClose) => {
+    const root = path.join(directory, "token-miser-objects");
+    const tokenMiserStore = new TokenMiserStore(root);
+    const entry = await tokenMiserStore.store({
+      ...metadata(randomUUID(), "helper-shutdown"), output: "fixture output",
+    });
+    Object.assign(registry, { tokenMiserStore });
+    for (const tokens of [100, 200]) {
+      await tokenMiserStore.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: tokens });
+    }
+    const queuedUpdate = tokenMiserStore.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 300 });
+    if (failClose) {
+      const internals = registry as unknown as { codexClient: { close(): Promise<void> } };
+      vi.spyOn(internals.codexClient, "close").mockRejectedValueOnce(new Error("fixture close failure"));
+      await expect(registry.close()).rejects.toThrow("codex");
+    } else {
+      await registry.close();
+    }
+    await queuedUpdate;
+    expect(await new TokenMiserStore(root).readMetadata(entry.objectId, entry.threadId)).toMatchObject({ cachedReplayCount: 1 });
+  });
+
   it("reads thread metadata once for both accounting and savings", async () => {
     const tokenMiserStore = new TokenMiserStore(path.join(directory, "token-miser-objects"));
     for (const threadId of ["thread-parent", "thread-unrelated"]) {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -4734,7 +4734,7 @@ describe("DesktopBackendRegistry", () => {
       };
       resolveTokenMiserCodexRuntimeFn?: typeof resolveRuntime;
     };
-    internals.tokenMiserStore = {} as TokenMiserStore;
+    internals.tokenMiserStore = { flushAll: vi.fn(async () => {}) } as unknown as TokenMiserStore;
     internals.tokenMiserHookBridge = {
       start: startBridge,
       close: closeBridge,
@@ -4811,7 +4811,7 @@ describe("DesktopBackendRegistry", () => {
       };
       resolveTokenMiserCodexRuntimeFn?: typeof resolveRuntime;
     };
-    internals.tokenMiserStore = {} as TokenMiserStore;
+    internals.tokenMiserStore = { flushAll: vi.fn(async () => {}) } as unknown as TokenMiserStore;
     internals.tokenMiserHookBridge = {
       start: vi.fn(async () => undefined),
       close: vi.fn(async () => undefined),
@@ -45537,6 +45537,7 @@ script = "printf setup"
     });
 
     Object.assign(registry, { tokenMiserStore: {
+      flushAll: vi.fn(async () => {}),
       archiveThread: vi.fn(async () => { throw new Error("fixture retention failure"); }),
     } });
     const internals = registry as unknown as {
@@ -45634,7 +45635,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("clears archive messaging cleanup cache when a thread is restored", async () => {
+  it("completes restoration after Token Miser retention fails", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",
       title: "Archive me again",
@@ -45657,21 +45658,28 @@ script = "printf setup"
       notifiedCount: 1,
       revokedCount: 1,
     });
+    const overlayStore = createOverlayStoreMock();
+    const tombstone = vi.spyOn(overlayStore, "setThreadArchiveTombstone");
     const registry = new DesktopBackendRegistry({
       codexClient,
       messagingArchiveCleaner,
       messagingStore,
-      overlayStore: createOverlayStoreMock(),
+      overlayStore,
     });
 
-    const restoreTokenMiser = vi.fn(async () => {});
+    const restoreWorktrees = vi.fn(async () => []);
+    Object.assign(registry, { restoreThreadWorktrees: restoreWorktrees });
+    const restoreTokenMiser = vi.fn(async () => { throw new Error("fixture restore retention failure"); });
     Object.assign(registry, { tokenMiserStore: {
+      flushAll: vi.fn(async () => {}),
       archiveThread: vi.fn(async () => {}),
       restoreThread: restoreTokenMiser,
     } });
 
     await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
     await registry.restoreThread({ backend: "codex", threadId: "thread-1" });
+    expect(tombstone).toHaveBeenLastCalledWith({ backend: "codex", threadId: "thread-1", archivedAt: undefined });
+    expect(restoreWorktrees).toHaveBeenCalledTimes(1);
     await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
 
     expect(messagingArchiveCleaner.requests).toEqual([
@@ -45711,8 +45719,9 @@ script = "printf setup"
       overlayStore: createOverlayStoreMock(),
     });
 
-    const restoreTokenMiser = vi.fn(async () => {});
+    const restoreTokenMiser = vi.fn(async () => { throw new Error("fixture restore retention failure"); });
     Object.assign(registry, { tokenMiserStore: {
+      flushAll: vi.fn(async () => {}),
       archiveThread: vi.fn(async () => { throw new Error("fixture notification retention failure"); }),
       restoreThread: restoreTokenMiser,
     } });
@@ -45721,11 +45730,12 @@ script = "printf setup"
     const unsubscribe = registry.onEvent((event) => { events.push(event); });
     await codexClient.emit({ method: "thread/archived", params: { threadId: "thread-1" } });
     expect(events.some((event) => event.notification.method === "thread/archived")).toBe(true);
-    unsubscribe();
     await codexClient.emit({
       method: "thread/unarchived",
       params: { threadId: "thread-1" },
     });
+    expect(events.some((event) => event.notification.method === "thread/unarchived")).toBe(true);
+    unsubscribe();
     await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
 
     expect(messagingArchiveCleaner.requests).toHaveLength(2);

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -45508,7 +45508,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("routes archive binding revocation through the messaging archive cleaner when available", async () => {
+  it("continues archive cleanup and reports Token Miser persistence failures", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",
       title: "Archive me",
@@ -45536,6 +45536,15 @@ script = "printf setup"
       overlayStore: createOverlayStoreMock(),
     });
 
+    Object.assign(registry, { tokenMiserStore: {
+      archiveThread: vi.fn(async () => { throw new Error("fixture retention failure"); }),
+    } });
+    const internals = registry as unknown as {
+      ungroupChildrenOfArchivedThread(params: unknown): Promise<void>;
+      archiveThreadWorktrees(params: unknown): Promise<unknown[]>;
+    };
+    const ungroup = vi.spyOn(internals, "ungroupChildrenOfArchivedThread");
+    const worktrees = vi.spyOn(internals, "archiveThreadWorktrees");
     await registry.archiveThread({
       backend: "codex",
       threadId: "thread-1",
@@ -45553,6 +45562,9 @@ script = "printf setup"
     ]);
     expect(messagingStore.revokedBindingIds).toEqual([]);
 
+    expect(ungroup).toHaveBeenCalledOnce();
+    expect(worktrees).toHaveBeenCalledOnce();
+    expect(mainLoggerMock.warn).toHaveBeenCalledWith("Token Miser archive retention failed", expect.objectContaining({ threadId: "thread-1", error: "fixture retention failure" }));
     await registry.close();
   });
 
@@ -45671,7 +45683,7 @@ script = "printf setup"
     await registry.close();
   });
 
-  it("clears archive messaging cleanup cache when an unarchive notification arrives", async () => {
+  it("publishes archive notifications and cleans messaging after retention failure", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-1",
       title: "Archive me again",
@@ -45701,11 +45713,15 @@ script = "printf setup"
 
     const restoreTokenMiser = vi.fn(async () => {});
     Object.assign(registry, { tokenMiserStore: {
-      archiveThread: vi.fn(async () => {}),
+      archiveThread: vi.fn(async () => { throw new Error("fixture notification retention failure"); }),
       restoreThread: restoreTokenMiser,
     } });
 
-    await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
+    const events: AgentEvent[] = [];
+    const unsubscribe = registry.onEvent((event) => { events.push(event); });
+    await codexClient.emit({ method: "thread/archived", params: { threadId: "thread-1" } });
+    expect(events.some((event) => event.notification.method === "thread/archived")).toBe(true);
+    unsubscribe();
     await codexClient.emit({
       method: "thread/unarchived",
       params: { threadId: "thread-1" },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -45652,6 +45652,12 @@ script = "printf setup"
       overlayStore: createOverlayStoreMock(),
     });
 
+    const restoreTokenMiser = vi.fn(async () => {});
+    Object.assign(registry, { tokenMiserStore: {
+      archiveThread: vi.fn(async () => {}),
+      restoreThread: restoreTokenMiser,
+    } });
+
     await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
     await registry.restoreThread({ backend: "codex", threadId: "thread-1" });
     await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
@@ -45661,6 +45667,7 @@ script = "printf setup"
       { backend: "codex", threadId: "thread-1", origin: "thread-archive" },
     ]);
 
+    expect(restoreTokenMiser).toHaveBeenCalledExactlyOnceWith("thread-1");
     await registry.close();
   });
 
@@ -45692,6 +45699,12 @@ script = "printf setup"
       overlayStore: createOverlayStoreMock(),
     });
 
+    const restoreTokenMiser = vi.fn(async () => {});
+    Object.assign(registry, { tokenMiserStore: {
+      archiveThread: vi.fn(async () => {}),
+      restoreThread: restoreTokenMiser,
+    } });
+
     await registry.archiveThread({ backend: "codex", threadId: "thread-1" });
     await codexClient.emit({
       method: "thread/unarchived",
@@ -45701,6 +45714,7 @@ script = "printf setup"
 
     expect(messagingArchiveCleaner.requests).toHaveLength(2);
 
+    expect(restoreTokenMiser).toHaveBeenCalledExactlyOnceWith("thread-1");
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
@@ -94,11 +94,16 @@ it("does not materialize an absent profile during startup migration and accounti
 });
 it("migrates contrived legacy content while preserving historical costs and deleting originals", async () => {
   const { store, root } = await fixture();
+  const tokenUsage = {
+    total: { inputTokens: 100, cachedInputTokens: 40, cacheWriteInputTokens: 20, outputTokens: 10, reasoningOutputTokens: 5, totalTokens: 110 },
+    last: { inputTokens: 50, cachedInputTokens: 20, cacheWriteInputTokens: 10, outputTokens: 5, reasoningOutputTokens: 2, totalTokens: 55 },
+    modelContextWindow: 128_000,
+  };
   const metadata = await store.store({ ...params, helperUsage: { model: "test", tokenUsage: { inputTokens: 10, outputTokens: 2 } } });
   await fs.rm(path.join(root, "threads"), { recursive: true, force: true });
   await fs.writeFile(path.join(root, `${metadata.objectId}.txt`), "PRIVATE_LEGACY_RAW");
   await fs.writeFile(path.join(root, `${metadata.objectId}.json`), JSON.stringify({
-    ...metadata, summary: params.summary, extraPreview: "PRIVATE_EXTRA", helperUsage: { model: "test", tokenUsage: { inputTokens: 10, outputTokens: 2, secret: "PRIVATE_USAGE" } },
+    ...metadata, summary: params.summary, extraPreview: "PRIVATE_EXTRA", helperUsage: { model: "test", tokenUsage: { ...tokenUsage, secret: "PRIVATE_USAGE" } },
   }));
   const writes = vi.spyOn(fs, "writeFile");
   try {
@@ -106,7 +111,7 @@ it("migrates contrived legacy content while preserving historical costs and dele
     expect(writes.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain("PRIVATE_");
     expect(await fs.readdir(root)).toEqual(["threads"]);
     const [restored] = await new TokenMiserStore(root).listMetadata("owner");
-    expect(restored?.helperUsage?.tokenUsage).toEqual({ inputTokens: 10, outputTokens: 2 });
+    expect(restored?.helperUsage?.tokenUsage).toEqual(tokenUsage);
     expect(restored?.originalCharacters).toBe(metadata.originalCharacters);
     writes.mockClear();
     await store.prune({ maxAgeMs: 0, maxBytes: 0 });

--- a/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
@@ -154,3 +154,51 @@ it("rejects cross-thread reuse of a staged id", async () => {
   await first.commit();
   expect((await store.readAll({ objectId: "00000000-0000-4000-8000-000000000001", threadId: "owner" }))?.text).toBe(params.output);
 });
+it("restores new reductions without reviving originals, deliveries, or staged callbacks in another store", async () => {
+  const { store, root } = await fixture();
+  const archiveOwner = new TokenMiserStore(root);
+  const accepted = await store.store(params);
+  const staged = await store.stage(params);
+  await staged.persist();
+  const delivery = await store.prepareRetrievalDelivery({ objectId: accepted.objectId, threadId: "owner", visibleText: params.output });
+  await archiveOwner.archiveThread("owner");
+  await archiveOwner.restoreThread("owner");
+  expect(await store.readAll({ objectId: accepted.objectId, threadId: "owner" })).toBeUndefined();
+  expect((await store.summarizeThreadUsage("owner")).interceptions[0]?.originalOutputAvailableUntil).toBeUndefined();
+  expect(await store.confirmModelVisibleRetrievals({ threadId: "owner", output: delivery!.text })).toBe(0);
+  await expect(staged.persist()).rejects.toThrow("unavailable");
+  await expect(staged.commit()).rejects.toThrow("unavailable");
+  const fresh = await store.store(params);
+  expect(await store.readAll({ objectId: fresh.objectId, threadId: "owner" })).toBeDefined();
+  const restarted = new TokenMiserStore(root);
+  expect(await restarted.listMetadata("owner")).toHaveLength(2);
+  await expect(restarted.store(params)).resolves.toBeDefined();
+});
+it("makes duplicate restoration harmless and writes only a bounded lifecycle marker", async () => {
+  const { store } = await fixture();
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    await store.archiveThread("owner");
+    expect(writes).toHaveBeenCalledTimes(1);
+    expect(Buffer.byteLength(String(writes.mock.calls[0]![1]))).toBe(37);
+    writes.mockClear();
+    await Promise.all([store.restoreThread("owner"), store.restoreThread("owner")]);
+    expect(writes).not.toHaveBeenCalled();
+    const fresh = await store.store(params);
+    writes.mockClear();
+    await store.restoreThread("owner");
+    expect(writes).not.toHaveBeenCalled();
+    expect(await store.readAll({ objectId: fresh.objectId, threadId: "owner" })).toBeDefined();
+  } finally { writes.mockRestore(); }
+});
+it("keeps restoration fail-closed if the archive marker cannot be moved", async () => {
+  const { store } = await fixture();
+  await store.archiveThread("owner");
+  const rename = vi.spyOn(fs, "rename").mockRejectedValue(new Error("fixture rename failure"));
+  try {
+    await expect(store.restoreThread("owner")).rejects.toThrow("fixture rename failure");
+    await expect(store.stage(params)).rejects.toThrow("archived");
+  } finally { rename.mockRestore(); }
+  await store.restoreThread("owner");
+  await expect(store.store(params)).resolves.toBeDefined();
+});

--- a/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
@@ -1,0 +1,156 @@
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import { TokenMiserStore } from "../token-miser/token-miser-store";
+
+const roots: string[] = [];
+afterEach(async () => {
+  vi.useRealTimers();
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+async function fixture() {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "token-miser-retention-"));
+  roots.push(root);
+  return { root, store: new TokenMiserStore(root) };
+}
+const params = {
+  threadId: "owner", turnId: "turn", toolUseId: "tool", toolName: "Bash",
+  output: "PRIVATE_RAW_CANARY", replacementCharacters: 10,
+  summary: { summary: "PRIVATE_SUMMARY_CANARY", usefulDetails: ["PRIVATE_DETAILS_CANARY"] },
+};
+it("never writes raw output, summaries, scripts or previews, including pass-through", async () => {
+  const { store } = await fixture();
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    await store.store(params);
+    await store.store({ ...params, disposition: "passed_through" });
+    await store.recordCodeModeObservation({
+      threadId: "owner", turnId: "turn", callId: "call", cellId: "cell",
+      outputCharacters: 10, outputPreview: "PRIVATE_PREVIEW_CANARY",
+      script: "PRIVATE_SCRIPT_CANARY", maxOutputTokens: 100,
+      scriptStatus: "completed", retrieval: false, capturedNestedInvocationCount: 1,
+    });
+    expect(writes.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain("PRIVATE_");
+    expect(writes.mock.calls.some((call) => String(call[0]).includes(".txt"))).toBe(false);
+  } finally { writes.mockRestore(); }
+});
+it("expires originals after five minutes and cannot retrieve them in a fresh store", async () => {
+  const { store, root } = await fixture();
+  const entry = await store.store(params);
+  expect(await store.readAll({ objectId: entry.objectId, threadId: "owner" })).toBeDefined();
+  expect((await store.summarizeThreadUsage("owner")).interceptions[0]?.originalOutputAvailableUntil).toBeGreaterThan(Date.now());
+  expect(await new TokenMiserStore(root).readAll({ objectId: entry.objectId, threadId: "owner" })).toBeUndefined();
+  vi.useFakeTimers();
+  vi.setSystemTime(Date.now() + 5 * 60_000 + 1);
+  expect(await store.readAll({ objectId: entry.objectId, threadId: "owner" })).toBeUndefined();
+  expect((await store.summarizeThreadUsage("owner")).interceptions[0]?.originalOutputAvailableUntil).toBeUndefined();
+  expect((await store.listMetadata("owner"))[0]?.baselineParentTokens).toBe(entry.baselineParentTokens);
+});
+it("retains accepted accounting across archive but rejects pending and late originals", async () => {
+  const { store, root } = await fixture();
+  const accepted = await store.store(params);
+  const pending = await store.stage(params);
+  await pending.persist();
+  await store.archiveThread("owner");
+  await expect(pending.persist()).rejects.toThrow("unavailable");
+  await expect(new TokenMiserStore(root).stage(params)).rejects.toThrow("archived");
+  expect(await store.readAll({ objectId: accepted.objectId, threadId: "owner" })).toBeUndefined();
+  expect(await new TokenMiserStore(root).listMetadata("owner")).toHaveLength(1);
+});
+it("cold thread queries never enumerate or open unrelated thread directories", async () => {
+  const { store, root } = await fixture();
+  await store.store(params);
+  await store.store({ ...params, threadId: "other" });
+  const read = vi.spyOn(fs, "readFile");
+  const list = vi.spyOn(fs, "readdir");
+  try {
+    const cold = new TokenMiserStore(root);
+    expect(await cold.listMetadata("owner")).toHaveLength(1);
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(list).toHaveBeenCalledTimes(1);
+    expect(String(list.mock.calls[0]![0])).toMatch(/threads\/[a-f0-9]{64}$/);
+    await store.store({ ...params, threadId: "owner" });
+    expect(await cold.listMetadata("owner")).toHaveLength(2);
+  } finally { read.mockRestore(); list.mockRestore(); }
+});
+it("migrates contrived legacy content while preserving historical costs and deleting originals", async () => {
+  const { store, root } = await fixture();
+  const metadata = await store.store({ ...params, helperUsage: { model: "test", tokenUsage: { inputTokens: 10, outputTokens: 2 } } });
+  await fs.rm(path.join(root, "threads"), { recursive: true, force: true });
+  await fs.writeFile(path.join(root, `${metadata.objectId}.txt`), "PRIVATE_LEGACY_RAW");
+  await fs.writeFile(path.join(root, `${metadata.objectId}.json`), JSON.stringify({
+    ...metadata, summary: params.summary, extraPreview: "PRIVATE_EXTRA", helperUsage: { model: "test", tokenUsage: { inputTokens: 10, outputTokens: 2, secret: "PRIVATE_USAGE" } },
+  }));
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    await store.prune({ maxAgeMs: 0, maxBytes: 0 });
+    expect(writes.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain("PRIVATE_");
+    expect(await fs.readdir(root)).toEqual(["threads"]);
+    const [restored] = await new TokenMiserStore(root).listMetadata("owner");
+    expect(restored?.helperUsage?.tokenUsage).toEqual({ inputTokens: 10, outputTokens: 2 });
+    expect(restored?.originalCharacters).toBe(metadata.originalCharacters);
+    writes.mockClear();
+    await store.prune({ maxAgeMs: 0, maxBytes: 0 });
+    expect(writes).not.toHaveBeenCalled();
+  } finally { writes.mockRestore(); }
+});
+it("bounds filesystem bytes and writes at acceptance and lifecycle boundaries", async () => {
+  const { store } = await fixture();
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    const entry = await store.store(params);
+    expect(writes).toHaveBeenCalledTimes(1);
+    const acceptedBytes = Buffer.byteLength(String(writes.mock.calls[0]![1]));
+    expect(acceptedBytes).toBeLessThan(1024);
+    writes.mockClear();
+    for (let request = 1; request <= 100; request += 1) {
+      await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: request * 100 });
+    }
+    expect(writes).not.toHaveBeenCalled();
+    await store.flushThread("owner");
+    expect(writes).toHaveBeenCalledTimes(1);
+    expect(Buffer.byteLength(String(writes.mock.calls[0]![1]))).toBeLessThan(1024);
+  } finally { writes.mockRestore(); }
+});
+it("never publishes a failed acceptance or exposes another thread's payload", async () => {
+  const { store } = await fixture();
+  const staged = await store.stage(params);
+  await staged.persist();
+  const rename = vi.spyOn(fs, "rename").mockRejectedValue(new Error("fixture failure"));
+  try { await expect(staged.commit()).rejects.toThrow("fixture failure"); }
+  finally { rename.mockRestore(); }
+  expect(await store.readAll({ objectId: staged.metadata.objectId, threadId: "owner" })).toBeUndefined();
+  await staged.discard();
+  const accepted = await store.store(params);
+  expect(await store.readAll({ objectId: accepted.objectId, threadId: "other" })).toBeUndefined();
+  expect(await store.readAll({ objectId: accepted.objectId, threadId: "owner" })).toBeDefined();
+});
+it("shares the payload byte budget across cache instances and bounds individual entries", async () => {
+  const { TokenMiserOutputCache, TOKEN_MISER_OUTPUT_ENTRY_BYTES } = await import("../token-miser/token-miser-output-cache");
+  const first = new TokenMiserOutputCache();
+  const second = new TokenMiserOutputCache();
+  expect(first.put("oversized", "x".repeat(TOKEN_MISER_OUTPUT_ENTRY_BYTES))).toBe(false);
+  const payload = "x".repeat(1024 * 1024);
+  expect(first.put("oldest", payload)).toBe(true);
+  for (let index = 0; index < 12; index += 1) expect(second.put(String(index), payload)).toBe(true);
+  expect(first.get("oldest")).toBeUndefined();
+  expect(second.get("11")).toBe(payload);
+  for (let index = 0; index < 12; index += 1) second.remove(String(index));
+});
+it("does not write grouped member output or helper facts", async () => {
+  const { store } = await fixture();
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    await store.store({ ...params, groupId: "group", output: JSON.stringify({ version: 1, groupId: "group", members: [{ objectId: "member", toolCallId: "call", toolName: "Bash", output: "PRIVATE_GROUP_RAW" }] }), groupMembers: [{ objectId: "member", toolCallId: "call", toolName: "Bash", summary: "PRIVATE_GROUP_FACT" }] });
+    expect(writes.mock.calls.map((call) => String(call[1])).join("\n")).not.toContain("PRIVATE_");
+  } finally { writes.mockRestore(); }
+});
+
+it("rejects cross-thread reuse of a staged id", async () => {
+  const { store } = await fixture();
+  const first = await store.stage({ ...params, objectId: "00000000-0000-4000-8000-000000000001" });
+  await expect(store.stage({ ...params, objectId: "00000000-0000-4000-8000-000000000001", threadId: "other" })).rejects.toThrow("reserved");
+  await first.commit();
+  expect((await store.readAll({ objectId: "00000000-0000-4000-8000-000000000001", threadId: "owner" }))?.text).toBe(params.output);
+});

--- a/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
@@ -202,3 +202,25 @@ it("keeps restoration fail-closed if the archive marker cannot be moved", async 
   await store.restoreThread("owner");
   await expect(store.store(params)).resolves.toBeDefined();
 });
+it.each(["marker", "flush"])("invalidates originals and deliveries before archive %s failure", async (failure) => {
+  const { store } = await fixture();
+  const accepted = await store.store(params);
+  const pending = await store.stage(params);
+  await pending.persist();
+  const delivery = await store.prepareRetrievalDelivery({ objectId: accepted.objectId, threadId: "owner", visibleText: params.output });
+  const fail = failure === "marker"
+    ? vi.spyOn(fs, "rename").mockRejectedValue(new Error("fixture marker failure"))
+    : vi.spyOn(store, "flushThread").mockRejectedValue(new Error("fixture flush failure"));
+  try { await expect(store.archiveThread("owner")).rejects.toThrow("fixture"); }
+  finally { fail.mockRestore(); }
+  expect(await store.readAll({ objectId: accepted.objectId, threadId: "owner" })).toBeUndefined();
+  expect(await store.confirmModelVisibleRetrievals({ threadId: "owner", output: delivery!.text })).toBe(0);
+  await expect(pending.commit()).rejects.toThrow("unavailable");
+  expect(await store.listMetadata("owner")).toHaveLength(1);
+});
+it("observes restoration by another instance after successful archive persistence", async () => {
+  const { store, root } = await fixture();
+  await store.archiveThread("owner");
+  await new TokenMiserStore(root).restoreThread("owner");
+  await expect(store.store(params)).resolves.toBeDefined();
+});

--- a/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
@@ -136,6 +136,80 @@ it("bounds filesystem bytes and writes at acceptance and lifecycle boundaries", 
     expect(Buffer.byteLength(String(writes.mock.calls[0]![1]))).toBeLessThan(1024);
   } finally { writes.mockRestore(); }
 });
+it("merges buffered replay deltas with another instance's retirement and retrieval updates", async () => {
+  const { store, root } = await fixture();
+  const entry = await store.store(params);
+  for (const tokens of [100, 200, 300]) {
+    await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: tokens });
+  }
+  const other = new TokenMiserStore(root);
+  await (other as unknown as { recordRetrieval(id: string, characters: number): Promise<void> }).recordRetrieval(entry.objectId, 12);
+  await other.stopReplayTracking({ objectId: entry.objectId, stoppedAt: 1234 });
+  expect(await store.readMetadata(entry.objectId, "owner")).toMatchObject({ retrievedCharacters: 12, replayTrackingStoppedAt: 1234 });
+  await store.flushThread("owner");
+  const restored = await new TokenMiserStore(root).readMetadata(entry.objectId, "owner");
+  expect(restored).toMatchObject({ cachedReplayCount: 1, retrievedCharacters: 12, replayTrackingStoppedAt: 1234 });
+  expect(await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 400 })).toBeUndefined();
+});
+it("adds independent replay deltas without replacing newer durable counters", async () => {
+  const { store, root } = await fixture();
+  const entry = await store.store(params);
+  for (const tokens of [100, 200]) await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: tokens });
+  await store.flushThread("owner");
+  await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 300 });
+  const other = new TokenMiserStore(root);
+  await other.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 400 });
+  await other.flushThread("owner");
+  await store.flushThread("owner");
+  expect(await new TokenMiserStore(root).readMetadata(entry.objectId, "owner")).toMatchObject({
+    cachedReplayCount: 2, parentRequestsObservedAfterGate: 4, lastParentCumulativeInputTokens: 400,
+  });
+});
+it("retains failed flush deltas and drains other threads before reporting shutdown failure", async () => {
+  const { store, root } = await fixture();
+  const entries = await Promise.all([store.store(params), store.store({ ...params, threadId: "other" })]);
+  for (const entry of entries) {
+    for (const tokens of [100, 200, 300]) await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: tokens });
+  }
+  const writeFile = fs.writeFile.bind(fs);
+  const write = vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+    if (String(file).includes(entries[0]!.objectId)) throw new Error("fixture flush failure");
+    return writeFile(file, data, options);
+  });
+  try {
+    await expect(store.flushAll()).rejects.toThrow("replay flush failed");
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write.mock.calls.every((call) => Buffer.byteLength(String(call[1])) < 1024)).toBe(true);
+  }
+  finally { write.mockRestore(); }
+  const other = new TokenMiserStore(root);
+  expect((await other.readMetadata(entries[1]!.objectId))?.cachedReplayCount).toBe(1);
+  await other.stopReplayTracking({ objectId: entries[0]!.objectId, stoppedAt: 1234 });
+  await store.flushAll();
+  expect(await other.readMetadata(entries[0]!.objectId)).toMatchObject({ cachedReplayCount: 1, replayTrackingStoppedAt: 1234 });
+  expect((await other.readMetadata(entries[1]!.objectId))?.cachedReplayCount).toBe(1);
+  const writes = vi.spyOn(fs, "writeFile");
+  try { await store.flushAll(); expect(writes).not.toHaveBeenCalled(); }
+  finally { writes.mockRestore(); }
+});
+it("preserves a newer durable request epoch when older buffered estimates flush", async () => {
+  const { store, root } = await fixture();
+  const entry = await store.store(params);
+  await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 100, requestEpoch: "old" });
+  await store.flushThread("owner");
+  await store.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 200, requestEpoch: "old" });
+  const other = new TokenMiserStore(root);
+  await other.recordParentModelRequest({ objectId: entry.objectId, cumulativeInputTokens: 10, requestEpoch: "new" });
+  await other.flushThread("owner");
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    await Promise.all([store.flushAll(), store.flushAll()]);
+    expect(writes).toHaveBeenCalledTimes(1);
+  } finally { writes.mockRestore(); }
+  expect(await other.readMetadata(entry.objectId)).toMatchObject({
+    parentRequestEpoch: "new", lastParentCumulativeInputTokens: 10, parentRequestsObservedAfterGate: 3,
+  });
+});
 it("never publishes a failed acceptance or exposes another thread's payload", async () => {
   const { store } = await fixture();
   const staged = await store.stage(params);

--- a/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-retention.test.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from "node:fs";
+import { createHash } from "node:crypto";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
@@ -69,10 +70,27 @@ it("cold thread queries never enumerate or open unrelated thread directories", a
     expect(await cold.listMetadata("owner")).toHaveLength(1);
     expect(read).toHaveBeenCalledTimes(1);
     expect(list).toHaveBeenCalledTimes(1);
-    expect(String(list.mock.calls[0]![0])).toMatch(/threads\/[a-f0-9]{64}$/);
+    expect(String(list.mock.calls[0]![0])).toBe(path.join(
+      root, "threads", createHash("sha256").update("owner").digest("hex"),
+    ));
     await store.store({ ...params, threadId: "owner" });
     expect(await cold.listMetadata("owner")).toHaveLength(2);
   } finally { read.mockRestore(); list.mockRestore(); }
+});
+it("does not materialize an absent profile during startup migration and accounting reads", async () => {
+  const { root } = await fixture();
+  const store = new TokenMiserStore(path.join(root, "profiles", "default", "state", "token-miser", "objects"));
+  const mkdir = vi.spyOn(fs, "mkdir");
+  const writes = vi.spyOn(fs, "writeFile");
+  try {
+    await store.prune({ maxAgeMs: 0, maxBytes: 0 });
+    expect(await store.listMetadata()).toEqual([]);
+    expect(await store.listMetadata("owner")).toEqual([]);
+    expect(await store.listCodeModeObservations()).toEqual([]);
+    expect(mkdir).not.toHaveBeenCalled();
+    expect(writes).not.toHaveBeenCalled();
+    expect(await fs.readdir(root)).toEqual([]);
+  } finally { mkdir.mockRestore(); writes.mockRestore(); }
 });
 it("migrates contrived legacy content while preserving historical costs and deleting originals", async () => {
   const { store, root } = await fixture();

--- a/apps/desktop/src/main/__tests__/token-miser-service.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-service.test.ts
@@ -66,7 +66,7 @@ describe("TokenMiserService", () => {
     expect(result?.stopReason).toContain("Summary: The command printed");
     expect(result?.stopReason).toContain("Output reference:");
     expect(result?.stopReason).toContain(
-      "Exact source material is available when required.",
+      "Original output is temporary (up to five minutes); expiry, eviction or restart makes it unavailable.",
     );
     expect(result?.stopReason).not.toMatch(BEHAVIOR_PRIMING_LANGUAGE);
     expect(result?.stopReason).not.toMatch(/suggested next step/i);
@@ -828,7 +828,7 @@ describe("TokenMiserService code-mode reduction", () => {
     expect(metadata).toMatchObject({
       disposition: "passed_through",
       summary: {
-        summary: "A deliberate exact instruction-file read passed through unchanged by policy.",
+        summary: "Output passed through.",
       },
     });
     expect(metadata?.helperUsage).toBeUndefined();
@@ -838,6 +838,32 @@ describe("TokenMiserService code-mode reduction", () => {
         passThroughCount: 1,
         directCount: 0,
       });
+  });
+
+  it("charges pre-reduction nested captures to the shared original-output budget", async () => {
+    const store = await createStore();
+    const original = await store.store({
+      threadId: "thread-1", turnId: "turn-1", toolUseId: "original", toolName: "Bash",
+      output: "original", replacementCharacters: 10,
+      summary: { summary: "Output summarized.", usefulDetails: [] },
+    });
+    let enabled = true;
+    const service = new TokenMiserService({
+      store, isEnabled: () => enabled, codeModeGroupingVersion: () => 1,
+      generateSummary: async () => ({ status: "unavailable", reason: "fixture" }),
+    });
+    for (let index = 0; index < 16; index += 1) {
+      await service.captureNestedPostToolUse({
+        ...payload("x".repeat(900_000)), is_code_mode_nested: true,
+        token_miser_grouping_version: 1, code_mode_cell_id: `budget-${index}`,
+        code_mode_tool_call_id: "nested",
+      });
+    }
+    expect(await store.readAll({ objectId: original.objectId, threadId: "thread-1" })).toBeUndefined();
+    enabled = false;
+    for (let index = 0; index < 16; index += 1) {
+      await service.prepareCodeModeOutput({ ...codeModePayload([]), cell_id: `budget-${index}` });
+    }
   });
 
   it("joins parallel nested outputs into one retrievable group gate", async () => {
@@ -911,14 +937,14 @@ describe("TokenMiserService code-mode reduction", () => {
         { toolName: "Bash", summary: "Found alpha matches." },
         { toolName: "Read", summary: "Found beta matches." },
       ],
-      sourceMaterial: "Available by group and member reference when required.",
+      sourceMaterial: "Temporary: expires within five minutes; unavailable after eviction or restart.",
     });
     expect(replacementText).not.toMatch(BEHAVIOR_PRIMING_LANGUAGE);
     const [metadata] = await store.listMetadata();
     expect(metadata).toMatchObject({
       groupId: "cell-1",
       originalCharacters: 59,
-      groupMembers: replacement.members,
+      groupMembers: replacement.members.map((member) => ({ ...member, summary: "Output summarized." })),
     });
     expect(metadata!.replacementCharacters).toBe(
       replacementText.length
@@ -1177,7 +1203,7 @@ describe("TokenMiserService code-mode reduction", () => {
       disposition: "passed_through",
       toolName: "Code Mode",
       summary: {
-        summary: expect.stringContaining("live process or session handle"),
+        summary: "Output passed through.",
       },
     });
     expect(metadata?.helperUsage).toBeUndefined();

--- a/apps/desktop/src/main/__tests__/token-miser-storage-pressure.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-storage-pressure.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -103,6 +104,7 @@ describe("Token Miser storage I/O budgets", () => {
     await writer.recordParentModelRequest({ objectId: original.objectId, cumulativeInputTokens: 100 });
     await writer.recordParentModelRequest({ objectId: original.objectId, cumulativeInputTokens: 200 });
     await writer.recordParentModelRequest({ objectId: original.objectId, cumulativeInputTokens: 300 });
+    await writer.flushThread("thread-a");
     const added = await addObject(writer, "thread-a");
     await addObservation(writer, "thread-a", "call-2");
     expect(await reader.summarizeThreadUsage("thread-a")).toMatchObject({
@@ -110,8 +112,8 @@ describe("Token Miser storage I/O budgets", () => {
       cachedReplayCount: 1,
       codeMode: { callCount: 2 },
     });
-    await fs.rm(path.join(root, `${added.objectId}.json`));
-    await fs.rm(path.join(root, "code-mode-observations", `${records[0]!.observation.observationId}.json`));
+    await fs.rm(path.join(threadRoot(root), `${added.objectId}.json`));
+    await fs.rm(path.join(threadRoot(root), "code-mode-observations", `${records[0]!.observation.observationId}.json`));
     expect(await reader.summarizeThreadUsage("thread-a")).toMatchObject({
       interceptionCount: 1,
       cachedReplayCount: 1,
@@ -164,7 +166,7 @@ describe("Token Miser storage I/O budgets", () => {
     const readFile = fs.readFile.bind(fs);
     let blocked = false;
     vi.spyOn(fs, "readFile").mockImplementation(async (file, options) => {
-      if (!blocked && String(file) === path.join(root, `${records[0]!.metadata.objectId}.json`)) {
+      if (!blocked && String(file) === path.join(threadRoot(root), `${records[0]!.metadata.objectId}.json`)) {
         blocked = true;
         entered();
         await gate;
@@ -196,10 +198,14 @@ describe("Token Miser storage I/O budgets", () => {
       (_, index) => addObservation(writer, "thread-a", `failed-${index}`),
     ));
     expect(results.every((result) => result.status === "rejected")).toBe(true);
-    expect((await fs.readdir(path.join(root, "code-mode-observations")))
+    expect((await fs.readdir(path.join(threadRoot(root), "code-mode-observations")))
       .some((name) => name.endsWith(".tmp"))).toBe(false);
     rename.mockRestore();
     await addObservation(writer, "thread-a", "successful");
     expect(await writer.listCodeModeObservations("thread-a")).toHaveLength(2);
   });
 });
+
+function threadRoot(root: string): string {
+  return path.join(root, "threads", createHash("sha256").update("thread-a").digest("hex"));
+}

--- a/apps/desktop/src/main/__tests__/token-miser-store.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-store.test.ts
@@ -219,7 +219,7 @@ describe("TokenMiserStore", () => {
       maxAgeMs: Number.MAX_SAFE_INTEGER,
       maxBytes: 0,
     });
-    expect(await store.listCodeModeObservations("thread-owner")).toEqual([]);
+    expect(await store.listCodeModeObservations("thread-owner")).toHaveLength(2);
   });
 
   it("reports new and retrieved metadata for turn-batched accounting", async () => {
@@ -279,9 +279,7 @@ describe("TokenMiserStore", () => {
 
     await expect(fs.stat(root)).rejects.toMatchObject({ code: "ENOENT" });
     await rejected.persist();
-    expect((await fs.readdir(root)).sort()).toEqual([
-      `${rejected.metadata.objectId}.txt`,
-    ]);
+    await expect(fs.stat(root)).rejects.toMatchObject({ code: "ENOENT" });
     expect(await store.listMetadata()).toEqual([]);
     expect(await store.readMetadata(rejected.metadata.objectId))
       .toBeUndefined();
@@ -318,7 +316,7 @@ describe("TokenMiserStore", () => {
       rejected.discard(),
       rejected.persist(),
     ]);
-    expect(await fs.readdir(root)).toEqual([]);
+    expect(await fs.readdir(root).catch(() => [])).toEqual([]);
     expect(await store.listMetadata()).toEqual([]);
 
     const accepted = await store.stage(params);
@@ -327,10 +325,7 @@ describe("TokenMiserStore", () => {
       accepted.commit(),
       accepted.persist(),
     ]);
-    expect((await fs.readdir(root)).sort()).toEqual([
-      `${accepted.metadata.objectId}.json`,
-      `${accepted.metadata.objectId}.txt`,
-    ]);
+    expect(await fs.readdir(root)).toEqual(["threads"]);
     expect(await store.listMetadata()).toEqual([accepted.metadata]);
     expect(onMetadataUpdated).toHaveBeenCalledOnce();
     expect(onMetadataUpdated).toHaveBeenCalledWith(
@@ -591,7 +586,7 @@ describe("TokenMiserStore", () => {
     });
   });
 
-  it("prunes expired and over-budget outputs oldest first", async () => {
+  it("preserves accounting independently of the former raw-output quota", async () => {
     const store = await createStore();
     const expired = await createObject(store, "expired", 1);
     const older = await createObject(store, "older", 100);
@@ -599,47 +594,18 @@ describe("TokenMiserStore", () => {
 
     await store.prune({ maxAgeMs: 250, maxBytes: 6, now: 300 });
 
-    expect(await store.readMetadata(expired.objectId)).toBeUndefined();
-    expect(await store.readMetadata(older.objectId)).toBeUndefined();
+    expect(await store.readMetadata(expired.objectId)).toBeDefined();
+    expect(await store.readMetadata(older.objectId)).toBeDefined();
     expect(await store.readMetadata(newer.objectId)).toBeDefined();
   });
 
-  it("prunes stale hidden output without touching fresh cross-instance stages", async () => {
-    const root = await fs.mkdtemp(
-      path.join(os.tmpdir(), "pwragent-token-miser-"),
-    );
-    temporaryDirectories.push(root);
-    const store = new TokenMiserStore(root);
-    const params = {
-      threadId: "thread-owner",
-      turnId: "turn-pending",
-      toolUseId: "tool-pending",
-      toolName: "Code Mode",
-      output: "pending raw output",
-      replacementCharacters: 100,
-      summary: {
-        summary: "Pending output.",
-        usefulDetails: [],
-        suggestedNextStep: "None.",
-      },
-    };
-    const stale = await store.stage(params);
-    const fresh = await store.stage(params);
-    await Promise.all([stale.persist(), fresh.persist()]);
-    const now = Date.now();
-    const stalePath = path.join(root, `${stale.metadata.objectId}.txt`);
-    const freshPath = path.join(root, `${fresh.metadata.objectId}.txt`);
-    const old = new Date(now - 10 * 60_000);
-    await fs.utimes(stalePath, old, old);
-
-    await store.prune({
-      maxAgeMs: 24 * 60 * 60_000,
-      maxBytes: 1024 * 1024,
-      now,
-    });
-
-    await expect(fs.stat(stalePath)).rejects.toMatchObject({ code: "ENOENT" });
-    await expect(fs.stat(freshPath)).resolves.toBeDefined();
+  it("never writes staged originals into the legacy flat directory", async () => {
+    const store = await createStore();
+    const staged = await store.stage({ threadId: "owner", turnId: "turn", toolUseId: "tool", toolName: "Bash", output: "private", replacementCharacters: 10, summary: { summary: "private", usefulDetails: [] } });
+    await staged.persist();
+    await store.prune({ maxAgeMs: 0, maxBytes: 0 });
+    expect(await store.listMetadata()).toEqual([]);
+    await staged.discard();
   });
 });
 

--- a/apps/desktop/src/main/agent-tools/token-miser-agent-tools.ts
+++ b/apps/desktop/src/main/agent-tools/token-miser-agent-tools.ts
@@ -18,7 +18,7 @@ export function buildTokenMiserToolDefinitions(
       namespace: PWRAGENT_TOOL_NAMESPACE,
       name: "search_token_miser_output",
       description:
-        "Search one preserved tool result by literal text. The returned matches remain subject to the 10k-token parent-result cap. Code Mode receives a plain string and should emit that string directly; MCP clients receive an ordinary text content block. The source must belong to the invoking thread.",
+        "Search one preserved tool result by literal text. The returned matches remain subject to the 10k-token parent-result cap. Code Mode receives a plain string and should emit that string directly; MCP clients receive an ordinary text content block. The source must belong to the invoking thread. Originals expire within five minutes and are unavailable after eviction, archive or restart.",
       inputSchema: {
         type: "object",
         additionalProperties: false,
@@ -58,7 +58,7 @@ export function buildTokenMiserToolDefinitions(
       namespace: PWRAGENT_TOOL_NAMESPACE,
       name: "read_token_miser_output",
       description:
-        "Read an inclusive line range from one preserved tool result. The returned range remains subject to the 10k-token parent-result cap, including one very long line. Code Mode receives the requested text as a plain string and should emit that string directly; MCP clients receive an ordinary text content block. The source must belong to the invoking thread.",
+        "Read an inclusive line range from one preserved tool result. The returned range remains subject to the 10k-token parent-result cap, including one very long line. Code Mode receives the requested text as a plain string and should emit that string directly; MCP clients receive an ordinary text content block. The source must belong to the invoking thread. Originals expire within five minutes and are unavailable after eviction, archive or restart.",
       inputSchema: {
         type: "object",
         additionalProperties: false,
@@ -161,7 +161,7 @@ export function buildTokenMiserToolDefinitions(
       namespace: PWRAGENT_TOOL_NAMESPACE,
       name: "read_all_token_miser_output",
       description:
-        "Read the complete preserved tool result as plain text in Code Mode or a text content block over MCP. The source must belong to the invoking thread.",
+        "Read the complete preserved tool result as plain text in Code Mode or a text content block over MCP. The source must belong to the invoking thread. Originals expire within five minutes and are unavailable after eviction, archive or restart.",
       inputSchema: {
         type: "object",
         additionalProperties: false,
@@ -300,6 +300,6 @@ function invalidArguments(message: string) {
 function notFound() {
   return agentToolFailure({
     code: "not_found",
-    message: "Token Miser output was not found or does not belong to this thread.",
+    message: "Token Miser original output is expired, unavailable, or does not belong to this thread. Historical accounting does not retain original content.",
   });
 }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -9177,7 +9177,7 @@ export class DesktopBackendRegistry {
             // single usage event into N pricing reads and 2N notifications;
             // `recordTokenMiserParentModelRequest` already emits once for the
             // whole batch.
-            if (reason === "replay") {
+            if (reason === "replay" || reason === "flushed") {
               return;
             }
             const publish = this.tokenMiserLivePublishChain.then(() =>
@@ -12484,6 +12484,7 @@ export class DesktopBackendRegistry {
       result = { threadId: request.threadId };
     }
     this.invalidateThreadListCache(backend);
+    if (backend === "codex") await this.tokenMiserStore?.archiveThread(result.threadId);
     const messagingCleanup = await this.cleanupMessagingForArchivedThread({
       backend,
       threadId: result.threadId,
@@ -22154,7 +22155,7 @@ export class DesktopBackendRegistry {
    * something else happened to start one — five minutes of fail-open on the
    * turn this was diagnosed from, nine large results ungated. Every call
    * after the first is cheap: the bridge start and the plugin install are
-   * memoized, retention pruning is boot-only, and the activation record is
+   * memoized, legacy cleanup runs at boot and managed runtime restart, and the activation record is
    * written only when its state changes.
    */
   private async prepareTokenMiserRuntime(
@@ -22168,6 +22169,12 @@ export class DesktopBackendRegistry {
       return;
     }
     try {
+      if (options.prune) {
+        await this.tokenMiserStore.prune({
+          maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
+          maxBytes: 512 * 1024 * 1024,
+        });
+      }
       await this.tokenMiserHookBridge.start();
       const capabilities = await this.readTokenMiserServerCapabilities(
         this.codexClient,
@@ -22191,12 +22198,6 @@ export class DesktopBackendRegistry {
           : codexRuntime
             ? this.tokenMiserPluginManager.ensureInstalled(codexRuntime)
             : this.tokenMiserPluginManager.ensurePluginSource(),
-        options.prune
-          ? this.tokenMiserStore.prune({
-              maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
-              maxBytes: 512 * 1024 * 1024,
-            })
-          : Promise.resolve(),
       ]);
       this.tokenMiserRuntimePreparationFailure = undefined;
       await this.recordTokenMiserActivation(
@@ -22927,6 +22928,7 @@ export class DesktopBackendRegistry {
           this.invalidateThreadListCache(backend);
         }
         if (notification.method === "thread/archived") {
+          if (backend === "codex") await this.tokenMiserStore?.archiveThread(notification.params.threadId);
           await this.cleanupMessagingForArchivedThread({
             backend,
             threadId: notification.params.threadId,
@@ -22949,6 +22951,7 @@ export class DesktopBackendRegistry {
             || notification.method === "turn/cancelled"
           )
         ) {
+          await this.tokenMiserStore?.flushThread(notification.params.threadId);
           await this.handleCodexTurnTerminalForInvalidIdRecovery(
             notification as Extract<
               AppServerNotification,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8385,6 +8385,7 @@ export class DesktopBackendRegistry {
     string,
     Map<string, ThreadUsageLineRecord>
   >();
+  private tokenMiserStoragePreparation: Promise<void> = Promise.resolve();
   private tokenMiserLedgerReconciliation: Promise<void> = Promise.resolve();
   private tokenMiserLivePublishChain: Promise<void> = Promise.resolve();
   private liveThreadUsageObservationSequence = 0;
@@ -9281,13 +9282,7 @@ export class DesktopBackendRegistry {
       ?? ACP_AVAILABLE_COMMAND_PROBE_BUDGET_MS;
     this.overlayStore = options?.overlayStore ?? getDesktopOverlayStore();
     if (this.tokenMiserStore) {
-      this.tokenMiserLedgerReconciliation = Promise.resolve()
-        .then(async () => await this.reconcileTokenMiserLedger())
-        .catch((error) => {
-          backendRegistryLog.warn("Token Miser ledger reconciliation failed", {
-            error: error instanceof Error ? error.message : String(error),
-          });
-        });
+      void this.initializeTokenMiserLedger();
     }
     this.gitDirectoryService =
       options?.gitDirectoryService ??
@@ -10872,7 +10867,8 @@ export class DesktopBackendRegistry {
   /**
    * Bring the Token Miser gate up at boot when the feature is on, so a resumed
    * thread is covered from its first tool call rather than from whenever a new
-   * thread happens to be created. Retention pruning rides this one call.
+   * thread happens to be created. Accounting migration runs independently during
+   * registry initialization, even when this feature is disabled.
    *
    * The caller must run this AFTER the one permitted startup Codex discovery
    * has published a selection. Preparation opens the app-server to read its
@@ -10890,10 +10886,10 @@ export class DesktopBackendRegistry {
     // could be followed by a fresh Codex child process and writes to a store
     // `close()` already finalized. `maybeRestartCodexForManagedRuntimeChange`
     // guards on `closed` for the same reason.
-    if (this.closed || !this.resolveTokenMiserEnabledFn()) {
-      return;
-    }
-    await this.prepareTokenMiserRuntime({ prune: true });
+    if (this.closed) return;
+    await this.tokenMiserLedgerReconciliation;
+    if (this.closed || !this.resolveTokenMiserEnabledFn()) return;
+    await this.prepareTokenMiserRuntime();
   }
 
   refreshProvidersAtStartup(permit: ProviderDiscoveryPermit): Promise<void> {
@@ -12484,7 +12480,7 @@ export class DesktopBackendRegistry {
       result = { threadId: request.threadId };
     }
     this.invalidateThreadListCache(backend);
-    if (backend === "codex") await this.tokenMiserStore?.archiveThread(result.threadId);
+    if (backend === "codex") await this.archiveTokenMiserThread(result.threadId);
     const messagingCleanup = await this.cleanupMessagingForArchivedThread({
       backend,
       threadId: result.threadId,
@@ -12589,6 +12585,19 @@ export class DesktopBackendRegistry {
           : "Unable to load thread metadata for archive cleanup.",
       },
     ];
+  }
+
+  private async archiveTokenMiserThread(threadId: string): Promise<void> {
+    try {
+      await this.tokenMiserStore?.archiveThread(threadId);
+    } catch (error) {
+      // Codex has already archived the thread. Retention failures must not
+      // prevent binding revocation, child cleanup, bookkeeping or publication.
+      backendRegistryLog.warn("Token Miser archive retention failed", {
+        threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async restoreThread(
@@ -14228,6 +14237,7 @@ export class DesktopBackendRegistry {
       return params.accounting;
     }
     try {
+      await this.tokenMiserStoragePreparation;
       const metadata = await this.tokenMiserStore.listMetadata(params.threadId);
       const tokenMiser = await this.tokenMiserStore.summarizeThreadUsage(
         params.threadId,
@@ -22159,9 +22169,7 @@ export class DesktopBackendRegistry {
    * memoized, legacy cleanup runs at boot and managed runtime restart, and the activation record is
    * written only when its state changes.
    */
-  private async prepareTokenMiserRuntime(
-    options: { prune?: boolean } = {},
-  ): Promise<void> {
+  private async prepareTokenMiserRuntime(): Promise<void> {
     if (
       !this.tokenMiserStore
       || !this.tokenMiserHookBridge
@@ -22170,12 +22178,7 @@ export class DesktopBackendRegistry {
       return;
     }
     try {
-      if (options.prune) {
-        await this.tokenMiserStore.prune({
-          maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
-          maxBytes: 512 * 1024 * 1024,
-        });
-      }
+      await this.tokenMiserLedgerReconciliation;
       await this.tokenMiserHookBridge.start();
       const capabilities = await this.readTokenMiserServerCapabilities(
         this.codexClient,
@@ -22929,7 +22932,7 @@ export class DesktopBackendRegistry {
           this.invalidateThreadListCache(backend);
         }
         if (notification.method === "thread/archived") {
-          if (backend === "codex") await this.tokenMiserStore?.archiveThread(notification.params.threadId);
+          if (backend === "codex") await this.archiveTokenMiserThread(notification.params.threadId);
           await this.cleanupMessagingForArchivedThread({
             backend,
             threadId: notification.params.threadId,
@@ -27871,8 +27874,9 @@ export class DesktopBackendRegistry {
       this.tokenMiserCodeModeGroupingVersion = undefined;
       this.tokenMiserPostToolUseExactOutputVersion = undefined;
       this.tokenMiserRuntimePreparationFailure = undefined;
+      if (this.tokenMiserStore) await this.initializeTokenMiserLedger();
       if (this.resolveTokenMiserEnabledFn()) {
-        await this.prepareTokenMiserRuntime({ prune: true });
+        await this.prepareTokenMiserRuntime();
       }
       if (completesManagedSwitch) {
         this.markManagedCodexRuntimeSwitchCompleteFn();
@@ -29481,6 +29485,25 @@ export class DesktopBackendRegistry {
         threadId: line.parentThreadId ?? line.threadId,
       });
     }
+  }
+
+  private initializeTokenMiserLedger(): Promise<void> {
+    this.tokenMiserStoragePreparation = this.tokenMiserStoragePreparation
+      .catch(() => undefined)
+      .then(async () => {
+        await this.tokenMiserStore?.prune({
+          maxAgeMs: 7 * 24 * 60 * 60 * 1_000,
+          maxBytes: 512 * 1024 * 1024,
+        });
+      });
+    this.tokenMiserLedgerReconciliation = this.tokenMiserStoragePreparation
+      .then(async () => await this.reconcileTokenMiserLedger())
+      .catch((error) => {
+        backendRegistryLog.warn("Token Miser ledger reconciliation failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      });
+    return this.tokenMiserLedgerReconciliation;
   }
 
   private async reconcileTokenMiserLedger(): Promise<void> {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -12600,6 +12600,19 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private async restoreTokenMiserThread(threadId: string): Promise<void> {
+    try {
+      await this.tokenMiserStore?.restoreThread(threadId);
+    } catch (error) {
+      // Codex restoration already succeeded. The retained archive marker
+      // keeps originals unavailable while desktop restoration still finishes.
+      backendRegistryLog.warn("Token Miser restore retention failed", {
+        threadId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
   async restoreThread(
     request: RestoreThreadRequest,
   ): Promise<RestoreThreadResponse> {
@@ -12618,7 +12631,7 @@ export class DesktopBackendRegistry {
       await this.restoreWithClient(client, request.threadId),
     );
     if (backend === "codex") {
-      await this.tokenMiserStore?.restoreThread(result.threadId);
+      await this.restoreTokenMiserThread(result.threadId);
       await this.overlayStore.setThreadArchiveTombstone({
         backend,
         threadId: result.threadId,
@@ -21833,6 +21846,13 @@ export class DesktopBackendRegistry {
         ? [{ name: resources[index].name, reason: result.reason }]
         : [],
     );
+    // Producers are now closed and previously admitted observations drained.
+    // Preserve active-turn estimates even when another resource failed close.
+    try {
+      await this.tokenMiserStore?.flushAll();
+    } catch (error) {
+      failures.push({ name: "token-miser-replay", reason: error });
+    }
     if (failures.length > 0) {
       throw new AggregateError(
         failures.map((failure) => failure.reason),
@@ -22940,7 +22960,7 @@ export class DesktopBackendRegistry {
           });
         }
         if (notification.method === "thread/unarchived") {
-          if (backend === "codex") await this.tokenMiserStore?.restoreThread(notification.params.threadId);
+          if (backend === "codex") await this.restoreTokenMiserThread(notification.params.threadId);
           this.clearArchivedMessagingCleanupCache({
             backend,
             threadId: notification.params.threadId,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -12609,6 +12609,7 @@ export class DesktopBackendRegistry {
       await this.restoreWithClient(client, request.threadId),
     );
     if (backend === "codex") {
+      await this.tokenMiserStore?.restoreThread(result.threadId);
       await this.overlayStore.setThreadArchiveTombstone({
         backend,
         threadId: result.threadId,
@@ -22936,6 +22937,7 @@ export class DesktopBackendRegistry {
           });
         }
         if (notification.method === "thread/unarchived") {
+          if (backend === "codex") await this.tokenMiserStore?.restoreThread(notification.params.threadId);
           this.clearArchivedMessagingCleanupCache({
             backend,
             threadId: notification.params.threadId,

--- a/apps/desktop/src/main/token-miser/token-miser-output-cache.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-output-cache.ts
@@ -1,0 +1,54 @@
+import { randomUUID } from "node:crypto";
+
+export const TOKEN_MISER_OUTPUT_TTL_MS = 5 * 60_000;
+export const TOKEN_MISER_OUTPUT_BUDGET_BYTES = 32 * 1024 * 1024;
+export const TOKEN_MISER_OUTPUT_ENTRY_BYTES = 4 * 1024 * 1024;
+const entries = new Map<string, { text: string; bytes: number; expiresAt: number; timer: NodeJS.Timeout }>();
+let retainedBytes = 0;
+function remove(key: string): void {
+  const entry = entries.get(key);
+  if (!entry) return;
+  clearTimeout(entry.timer);
+  retainedBytes -= entry.bytes;
+  entries.delete(key);
+}
+
+/** All stores and staged/delivery payloads share one process memory budget. */
+export class TokenMiserOutputCache {
+  private readonly namespace = randomUUID();
+
+  put(id: string, text: string): boolean {
+    const key = `${this.namespace}:${id}`;
+    remove(key);
+    const bytes = 256 + id.length * 2 + Buffer.byteLength(text, "utf8") + text.length * 2;
+    if (bytes > TOKEN_MISER_OUTPUT_ENTRY_BYTES) return false;
+    for (const [candidate, entry] of entries) {
+      if (entry.expiresAt <= Date.now()) remove(candidate);
+    }
+    while (retainedBytes + bytes > TOKEN_MISER_OUTPUT_BUDGET_BYTES) {
+      remove(entries.keys().next().value!);
+    }
+    const timer = setTimeout(() => remove(key), TOKEN_MISER_OUTPUT_TTL_MS);
+    timer.unref();
+    entries.set(key, { text, bytes, expiresAt: Date.now() + TOKEN_MISER_OUTPUT_TTL_MS, timer });
+    retainedBytes += bytes;
+    return true;
+  }
+
+  get(id: string): string | undefined {
+    const key = `${this.namespace}:${id}`;
+    const entry = entries.get(key);
+    if (entry && entry.expiresAt <= Date.now()) {
+      remove(key);
+      return undefined;
+    }
+    return entry?.text;
+  }
+
+  expiresAt(id: string): number | undefined {
+    if (this.get(id) === undefined) return undefined;
+    return entries.get(`${this.namespace}:${id}`)?.expiresAt;
+  }
+
+  remove(id: string): void { remove(`${this.namespace}:${id}`); }
+}

--- a/apps/desktop/src/main/token-miser/token-miser-service.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-service.ts
@@ -1,3 +1,4 @@
+import { TokenMiserOutputCache } from "./token-miser-output-cache";
 import { randomUUID } from "node:crypto";
 import {
   TOKEN_MISER_CODE_MODE_MAX_RESPONSE_BYTES,
@@ -177,7 +178,8 @@ export type TokenMiserServiceOptions = {
 export class TokenMiserService {
   private readonly thresholdCharacters: number;
   private readonly summaryTimeoutMs: number;
-  private readonly capturedGroups = new Map<string, CapturedGroup>();
+  private readonly capturedGroups = new Map<string, Omit<CapturedGroup, "members">>();
+  private readonly capturedOutputs = new TokenMiserOutputCache();
 
   constructor(private readonly options: TokenMiserServiceOptions) {
     this.thresholdCharacters =
@@ -213,29 +215,37 @@ export class TokenMiserService {
     if (!group) {
       const timer = setTimeout(() => {
         this.capturedGroups.delete(key);
+        this.capturedOutputs.remove(key);
       }, CAPTURED_GROUP_TTL_MS);
       timer.unref?.();
-      group = { members: new Map(), characters: 0, overflowed: false, timer };
+      group = { characters: 0, overflowed: false, timer };
       this.capturedGroups.set(key, group);
     }
-    const previous = group.members.get(payload.code_mode_tool_call_id);
+    const stored = this.capturedOutputs.get(key);
+    if (!stored && group.characters > 0) {
+      group.overflowed = true;
+      return;
+    }
+    const members = new Map<string, CapturedGroupMember>(stored ? JSON.parse(stored) : []);
+    const previous = members.get(payload.code_mode_tool_call_id);
     const nextCharacters = group.characters
       - ((previous?.output.length ?? 0) + (previous?.toolInput.length ?? 0))
       + output.length
       + toolInput.length;
     if (
-      (!previous && group.members.size >= MAX_CAPTURED_GROUP_MEMBERS)
+      (!previous && members.size >= MAX_CAPTURED_GROUP_MEMBERS)
       || nextCharacters > MAX_CAPTURED_GROUP_CHARACTERS
     ) {
       group.overflowed = true;
       return;
     }
-    group.members.set(payload.code_mode_tool_call_id, {
+    members.set(payload.code_mode_tool_call_id, {
       toolCallId: payload.code_mode_tool_call_id,
       toolName: payload.tool_name,
       toolInput,
       output,
     });
+    group.overflowed ||= !this.capturedOutputs.put(key, JSON.stringify([...members]));
     group.characters = nextCharacters;
   }
 
@@ -503,7 +513,10 @@ export class TokenMiserService {
       clearTimeout(group.timer);
       this.capturedGroups.delete(key);
     }
-    return group;
+    if (!group) return undefined;
+    const stored = this.capturedOutputs.get(key);
+    this.capturedOutputs.remove(key);
+    return { ...group, overflowed: group.overflowed || !stored, members: new Map(stored ? JSON.parse(stored) : []) };
   }
 
   private codeModeActionableStateCharacters(
@@ -1120,7 +1133,7 @@ function buildCappedReplacement(params: {
   if (utf8ByteLength(full) <= params.maxBytes) {
     return full;
   }
-  const reference = `Output reference: ${params.objectId}`;
+  const reference = `Output reference: ${params.objectId} (temporary, expires within 5m)`;
   if (utf8ByteLength(reference) > params.maxBytes) {
     return undefined;
   }
@@ -1145,7 +1158,7 @@ function buildReplacement(params: {
     buildReplacementBody(params.summary),
     "",
     `Output reference: ${params.objectId}`,
-    "Exact source material is available when required.",
+    "Original output is temporary (up to five minutes); expiry, eviction or restart makes it unavailable.",
   ].join("\n");
 }
 
@@ -1176,7 +1189,7 @@ function buildCappedGroupReplacement(params: {
       toolName: member.toolName,
       summary: member.summary,
     })),
-    sourceMaterial: "Available by group and member reference when required.",
+    sourceMaterial: "Temporary: expires within five minutes; unavailable after eviction or restart.",
   }, null, 2);
   if (utf8ByteLength(full) <= params.maxBytes) {
     return full;
@@ -1189,7 +1202,7 @@ function buildCappedGroupReplacement(params: {
       objectId: member.objectId,
       toolName: member.toolName,
     })),
-    sourceMaterial: "Retrieve source material by group or member reference.",
+    sourceMaterial: "Temporary group/member retrieval; expires within five minutes or earlier.",
   });
   if (utf8ByteLength(compact) <= params.maxBytes) {
     return compact;

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -1116,7 +1116,7 @@ function safeHelperUsage(value: TokenMiserHelperUsage): TokenMiserHelperUsage {
 function safeTokenUsage(value: unknown, depth = 0): unknown {
   if (!value || typeof value !== "object" || depth > 8) return undefined;
   const result: Record<string, unknown> = {};
-  const counts = new Set(["inputTokens", "outputTokens", "totalTokens", "cachedInputTokens", "reasoningOutputTokens", "input_tokens", "output_tokens", "total_tokens", "cached_input_tokens", "reasoning_output_tokens", "cache_read_input_tokens", "cached_tokens", "reasoning_tokens"]);
+  const counts = new Set(["inputTokens", "outputTokens", "totalTokens", "cachedInputTokens", "cacheWriteInputTokens", "reasoningOutputTokens", "modelContextWindow", "input_tokens", "output_tokens", "total_tokens", "cached_input_tokens", "reasoning_output_tokens", "cache_read_input_tokens", "cached_tokens", "reasoning_tokens"]);
   const containers = new Set(["tokenUsage", "token_usage", "info", "last", "last_token_usage", "total", "total_token_usage", "data", "payload", "usage", "result", "input_tokens_details", "output_tokens_details"]);
   for (const [key, entry] of Object.entries(value)) {
     if (counts.has(key) && typeof entry === "number" && Number.isFinite(entry) && entry >= 0) result[key] = entry;

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -24,6 +24,33 @@ const MAX_GROUP_BATCH_OPERATIONS = 16;
 const DEFAULT_GROUP_BATCH_OUTPUT_CHARACTERS = 20_000;
 const MAX_GROUP_BATCH_OUTPUT_CHARACTERS = 40_000;
 const RETRIEVAL_DELIVERY_TTL_MS = 2 * 60_000;
+const REPLAY_COUNTER_KEYS = ["parentRequestsObservedAfterGate", "cachedReplayCount", "cachedBaselineTokens", "cachedRevealedTokens"] as const;
+type ReplayCounter = typeof REPLAY_COUNTER_KEYS[number];
+type PendingReplayUpdate = {
+  view: TokenMiserObjectMetadata;
+  deltas: Partial<Record<ReplayCounter, number>>;
+  baseRequestEpoch?: string;
+};
+
+function mergeReplayUpdate(metadata: TokenMiserObjectMetadata, pending?: PendingReplayUpdate): TokenMiserObjectMetadata {
+  if (!pending) return metadata;
+  const merged = { ...metadata };
+  for (const key of REPLAY_COUNTER_KEYS) {
+    if (pending.deltas[key]) merged[key] = (metadata[key] ?? 0) + pending.deltas[key]!;
+  }
+  // A different epoch written since we buffered this work belongs to the
+  // other instance. Do not replace its request cursor with our older epoch.
+  if (metadata.parentRequestEpoch === pending.view.parentRequestEpoch) {
+    merged.lastParentCumulativeInputTokens = Math.max(
+      metadata.lastParentCumulativeInputTokens ?? -1,
+      pending.view.lastParentCumulativeInputTokens ?? -1,
+    );
+  } else if (metadata.parentRequestEpoch === pending.baseRequestEpoch) {
+    merged.parentRequestEpoch = pending.view.parentRequestEpoch;
+    merged.lastParentCumulativeInputTokens = pending.view.lastParentCumulativeInputTokens;
+  }
+  return merged;
+}
 
 async function readStoredFile(filePath: string): Promise<string> {
   return await withTokenMiserFileOperation(() => fs.readFile(filePath, "utf8"));
@@ -229,7 +256,7 @@ export class TokenMiserStore {
   private readonly updateLocks = new Map<string, Promise<void>>();
   private readonly pendingRetrievalDeliveries =
     new Map<string, { createdAt: number; threadId: string }>();
-  private readonly replayUpdates = new Map<string, TokenMiserObjectMetadata>();
+  private readonly replayUpdates = new Map<string, PendingReplayUpdate>();
   private readonly outputGenerations = new Map<string, string>();
   private readonly owners = new Map<string, string>();
   private readonly metadataIndexes = new Map<string, TokenMiserRecordIndex<TokenMiserObjectMetadata>>();
@@ -409,11 +436,14 @@ export class TokenMiserStore {
   }
 
   async readMetadata(objectId: string, threadId?: string): Promise<TokenMiserObjectMetadata | undefined> {
+    const metadata = await this.readDurableMetadata(objectId, threadId);
+    return metadata ? mergeReplayUpdate(metadata, this.replayUpdates.get(objectId)) : undefined;
+  }
+
+  private async readDurableMetadata(objectId: string, threadId?: string): Promise<TokenMiserObjectMetadata | undefined> {
     if (!isSafeObjectId(objectId)) {
       return undefined;
     }
-    const pending = this.replayUpdates.get(objectId);
-    if (pending && (threadId === undefined || pending.threadId === threadId)) return { ...pending };
     if (threadId === undefined && !this.owners.has(objectId)) await this.listMetadata();
     const key = threadId === undefined ? this.owners.get(objectId) : this.threadKey(threadId);
     if (!key) return undefined;
@@ -647,7 +677,7 @@ export class TokenMiserStore {
 
   async listMetadata(threadId?: string): Promise<TokenMiserObjectMetadata[]> {
     return (await mapTokenMiserFiles(await this.threadKeys(threadId), (key) => this.metadataIndex(key).list(threadId))).flat()
-      .map((entry) => this.replayUpdates.get(entry.objectId) ?? entry)
+      .map((entry) => mergeReplayUpdate(entry, this.replayUpdates.get(entry.objectId)))
       .sort((left, right) => right.createdAt - left.createdAt);
   }
 
@@ -834,10 +864,22 @@ export class TokenMiserStore {
   }
 
   async flushThread(threadId: string): Promise<void> {
-    for (const [objectId, metadata] of this.replayUpdates) {
-      if (metadata.threadId !== threadId) continue;
+    for (const [objectId, pending] of this.replayUpdates) {
+      if (pending.view.threadId !== threadId) continue;
       await this.updateMetadata(objectId, () => true, "flushed");
     }
+  }
+
+  async flushAll(): Promise<void> {
+    // The caller stops event producers before draining. Include updates that
+    // have entered the serialization queue but have not reached the buffer.
+    await Promise.allSettled([...this.updateLocks.values()]);
+    const failures: unknown[] = [];
+    for (const objectId of [...this.replayUpdates.keys()]) {
+      try { await this.updateMetadata(objectId, () => true, "flushed"); }
+      catch (error) { failures.push(error); }
+    }
+    if (failures.length) throw new AggregateError(failures, "Token Miser replay flush failed");
   }
 
   private async isArchived(threadId: string): Promise<boolean> {
@@ -875,7 +917,10 @@ export class TokenMiserStore {
       path.join(root, "archived"),
       path.join(root, "retention-generation"),
     )).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== "ENOENT") throw error;
+      if (error.code !== "ENOENT") {
+        this.archivedThreads.add(threadId);
+        throw error;
+      }
     });
     this.archivedThreads.delete(threadId);
   }
@@ -1042,12 +1087,31 @@ export class TokenMiserStore {
       .catch(() => undefined);
     let updated: TokenMiserObjectMetadata | undefined;
     const next = previous.then(async () => {
-      const metadata = this.replayUpdates.get(objectId) ?? await this.readMetadata(objectId);
-      if (!metadata || !update(metadata)) {
+      const pending = this.replayUpdates.get(objectId);
+      if (reason === "flushed" && !pending) return;
+      // Replay events stay in RAM. Persistence boundaries always merge our
+      // counter deltas into fresh disk state, preserving retirement/retrieval.
+      const current = reason === "replay" && pending
+        ? pending.view
+        : await this.readMetadata(objectId);
+      if (!current) {
+        this.replayUpdates.delete(objectId);
+        return;
+      }
+      const metadata = { ...current };
+      if (!update(metadata)) {
         return;
       }
       if (reason === "replay") {
-        this.replayUpdates.set(objectId, metadata);
+        const deltas = { ...pending?.deltas };
+        for (const key of REPLAY_COUNTER_KEYS) {
+          const delta = (metadata[key] ?? 0) - (current[key] ?? 0);
+          if (delta) deltas[key] = (deltas[key] ?? 0) + delta;
+        }
+        this.replayUpdates.set(objectId, {
+          view: metadata, deltas,
+          baseRequestEpoch: pending ? pending.baseRequestEpoch : current.parentRequestEpoch,
+        });
       } else {
         await this.writeMetadata(metadata);
         this.replayUpdates.delete(objectId);

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -898,9 +898,13 @@ export class TokenMiserStore {
   }
 
   async prune(_params: { maxAgeMs: number; maxBytes: number; now?: number }): Promise<void> {
-    await this.ensureRoot();
     // Only legacy flat files are migrated; safe accounting has no payload TTL.
-    const directory = await fs.opendir(this.rootDir);
+    // Startup migration must not create a profile before onboarding selects it.
+    const directory = await fs.opendir(this.rootDir).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (!directory) return;
     for await (const entry of directory) {
       if (!entry.isFile()) continue;
       const file = path.join(this.rootDir, entry.name);
@@ -1069,10 +1073,6 @@ export class TokenMiserStore {
       fs.rm(this.metadataPath(objectId), { force: true }),
     ]);
     this.metadataIndex(this.owners.get(objectId)!).forget(`${objectId}${METADATA_SUFFIX}`);
-  }
-
-  private async ensureRoot(): Promise<void> {
-    await fs.mkdir(this.rootDir, { recursive: true, mode: 0o700 });
   }
 
   private async writeMetadata(metadata: TokenMiserObjectMetadata): Promise<void> {

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -89,6 +89,7 @@ export type TokenMiserRetrievalDelivery = {
 };
 
 type PendingRetrievalDelivery = {
+  generation: string;
   createdAt: number;
   objectId: string;
   threadId: string;
@@ -228,6 +229,7 @@ export class TokenMiserStore {
   private readonly pendingRetrievalDeliveries =
     new Map<string, { createdAt: number; threadId: string }>();
   private readonly replayUpdates = new Map<string, TokenMiserObjectMetadata>();
+  private readonly outputGenerations = new Map<string, string>();
   private readonly owners = new Map<string, string>();
   private readonly metadataIndexes = new Map<string, TokenMiserRecordIndex<TokenMiserObjectMetadata>>();
   private readonly observationIndexes = new Map<string, TokenMiserRecordIndex<TokenMiserCodeModeObservation>>();
@@ -289,6 +291,7 @@ export class TokenMiserStore {
   }
 
   async stage(params: TokenMiserStoreParams): Promise<TokenMiserStagedObject> {
+    const generation = await this.readRetentionGeneration(params.threadId);
     if (await this.isArchived(params.threadId)) throw new Error("Token Miser originals are unavailable for an archived thread.");
     const objectId = params.objectId ?? randomUUID();
     if (!isSafeObjectId(objectId)) {
@@ -344,6 +347,7 @@ export class TokenMiserStore {
       || this.outputs.put(objectId, params.output);
     if (!retained) throw new Error("Token Miser temporary output capacity exceeded.");
     this.owners.set(objectId, this.threadKey(params.threadId));
+    this.outputGenerations.set(objectId, generation);
     let persisted = false;
     let committed = false;
     let discarded = false;
@@ -354,7 +358,7 @@ export class TokenMiserStore {
     };
     const persist = async (): Promise<void> => {
       await serialize(async () => {
-        if (await this.isArchived(metadata.threadId)) {
+        if (!await this.isCurrentRetention(metadata.threadId, generation)) {
           this.outputs.remove(objectId);
           throw new Error("Token Miser original output expired or unavailable.");
         }
@@ -374,6 +378,10 @@ export class TokenMiserStore {
         await serialize(async () => {
           if (committed || discarded) {
             return;
+          }
+          if (!await this.isCurrentRetention(metadata.threadId, generation)) {
+            this.outputs.remove(objectId);
+            throw new Error("Token Miser original output expired or unavailable.");
           }
           if (!persisted) {
             if (metadata.disposition !== "passed_through" && this.outputs.get(objectId) === undefined) {
@@ -551,7 +559,8 @@ export class TokenMiserStore {
     threadId: string;
     visibleText: string;
   }): Promise<TokenMiserRetrievalDelivery | undefined> {
-    if (await this.isArchived(params.threadId)) return undefined;
+    const generation = this.outputGenerations.get(params.objectId);
+    if (!await this.isCurrentRetention(params.threadId, generation)) return undefined;
     const metadata = await this.readMetadata(params.objectId, params.threadId);
     if (
       !metadata
@@ -571,6 +580,7 @@ export class TokenMiserStore {
     const end = `</pwragent_token_miser_retrieval id="${deliveryId}">`;
     const wrappedText = `${begin}\n${params.visibleText}\n${end}`;
     if (!this.outputs.put(deliveryId, JSON.stringify({
+      generation,
       createdAt: now,
       objectId: params.objectId,
       threadId: params.threadId,
@@ -592,6 +602,7 @@ export class TokenMiserStore {
     // both the beginning and end, so attribute only the intersections with
     // those exact UTF-8 byte-budgeted ranges.
     if (await this.isArchived(params.threadId)) return 0;
+    const generation = await this.readRetentionGeneration(params.threadId);
     const candidates = [...this.pendingRetrievalDeliveries.entries()]
       .filter(([, pending]) => pending.threadId === params.threadId)
       .flatMap(([deliveryId, reference]) => {
@@ -612,6 +623,7 @@ export class TokenMiserStore {
     let confirmedCharacters = 0;
     for (const { deliveryId, outputOffset, pending } of candidates) {
       this.abandonRetrievalDelivery(deliveryId);
+      if (pending.generation !== generation) continue;
       const visibleTextStart = outputOffset + pending.visibleTextOffset;
       const visibleTextEnd = visibleTextStart + pending.visibleText.length;
       const visibleCharacters = visibleRanges.reduce((total, range) => {
@@ -702,6 +714,9 @@ export class TokenMiserStore {
     // Accounting and savings can share the same current metadata snapshot.
     const metadata = (metadataSnapshot ?? await this.listMetadata(threadId))
       .filter((entry) => entry.threadId === threadId);
+    const generation = metadata.some((entry) => this.outputs.expiresAt(entry.objectId) !== undefined)
+      ? await this.readRetentionGeneration(threadId)
+      : undefined;
     const archived = await this.isArchived(threadId);
     const observations = await this.listCodeModeObservations(threadId);
     const metadataByToolUseId = new Map(
@@ -732,7 +747,9 @@ export class TokenMiserStore {
         const retrievedTokens = estimateTokenCount(entry.retrievedCharacters);
         return {
           objectId: entry.objectId,
-          originalOutputAvailableUntil: archived ? undefined : this.outputs.expiresAt(entry.objectId),
+          originalOutputAvailableUntil: archived || this.outputGenerations.get(entry.objectId) !== generation
+            ? undefined
+            : this.outputs.expiresAt(entry.objectId),
           turnId: entry.turnId,
           toolUseId: entry.toolUseId,
           toolName: entry.toolName,
@@ -831,10 +848,36 @@ export class TokenMiserStore {
       });
   }
 
+  private async readRetentionGeneration(threadId: string): Promise<string> {
+    return await readStoredFile(path.join(this.threadRoot(this.threadKey(threadId)), "retention-generation"))
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return "";
+        throw error;
+      });
+  }
+
+  private async isCurrentRetention(threadId: string, generation: string | undefined): Promise<boolean> {
+    return generation !== undefined
+      && !await this.isArchived(threadId)
+      && generation === await this.readRetentionGeneration(threadId);
+  }
+
+  async restoreThread(threadId: string): Promise<void> {
+    const root = this.threadRoot(this.threadKey(threadId));
+    // Atomically remove the archive marker and retain its unique generation.
+    // Duplicate restoration cannot rotate the generation of newly staged work.
+    await withTokenMiserFileOperation(() => fs.rename(
+      path.join(root, "archived"),
+      path.join(root, "retention-generation"),
+    )).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== "ENOENT") throw error;
+    });
+  }
+
   async archiveThread(threadId: string): Promise<void> {
     const key = this.threadKey(threadId);
     await fs.mkdir(this.threadRoot(key), { recursive: true, mode: 0o700 });
-    if (!await this.isArchived(threadId)) await writePrivateFileAtomic(path.join(this.threadRoot(key), "archived"), "1\n");
+    if (!await this.isArchived(threadId)) await writePrivateFileAtomic(path.join(this.threadRoot(key), "archived"), `${randomUUID()}\n`);
     for (const [objectId, owner] of this.owners) {
       if (owner === key) this.outputs.remove(objectId);
     }
@@ -882,7 +925,7 @@ export class TokenMiserStore {
     objectId: string,
     threadId: string,
   ): Promise<TokenMiserStoredObject | undefined> {
-    if (await this.isArchived(threadId)) return undefined;
+    if (!await this.isCurrentRetention(threadId, this.outputGenerations.get(objectId))) return undefined;
     const metadata = await this.readMetadata(objectId, threadId);
     if (
       !metadata

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { mapTokenMiserFiles, withTokenMiserFileOperation } from "./token-miser-file-io";
+import { TokenMiserOutputCache } from "./token-miser-output-cache";
 import { TokenMiserRecordIndex } from "./token-miser-record-index";
 import {
   TOKEN_MISER_MODEL_VISIBLE_CAP_BYTES,
@@ -23,10 +24,6 @@ const MAX_GROUP_BATCH_OPERATIONS = 16;
 const DEFAULT_GROUP_BATCH_OUTPUT_CHARACTERS = 20_000;
 const MAX_GROUP_BATCH_OUTPUT_CHARACTERS = 40_000;
 const RETRIEVAL_DELIVERY_TTL_MS = 2 * 60_000;
-// Reducer acknowledgements expire after 60 seconds. A longer grace protects a
-// fresh pending output owned by another PwrAgent process sharing the profile,
-// while still reclaiming raw files left by a crash before acceptance.
-const PENDING_OUTPUT_ORPHAN_GRACE_MS = 5 * 60_000;
 
 async function readStoredFile(filePath: string): Promise<string> {
   return await withTokenMiserFileOperation(() => fs.readFile(filePath, "utf8"));
@@ -120,6 +117,7 @@ export type TokenMiserUsageSummary = {
 export type TokenMiserThreadUsageSummary = TokenMiserUsageSummary & {
   interceptions: Array<{
     objectId: string;
+    originalOutputAvailableUntil?: number;
     turnId: string;
     toolUseId: string;
     toolName: string;
@@ -173,7 +171,8 @@ export type TokenMiserMetadataUpdateReason =
   | "replay"
   | "retrieval"
   | "stopped"
-  | "stored";
+  | "stored"
+  | "flushed";
 
 export type TokenMiserStoreOptions = {
   onMetadataUpdated?: (
@@ -215,32 +214,72 @@ export type TokenMiserStoreParams = {
 
 export type TokenMiserStagedObject = {
   metadata: TokenMiserObjectMetadata;
-  /** Persist the retrievable object before its replacement is delivered. */
+  /** Verify the temporary reservation before its replacement is delivered. */
   persist(): Promise<void>;
-  /** Publish the already-persisted object to live accounting and cards. */
+  /** Persist accepted accounting and publish its fixed decision note. */
   commit(): Promise<void>;
   /** Remove an object whose replacement was not accepted by the caller. */
   discard(): Promise<void>;
 };
 
 export class TokenMiserStore {
+  private readonly outputs = new TokenMiserOutputCache();
   private readonly updateLocks = new Map<string, Promise<void>>();
   private readonly pendingRetrievalDeliveries =
-    new Map<string, PendingRetrievalDelivery>();
-  private readonly metadataIndex: TokenMiserRecordIndex<TokenMiserObjectMetadata>;
-  private readonly observationIndex: TokenMiserRecordIndex<TokenMiserCodeModeObservation>;
+    new Map<string, { createdAt: number; threadId: string }>();
+  private readonly replayUpdates = new Map<string, TokenMiserObjectMetadata>();
+  private readonly owners = new Map<string, string>();
+  private readonly metadataIndexes = new Map<string, TokenMiserRecordIndex<TokenMiserObjectMetadata>>();
+  private readonly observationIndexes = new Map<string, TokenMiserRecordIndex<TokenMiserCodeModeObservation>>();
 
   constructor(
     private readonly rootDir: string,
     private readonly options: TokenMiserStoreOptions = {},
-  ) {
-    this.metadataIndex = new TokenMiserRecordIndex(rootDir, (name) =>
-      this.readMetadata(name.slice(0, -METADATA_SUFFIX.length))
-    );
-    this.observationIndex = new TokenMiserRecordIndex(
-      this.observationRoot(),
-      (name) => this.readCodeModeObservation(name),
-    );
+  ) {}
+
+  private threadKey(threadId: string): string {
+    return createHash("sha256").update(threadId).digest("hex");
+  }
+
+  private threadRoot(key: string): string {
+    return path.join(this.rootDir, "threads", key);
+  }
+
+  private async threadKeys(threadId?: string): Promise<string[]> {
+    if (threadId !== undefined) return [this.threadKey(threadId)];
+    return await withTokenMiserFileOperation(() => fs.readdir(path.join(this.rootDir, "threads")))
+      .then((names) => names.filter((name) => /^[a-f0-9]{64}$/.test(name)))
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return [];
+        throw error;
+      });
+  }
+
+  private metadataIndex(key: string): TokenMiserRecordIndex<TokenMiserObjectMetadata> {
+    let index = this.metadataIndexes.get(key);
+    if (!index) {
+      index = new TokenMiserRecordIndex(this.threadRoot(key), async (name) => {
+        const value = JSON.parse(await readStoredFile(path.join(this.threadRoot(key), name))) as TokenMiserObjectMetadata;
+        if (value.version !== 1 || this.threadKey(value.threadId) !== key || `${value.objectId}.json` !== name) return undefined;
+        this.owners.set(value.objectId, key);
+        return value;
+      });
+      this.metadataIndexes.set(key, index);
+    }
+    return index;
+  }
+
+  private observationIndex(key: string): TokenMiserRecordIndex<TokenMiserCodeModeObservation> {
+    let index = this.observationIndexes.get(key);
+    if (!index) {
+      const directory = path.join(this.threadRoot(key), OBSERVATION_DIRECTORY);
+      index = new TokenMiserRecordIndex(directory, async (name) => {
+        const value = JSON.parse(await readStoredFile(path.join(directory, name))) as TokenMiserCodeModeObservation;
+        return value.version === 1 && this.threadKey(value.threadId) === key ? value : undefined;
+      });
+      this.observationIndexes.set(key, index);
+    }
+    return index;
   }
 
   async store(params: TokenMiserStoreParams): Promise<TokenMiserObjectMetadata> {
@@ -250,10 +289,12 @@ export class TokenMiserStore {
   }
 
   async stage(params: TokenMiserStoreParams): Promise<TokenMiserStagedObject> {
+    if (await this.isArchived(params.threadId)) throw new Error("Token Miser originals are unavailable for an archived thread.");
     const objectId = params.objectId ?? randomUUID();
     if (!isSafeObjectId(objectId)) {
       throw new Error("Invalid Token Miser object id.");
     }
+    if (await this.readMetadata(objectId, params.threadId)) throw new Error("Token Miser object id already exists.");
     const originalCharacters =
       params.baselineCharacters ?? utf8ByteLength(params.output);
     const metadata: TokenMiserObjectMetadata = {
@@ -287,16 +328,22 @@ export class TokenMiserStore {
               params.parentCumulativeInputTokens,
           }
         : {}),
-      summary: params.summary,
+      summary: { summary: params.disposition === "passed_through" ? "Output passed through." : "Output summarized.", usefulDetails: [] },
       ...(params.disposition ? { disposition: params.disposition } : {}),
       ...(params.groupId ? { groupId: params.groupId } : {}),
-      ...(params.groupMembers ? { groupMembers: params.groupMembers } : {}),
-      ...(params.helperUsage ? { helperUsage: params.helperUsage } : {}),
+      ...(params.groupMembers ? { groupMembers: params.groupMembers.map((member) => ({ objectId: member.objectId, toolCallId: member.toolCallId, toolName: member.toolName, summary: "Output summarized." })) } : {}),
+      ...(params.helperUsage ? { helperUsage: safeHelperUsage(params.helperUsage) } : {}),
       ...(params.parentModel ? { parentModel: params.parentModel } : {}),
       ...(params.parentServiceTier
         ? { parentServiceTier: params.parentServiceTier }
         : {}),
     };
+    if (this.owners.has(objectId)) throw new Error("Token Miser object id already reserved.");
+    // Reserve before returning a replacement. The closure retains no raw text.
+    const retained = params.disposition === "passed_through"
+      || this.outputs.put(objectId, params.output);
+    if (!retained) throw new Error("Token Miser temporary output capacity exceeded.");
+    this.owners.set(objectId, this.threadKey(params.threadId));
     let persisted = false;
     let committed = false;
     let discarded = false;
@@ -307,11 +354,16 @@ export class TokenMiserStore {
     };
     const persist = async (): Promise<void> => {
       await serialize(async () => {
+        if (await this.isArchived(metadata.threadId)) {
+          this.outputs.remove(objectId);
+          throw new Error("Token Miser original output expired or unavailable.");
+        }
         if (persisted || committed || discarded) {
           return;
         }
-        await this.ensureRoot();
-        await writePrivateFileAtomic(this.outputPath(objectId), params.output);
+        if (metadata.disposition !== "passed_through" && this.outputs.get(objectId) === undefined) {
+          throw new Error("Token Miser original output expired or unavailable.");
+        }
         persisted = true;
       });
     };
@@ -324,11 +376,9 @@ export class TokenMiserStore {
             return;
           }
           if (!persisted) {
-            await this.ensureRoot();
-            await writePrivateFileAtomic(
-              this.outputPath(objectId),
-              params.output,
-            );
+            if (metadata.disposition !== "passed_through" && this.outputs.get(objectId) === undefined) {
+              throw new Error("Token Miser original output expired or unavailable.");
+            }
             persisted = true;
           }
           await this.writeMetadata(metadata);
@@ -349,14 +399,19 @@ export class TokenMiserStore {
     };
   }
 
-  async readMetadata(objectId: string): Promise<TokenMiserObjectMetadata | undefined> {
+  async readMetadata(objectId: string, threadId?: string): Promise<TokenMiserObjectMetadata | undefined> {
     if (!isSafeObjectId(objectId)) {
       return undefined;
     }
+    const pending = this.replayUpdates.get(objectId);
+    if (pending && (threadId === undefined || pending.threadId === threadId)) return { ...pending };
+    if (threadId === undefined && !this.owners.has(objectId)) await this.listMetadata();
+    const key = threadId === undefined ? this.owners.get(objectId) : this.threadKey(threadId);
+    if (!key) return undefined;
     try {
-      const raw = await readStoredFile(this.metadataPath(objectId));
+      const raw = await readStoredFile(path.join(this.threadRoot(key), `${objectId}.json`));
       const value = JSON.parse(raw) as TokenMiserObjectMetadata;
-      return value?.version === 1 && value.objectId === objectId
+      return value?.version === 1 && value.objectId === objectId && this.threadKey(value.threadId) === key
         ? value
         : undefined;
     } catch (error) {
@@ -496,7 +551,8 @@ export class TokenMiserStore {
     threadId: string;
     visibleText: string;
   }): Promise<TokenMiserRetrievalDelivery | undefined> {
-    const metadata = await this.readMetadata(params.objectId);
+    if (await this.isArchived(params.threadId)) return undefined;
+    const metadata = await this.readMetadata(params.objectId, params.threadId);
     if (
       !metadata
       || metadata.threadId !== params.threadId
@@ -514,14 +570,15 @@ export class TokenMiserStore {
     const begin = `<pwragent_token_miser_retrieval id="${deliveryId}">`;
     const end = `</pwragent_token_miser_retrieval id="${deliveryId}">`;
     const wrappedText = `${begin}\n${params.visibleText}\n${end}`;
-    this.pendingRetrievalDeliveries.set(deliveryId, {
+    if (!this.outputs.put(deliveryId, JSON.stringify({
       createdAt: now,
       objectId: params.objectId,
       threadId: params.threadId,
       visibleText: params.visibleText,
       visibleTextOffset: begin.length + 1,
       wrappedText,
-    });
+    }))) return undefined;
+    this.pendingRetrievalDeliveries.set(deliveryId, { createdAt: now, threadId: params.threadId });
     return { deliveryId, text: wrappedText };
   }
 
@@ -534,13 +591,18 @@ export class TokenMiserStore {
     // Codex applies one shared ceiling to the outer result. Its truncator keeps
     // both the beginning and end, so attribute only the intersections with
     // those exact UTF-8 byte-budgeted ranges.
+    if (await this.isArchived(params.threadId)) return 0;
     const candidates = [...this.pendingRetrievalDeliveries.entries()]
       .filter(([, pending]) => pending.threadId === params.threadId)
-      .map(([deliveryId, pending]) => ({
-        deliveryId,
-        outputOffset: params.output.indexOf(pending.wrappedText),
-        pending,
-      }))
+      .flatMap(([deliveryId, reference]) => {
+        const text = this.outputs.get(deliveryId);
+        if (!text || Date.now() - reference.createdAt > RETRIEVAL_DELIVERY_TTL_MS) {
+          this.abandonRetrievalDelivery(deliveryId);
+          return [];
+        }
+        const pending = JSON.parse(text) as PendingRetrievalDelivery;
+        return [{ deliveryId, outputOffset: params.output.indexOf(pending.wrappedText), pending }];
+      })
       .filter((candidate) => candidate.outputOffset >= 0)
       .sort((left, right) => left.outputOffset - right.outputOffset);
     const visibleRanges = codexVisibleStringRanges(
@@ -549,7 +611,7 @@ export class TokenMiserStore {
     );
     let confirmedCharacters = 0;
     for (const { deliveryId, outputOffset, pending } of candidates) {
-      this.pendingRetrievalDeliveries.delete(deliveryId);
+      this.abandonRetrievalDelivery(deliveryId);
       const visibleTextStart = outputOffset + pending.visibleTextOffset;
       const visibleTextEnd = visibleTextStart + pending.visibleText.length;
       const visibleCharacters = visibleRanges.reduce((total, range) => {
@@ -567,17 +629,19 @@ export class TokenMiserStore {
 
   abandonRetrievalDelivery(deliveryId: string): void {
     this.pendingRetrievalDeliveries.delete(deliveryId);
+    this.outputs.remove(deliveryId);
   }
 
   async listMetadata(threadId?: string): Promise<TokenMiserObjectMetadata[]> {
-    return (await this.metadataIndex.list(threadId))
+    return (await mapTokenMiserFiles(await this.threadKeys(threadId), (key) => this.metadataIndex(key).list(threadId))).flat()
+      .map((entry) => this.replayUpdates.get(entry.objectId) ?? entry)
       .sort((left, right) => right.createdAt - left.createdAt);
   }
 
   async recordCodeModeObservation(params: Omit<
     TokenMiserCodeModeObservation,
     "version" | "observationId" | "createdAt"
-  > & { createdAt?: number }): Promise<TokenMiserCodeModeObservation> {
+  > & { createdAt?: number }, publish = true): Promise<TokenMiserCodeModeObservation> {
     const observationId = createHash("sha256")
       .update(JSON.stringify([params.threadId, params.turnId, params.callId]))
       .digest("hex");
@@ -590,15 +654,8 @@ export class TokenMiserStore {
       cellId: params.cellId,
       createdAt: params.createdAt ?? Date.now(),
       outputCharacters: params.outputCharacters,
-      ...(params.outputPreview
-        ? { outputPreview: params.outputPreview.slice(0, 5_000) }
-        : {}),
-      ...(params.outputPreviewTruncated
-        ? { outputPreviewTruncated: true }
-        : {}),
       maxOutputTokens: params.maxOutputTokens,
-      scriptStatus: params.scriptStatus,
-      ...(params.script ? { script: params.script.slice(-4_000) } : {}),
+      scriptStatus: ["completed", "running", "failed", "cancelled"].includes(params.scriptStatus) ? params.scriptStatus : "unknown",
       retrieval: params.retrieval,
       capturedNestedInvocationCount: params.capturedNestedInvocationCount,
       ...(params.capturedCommandInvocationCount === undefined
@@ -614,34 +671,21 @@ export class TokenMiserStore {
         ? {}
         : { capturedOtherInvocationCount: params.capturedOtherInvocationCount }),
     };
-    await fs.mkdir(this.observationRoot(), { recursive: true, mode: 0o700 });
+    await fs.mkdir(this.observationRoot(params.threadId), { recursive: true, mode: 0o700 });
     await writePrivateFileAtomic(
-      this.observationPath(observationId),
+      this.observationPath(observationId, params.threadId),
       `${JSON.stringify(observation)}\n`,
     );
-    this.observationIndex.remember(`${observationId}${METADATA_SUFFIX}`, observation.threadId);
-    await this.options.onCodeModeObservationUpdated?.(observation);
+    this.observationIndex(this.threadKey(observation.threadId)).remember(`${observationId}${METADATA_SUFFIX}`, observation.threadId);
+    if (publish) await this.options.onCodeModeObservationUpdated?.(observation);
     return observation;
   }
 
   async listCodeModeObservations(
     threadId?: string,
   ): Promise<TokenMiserCodeModeObservation[]> {
-    return (await this.observationIndex.list(threadId))
+    return (await mapTokenMiserFiles(await this.threadKeys(threadId), (key) => this.observationIndex(key).list(threadId))).flat()
       .sort((left, right) => left.createdAt - right.createdAt);
-  }
-
-  private async readCodeModeObservation(name: string): Promise<TokenMiserCodeModeObservation | undefined> {
-    try {
-      const raw = await readStoredFile(path.join(this.observationRoot(), name));
-      const value = JSON.parse(raw) as TokenMiserCodeModeObservation;
-      return value?.version === 1
-        && value.observationId === name.slice(0, -METADATA_SUFFIX.length)
-        ? value
-        : undefined;
-    } catch {
-      return undefined;
-    }
   }
 
   async summarizeUsage(params?: {
@@ -658,6 +702,7 @@ export class TokenMiserStore {
     // Accounting and savings can share the same current metadata snapshot.
     const metadata = (metadataSnapshot ?? await this.listMetadata(threadId))
       .filter((entry) => entry.threadId === threadId);
+    const archived = await this.isArchived(threadId);
     const observations = await this.listCodeModeObservations(threadId);
     const metadataByToolUseId = new Map(
       metadata.map((entry) => [entry.toolUseId, entry]),
@@ -687,6 +732,7 @@ export class TokenMiserStore {
         const retrievedTokens = estimateTokenCount(entry.retrievedCharacters);
         return {
           objectId: entry.objectId,
+          originalOutputAvailableUntil: archived ? undefined : this.outputs.expiresAt(entry.objectId),
           turnId: entry.turnId,
           toolUseId: entry.toolUseId,
           toolName: entry.toolName,
@@ -769,63 +815,66 @@ export class TokenMiserStore {
     };
   }
 
-  async prune(params: {
-    maxAgeMs: number;
-    maxBytes: number;
-    now?: number;
-  }): Promise<void> {
-    const now = params.now ?? Date.now();
-    const metadata = await this.listMetadata();
-    const observations = await this.listCodeModeObservations();
-    const retainedObservations: Array<{
-      observation: TokenMiserCodeModeObservation;
-      bytes: number;
-    }> = [];
-    for (const observation of observations) {
-      const observationPath = this.observationPath(observation.observationId);
-      const stats = await fs.stat(observationPath).catch(() => undefined);
-      if (!stats || now - observation.createdAt > params.maxAgeMs) {
-        await fs.rm(observationPath, { force: true });
-        continue;
-      }
-      retainedObservations.push({ observation, bytes: stats.size });
+  async flushThread(threadId: string): Promise<void> {
+    for (const [objectId, metadata] of this.replayUpdates) {
+      if (metadata.threadId !== threadId) continue;
+      await this.updateMetadata(objectId, () => true, "flushed");
     }
-    await this.pruneStalePendingOutputs(
-      new Set(metadata.map((entry) => entry.objectId)),
-      now,
-    );
-    const retained: Array<{ metadata: TokenMiserObjectMetadata; bytes: number }> = [];
-    for (const entry of metadata) {
-      const outputPath = this.outputPath(entry.objectId);
-      const stats = await fs.stat(outputPath).catch(() => undefined);
-      if (!stats || now - entry.createdAt > params.maxAgeMs) {
-        await this.remove(entry.objectId);
-        continue;
-      }
-      retained.push({ metadata: entry, bytes: stats.size });
+  }
+
+  private async isArchived(threadId: string): Promise<boolean> {
+    return await withTokenMiserFileOperation(() => fs.stat(path.join(this.threadRoot(this.threadKey(threadId)), "archived")))
+      .then(() => true)
+      .catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return false;
+        throw error;
+      });
+  }
+
+  async archiveThread(threadId: string): Promise<void> {
+    const key = this.threadKey(threadId);
+    await fs.mkdir(this.threadRoot(key), { recursive: true, mode: 0o700 });
+    if (!await this.isArchived(threadId)) await writePrivateFileAtomic(path.join(this.threadRoot(key), "archived"), "1\n");
+    for (const [objectId, owner] of this.owners) {
+      if (owner === key) this.outputs.remove(objectId);
     }
-    const candidates = [
-      ...retained.map((entry) => ({
-        bytes: entry.bytes,
-        createdAt: entry.metadata.createdAt,
-        remove: () => this.remove(entry.metadata.objectId),
-      })),
-      ...retainedObservations.map((entry) => ({
-        bytes: entry.bytes,
-        createdAt: entry.observation.createdAt,
-        remove: () => fs.rm(
-          this.observationPath(entry.observation.observationId),
-          { force: true },
-        ),
-      })),
-    ].sort((left, right) => left.createdAt - right.createdAt);
-    let totalBytes = candidates.reduce((total, entry) => total + entry.bytes, 0);
-    for (const entry of candidates) {
-      if (totalBytes <= params.maxBytes) {
-        break;
+    for (const [id, pending] of this.pendingRetrievalDeliveries) {
+      if (pending.threadId === threadId) this.abandonRetrievalDelivery(id);
+    }
+    await this.flushThread(threadId);
+  }
+
+  async prune(_params: { maxAgeMs: number; maxBytes: number; now?: number }): Promise<void> {
+    await this.ensureRoot();
+    // Only legacy flat files are migrated; safe accounting has no payload TTL.
+    const directory = await fs.opendir(this.rootDir);
+    for await (const entry of directory) {
+      if (!entry.isFile()) continue;
+      const file = path.join(this.rootDir, entry.name);
+      if (entry.name.endsWith(".txt") || entry.name.endsWith(".tmp")) {
+        await withTokenMiserFileOperation(() => fs.rm(file, { force: true }));
+      } else if (entry.name.endsWith(".json")) {
+        const metadata = JSON.parse(await readStoredFile(file)) as TokenMiserObjectMetadata;
+        if (metadata.version !== 1 || !isSafeObjectId(metadata.objectId) || typeof metadata.threadId !== "string") {
+          throw new Error("Invalid legacy Token Miser accounting record; migration stopped.");
+        }
+        metadata.summary = { summary: metadata.disposition === "passed_through" ? "Output passed through." : "Output summarized.", usefulDetails: [] };
+        metadata.groupMembers = metadata.groupMembers?.map((member) => ({ objectId: member.objectId, toolCallId: member.toolCallId, toolName: member.toolName, summary: "Output summarized." }));
+        if (!await this.readMetadata(metadata.objectId, metadata.threadId)) await this.writeMetadata(metadata);
+        await withTokenMiserFileOperation(() => fs.rm(file, { force: true }));
       }
-      await entry.remove();
-      totalBytes -= entry.bytes;
+    }
+    const legacy = await fs.opendir(path.join(this.rootDir, OBSERVATION_DIRECTORY)).catch((error: NodeJS.ErrnoException) => {
+      if (error.code === "ENOENT") return undefined;
+      throw error;
+    });
+    if (legacy) for await (const entry of legacy) {
+      if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+      const file = path.join(this.rootDir, OBSERVATION_DIRECTORY, entry.name);
+      const observation = JSON.parse(await readStoredFile(file)) as TokenMiserCodeModeObservation;
+      if (observation.version !== 1 || typeof observation.threadId !== "string") throw new Error("Invalid legacy Token Miser observation; migration stopped.");
+      await this.recordCodeModeObservation(observation, false);
+      await withTokenMiserFileOperation(() => fs.rm(file, { force: true }));
     }
   }
 
@@ -833,7 +882,8 @@ export class TokenMiserStore {
     objectId: string,
     threadId: string,
   ): Promise<TokenMiserStoredObject | undefined> {
-    const metadata = await this.readMetadata(objectId);
+    if (await this.isArchived(threadId)) return undefined;
+    const metadata = await this.readMetadata(objectId, threadId);
     if (
       !metadata
       || metadata.threadId !== threadId
@@ -841,44 +891,8 @@ export class TokenMiserStore {
     ) {
       return undefined;
     }
-    const output = await readStoredFile(this.outputPath(objectId)).catch(
-      (error: unknown) => {
-        if (isMissingFileError(error)) {
-          return undefined;
-        }
-        throw error;
-      },
-    );
+    const output = this.outputs.get(objectId);
     return output === undefined ? undefined : { metadata, output };
-  }
-
-  private async pruneStalePendingOutputs(
-    committedObjectIds: ReadonlySet<string>,
-    now: number,
-  ): Promise<void> {
-    const entries = await fs.readdir(this.rootDir).catch((error: unknown) => {
-      if (isMissingFileError(error)) {
-        return [];
-      }
-      throw error;
-    });
-    await mapTokenMiserFiles(entries, async (entry) => {
-      if (!entry.endsWith(OUTPUT_SUFFIX)) {
-        return;
-      }
-      const objectId = entry.slice(0, -OUTPUT_SUFFIX.length);
-      if (!isSafeObjectId(objectId) || committedObjectIds.has(objectId)) {
-        return;
-      }
-      const outputPath = this.outputPath(objectId);
-      const stats = await fs.stat(outputPath).catch(() => undefined);
-      if (
-        stats
-        && now - stats.mtimeMs > PENDING_OUTPUT_ORPHAN_GRACE_MS
-      ) {
-        await fs.rm(outputPath, { force: true });
-      }
-    });
   }
 
   private async recordRetrieval(objectId: string, characters: number): Promise<void> {
@@ -971,11 +985,16 @@ export class TokenMiserStore {
       .catch(() => undefined);
     let updated: TokenMiserObjectMetadata | undefined;
     const next = previous.then(async () => {
-      const metadata = await this.readMetadata(objectId);
+      const metadata = this.replayUpdates.get(objectId) ?? await this.readMetadata(objectId);
       if (!metadata || !update(metadata)) {
         return;
       }
-      await this.writeMetadata(metadata);
+      if (reason === "replay") {
+        this.replayUpdates.set(objectId, metadata);
+      } else {
+        await this.writeMetadata(metadata);
+        this.replayUpdates.delete(objectId);
+      }
       await this.options.onMetadataUpdated?.(metadata, reason);
       updated = metadata;
     });
@@ -991,11 +1010,12 @@ export class TokenMiserStore {
   }
 
   private async remove(objectId: string): Promise<void> {
+    this.outputs.remove(objectId);
     await Promise.all([
       fs.rm(this.outputPath(objectId), { force: true }),
       fs.rm(this.metadataPath(objectId), { force: true }),
     ]);
-    this.metadataIndex.forget(`${objectId}${METADATA_SUFFIX}`);
+    this.metadataIndex(this.owners.get(objectId)!).forget(`${objectId}${METADATA_SUFFIX}`);
   }
 
   private async ensureRoot(): Promise<void> {
@@ -1003,28 +1023,68 @@ export class TokenMiserStore {
   }
 
   private async writeMetadata(metadata: TokenMiserObjectMetadata): Promise<void> {
+    await fs.mkdir(this.threadRoot(this.threadKey(metadata.threadId)), { recursive: true, mode: 0o700 });
+    this.owners.set(metadata.objectId, this.threadKey(metadata.threadId));
     await writePrivateFileAtomic(
       this.metadataPath(metadata.objectId),
-      `${JSON.stringify(metadata)}\n`,
+      `${JSON.stringify(safeMetadata(metadata))}\n`,
     );
-    this.metadataIndex.remember(`${metadata.objectId}${METADATA_SUFFIX}`, metadata.threadId);
+    this.metadataIndex(this.threadKey(metadata.threadId)).remember(`${metadata.objectId}${METADATA_SUFFIX}`, metadata.threadId);
   }
 
   private metadataPath(objectId: string): string {
-    return path.join(this.rootDir, `${objectId}${METADATA_SUFFIX}`);
+    return path.join(this.threadRoot(this.owners.get(objectId)!), `${objectId}${METADATA_SUFFIX}`);
   }
 
   private outputPath(objectId: string): string {
     return path.join(this.rootDir, `${objectId}${OUTPUT_SUFFIX}`);
   }
 
-  private observationRoot(): string {
-    return path.join(this.rootDir, OBSERVATION_DIRECTORY);
+  private observationRoot(threadId: string): string {
+    return path.join(this.threadRoot(this.threadKey(threadId)), OBSERVATION_DIRECTORY);
   }
 
-  private observationPath(observationId: string): string {
-    return path.join(this.observationRoot(), `${observationId}${METADATA_SUFFIX}`);
+  private observationPath(observationId: string, threadId: string): string {
+    return path.join(this.observationRoot(threadId), `${observationId}${METADATA_SUFFIX}`);
   }
+}
+
+function safeHelperUsage(value: TokenMiserHelperUsage): TokenMiserHelperUsage {
+  return {
+    helperThreadId: value.helperThreadId,
+    helperTurnId: value.helperTurnId,
+    model: value.model,
+    reasoningEffort: value.reasoningEffort,
+    serviceTier: value.serviceTier,
+    tokenUsage: safeTokenUsage(value.tokenUsage),
+  };
+}
+
+function safeTokenUsage(value: unknown, depth = 0): unknown {
+  if (!value || typeof value !== "object" || depth > 8) return undefined;
+  const result: Record<string, unknown> = {};
+  const counts = new Set(["inputTokens", "outputTokens", "totalTokens", "cachedInputTokens", "reasoningOutputTokens", "input_tokens", "output_tokens", "total_tokens", "cached_input_tokens", "reasoning_output_tokens", "cache_read_input_tokens", "cached_tokens", "reasoning_tokens"]);
+  const containers = new Set(["tokenUsage", "token_usage", "info", "last", "last_token_usage", "total", "total_token_usage", "data", "payload", "usage", "result", "input_tokens_details", "output_tokens_details"]);
+  for (const [key, entry] of Object.entries(value)) {
+    if (counts.has(key) && typeof entry === "number" && Number.isFinite(entry) && entry >= 0) result[key] = entry;
+    else if (containers.has(key)) result[key] = safeTokenUsage(entry, depth + 1);
+  }
+  return result;
+}
+
+function safeMetadata(value: TokenMiserObjectMetadata): TokenMiserObjectMetadata {
+  const result = {} as TokenMiserObjectMetadata;
+  // Deliberate allowlist: legacy JSON and helper objects may have extra content.
+  const keys = ["version", "objectId", "threadId", "turnId", "toolUseId", "toolName", "createdAt", "originalCharacters", "baselineParentTokens", "replacementCharacters", "retrievedCharacters", "replayTrackingVersion", "parentRequestsObservedAfterGate", "lastParentCumulativeInputTokens", "cachedReplayCount", "cachedBaselineTokens", "cachedRevealedTokens", "replayTrackingStoppedAt", "parentRequestEpoch", "disposition", "groupId", "parentModel", "parentServiceTier"] as const;
+  for (const key of keys) {
+    Object.assign(result, { [key]: value[key] });
+  }
+  result.summary = { summary: value.disposition === "passed_through" ? "Output passed through." : "Output summarized.", usefulDetails: [] };
+  if (value.helperUsage) result.helperUsage = safeHelperUsage(value.helperUsage);
+  if (value.groupMembers) result.groupMembers = value.groupMembers.map((member) => ({
+    objectId: member.objectId, toolCallId: member.toolCallId, toolName: member.toolName, summary: "Output summarized.",
+  }));
+  return result;
 }
 
 async function writePrivateFileAtomic(filePath: string, contents: string): Promise<void> {

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -224,6 +224,7 @@ export type TokenMiserStagedObject = {
 };
 
 export class TokenMiserStore {
+  private readonly archivedThreads = new Set<string>();
   private readonly outputs = new TokenMiserOutputCache();
   private readonly updateLocks = new Map<string, Promise<void>>();
   private readonly pendingRetrievalDeliveries =
@@ -840,6 +841,10 @@ export class TokenMiserStore {
   }
 
   private async isArchived(threadId: string): Promise<boolean> {
+    return this.archivedThreads.has(threadId) || await this.hasArchiveMarker(threadId);
+  }
+
+  private async hasArchiveMarker(threadId: string): Promise<boolean> {
     return await withTokenMiserFileOperation(() => fs.stat(path.join(this.threadRoot(this.threadKey(threadId)), "archived")))
       .then(() => true)
       .catch((error: NodeJS.ErrnoException) => {
@@ -872,18 +877,23 @@ export class TokenMiserStore {
     )).catch((error: NodeJS.ErrnoException) => {
       if (error.code !== "ENOENT") throw error;
     });
+    this.archivedThreads.delete(threadId);
   }
 
   async archiveThread(threadId: string): Promise<void> {
     const key = this.threadKey(threadId);
-    await fs.mkdir(this.threadRoot(key), { recursive: true, mode: 0o700 });
-    if (!await this.isArchived(threadId)) await writePrivateFileAtomic(path.join(this.threadRoot(key), "archived"), `${randomUUID()}\n`);
+    this.archivedThreads.add(threadId);
     for (const [objectId, owner] of this.owners) {
       if (owner === key) this.outputs.remove(objectId);
     }
     for (const [id, pending] of this.pendingRetrievalDeliveries) {
       if (pending.threadId === threadId) this.abandonRetrievalDelivery(id);
     }
+    await fs.mkdir(this.threadRoot(key), { recursive: true, mode: 0o700 });
+    if (!await this.hasArchiveMarker(threadId)) await writePrivateFileAtomic(path.join(this.threadRoot(key), "archived"), `${randomUUID()}\n`);
+    // Successful persistence is authoritative across instances, including a
+    // later restore elsewhere. Keep the local guard only on write failure.
+    this.archivedThreads.delete(threadId);
     await this.flushThread(threadId);
   }
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -2467,30 +2467,15 @@ function TokenMiserResultList(props: {
                 {isOpen ? (
                   <div className="incident-explorer__gate-detail">
                     {entry.edge ? <p>{entry.edge.detail}</p> : null}
-                    {entry.interception.summary ? (
-                      <>
-                        <p className="incident-explorer__gate-summary">
-                          {entry.interception.summary.summary}
-                        </p>
-                        {entry.interception.summary.usefulDetails.length > 0 ? (
-                          <ul>
-                            {entry.interception.summary.usefulDetails.map((detail) => (
-                              <li key={detail}>{detail}</li>
-                            ))}
-                          </ul>
-                        ) : null}
-                        {entry.interception.summary.suggestedNextStep ? (
-                          <p className="incident-explorer__gate-next">
-                            <b>Legacy suggested next step</b>{" "}
-                            {entry.interception.summary.suggestedNextStep}
-                          </p>
-                        ) : null}
-                      </>
-                    ) : (
-                      <p className="incident-explorer__gate-summary">
-                        No summary was recorded for this gate.
-                      </p>
-                    )}
+                    <p className="incident-explorer__gate-summary">
+                      {entry.interception.disposition === "passed_through" ? "Output passed through." : "Output summarized."}
+                    </p>
+                    <p>
+                      {entry.interception.originalOutputAvailableUntil && entry.interception.originalOutputAvailableUntil > Date.now()
+                        ? `Original output is temporary and expires by ${new Date(entry.interception.originalOutputAvailableUntil).toLocaleTimeString()}. It may become unavailable earlier.`
+                        : "Original output is expired or unavailable."}
+                      {" "}Costs and tokens are saved. Originals are unavailable after archive or restart.
+                    </p>
                   </div>
                 ) : null}
               </li>
@@ -2524,13 +2509,7 @@ function TokenMiserResultList(props: {
                       No reducer replacement was selected; the ordinary result
                       reached the parent directly.
                     </p>
-                    {entry.script ? <pre><code>{entry.script}</code></pre> : null}
-                    {entry.outputPreview ? (
-                      <pre><code>
-                        {entry.outputPreview}
-                        {entry.outputPreviewTruncated ? "\n… preview truncated" : ""}
-                      </code></pre>
-                    ) : null}
+                    <p>Scripts and output previews are not retained.</p>
                   </div>
                 ) : null}
               </li>

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -418,7 +418,7 @@ describe("ToolOutputIncidentExplorerWindow", () => {
   // The summary is what the parent actually received in place of the payload.
   // Without it the screen can only say how many tokens were traded, never what
   // was traded for — which is the only way to judge whether a "win" was one.
-  it("shows Luna's summary for a gate and filters gates by outcome", async () => {
+  it("shows safe decision notes and unavailable originals while filtering outcomes", async () => {
     const response = buildResponse();
     const gate = (
       objectId: string,
@@ -467,11 +467,10 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     // The summary is behind a disclosure so the list stays scannable.
     expect(screen.queryByText("Traced the handler for win-1.")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /win-1/ }));
-    expect(screen.getByText("Traced the handler for win-1.")).toBeInTheDocument();
-    expect(
-      screen.getByText("pr-auto-dispatch.ts:326 clears the timer for win-1"),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Inspect notifyPending for win-1/)).toBeInTheDocument();
+    expect(screen.getByText("Output summarized.")).toBeInTheDocument();
+    expect(screen.getByText(/Original output is expired or unavailable/)).toBeInTheDocument();
+    expect(screen.queryByText("Traced the handler for win-1.")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Inspect notifyPending for win-1/)).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /^Big misses\s*1$/ }));
     expect(screen.getByRole("button", { name: /cost-1/ })).toBeInTheDocument();

--- a/docs/design/token-miser-storage-review.md
+++ b/docs/design/token-miser-storage-review.md
@@ -223,3 +223,28 @@ separately and continues messaging revocation, child/worktree cleanup, archive
 bookkeeping and notification publication. A failed durable marker cannot inform
 other processes by itself; the failure remains visible in the log. No new SQLite
 write or periodic filesystem write is introduced by this handling.
+
+### Replay flush and restoration review
+
+Pending replay accounting stores counter deltas plus an in-memory view for the
+next model request. Durable writes and accounting reads merge those deltas with
+fresh metadata. Retirement timestamps, retrieval counts, and a newer request
+cursor written by another instance survive a later flush. This fixes sequential
+stale-buffer overwrites; it does not turn overlapping cross-process file
+read/modify/write operations into transactions, as noted above.
+
+Orderly registry shutdown stops producers, drains admitted updates, and flushes
+all pending gates after closing resources. One failed gate does not prevent the
+remaining gates from flushing; failed deltas remain retryable and shutdown
+reports the failure. Empty or duplicate drains make no writes. The existing
+per-gate filesystem budget remains below 1 KiB for the contrived fixture. Closing
+with 100 dirty gates therefore adds less than 0.1024 MB of JSON payload writes
+per shutdown (excluding filesystem journaling). No SQLite write, per-stream
+write, or periodic write is added. Abrupt termination can still lose estimates
+that have not reached a lifecycle flush.
+
+Both explicit restoration and unarchive notifications log retention failures
+separately. The desktop still clears archive bookkeeping, restores worktrees,
+invalidates cached state, and publishes notifications after Codex succeeds.
+A failed retention restore keeps originals unavailable through the durable
+archive marker and a local guard; successful restoration can clear that guard.

--- a/docs/design/token-miser-storage-review.md
+++ b/docs/design/token-miser-storage-review.md
@@ -204,3 +204,22 @@ or SQLite commit (0 MB/day incremental SQLite traffic). At 100 archive/restore
 cycles per day, marker payload writes are 0.0037 MB/day, excluding filesystem
 journaling.
 No operator profile, app restart, or Codex-owned file was used for validation.
+
+
+### Upgrade ordering and archive persistence failures
+
+Registry initialization now owns migration before ledger reconciliation,
+independently of reducer activation. Accounting readers await storage preparation;
+startup activation awaits reconciliation, so historical replay gates are ready in
+the first resumed session. Managed runtime restart uses the same ordering even
+when Token Miser is disabled. This moves the existing migration rather than
+adding a per-turn or timer write path.
+
+Archive first invalidates local originals, deliveries and pending acknowledgments.
+If its marker cannot be persisted, a local guard keeps retrieval unavailable.
+Once the marker is durable, disk state remains authoritative so restoration by
+another instance works. The registry logs retention persistence failures
+separately and continues messaging revocation, child/worktree cleanup, archive
+bookkeeping and notification publication. A failed durable marker cannot inform
+other processes by itself; the failure remains visible in the log. No new SQLite
+write or periodic filesystem write is introduced by this handling.

--- a/docs/design/token-miser-storage-review.md
+++ b/docs/design/token-miser-storage-review.md
@@ -196,5 +196,11 @@ or against archived-thread accounting. An invalid legacy JSON record stops
 cleanup with an error rather than silently dropping potentially valid costs;
 that record requires follow-up. Multiple old app versions can still create
 legacy payloads until those processes are upgraded. Archived threads retain
-accounting but cannot create new temporary originals, including after reopening.
+accounting. Restoration atomically moves the unique archive marker to a retention
+generation file, allowing new originals without reactivating old payloads or
+staged callbacks in any store instance. Duplicate restoration is harmless. Each
+archive writes 37 marker bytes; restoration adds a rename and no payload write
+or SQLite commit (0 MB/day incremental SQLite traffic). At 100 archive/restore
+cycles per day, marker payload writes are 0.0037 MB/day, excluding filesystem
+journaling.
 No operator profile, app restart, or Codex-owned file was used for validation.

--- a/docs/design/token-miser-storage-review.md
+++ b/docs/design/token-miser-storage-review.md
@@ -53,10 +53,10 @@ descriptors above 10,239: <https://github.com/libuv/libuv/issues/5204>.
 5. Startup reconciliation and retention legitimately need profile-wide data.
    Settings also requests a profile-wide usage summary. They need bounded scans
    even after thread-specific callers stop reading unrelated records.
-6. Retention runs at startup, with a seven-day age and 512 MiB payload budget.
+6. Retention runs at startup and managed Codex runtime restart, with a seven-day age and 512 MiB payload budget.
    This is not a continuous disk quota. It currently counts output and
    observation bytes, but omits result JSON bytes. Script/preview collection and
-   the boot-only retention schedule are existing product behavior; this repair
+   the startup/runtime-restart retention schedule are existing product behavior; this repair
    should not silently redefine them.
 
 ## Selected design
@@ -126,3 +126,75 @@ accounting/savings reads, and failed-rename temporary-file cleanup. The original
 mixed workload reaches 42 simultaneous operations against a budget of 16.
 The corrected implementation also covers local/external commits during discovery
 and live cross-instance changes without a persistent content cache.
+
+
+## Retention redesign review (September 6, 2026)
+
+The stacked retention change supersedes the original retention choice above.
+Raw output is sensitive even when it is small or passed through. Helper summaries,
+useful details, group summaries, scripts, and previews are also content. Durable
+records must project an explicit accounting schema, with fixed decision notes.
+They must never serialize arbitrary helper output. Codex thread APIs cannot
+reconstruct the exact pre-reduction output; no rollout reader is appropriate.
+
+The selected retrieval lifetime is five minutes in process memory, with a shared
+32 MiB process budget and a 4 MiB entry ceiling. Staged outputs count against the
+same budget. Expiry and eviction are irreversible; acceptance does not extend
+TTL. Failed staging cannot advertise retrieval. Restart provides accounting only.
+Archive invalidates staged and accepted payloads and prevents late callbacks from
+resurrecting them, while retaining historical accounting.
+
+Durable accounting belongs under a SHA-256 thread key, so a cold thread read
+opens only that thread's records. Global maintenance is an explicit bounded
+operation under the existing process-wide file I/O limiter. Migration removes
+legacy payload files and replaces content-bearing records with accounting-only
+records before removing the legacy JSON. Migration must be restartable and must
+not silently drop valid historical costs. No operator profile is used in tests.
+
+Replay counters should be persisted at lifecycle boundaries, not once per gate
+per model request. No new SQLite path or timer is warranted. Filesystem bytes and
+atomic replacements, in addition to SQLite commits, require regression budgets.
+A crash may lose unflushed replay estimates; accepted gate/helper costs must stay
+durable. The UI must explain temporary original availability and retain costs,
+tokens and fixed notes after restart. Implementation validation and measured
+write costs will be recorded below before publication.
+
+
+### Implemented limits and validation
+
+The cache charges UTF-8 bytes plus UTF-16 string storage and per-entry overhead
+against its 32 MiB budget. Original and grouped payloads, staged reservations,
+pending delivery text, and pre-reduction nested Code Mode captures share this process budget. A 4 MiB charged entry limit
+can cause a large reduction to fail open without advertising a retrieval ID.
+Cache timers only release memory; they do not write to disk.
+
+The filesystem regression permits one atomic accounting replacement below 1 KiB
+for the contrived single-output acceptance, zero replacements for 100 replay
+requests, and one replacement below 1 KiB at turn-boundary flush. At ten such
+gates per minute for an eight-hour day, these upper bounds project 9.83 MB/day
+of filesystem payload writes, assuming one flush per gate. Each further turn
+with that gate active adds another fixture-sized replacement. Actual filesystem journal/page traffic is not
+included. Group accounting scales with member IDs. Observations retain counts
+and correlation IDs and require one small JSON write per call. At a conservative
+1 KiB per observation and the same call rate, they add 4.92 MB/day. There is no
+new SQLite write path or timer: incremental SQLite write cost is 0 MB/day; the
+existing Token Miser ledger write-budget tests remain in force. Flush callbacks
+explicitly skip per-gate ledger publication.
+
+Eight retention regressions failed with the parent's store substituted in this
+worktree (raw/script/preview writes, restart, archive, thread-scoped discovery,
+legacy migration, filesystem write count, grouped content, cross-thread ID reuse). The prior I/O tests
+continue to enforce the shared 16-operation budget and cross-instance freshness.
+Other instances see replay totals after a lifecycle flush. A crash can lose the
+unflushed estimates; accepted gate and helper costs remain durable.
+
+Safe accounting is not aged out by the former raw-output TTL or byte quota.
+Its disk usage continues to grow with history. Legacy cleanup runs at startup
+and managed Codex runtime restart, before capability discovery, and does not
+publish one live refresh per migrated observation. It does not run periodically
+or against archived-thread accounting. An invalid legacy JSON record stops
+cleanup with an error rather than silently dropping potentially valid costs;
+that record requires follow-up. Multiple old app versions can still create
+legacy payloads until those processes are upgraded. Archived threads retain
+accounting but cannot create new temporary originals, including after reopening.
+No operator profile, app restart, or Codex-owned file was used for validation.

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1294,6 +1294,8 @@ export type ThreadTokenMiserCodeModeAccounting = {
 
 export type ThreadTokenMiserInterceptionAccounting = {
   objectId: string;
+  /** Temporary owner-process availability; eviction may make it unavailable earlier. */
+  originalOutputAvailableUntil?: number;
   turnId: string;
   toolUseId: string;
   toolName: string;
@@ -1323,9 +1325,7 @@ export type ThreadTokenMiserInterceptionAccounting = {
     summary: string;
   }>;
   /**
-   * What the parent actually received in place of the payload. This is the
-   * gate's real product — carrying it here is what lets the Explorer show the
-   * operator what was traded away, rather than only how many tokens it cost.
+   * Fixed accounting decision note. Original helper text is not retained.
    */
   summary?: {
     summary: string;


### PR DESCRIPTION
Token Miser currently saves sensitive originals, helper prose, scripts, and output previews to the profile. This change keeps original retrieval temporary and preserves only accounting, correlation IDs, and fixed decision notes after restart.


- Share a 32 MiB process-wide RAM budget across originals, staged/grouped outputs, pending retrieval deliveries, and pre-reduction Code Mode captures. Originals expire within five minutes; individual entries are limited to 4 MiB charged bytes. Oversized staging fails without publishing a retrieval reference.
- Store safe records under hashed thread directories. Cold thread reads no longer enumerate or open unrelated threads. Retain #2000's process-wide I/O limiter and cross-instance reads.
- Persist accepted accounting once, keep replay increments in memory, and flush at turn/lifecycle boundaries. Flushes skip per-gate SQLite ledger publication.
- Invalidate original retrieval on archive, including external archive notifications and late callbacks, while retaining historical accounting.
- Migrate legacy JSON to explicit safe fields and remove legacy raw files. Migration runs at startup and managed runtime restart before ledger reconciliation, independently of feature activation, without per-record UI refreshes. Tests use disposable contrived fixtures only.
- Replace the screen's helper prose/scripts/previews with fixed notes and temporary-expiry or unavailable state. Model-facing retrieval guidance no longer promises permanent original access. No Codex-owned files are read.

### Validation

- 163 selected Token Miser, backend integration, and renderer tests pass.
- Eight retention regressions fail with the parent store restored; all ten retention tests pass with this store. A separate integration regression covers pre-reduction captures sharing the budget.
- `pnpm lint` passes: ESLint (zero errors), SQL/storage/color/Electron/license checks, typecheck, and dependency boundaries.
- SQLite write-budget suite: 41 tests pass; no new SQLite write path.
- Filesystem regression: one acceptance replacement below 1 KiB; zero writes for 100 replay requests; one replacement below 1 KiB at flush.

### Costs and limits

At ten fixture-sized gates/minute for eight hours, one acceptance plus one flush per gate projects at most 9.83 MB/day of filesystem payload writes. A conservative 1 KiB observation allowance at that rate adds 4.92 MB/day. Further turns with a gate active add flush replacements; grouped accounting scales with member IDs. These numbers exclude filesystem journal/page traffic. Incremental SQLite cost is 0 MB/day.

A crash can lose unflushed replay estimates. Safe historical accounting continues to grow rather than being silently aged out. Malformed legacy JSON stops cleanup with an error and needs follow-up; old app processes can still write legacy files until upgraded. Concurrent cross-process mutation of the same gate is not transactional. Restored threads can create new temporary originals. An atomic retention-generation change keeps pre-archive originals, pending deliveries, and staged callbacks unavailable across store instances. The design review documents these limits.

No operator profile migration, app restart, real-data deletion, or live-data screenshots were performed.


### Restoration review fix

Both the explicit restore action and `thread/unarchived` notification now clear the archive marker through an atomic rename to a retention-generation file. Fresh reductions resume; old originals and callbacks stay invalid, and duplicate restore notifications are harmless. The marker writes 37 bytes per archive (0.0037 MB/day at 100 cycles), with no new payload writes on restoration or SQLite commits.

Validation: 118 focused Token Miser/backend tests and two registry restoration tests pass; full `pnpm lint` passes. New regressions cover cross-instance restoration, restart, old deliveries/staged callbacks, duplicate restoration, and rename failure. The initial restoration regressions failed before the fix.


### Startup and archive integration review fixes

Migration now precedes historical ledger registration and accounting reads, including when Token Miser is disabled. Startup activation waits for reconciliation, and migrated gates resume replay accounting in the first session. Archive persistence failures are logged separately while messaging revocation, child/worktree cleanup, bookkeeping, and notification publication continue. Local originals and pending deliveries are invalidated before persistence; a failed marker write keeps local retrieval blocked.

Validation: all 769 tests in the full backend-registry and Token Miser suites pass, as does full `pnpm lint` (including typecheck and boundaries). The initial three integration regressions failed before the fix. Additional coverage exercises marker and replay-flush failures and restoration from another instance. These changes add no SQLite or periodic write path.
