### PR TITLE
perf(desktop): retain directory mappings until filesystem changes

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
+import gitBudgets from "./fixtures/git-subprocess-budgets.json";
 import type { InitializeResponse } from "@pwrdrvr/codex-app-server-protocol";
 import type {
   ConfigWriteResponse,
@@ -2136,6 +2137,37 @@ describe("CodexAppServerClient", () => {
     expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/fixture-user/github/PwrAgnt");
 
     await client.close();
+  });
+
+  it("validates each directory once per listing even across mapper batches", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const threadDirectoryEnricher = vi.fn(async () => ({ linkedDirectories: [] }));
+    const client = new CodexAppServerClient({ command: "codex", threadDirectoryEnricher });
+    const threads: AppServerThreadSummary[] = Array.from(
+      { length: gitBudgets.directoryEnrichment.threadsPerListing },
+      (_, index) => ({
+        id: `thread-${index}`,
+        title: `Thread ${index}`,
+        titleSource: "explicit",
+        source: "codex",
+        projectKey: index % 2 ? "/repo/first" : "/repo/second",
+        linkedDirectories: [],
+      }),
+    );
+    try {
+      expect((await client.enrichThreadDirectories(threads)).map((thread) => thread.id))
+        .toEqual(threads.map((thread) => thread.id));
+      expect(threadDirectoryEnricher).toHaveBeenCalledTimes(
+        gitBudgets.directoryEnrichment.uniqueDirectories,
+      );
+      await client.enrichThreadDirectories(threads);
+      // A new listing must validate directories again to detect external changes.
+      expect(threadDirectoryEnricher).toHaveBeenCalledTimes(
+        2 * gitBudgets.directoryEnrichment.uniqueDirectories,
+      );
+    } finally {
+      await client.close();
+    }
   });
 
   it("preserves thread order while enriching directories concurrently", async () => {

--- a/apps/desktop/src/main/__tests__/fixtures/git-subprocess-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/git-subprocess-budgets.json
@@ -4,6 +4,14 @@
     "baselineGitCommands": 105,
     "maxGitCommands": 10
   },
+  "directoryEnrichment": {
+    "repeatedListings": 20,
+    "baselineWarmGitCommands": 60,
+    "warmGitCommands": 0,
+    "branchChangeGitCommands": 1,
+    "threadsPerListing": 100,
+    "uniqueDirectories": 2
+  },
   "automaticFleet": {
     "worktreeCount": 100,
     "navigationRequestsWhileInFlight": 100,

--- a/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enricher.test.ts
@@ -10,6 +10,15 @@ const expectedDir = (p: string): string => path.resolve(p).replace(/\\/g, "/");
 describe("createThreadDirectoryEnricher", () => {
   beforeEach(() => {
     vi.resetModules();
+    // This suite isolates Git discovery and fallback behavior. The companion
+    // enrichment-cache suite validates real filesystem invalidation.
+    vi.doMock("../codex-app-server/git-directory-observation", () => ({
+      createGitDirectoryObserver: () => async () => ({
+        relationship: "fixture",
+        head: "fixture-head",
+        repository: true,
+      }),
+    }));
   });
 
   it("resolves the home repo, preserves the worktree path, and caches repeated lookups", async () => {
@@ -77,9 +86,7 @@ describe("createThreadDirectoryEnricher", () => {
     const { createThreadDirectoryEnricher } = await import(
       "../app-server/thread-directory-enricher"
     );
-    const enricher = createThreadDirectoryEnricher({
-      cacheTtlMs: 60_000,
-    });
+    const enricher = createThreadDirectoryEnricher();
 
     const first = await enricher(projectPath);
     const second = await enricher(projectPath);
@@ -315,7 +322,7 @@ describe("createThreadDirectoryEnricher", () => {
     const { createThreadDirectoryEnricher } = await import(
       "../app-server/thread-directory-enricher"
     );
-    const enricher = createThreadDirectoryEnricher({ cacheTtlMs: 60_000 });
+    const enricher = createThreadDirectoryEnricher();
 
     await expect(enricher(projectPath)).resolves.toEqual({
       linkedDirectories: [],

--- a/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
@@ -51,6 +51,28 @@ afterEach(async () => {
   await fs.rm(root, { recursive: true, force: true });
 });
 
+async function initializeRealGit(initOptions: string[] = []) {
+  const { execFile } = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+  const run = (args: string[]) => new Promise<string>((resolve, reject) => {
+    execFile("git", args, { encoding: "utf8" }, (error, stdout) => {
+      if (error) reject(error);
+      else resolve(stdout);
+    });
+  });
+  await fs.rm(path.join(repo, ".git"), { recursive: true });
+  await run(["init", "--initial-branch=main", ...initOptions, repo]);
+  await run(["-C", repo, "config", "core.hooksPath", path.join(root, "empty-hooks")]);
+  await run(["-C", repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+    "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture"]);
+  git.mockImplementation((
+    command: string, args: string[], options: object,
+    callback: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+  ) => execFile(command, args, { ...options, encoding: "utf8" }, (error, stdout, stderr) => {
+    callback(error, { stdout, stderr });
+  }));
+  return run;
+}
+
 describe("directory enrichment invalidation", () => {
   it("keeps a confirmed mapping across a day of repeated reads without Git", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
@@ -233,26 +255,9 @@ describe("directory enrichment invalidation", () => {
   });
 
   it("preserves real Git worktree mappings, branch switches and detached HEAD", async () => {
-    const { execFile } = await vi.importActual<typeof import("node:child_process")>("node:child_process");
-    const run = (args: string[]) => new Promise<string>((resolve, reject) => {
-      execFile("git", args, { encoding: "utf8" }, (error, stdout) => {
-        if (error) reject(error);
-        else resolve(stdout);
-      });
-    });
-    await fs.rm(path.join(repo, ".git"), { recursive: true });
-    await run(["init", "--initial-branch=main", repo]);
-    await run(["-C", repo, "config", "core.hooksPath", path.join(root, "empty-hooks")]);
-    await run(["-C", repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
-      "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture"]);
+    const run = await initializeRealGit();
     const worktree = path.join(root, "linked");
     await run(["-C", repo, "worktree", "add", "-b", "feature/fixture", worktree]);
-    git.mockImplementation((
-      command: string, args: string[], options: object,
-      callback: (error: Error | null, result: { stdout: string; stderr: string }) => void,
-    ) => execFile(command, args, { ...options, encoding: "utf8" }, (error, stdout, stderr) => {
-      callback(error, { stdout, stderr });
-    }));
     const enrich = createThreadDirectoryEnricher();
     const first = await enrich(worktree);
     const normalized = (value: string) => value.replace(/\\/g, "/");
@@ -270,5 +275,77 @@ describe("directory enrichment invalidation", () => {
     await run(["-C", worktree, "checkout", "--detach"]);
     expect((await enrich(worktree)).observedGitBranch).toBe("HEAD");
     expect(git).toHaveBeenCalledTimes(1);
+  });
+
+  it("discovers the physical repository behind a symlinked subdirectory", async () => {
+    await initializeRealGit();
+    const subdirectory = path.join(repo, "subdirectory");
+    const alias = path.join(root, "alias-to-subdirectory");
+    await fs.mkdir(subdirectory);
+    await fs.symlink(subdirectory, alias, "junction");
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(alias);
+    expect(first).toMatchObject({
+      observedGitBranch: "main",
+      linkedDirectories: [{ path: repo.replace(/\\/g, "/"), kind: "local" }],
+    });
+    git.mockClear();
+    expect(await enrich(alias)).toEqual(first);
+    expect(git).not.toHaveBeenCalled();
+  });
+
+  it.each(["worktree", "common"])("invalidates branch evidence for the %s reftable stack", async (stack) => {
+    const worktree = path.join(root, "linked-stack");
+    const admin = path.join(repo, ".git", "worktrees", "linked-stack");
+    await fs.mkdir(worktree);
+    await fs.mkdir(admin, { recursive: true });
+    await fs.writeFile(path.join(worktree, ".git"), `gitdir: ${admin}\n`);
+    await fs.writeFile(path.join(admin, "commondir"), "../..\n");
+    await fs.writeFile(path.join(admin, "HEAD"), "ref: refs/heads/.invalid\n");
+    const tables = path.join(stack === "worktree" ? admin : path.join(repo, ".git"), "reftable");
+    await fs.mkdir(tables);
+    await fs.writeFile(path.join(tables, "tables.list"), "first.ref\n");
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(worktree);
+    git.mockClear();
+    branch = "changed-stack";
+    await fs.writeFile(path.join(tables, "tables.list.lock"), "second.ref\n");
+    await fs.rename(path.join(tables, "tables.list.lock"), path.join(tables, "tables.list"));
+    expect(await enrich(worktree)).toEqual({ ...first, observedGitBranch: branch });
+    expect(git).toHaveBeenCalledTimes(1);
+  });
+
+  it.for([false, true])("refreshes real reftable branches (linked worktree: %s)", async (linked, context) => {
+    const run = await initializeRealGit(["--ref-format=reftable"]).catch((error: unknown) => {
+      // Older supported Git releases cannot construct a reftable fixture.
+      // Only that explicit capability failure skips this real-Git case.
+      if (error instanceof Error && /unknown option.*ref-format/.test(error.message)) {
+        context.skip("Installed Git does not support reftable initialization");
+      }
+      throw error;
+    });
+    const cwd = linked ? path.join(root, "reftable-linked") : repo;
+    if (linked) await run(["-C", repo, "worktree", "add", "-b", "feature/linked", cwd]);
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(cwd);
+    expect(first.observedGitBranch).toBe(linked ? "feature/linked" : "main");
+    const headPath = (await run([
+      "-C", cwd, "rev-parse", "--path-format=absolute", "--git-path", "HEAD",
+    ])).trim();
+    const headBefore = await fs.readFile(headPath, "utf8");
+    git.mockClear();
+    expect(await enrich(cwd)).toEqual(first);
+    expect(git).not.toHaveBeenCalled();
+    await run(["-C", cwd, "checkout", "-b", "feature/reftable-next"]);
+    expect(await fs.readFile(headPath, "utf8")).toBe(headBefore);
+    expect(await enrich(cwd)).toEqual({ ...first, observedGitBranch: "feature/reftable-next" });
+    expect(git).toHaveBeenCalledTimes(1);
+    git.mockClear();
+    await run(["-C", cwd, "checkout", "--detach"]);
+    expect((await enrich(cwd)).observedGitBranch).toBe("HEAD");
+    expect(git).toHaveBeenCalledTimes(1);
+    git.mockClear();
+    await enrich(cwd);
+    expect(git).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
@@ -1,0 +1,274 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createThreadDirectoryEnricher } from "../app-server/thread-directory-enricher";
+import budgets from "./fixtures/git-subprocess-budgets.json";
+
+const git = vi.hoisted(() => vi.fn());
+const readPointer = vi.hoisted(() => vi.fn());
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  readPointer.mockImplementation(actual.readFile);
+  return { ...actual, readFile: readPointer };
+});
+vi.mock("node:child_process", () => ({ execFile: git }));
+vi.mock("../git-command", () => ({ getGitCommand: () => "git" }));
+vi.mock("../log", () => ({
+  getMainLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+
+let root: string;
+let repo: string;
+let branch: string;
+let fail: boolean;
+
+beforeEach(async () => {
+  root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-directory-cache-")));
+  repo = path.join(root, "repo");
+  branch = "main";
+  fail = false;
+  readPointer.mockClear();
+  await fs.mkdir(path.join(repo, ".git"), { recursive: true });
+  await fs.writeFile(path.join(repo, ".git", "HEAD"), "ref: refs/heads/main\n");
+  git.mockReset();
+  git.mockImplementation((
+    _command: string,
+    args: string[],
+    _options: unknown,
+    callback: (error: Error | null, result?: { stdout: string; stderr: string }) => void,
+  ) => {
+    if (fail) return callback(new Error("git temporarily unavailable"));
+    const stdout = args.includes("--show-toplevel") ? args[1]
+      : args.includes("--porcelain") ? `worktree ${repo}\nworktree ${args[1]}\n`
+      : branch;
+    callback(null, { stdout, stderr: "" });
+  });
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await fs.rm(root, { recursive: true, force: true });
+});
+
+describe("directory enrichment invalidation", () => {
+  it("keeps a confirmed mapping across a day of repeated reads without Git", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(repo);
+    git.mockClear();
+    for (let round = 1; round <= budgets.directoryEnrichment.repeatedListings; round += 1) {
+      now.mockReturnValue(1_000 + round * 86_400_000);
+      expect(await enrich(repo)).toEqual(first);
+    }
+    expect(git).toHaveBeenCalledTimes(budgets.directoryEnrichment.warmGitCommands);
+  });
+
+  it("refreshes only branch data immediately after an external checkout", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(repo);
+    git.mockClear();
+    branch = "feature/changed";
+    await fs.writeFile(path.join(repo, ".git", "HEAD"), `ref: refs/heads/${branch}\n`);
+    expect(await enrich(repo)).toEqual({ ...first, observedGitBranch: branch });
+    expect(git.mock.calls.map((call) => call[1].slice(2)))
+      .toEqual([["rev-parse", "--abbrev-ref", "HEAD"]]);
+    expect(git).toHaveBeenCalledTimes(budgets.directoryEnrichment.branchChangeGitCommands);
+  });
+
+  it("forgets a removed directory immediately and resolves its replacement", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(repo);
+    await fs.rm(repo, { recursive: true });
+    expect(await enrich(repo)).toEqual({ linkedDirectories: [] });
+    await fs.mkdir(path.join(repo, ".git"), { recursive: true });
+    branch = "replacement";
+    await fs.writeFile(path.join(repo, ".git", "HEAD"), `ref: refs/heads/${branch}\n`);
+    expect((await enrich(repo)).observedGitBranch).toBe(branch);
+  });
+
+  it("retries failed probes immediately instead of retaining a fallback", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    fail = true;
+    expect((await enrich(repo)).observedGitBranch).toBeUndefined();
+    fail = false;
+    expect((await enrich(repo)).observedGitBranch).toBe("main");
+  });
+
+  it("discovers a new nested repository without expiring the outer mapping", async () => {
+    const nested = path.join(repo, "nested");
+    await fs.mkdir(nested);
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(nested);
+    git.mockClear();
+    await fs.mkdir(path.join(nested, ".git"));
+    await fs.writeFile(path.join(nested, ".git", "HEAD"), "ref: refs/heads/nested\n");
+    branch = "nested";
+    expect((await enrich(nested)).observedGitBranch).toBe("nested");
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("shares aliases and simultaneous validations for the same directory", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    await Promise.all([enrich(repo), enrich(`${repo}${path.sep}.`), enrich(` ${repo} `)]);
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("invalidates a worktree mapping when its gitdir link changes", async () => {
+    const worktree = path.join(root, "worktree");
+    const admin = path.join(repo, ".git", "worktrees", "first");
+    await fs.mkdir(admin, { recursive: true });
+    await fs.mkdir(worktree);
+    await fs.writeFile(path.join(worktree, ".git"), `gitdir: ${admin}\n`);
+    await fs.writeFile(path.join(admin, "commondir"), "../..\n");
+    await fs.writeFile(path.join(admin, "HEAD"), "ref: refs/heads/main\n");
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(worktree);
+    git.mockClear();
+    const nextAdmin = path.join(repo, ".git", "worktrees", "second");
+    await fs.mkdir(nextAdmin);
+    await fs.writeFile(path.join(nextAdmin, "commondir"), "../..\n");
+    await fs.writeFile(path.join(nextAdmin, "HEAD"), "ref: refs/heads/second\n");
+    await fs.writeFile(path.join(worktree, ".git"), `gitdir: ${nextAdmin}\n`);
+    branch = "second";
+    expect((await enrich(worktree)).observedGitBranch).toBe("second");
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not rediscover topology for ordinary edits, commits or sibling worktrees", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(repo);
+    git.mockClear();
+    await fs.writeFile(path.join(repo, "edited.txt"), "edited\n");
+    await fs.mkdir(path.join(repo, ".git", "refs", "heads"), { recursive: true });
+    await fs.writeFile(path.join(repo, ".git", "refs", "heads", "main"), "new-commit\n");
+    await fs.mkdir(path.join(repo, ".git", "worktrees", "sibling"), { recursive: true });
+    expect(await enrich(repo)).toEqual(first);
+    expect(git).not.toHaveBeenCalled();
+  });
+
+  it("retains unchanged worktree pointer contents across later observations", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+    const worktree = path.join(root, "worktree");
+    const admin = path.join(repo, ".git", "worktrees", "pointer-budget");
+    await fs.mkdir(admin, { recursive: true });
+    await fs.mkdir(worktree);
+    await fs.writeFile(path.join(worktree, ".git"), `gitdir: ${admin}\n`);
+    await fs.writeFile(path.join(admin, "commondir"), "../..\n");
+    await fs.writeFile(path.join(admin, "HEAD"), "ref: refs/heads/main\n");
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(worktree);
+    readPointer.mockClear();
+    now.mockReturnValue(86_400_000);
+    await enrich(worktree);
+    expect(readPointer).not.toHaveBeenCalled();
+  });
+
+  it("invalidates topology when per-worktree configuration appears", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(repo);
+    git.mockClear();
+    await fs.writeFile(path.join(repo, ".git", "config.worktree"), "[core]\n bare = false\n");
+    await enrich(repo);
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("invalidates a directory symlink when its target changes", async () => {
+    const alias = path.join(root, "alias");
+    await fs.symlink(repo, alias, "junction");
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(alias);
+    const other = path.join(root, "other");
+    await fs.mkdir(path.join(other, ".git"), { recursive: true });
+    await fs.writeFile(path.join(other, ".git", "HEAD"), "ref: refs/heads/other\n");
+    await fs.rm(alias, { recursive: true });
+    await fs.symlink(other, alias, "junction");
+    branch = "other";
+    expect((await enrich(alias)).observedGitBranch).toBe("other");
+  });
+
+  it("does not retain a failed branch refresh", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(repo);
+    branch = "after-failure";
+    await fs.writeFile(path.join(repo, ".git", "HEAD"), `ref: refs/heads/${branch}\n`);
+    fail = true;
+    expect((await enrich(repo)).observedGitBranch).toBeUndefined();
+    fail = false;
+    expect((await enrich(repo)).observedGitBranch).toBe(branch);
+  });
+
+  it("does not spawn Git for an unversioned directory and detects git init immediately", async () => {
+    const plain = path.join(root, "plain");
+    await fs.mkdir(plain);
+    const enrich = createThreadDirectoryEnricher();
+    expect((await enrich(plain)).linkedDirectories[0]?.kind).toBe("local");
+    await enrich(plain);
+    expect(git).not.toHaveBeenCalled();
+    await fs.mkdir(path.join(plain, ".git"));
+    await fs.writeFile(path.join(plain, ".git", "HEAD"), "ref: refs/heads/main\n");
+    expect((await enrich(plain)).observedGitBranch).toBe("main");
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not publish a cache entry if HEAD changes while Git is running", async () => {
+    const enrich = createThreadDirectoryEnricher();
+    const invoke = git.getMockImplementation()!;
+    let release: () => void = () => {};
+    let started: () => void = () => {};
+    const probing = new Promise<void>((resolve) => { started = resolve; });
+    git.mockImplementationOnce((...args: Parameters<typeof invoke>) => {
+      release = () => invoke(...args);
+      started();
+    });
+    const pending = enrich(repo);
+    await probing;
+    await fs.writeFile(path.join(repo, ".git", "HEAD"), "ref: refs/heads/new-head\n");
+    release();
+    await pending;
+    branch = "new-head";
+    git.mockClear();
+    expect((await enrich(repo)).observedGitBranch).toBe(branch);
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("preserves real Git worktree mappings, branch switches and detached HEAD", async () => {
+    const { execFile } = await vi.importActual<typeof import("node:child_process")>("node:child_process");
+    const run = (args: string[]) => new Promise<string>((resolve, reject) => {
+      execFile("git", args, { encoding: "utf8" }, (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      });
+    });
+    await fs.rm(path.join(repo, ".git"), { recursive: true });
+    await run(["init", "--initial-branch=main", repo]);
+    await run(["-C", repo, "config", "core.hooksPath", path.join(root, "empty-hooks")]);
+    await run(["-C", repo, "-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+      "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture"]);
+    const worktree = path.join(root, "linked");
+    await run(["-C", repo, "worktree", "add", "-b", "feature/fixture", worktree]);
+    git.mockImplementation((
+      command: string, args: string[], options: object,
+      callback: (error: Error | null, result: { stdout: string; stderr: string }) => void,
+    ) => execFile(command, args, { ...options, encoding: "utf8" }, (error, stdout, stderr) => {
+      callback(error, { stdout, stderr });
+    }));
+    const enrich = createThreadDirectoryEnricher();
+    const first = await enrich(worktree);
+    const normalized = (value: string) => value.replace(/\\/g, "/");
+    expect(first).toMatchObject({
+      observedGitBranch: "feature/fixture",
+      linkedDirectories: [{ path: normalized(repo), worktreePath: normalized(worktree), kind: "worktree" }],
+    });
+    git.mockClear();
+    expect(await enrich(worktree)).toEqual(first);
+    expect(git).not.toHaveBeenCalled();
+    await run(["-C", worktree, "checkout", "-b", "feature/next"]);
+    expect((await enrich(worktree)).observedGitBranch).toBe("feature/next");
+    expect(git).toHaveBeenCalledTimes(1);
+    git.mockClear();
+    await run(["-C", worktree, "checkout", "--detach"]);
+    expect((await enrich(worktree)).observedGitBranch).toBe("HEAD");
+    expect(git).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -253,6 +253,10 @@ describe("thread read budgets across product flows", () => {
       reads: client.counts,
       scenario: "terminal-notification-burst",
     });
+    expect(client.listCalls.filter((call) => call.callerReason === "notification-context"))
+      .toEqual([expect.objectContaining({
+        params: expect.objectContaining({ enrichDirectories: false }),
+      })]);
   });
 
   it("reads the provider once for a window opening onto a warm profile", async () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -37161,7 +37161,7 @@ export class DesktopBackendRegistry {
       // is not a failure -- it is the answer for a thread this backend does not
       // list, which is precisely the case this dedup exists for, so keying the
       // retry on the label drops the entry every time and charges each of that
-      // thread's later notifications another enriched walk.
+      // thread's later notifications another walk.
       //
       // Rejection is not the signal either: `listThreads` absorbs a provider
       // error and resolves, so the `catch` below never runs for the restart it
@@ -37173,7 +37173,7 @@ export class DesktopBackendRegistry {
       reconciliation = this.listThreads({
         backend,
         callerReason: "notification-context",
-        enrichDirectories: true,
+        enrichDirectories: false,
       })
         .then((rows) => {
           walkListedRows = rows.length > 0;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -8301,6 +8301,11 @@ export class CodexAppServerClient {
     threads: RawCodexThreadSummary[],
   ): Promise<EnrichedCodexThread[]> {
     const enrichedThreads: Array<EnrichedCodexThread | undefined> = [];
+    // A listing can span many mapper batches and contain hundreds of threads
+    // sharing one checkout. Validate each directory once for this observation,
+    // including failures, rather than once for every row. The next listing
+    // observes it again so external workspace changes remain visible.
+    const directories = new Map<string, Promise<ThreadDirectoryEnrichment>>();
 
     for await (const enrichedThread of new IterableMapper(
       threads.map((thread, index) => ({ index, thread })),
@@ -8311,7 +8316,13 @@ export class CodexAppServerClient {
         const projectKey = await resolveThreadProjectKey(thread);
         let enrichment: ThreadDirectoryEnrichment;
         try {
-          enrichment = await this.threadDirectoryEnricher(projectKey);
+          const directoryKey = projectKey ? path.resolve(projectKey) : "";
+          let pending = directories.get(directoryKey);
+          if (!pending) {
+            pending = this.threadDirectoryEnricher(projectKey);
+            directories.set(directoryKey, pending);
+          }
+          enrichment = await pending;
         } catch (error) {
           codexClientLog.warn("thread directory enrichment failed", {
             threadId: thread.id,

--- a/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
+++ b/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
@@ -1,0 +1,106 @@
+import { readFile, realpath, stat } from "node:fs/promises";
+import path from "node:path";
+
+export type GitDirectoryObservation = {
+  repository: boolean;
+  relationship: string;
+  head: string;
+};
+
+type FileState = Awaited<ReturnType<typeof fileState>>;
+
+async function fileState(target: string) {
+  try {
+    const info = await stat(target, { bigint: true });
+    // Directory mtimes change for ordinary edits, commits and sibling worktree
+    // creation. Only replacement of the directory invalidates its identity.
+    return {
+      directory: info.isDirectory(),
+      signature: [
+        info.dev,
+        info.ino,
+        info.birthtimeNs,
+        ...(info.isDirectory() ? [] : [info.size, info.mtimeNs, info.ctimeNs]),
+      ].join(":"),
+    };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT" || code === "ENOTDIR") return undefined;
+    throw error;
+  }
+}
+
+/**
+ * On-demand filesystem evidence, never a timer or watcher. Tiny Git pointer
+ * files are read only when their stat signature changes. This reads Git's
+ * workspace metadata, never the coding harness's private storage.
+ */
+export function createGitDirectoryObserver(): (
+  cwd: string,
+) => Promise<GitDirectoryObservation | undefined> {
+  const files = new Map<string, { signature: string; value: string }>();
+  async function pointer(target: string, state: FileState): Promise<string> {
+    if (!state) {
+      files.delete(target);
+      return "";
+    }
+    if (files.get(target)?.signature === state.signature) {
+      return files.get(target)!.value;
+    }
+    const value = await readFile(target, "utf8");
+    if ((await fileState(target))?.signature !== state.signature) {
+      throw new Error("Git pointer changed during directory observation");
+    }
+    files.set(target, { signature: state.signature, value });
+    return value;
+  }
+
+  return async (cwd) => {
+    const directory = await fileState(cwd);
+    if (!directory?.directory) return undefined;
+    const resolved = await realpath(cwd);
+    let parent = cwd;
+    let dotGit: FileState;
+    let dotGitPath: string;
+    for (;;) {
+      dotGitPath = path.join(parent, ".git");
+      dotGit = await fileState(dotGitPath);
+      if (dotGit) break;
+      const next = path.dirname(parent);
+      if (parent === next) {
+        return {
+          repository: false,
+          relationship: JSON.stringify([resolved, directory.signature, "unversioned"]),
+          head: "",
+        };
+      }
+      parent = next;
+    }
+    const link = dotGit.directory ? "" : await pointer(dotGitPath, dotGit);
+    const gitdirMatch = link.match(/^gitdir:\s*(.+?)\s*$/m);
+    if (!dotGit.directory && !gitdirMatch) return undefined;
+    const gitdir = gitdirMatch ? path.resolve(parent, gitdirMatch[1]) : dotGitPath;
+    const admin = await fileState(gitdir);
+    if (!admin?.directory) return undefined;
+    const commonPath = path.join(gitdir, "commondir");
+    const commonState = await fileState(commonPath);
+    const common = (await pointer(commonPath, commonState)).trim();
+    const commonDir = common ? path.resolve(gitdir, common) : gitdir;
+    const commonInfo = await fileState(commonDir);
+    if (!commonInfo?.directory) return undefined;
+    const config = await fileState(path.join(commonDir, "config"));
+    const worktreeConfig = await fileState(path.join(gitdir, "config.worktree"));
+    const backlink = await fileState(path.join(gitdir, "gitdir"));
+    const head = await fileState(path.join(gitdir, "HEAD"));
+    if (!head || head.directory) return undefined;
+    return {
+      repository: true,
+      relationship: JSON.stringify([
+        resolved, directory.signature, dotGitPath, dotGit.signature, link,
+        gitdir, admin.signature, common, commonInfo.signature,
+        config?.signature, worktreeConfig?.signature, backlink?.signature,
+      ]),
+      head: head.signature,
+    };
+  };
+}

--- a/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
+++ b/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
@@ -59,7 +59,9 @@ export function createGitDirectoryObserver(): (
     const directory = await fileState(cwd);
     if (!directory?.directory) return undefined;
     const resolved = await realpath(cwd);
-    let parent = cwd;
+    // Git discovers repositories from the physical directory. Walking the
+    // alias's parents misses .git when cwd links to a repository subdirectory.
+    let parent = resolved;
     let dotGit: FileState;
     let dotGitPath: string;
     for (;;) {
@@ -93,6 +95,14 @@ export function createGitDirectoryObserver(): (
     const backlink = await fileState(path.join(gitdir, "gitdir"));
     const head = await fileState(path.join(gitdir, "HEAD"));
     if (!head || head.directory) return undefined;
+    // Reftable's HEAD is a static compatibility file. Ref updates atomically
+    // replace tables.list instead. Observe both stacks: linked worktrees own
+    // their HEAD stack while ordinary refs live in the common directory.
+    const refs = await fileState(path.join(gitdir, "reftable", "tables.list"));
+    const commonRefs = commonDir === gitdir
+      ? refs
+      : await fileState(path.join(commonDir, "reftable", "tables.list"));
+    if (refs?.directory || commonRefs?.directory) return undefined;
     return {
       repository: true,
       relationship: JSON.stringify([
@@ -100,7 +110,7 @@ export function createGitDirectoryObserver(): (
         gitdir, admin.signature, common, commonInfo.signature,
         config?.signature, worktreeConfig?.signature, backlink?.signature,
       ]),
-      head: head.signature,
+      head: JSON.stringify([head.signature, refs?.signature, commonRefs?.signature]),
     };
   };
 }

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -7,6 +7,7 @@ import { isToolManagedWorktreePath } from "@pwragent/shared";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { getMainLogger } from "../log";
 import { getGitCommand } from "../git-command";
+import { createGitDirectoryObserver, type GitDirectoryObservation } from "./git-directory-observation";
 
 const execFile = promisify(execFileCallback);
 const threadDirectoryLog = getMainLogger("pwragent:thread-directory-enricher");
@@ -29,9 +30,8 @@ export type ThreadDirectoryEnrichment = {
 };
 
 type CachedEnrichment = {
-  expiresAt: number;
-  inFlight?: Promise<ThreadDirectoryEnrichment>;
-  value?: ThreadDirectoryEnrichment;
+  observation: GitDirectoryObservation;
+  value: ThreadDirectoryEnrichment;
 };
 
 type GitMetadataEvidence = {
@@ -300,66 +300,56 @@ async function loadThreadDirectoryEnrichment(
   }
 }
 
-export function createThreadDirectoryEnricher(params?: {
-  cacheTtlMs?: number;
-}): (projectKey?: string) => Promise<ThreadDirectoryEnrichment> {
-  const cacheTtlMs = params?.cacheTtlMs ?? 5_000;
+/**
+ * Directory facts survive query invalidation and elapsed time. Filesystem
+ * identity is the invalidation authority; HEAD changes only refresh the branch.
+ * Failed/partial Git probes are returned as fallbacks but never memoized.
+ */
+export function createThreadDirectoryEnricher(): (
+  projectKey?: string,
+) => Promise<ThreadDirectoryEnrichment> {
   const cache = new Map<string, CachedEnrichment>();
+  const pending = new Map<string, Promise<ThreadDirectoryEnrichment>>();
+  const observe = createGitDirectoryObserver();
 
-  return async (projectKey?: string): Promise<ThreadDirectoryEnrichment> => {
-    const normalizedKey = projectKey?.trim();
-    if (!normalizedKey) {
-      return { linkedDirectories: [] };
-    }
-
-    const now = Date.now();
-    const cached = cache.get(normalizedKey);
-    if (cached?.inFlight) {
-      return await cached.inFlight;
-    }
-    if (cached?.value && cached.expiresAt > now) {
+  async function refresh(key: string): Promise<ThreadDirectoryEnrichment> {
+    const before = await observe(key).catch(() => undefined);
+    const cached = cache.get(key);
+    const sameRelationship = before
+      && cached?.observation.relationship === before.relationship;
+    if (sameRelationship && cached.observation.head === before.head) {
       return cached.value;
     }
+    cache.delete(key);
+    let value: ThreadDirectoryEnrichment;
+    if (before && !before.repository) {
+      value = { linkedDirectories: [buildFallbackLinkedDirectory(key)] };
+    } else if (sameRelationship) {
+      const branch = await runGit(key, ["rev-parse", "--abbrev-ref", "HEAD"])
+        .catch(() => undefined);
+      value = { ...cached.value, observedGitBranch: branch || undefined };
+    } else {
+      value = await loadThreadDirectoryEnrichment(key);
+    }
+    // The branch is present only when the complete probe succeeded. Retaining
+    // a fallback would hide recovery after a failed executable/filesystem read.
+    if (before && (!before.repository || value.observedGitBranch)) {
+      const after = await observe(key).catch(() => undefined);
+      if (after?.relationship === before.relationship && after.head === before.head) {
+        cache.set(key, { observation: after, value });
+      }
+    }
+    return value;
+  }
 
-    const inFlight = loadThreadDirectoryEnrichment(normalizedKey)
-      .then((value) => {
-        // A miss is deliberately left uncached, matching the ACP worktree
-        // resolver (`resolveAcpLinkedDirectories` persists only a directory
-        // it actually resolved). `loadThreadDirectoryEnrichment` yields no
-        // directories only when `access()` on the path fails — every other
-        // outcome, including a git probe that fails or times out, still
-        // returns one. Note what that does and does not prove: `access()`
-        // also fails for a path that is merely unreachable right now (denied
-        // permissions, an unmounted or stalled network volume), so a miss
-        // means "unresolved", not "deleted" — the same distinction the thread
-        // header's copy draws. Retrying is worth it because the common causes
-        // are transient: a scratch project root and a worktree are both
-        // created moments after a thread first refers to them. Caching pins
-        // the thread to "no linked project" for the rest of the TTL after the
-        // directory appears, which is long enough on a slow machine to show
-        // a workspace warning for a directory that exists by the time anyone
-        // reads it. Recomputing costs one `access()` and never spawns git.
-        if (value.linkedDirectories.length === 0) {
-          cache.delete(normalizedKey);
-          return value;
-        }
-        cache.set(normalizedKey, {
-          expiresAt: Date.now() + cacheTtlMs,
-          value,
-        });
-        return value;
-      })
-      .catch((error) => {
-        cache.delete(normalizedKey);
-        throw error;
-      });
-
-    cache.set(normalizedKey, {
-      expiresAt: cached?.expiresAt ?? 0,
-      inFlight,
-      value: cached?.value,
-    });
-
+  return async (projectKey) => {
+    if (!projectKey?.trim()) return { linkedDirectories: [] };
+    const key = path.resolve(projectKey.trim());
+    let inFlight = pending.get(key);
+    if (!inFlight) {
+      inFlight = refresh(key).finally(() => pending.delete(key));
+      pending.set(key, inFlight);
+    }
     return await inFlight;
   };
 }

--- a/docs/design/thread-directory-enrichment-cache-review.md
+++ b/docs/design/thread-directory-enrichment-cache-review.md
@@ -89,8 +89,9 @@ is still permitted.
 - The requested directory exists, is a directory, and has the same physical
   identity and resolved path. A missing path is unresolved, not an instruction
   to archive a thread.
-- The nearest `.git` boundary is still the same. Walking ancestors detects a
-  newly initialized nested repository without a timer or watcher.
+- The nearest `.git` boundary is still the same. Walking the physical path
+  returned by `realpath` detects a newly initialized nested repository and a
+  repository containing a symlink target, without a timer or watcher.
 - A `.git` pointer, worktree admin directory, `commondir`, common directory,
   repository/worktree config or worktree backlink change invalidates the mapping.
 - Directory identity uses device, inode and birth time. Directory modification
@@ -102,6 +103,12 @@ is still permitted.
 - HEAD has a separate signature. A HEAD change with stable topology runs only
   `git rev-parse --abbrev-ref HEAD`. Git retains responsibility for branch and
   detached-HEAD interpretation; this code does not parse branch names.
+- For [Git reftable storage](https://git-scm.com/docs/reftable), HEAD is a static
+  compatibility file. The branch signature also includes the worktree and
+  common `reftable/tables.list` file identities. Stack updates and compaction
+  can therefore trigger a conservative one-command branch refresh, including
+  when a ref other than HEAD changed; they do not rediscover topology. No
+  reftable contents are read or parsed.
 - An unversioned directory requires no Git subprocess. Its next observation
   still searches for a new `.git` boundary, so `git init` is visible immediately.
 
@@ -168,7 +175,7 @@ it by adding V8 profile percentages.
 
 ## Validation of this implementation
 
-- Final focused run: 944 tests passed across the directory-cache, directory
+- Final focused run: 949 tests passed across the directory-cache, directory
   enricher, Codex client, thread-read budgets, thread-info store, backend
   registry, Git working-state service and provider snapshot store suites.
 - Full `pnpm lint` passed: SQL, Codex-storage, colors, Electron policy,
@@ -181,3 +188,16 @@ it by adding V8 profile percentages.
   report predating this change has the same stack signature. The unchanged
   normal test command subsequently passed all 944 tests. No worker-pool,
   concurrency, timeout or retry setting was changed to obtain that result.
+
+## Review follow-up: physical discovery and reftable
+
+Three real-Git regressions reproduced both review findings before the fix:
+symlink-to-subdirectory discovery, ordinary reftable checkout, and linked
+reftable worktree checkout. The reftable tests also check detached HEAD and zero
+Git commands on unchanged reads. Two synthetic stack-replacement cases cover
+both manifest locations even on older Git versions that cannot initialize
+reftable repositories; only an explicit unsupported-init-option error skips
+those real-Git reftable cases.
+
+Review validation: 949 tests across eight suites passed, including all five new
+cases on Git 2.55.0. The three real-Git cases failed against the prior code.

--- a/docs/design/thread-directory-enrichment-cache-review.md
+++ b/docs/design/thread-directory-enrichment-cache-review.md
@@ -1,0 +1,183 @@
+# Thread directory enrichment: ownership and invalidation review
+
+## Incident and scope
+
+The September 6, 2026 main-process CPU session `65f58b`, captured at
+08:35–08:40 America/Detroit, contains two distinct sources of work:
+
+- Token Miser metadata/observation reads and buffer allocation. PR #2000 and
+  its storage follow-up own those changes.
+- `loadThreadDirectoryEnrichment` → `runGit` → `execFile` → native `spawn`.
+  The captured bundle's `Yge` and `fw` frames map to these functions. Native
+  spawning alone represents 8.4% of profile 0003 and 7.4% of profile 0005's
+  sampled time, including idle. These percentages are not process CPU usage
+  or a prediction of total CPU savings. Async stacks do not identify every
+  initiating caller, so the profile does not prove which UI or messaging
+  operation started each enrichment.
+
+This review and change address directory enrichment. They do not replace the
+Git working-state scheduler, Token Miser storage work, or Federation collection
+paging in #2001. No live application restart or post-fix live CPU claim is made.
+
+## What the earlier changes fixed
+
+| Change | Owner and behavior | Why directory probes remained |
+|---|---|---|
+| [#1895](https://github.com/pwrdrvr/PwrAgent/pull/1895) | Discord receipt/admission runs before REST metadata enrichment; stage timings identify delays | Provider ingress does not own local Git enrichment |
+| [#1914](https://github.com/pwrdrvr/PwrAgent/pull/1914) | Ordinary messaging navigation serves cached Git working state and schedules background convergence; review selection can still opt into awaited working state | Working-state hydration is distinct from Codex directory enrichment |
+| [#1916](https://github.com/pwrdrvr/PwrAgent/pull/1916) | `ThreadInfoStore` retains known summaries and fields across query invalidation; point reads and messaging admission reuse them | Whole provider listings still run their own enrichment before recording summaries in the store |
+| [#1921](https://github.com/pwrdrvr/PwrAgent/pull/1921) | Lifecycle-owned Full Access policy snapshot removes per-reply settings/config reload | Authorization policy does not own directory mappings |
+| [#1922](https://github.com/pwrdrvr/PwrAgent/pull/1922) | Response-mode snapshot and off-path metadata updates remove admission waits; Codex default-agent admission avoids fleet capability listing | Does not change the enricher or its cache |
+| [#1951](https://github.com/pwrdrvr/PwrAgent/pull/1951) | Registry owns bounded Git working-state rounds; base inference drops from 105 to 10 commands; absolute Git executable cached | The separate directory enricher still starts its three commands whenever its five-second cache expires |
+
+The fixes are complementary. Moving work off an admission path and retaining
+thread summaries did not give the lower directory-discovery layer the same
+invalidation contract. Increasing the existing TTL would leave that mismatch.
+
+## Stores and the gap between them
+
+| Store | Identity / lifetime | What it answers |
+|---|---|---|
+| Registry `threadListCache` | Query shape / short reuse window; invalidated by mutations | Membership, ordering and bounded provider-list reuse |
+| `ThreadInfoStore` | Instance + backend + thread / process lifetime | Last-known names, archival observations and summary rows; separate enriched summary slot survives cheap navigation polls |
+| Overlay store | Backend + thread / SQLite | Operator workspace links, handoff authority and repaired source worktree links; `replaceWorkspaceLinkedDirectory` also invalidates obsolete retained summaries |
+| `ProviderThreadSnapshotStore` | Backend / persisted startup snapshot | Initial navigation before provider refresh; persistence runs at the explicit startup-provider-refresh boundary, not every thread read |
+| Directory enricher (before) | Trimmed project path / five seconds | Repository mapping **and** current branch in a single expiring object |
+| Git working-state and directory-status caches | Workspace / dedicated freshness and scheduling policies | Dirty/untracked/unpushed state, review base and branch/status chips |
+
+`readThreadList` calls `listCodexThreads`, which calls the Codex client with the
+requested enrichment flag. The client enriches rows before the registry's
+`rememberThreadListContexts` records them. No `ThreadInfoStore` lookup can
+prevent work that has already happened inside that client call. Reusing the
+entire retained row would also risk masking current provider membership,
+titles, execution state and workspace changes.
+
+Unenriched navigation has another route: source relationship reconciliation
+and `backfillMissingCodexDirectoryRelationships` can enrich previously unknown
+managed worktrees. Persisted overlay links avoid that backfill after successful
+repair. Explicit enriched listings and selected-thread repair do not use that
+overlay as the lower-level directory-discovery cache. A partial fallback is
+also not proof that a directory was successfully resolved.
+
+## Callers and required freshness
+
+| Caller/path | Needs topology? | Needs live Git state? | Resolution |
+|---|---|---|---|
+| Known thread label, quit blockers, warm admission | No fresh topology | No | Existing `ThreadInfoStore` point read; zero new provider/Git reads |
+| Terminal notification for a never-observed thread | No; title/project label suffice | No | Keep the existing coalesced cold provider lookup; change its explicit enrichment flag to false |
+| Ordinary renderer/messaging navigation, prewarm | Missing source relationships only | Chips converge through separate owners | Existing cheap listing plus scoped backfill; confirmed topology no longer expires |
+| Selected-thread directory repair | Yes, for that thread's current provider cwd | Current branch is returned with enrichment | Validate only that directory; reuse confirmed mapping |
+| Explicit enriched listings, thread inspection/search, migration | Yes | Existing contract includes observed branch | Validate each distinct directory once per listing; cache topology across listings; refresh branch when HEAD changes |
+| Workspace handoff / actions | Current workspace identity | Operations can need current branch | Preserve provider-fresh versus last-known distinction and existing action-specific branch probes |
+| Review workspace/base selection | Yes, plus dirty/base state | Yes | Preserve explicit working-state opt-in and #1951 scheduling; no replacement with cached topology |
+
+The default enrichment flag remains compatible. This change removes the known
+label-only opt-in, not every enrichment caller. `observedGitBranch` participates
+in shared navigation reconciliation and review branch choices, so retaining it
+forever with an immutable directory mapping would be incorrect.
+
+## New ownership and invalidation contract
+
+The Codex client owns one directory-enricher instance. Its confirmed mapping
+cache lasts for that client instance, independent of elapsed time or thread
+query invalidation. It is not another SQLite store. Existing persisted
+workspace links retain their authority; cold discovery after process restart
+is still permitted.
+
+`createGitDirectoryObserver` validates filesystem evidence on demand:
+
+- The requested directory exists, is a directory, and has the same physical
+  identity and resolved path. A missing path is unresolved, not an instruction
+  to archive a thread.
+- The nearest `.git` boundary is still the same. Walking ancestors detects a
+  newly initialized nested repository without a timer or watcher.
+- A `.git` pointer, worktree admin directory, `commondir`, common directory,
+  repository/worktree config or worktree backlink change invalidates the mapping.
+- Directory identity uses device, inode and birth time. Directory modification
+  time is deliberately excluded: ordinary source edits, commits and sibling
+  worktree creation do not change this workspace's repository relationship.
+- File identity includes device, inode, birth time, size, mtime and ctime.
+  Pointer contents are memoized by this signature; unchanged `.git` and
+  `commondir` files are not reread.
+- HEAD has a separate signature. A HEAD change with stable topology runs only
+  `git rev-parse --abbrev-ref HEAD`. Git retains responsibility for branch and
+  detached-HEAD interpretation; this code does not parse branch names.
+- An unversioned directory requires no Git subprocess. Its next observation
+  still searches for a new `.git` boundary, so `git init` is visible immediately.
+
+Cold successful repository discovery retains the existing three-command Git
+implementation and its fallback semantics. Failures, incomplete observations,
+missing directories and partial Git results are not memoized as successful
+discoveries. Evidence is checked before and after a probe; a change while it is
+in flight prevents that result from becoming the next cache answer. The next
+lookup retries rather than publishing an obsolete generation indefinitely.
+
+The pending map covers **validation as well as Git**. Normalized absolute path
+aliases share the same in-flight operation. The client's listing-local promise
+map extends sharing across mapper batches, including failed resolutions. It is
+discarded after that listing, so a later listing revalidates external changes.
+
+This deliberately uses on-demand filesystem validation rather than a TTL,
+native watchers for every historical workspace, or a persistent cache whose
+validity would have to be reconstructed after downtime. External tools can
+change workspaces without emitting PwrAgent events. Filesystem metadata checks
+remain proportional to distinct requested directories and ancestor depth;
+provider pagination and live Git working-state probes are unchanged.
+
+## Budgets and regression evidence
+
+Checked-in counts live in `__tests__/fixtures/git-subprocess-budgets.json`.
+
+| Scenario | Before | After |
+|---|---:|---:|
+| 20 enriched reads of one confirmed directory, each beyond the old TTL | 60 Git commands | 0 Git commands |
+| 100 rows sharing two directories, one listing | 100 enricher calls | 2 validations |
+| External branch checkout, topology unchanged | stale branch inside TTL; 3 commands after expiry | immediate branch refresh, 1 command |
+| Non-Git directory | 3 failing Git commands on discovery | 0 Git commands |
+
+The final red run restored all three original production files while retaining
+the new tests: **16 regressions failed and one compatibility test passed**.
+Failures included 60 warm Git commands instead of zero, 100 directory
+validations instead of two, stale branches and workspace mappings, retained
+failures, repeated pointer reads, and the label-only provider call still
+requesting enrichment. The fixed files were restored in a `finally` block and
+verified byte-for-byte. Red-run logs are retained locally under
+`.local/directory-cache-review/`.
+
+The suite also verifies unchanged topology after edits/commits, failed branch
+refresh recovery, changes during an in-flight probe, and real Git worktree,
+branch checkout and detached-HEAD behavior using contrived temporary repos.
+Existing thread-info, thread-read, client, registry and working-state tests
+remain necessary: the lower-level optimization must not weaken provider
+freshness, handoff invalidation, review selection or admission.
+
+## Costs and limits
+
+No new SQLite write, commit, timer or persisted index is introduced. Incremental
+SQLite write projection is **0 MB/day**. In-memory maps are keyed by observed
+directories/pointer paths, not by refresh count; listing-local maps are released
+when the listing completes.
+
+This does not claim zero filesystem syscalls or zero Git processes throughout
+PwrAgent. Initial valid repository discovery still costs three commands per
+distinct directory per client lifetime. Broken repository/permission states
+can retry on subsequent explicit observations. Working-state probes keep their
+own budget. A post-fix live profile, after the independent Token Miser changes
+are deployed, is needed to measure the remaining process CPU rather than infer
+it by adding V8 profile percentages.
+
+## Validation of this implementation
+
+- Final focused run: 944 tests passed across the directory-cache, directory
+  enricher, Codex client, thread-read budgets, thread-info store, backend
+  registry, Git working-state service and provider snapshot store suites.
+- Full `pnpm lint` passed: SQL, Codex-storage, colors, Electron policy,
+  license gates, ESLint (0 errors, 47 warnings), typecheck and dependency
+  boundaries.
+- `pnpm build` and the main-bundle boundary check passed.
+- `git diff --check` passed.
+- One final test attempt exited 139 before reporting results. The native
+  report shows V8 weak callbacks during worker isolate teardown; a September 5
+  report predating this change has the same stack signature. The unchanged
+  normal test command subsequently passed all 944 tests. No worker-pool,
+  concurrency, timeout or retry setting was changed to obtain that result.


### PR DESCRIPTION
Directory enrichment still reran three Git commands per directory after five seconds, even after #1916 retained thread summaries and #1951 bounded the separate Git working-state service. The September 6 CPU captures contain this enrichment → execFile → spawn path. Provider listings enrich inside the Codex client before their results reach ThreadInfoStore, so the retained summaries did not prevent that work.

This change removes the directory cache TTL. Confirmed mappings remain for the client lifetime and are validated against filesystem identity; HEAD or reftable stack changes refresh only the branch; symlinked paths discover repositories through their physical ancestors. Missing/replaced directories, new Git boundaries, changed Git pointers/config, and failed probes are handled without retaining stale successes. Each listing validates each distinct directory once across mapper batches, and terminal-notification label lookup stops requesting enrichment.

## Design review

[Thread directory enrichment: ownership and invalidation](https://github.com/pwrdrvr/PwrAgent/blob/fix/desktop-directory-enrichment-cache/docs/design/thread-directory-enrichment-cache-review.md) traces #1895, #1914, #1916, #1921, #1922 and #1951; inventories query caches, ThreadInfoStore, durable snapshots, overlay links and Git-state owners; and documents callers, invalidation, costs and limits.

The cache is process-local. Existing persisted workspace links remain authoritative. Warm reads still validate filesystem metadata; cold repository discovery retains three Git commands. No new SQLite writes, timers or watchers: incremental SQLite cost is 0 MB/day. Token Miser storage (#2000 and its follow-up), Federation paging (#2001), and the existing working-state scheduler remain separate work.

## Regression evidence

With all three original production files restored, the final new-test selection reports **16 failures and one compatibility pass**. Restoring the fix makes the complete focused suites pass.

| Checked scenario | Before | After |
|---|---:|---:|
| 20 reads beyond the former TTL, already confirmed directory | 60 Git commands | 0 |
| 100 threads sharing two directories, one listing | 100 enricher calls | 2 |
| External checkout with unchanged topology | stale inside TTL; 3 commands after expiry | immediate refresh, 1 command |
| Unchanged `.git` / `commondir` pointer files on later reads | reread after expiry | no content reads |

Coverage includes removal/recreation, new nested repositories, gitdir changes, symlink retargeting, per-worktree config, failure recovery, in-flight mutation, ordinary edits/commits, and actual Git worktree/checkout/detached-HEAD behavior in temporary fixture repositories. Subprocess/validation budgets are checked in. Review regressions additionally cover symlinks to repository subdirectories and reftable-backed checkout/detached HEAD in both primary and linked worktrees. All three real-Git review cases failed before the fix; two synthetic manifest-replacement cases preserve coverage on older Git versions.

## Validation

- 949 tests passed across eight focused suites: directory cache/enricher, Codex client, thread-read budgets, ThreadInfoStore, backend registry, working-state service and provider snapshot store.
- Full `pnpm lint` passed, including typecheck and dependency boundaries (ESLint: 0 errors, 47 warnings).
- `pnpm build`, main-bundle boundary and `git diff --check` passed.
- One test attempt exited 139 in V8 weak-callback/worker teardown before reporting results. A September 5 native report predating this change has the same stack signature; the unchanged normal command subsequently passed all 944 tests. No worker-pool, timeout, concurrency or retry setting was changed.

No live-profile migration or app restart was performed. Post-deployment CPU improvement still needs a fresh capture, especially while the independent Token Miser scan remains in the running build.

