### PR TITLE
fix(desktop): keep composer available during thread setup

### DIFF
--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -69,6 +69,7 @@ import {
   type EditedFilesDock,
 } from "./features/thread-detail/context-panels/context-tab";
 import { ThreadPlaceholderHeader } from "./features/thread-detail/ThreadPlaceholderHeader";
+import { handoffLaunchpadComposer } from "./features/composer/launchpad-composer-handoff";
 import { useComposerDraftStore } from "./features/composer/useComposerDraftStore";
 import { useDurableComposerDraftStore } from "./features/composer/useDurableComposerDraftStore";
 import { useAppearance, type AppearanceController } from "./lib/useAppearance";
@@ -2227,6 +2228,9 @@ function DesktopAppShell(props: {
   }, [navigation.selectedThread, session.response?.pricing?.lines]);
 
   const threadViewProps = {
+    pendingLaunchpadCreation: navigation.pendingLaunchpadCreations.find(
+      (creation) => creation.selectionKey === navigation.selectedItemKey,
+    ),
     activeFederationOwnerLabel,
     activeFederationTarget,
     activeTurnId: session.activeTurnId,
@@ -2464,6 +2468,7 @@ function DesktopAppShell(props: {
         undefined,
         extraDirectoryPaths,
         scheduledFor,
+        (thread) => handoffLaunchpadComposer(composerDraftStore, directoryKey, thread, desktopApi),
       ),
     onPendingStatusChange: session.setPendingStatusText,
     onRefreshNavigation: navigation.refresh,
@@ -2630,6 +2635,10 @@ function DesktopAppShell(props: {
         style={{ "--sidebar-width": `${sidebarWidthRef.current}px` } as CSSProperties}
       >
         <Sidebar
+          pendingLaunchpadCreations={navigation.pendingLaunchpadCreations}
+          onSelectPendingLaunchpad={(creation) => {
+            navigation.selectPendingLaunchpad(creation.selectionKey);
+          }}
           addingProjectDirectory={navigation.pickingDirectory}
           backends={backendSummaries.backends}
           browseMode={navigation.browseMode}

--- a/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
+++ b/apps/desktop/src/renderer/src/__tests__/app-shell.test.tsx
@@ -2801,7 +2801,13 @@ describe("App", () => {
     expect(
       await screen.findByRole("region", { name: "Preparing transcript" })
     ).toBeInTheDocument();
-    expect(screen.queryByRole("textbox", { name: "New thread" })).not.toBeInTheDocument();
+    const followUpComposer = screen.getByRole("textbox", { name: "New thread" });
+    expect(followUpComposer).toBe(newThreadComposer);
+    expect(followUpComposer).toHaveAttribute("contenteditable", "true");
+    expect(getComposerValueHost(followUpComposer)).toHaveAttribute("data-value", "");
+    expect(screen.getByRole("article", { name: "Submitted message" })).toHaveTextContent(
+      "Start a Grok-backed thread from the sidebar.",
+    );
 
     await waitFor(() => {
       expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -1,3 +1,10 @@
+import {
+  beginLaunchpadComposition,
+  getLaunchpadComposerDestination,
+  notifyLaunchpadAttachmentHandoff,
+  resolveLaunchpadComposerScope,
+  subscribeLaunchpadAttachmentHandoffs,
+} from "./launchpad-composer-handoff";
 import { QueuedMessageInspector } from "./QueuedMessageInspector";
 import { restoreQueuedMessage } from "./queued-message-content";
 import {
@@ -253,6 +260,7 @@ type ComposerProps = {
   draftStore?: ComposerDraftStore;
   launchpad?: NavigationLaunchpadDraft;
   launchpadError?: string;
+  launchpadMaterializing?: boolean;
   unavailableReason?: string;
   onActiveTurnIdChange?: (turnId?: string) => void;
   fullAccessRiskWarningDismissed?: boolean;
@@ -500,6 +508,8 @@ function resolveSelectedCodexEnvironmentActionId(params: {
 
 type QueuedTurnDraft = {
   id: string;
+  waitingForScheduledActionId?: string;
+  steerWhenReady?: boolean;
   backendQueuePending?: boolean;
   queueEntryId?: string;
   scheduledActionId?: string;
@@ -2857,7 +2867,7 @@ export function Composer(props: ComposerProps) {
   const draftStore = props.draftStore ?? localDraftStore;
   const draftStoreHydrationVersion = draftStore.hydrationVersion ?? 0;
   const savedInitialDraft = draftStore.get(composerScopeKey);
-  const savedInitialQueuedTurns = props.thread
+  const savedInitialQueuedTurns = props.thread || props.launchpad
     ? draftStore.getQueuedTurns(composerScopeKey)
     : undefined;
   const savedInitialPendingSteer = props.thread
@@ -2867,7 +2877,7 @@ export function Composer(props: ComposerProps) {
     savedInitialDraft || !props.launchpad
       ? undefined
       : hydrateComposerDraft(
-          props.launchpad.prompt ?? "",
+          props.launchpadMaterializing ? "" : props.launchpad.prompt ?? "",
           props.skills,
           threadLinks,
           pullRequestLinks,
@@ -2883,7 +2893,8 @@ export function Composer(props: ComposerProps) {
       }
     | undefined
   >(undefined);
-  const submittedDraftScopeKeysRef = useRef<Set<string>>(new Set());
+  const launchpadMaterializingRef = useRef(props.launchpadMaterializing);
+  launchpadMaterializingRef.current = props.launchpadMaterializing;
   const recoveryCycleRef = useRef<{
     activeIndex?: number;
     candidates: ComposerDraftSnapshot[];
@@ -3633,6 +3644,22 @@ export function Composer(props: ComposerProps) {
     setImageAttachments([]);
     setFileAttachments([]);
   };
+  const beginLaunchpadSubmission = (scopeKey: string): ComposerDraftSnapshot => {
+    const submitted = latestDraftSnapshotRef.current.snapshot;
+    resetComposerDraftAndState(scopeKey);
+    const parked = draftStore.popDraft(scopeKey);
+    if (parked) {
+      draftStore.set(scopeKey, parked);
+      latestDraftSnapshotRef.current = { scopeKey, snapshot: parked };
+      setDraft(parked.draft);
+      setEditorDocument(parked.editorDocument);
+      setImageAttachments(parked.imageAttachments);
+      setFileAttachments(parked.fileAttachments ?? []);
+      setSkillTokens(parked.skillTokens);
+    }
+    requestAnimationFrame(() => inputRef.current?.focus());
+    return submitted;
+  };
   const hasLiveComposerContent = (): boolean => {
     const latest = latestDraftSnapshotRef.current;
     return Boolean(
@@ -4003,7 +4030,7 @@ export function Composer(props: ComposerProps) {
     applyRecoveredComposerDraft(cycle.candidates[nextIndex]);
   };
   const isQueuedTurnStoreScope = (scopeKey: string): boolean =>
-    scopeKey.startsWith("thread:");
+    scopeKey.startsWith("thread:") || scopeKey.startsWith("launchpad:");
   const savePendingSteerSnapshot = (
     scopeKey: string,
     state?: ComposerPendingSteerSnapshot,
@@ -4422,65 +4449,13 @@ export function Composer(props: ComposerProps) {
     }
   }, [futureScheduledDraftSendAt, scheduledDraftSendAt]);
 
-  const markComposerDraftSubmitted = (scopeKey: string): void => {
-    if (!isDraftStoreScope(scopeKey)) {
-      return;
-    }
-
-    submittedDraftScopeKeysRef.current.add(scopeKey);
-    clearComposerDraftSnapshot(scopeKey);
-  };
-  const unmarkComposerDraftSubmitted = (scopeKey: string): void => {
-    submittedDraftScopeKeysRef.current.delete(scopeKey);
-  };
-  const clearSubmittedComposerDraft = (scopeKey: string): void => {
-    const emptySnapshot = createEmptyComposerDraftSnapshot();
-
-    const latest = latestDraftSnapshotRef.current;
-    if (latest.scopeKey === scopeKey) {
-      recordComposerDraftHistory(scopeKey, latest.snapshot, "sent");
-    }
-    clearComposerDraftSnapshot(scopeKey);
-    const restoredSnapshot = draftStore.popDraft(scopeKey);
-    submittedDraftScopeKeysRef.current.delete(scopeKey);
-    if (restoredSnapshot) {
-      pendingProgrammaticComposerChangeRef.current = {
-        expectedDraft: restoredSnapshot.draft,
-        expectedSkillTokensSignature: getComposerSkillTokensSignature(
-          restoredSnapshot.skillTokens,
-        ),
-        staleDraft: latest.snapshot.draft,
-        staleSkillTokensSignature: getComposerSkillTokensSignature(
-          latest.snapshot.skillTokens,
-        ),
-      };
-      saveComposerDraftSnapshot(scopeKey, restoredSnapshot);
-      latestDraftSnapshotRef.current = {
-        scopeKey,
-        snapshot: restoredSnapshot,
-      };
-      setDraft(restoredSnapshot.draft);
-      setEditorDocument(restoredSnapshot.editorDocument);
-      setImageAttachments(restoredSnapshot.imageAttachments);
-      setFileAttachments(restoredSnapshot.fileAttachments ?? []);
-      setSkillTokens(restoredSnapshot.skillTokens);
-      return;
-    }
-    latestDraftSnapshotRef.current = {
-      scopeKey,
-      snapshot: emptySnapshot,
-    };
-    clearComposerDraft();
-    setImageAttachments([]);
-    setFileAttachments([]);
-  };
   const persistLaunchpadDraftSnapshot = (
     scopeKey: string,
     snapshot: ComposerDraftSnapshot,
   ): void => {
     const directoryKey = getLaunchpadDirectoryKeyFromScope(scopeKey);
     const updateLaunchpad = launchpadUpdateRef.current;
-    if (!directoryKey || !updateLaunchpad) {
+    if (!directoryKey || !updateLaunchpad || launchpadMaterializingRef.current) {
       return;
     }
 
@@ -4498,11 +4473,7 @@ export function Composer(props: ComposerProps) {
     scopeKey: string,
     snapshot: ComposerDraftSnapshot,
   ): void => {
-    if (submittedDraftScopeKeysRef.current.has(scopeKey)) {
-      clearComposerDraftSnapshot(scopeKey);
-      return;
-    }
-
+    if (resolveLaunchpadComposerScope(draftStore, scopeKey) !== scopeKey) return;
     saveComposerDraftSnapshot(scopeKey, snapshot);
     persistLaunchpadDraftSnapshot(scopeKey, snapshot);
   };
@@ -4849,6 +4820,18 @@ export function Composer(props: ComposerProps) {
     reviewConfig?.target,
   ]);
 
+  useEffect(() => subscribeLaunchpadAttachmentHandoffs(draftStore, (scopeKey) => {
+    if (activeComposerScopeKeyRef.current !== scopeKey) return;
+    const saved = draftStore.get(scopeKey);
+    if (!saved) return;
+    latestDraftSnapshotRef.current = { scopeKey, snapshot: saved };
+    setDraft(saved.draft);
+    setEditorDocument(saved.editorDocument);
+    setSkillTokens(saved.skillTokens);
+    setImageAttachments(saved.imageAttachments);
+    setFileAttachments(saved.fileAttachments ?? []);
+  }), [draftStore]);
+
   useEffect(() => {
     let refreshQueuedTurnsPending = false;
     let disposed = false;
@@ -4981,7 +4964,7 @@ export function Composer(props: ComposerProps) {
       setQueuedTurnsState(savedQueuedTurns);
     } else {
       setPendingSteerState(undefined);
-      setQueuedTurnsState([]);
+      setQueuedTurnsState(draftStore.getQueuedTurns(composerScopeKey));
     }
     updateSending(false);
     setInterrupting(false);
@@ -5177,6 +5160,7 @@ export function Composer(props: ComposerProps) {
     }
 
     hydratedLaunchpadKeyRef.current = props.launchpad?.directoryKey;
+    if (!props.launchpadMaterializing) beginLaunchpadComposition(draftStore, composerScopeKey);
     const saved = draftStore.get(composerScopeKey);
     if (saved) {
       setDraft(saved.draft);
@@ -5184,6 +5168,8 @@ export function Composer(props: ComposerProps) {
       setImageAttachments(saved.imageAttachments);
       setFileAttachments(saved.fileAttachments ?? []);
       setSkillTokens(saved.skillTokens);
+    } else if (props.launchpadMaterializing) {
+      resetComposerDraftAndState(composerScopeKey);
     } else {
       setComposerDraftFromCanonical(props.launchpad?.prompt ?? "");
       setEditorDocument(
@@ -5198,7 +5184,7 @@ export function Composer(props: ComposerProps) {
     updateActiveTurnId(undefined);
     setActiveOptimisticMessageId(undefined);
     setReviewConfig(undefined);
-    setQueuedTurnsState([]);
+    setQueuedTurnsState(draftStore.getQueuedTurns(composerScopeKey));
     setPendingSteer(undefined);
     window.setTimeout(() => {
       inputRef.current?.focus();
@@ -5609,7 +5595,8 @@ export function Composer(props: ComposerProps) {
     }
 
     const timeout = window.setTimeout(() => {
-      if (submittedDraftScopeKeysRef.current.has(composerScopeKey)) {
+      if (launchpadMaterializingRef.current
+        || resolveLaunchpadComposerScope(draftStore, composerScopeKey) !== composerScopeKey) {
         return;
       }
 
@@ -5694,7 +5681,7 @@ export function Composer(props: ComposerProps) {
 
     if (props.launchpad && props.onMaterializeLaunchpad) {
       const submittedScopeKey = composerScopeKey;
-      markComposerDraftSubmitted(submittedScopeKey);
+      const submittedSnapshot = beginLaunchpadSubmission(submittedScopeKey);
       props.onPendingStatusChange?.(
         props.launchpad.codexEnvironmentId &&
           selectedCodexEnvironment?.setupScript
@@ -5717,10 +5704,14 @@ export function Composer(props: ComposerProps) {
             .map((directory) => directory.path)
             .filter((path): path is string => Boolean(path))
         );
-        clearSubmittedComposerDraft(submittedScopeKey);
         setReviewConfig(undefined);
       } catch (error) {
-        unmarkComposerDraftSubmitted(submittedScopeKey);
+        if (!draftStore.get(submittedScopeKey)
+          && activeComposerScopeKeyRef.current === submittedScopeKey) {
+          restoreSubmittedComposerDraftInScope(submittedScopeKey, submittedSnapshot);
+        } else {
+          draftStore.pushDraft(submittedScopeKey, submittedSnapshot);
+        }
         inFlightReviewSubmissionKeyRef.current = undefined;
         props.onPendingStatusChange?.(undefined);
         restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
@@ -6885,25 +6876,10 @@ export function Composer(props: ComposerProps) {
       !props.launchpad
       || !props.onMaterializeLaunchpad
       || props.disabled
+      || sendingRef.current
+      || turnPayloadPreparationInFlightRef.current
     ) {
       return;
-    }
-
-    let input: AppServerTurnInputItem[] | undefined;
-    if (!reviewTarget) {
-      const payloadOrPromise = buildTurnPayload(
-        canonicalDraft,
-        imageAttachments,
-        fileAttachments,
-        skillTokens,
-      );
-      const payload = isPromiseLike(payloadOrPromise)
-        ? await payloadOrPromise
-        : payloadOrPromise;
-      if (payload.input.length === 0) {
-        return;
-      }
-      input = payload.input;
     }
 
     const collaborationMode =
@@ -6916,7 +6892,7 @@ export function Composer(props: ComposerProps) {
           } satisfies AppServerCollaborationModeRequest)
         : undefined;
     const submittedScopeKey = composerScopeKey;
-    markComposerDraftSubmitted(submittedScopeKey);
+    const submittedSnapshot = beginLaunchpadSubmission(submittedScopeKey);
     setSendError(undefined);
     updateSending(true);
     props.onPendingStatusChange?.(
@@ -6925,6 +6901,23 @@ export function Composer(props: ComposerProps) {
         : "Scheduling thread",
     );
     try {
+      let input: AppServerTurnInputItem[] | undefined;
+      if (!reviewTarget) {
+        const payloadOrPromise = buildTurnPayload(
+          canonicalDraft,
+          imageAttachments,
+          fileAttachments,
+          skillTokens,
+        );
+        const payload = isPromiseLike(payloadOrPromise)
+          ? await payloadOrPromise
+          : payloadOrPromise;
+        if (payload.input.length === 0) {
+          restoreSubmittedComposerDraftInScope(submittedScopeKey, submittedSnapshot);
+          return;
+        }
+        input = payload.input;
+      }
       await props.onMaterializeLaunchpad(
         props.launchpad.directoryKey,
         input,
@@ -6938,7 +6931,6 @@ export function Composer(props: ComposerProps) {
           .filter((path): path is string => Boolean(path)),
         scheduledSendAt,
       );
-      clearSubmittedComposerDraft(submittedScopeKey);
       setReviewConfig(undefined);
       setScheduledDraftSendAt(undefined);
       setScheduleArmed(true);
@@ -6946,7 +6938,12 @@ export function Composer(props: ComposerProps) {
         setPlanModeEnabled(false);
       }
     } catch (error) {
-      unmarkComposerDraftSubmitted(submittedScopeKey);
+      if (!draftStore.get(submittedScopeKey)
+        && activeComposerScopeKeyRef.current === submittedScopeKey) {
+        restoreSubmittedComposerDraftInScope(submittedScopeKey, submittedSnapshot);
+      } else {
+        draftStore.pushDraft(submittedScopeKey, submittedSnapshot);
+      }
       setSendError(error instanceof Error ? error.message : String(error));
     } finally {
       props.onPendingStatusChange?.(undefined);
@@ -7518,6 +7515,40 @@ export function Composer(props: ComposerProps) {
     ) {
       return;
     }
+    if (props.launchpad && (props.launchpadMaterializing || sendingRef.current)) {
+      if (props.disabled || !hasLiveComposerContent()) return;
+      const scopeKey = composerScopeKey;
+      const destination = getLaunchpadComposerDestination(draftStore, scopeKey);
+      const snapshot = latestDraftSnapshotRef.current.snapshot;
+      const text = canonicalDraft;
+      const queued: QueuedTurnDraft = {
+        id: createQueuedTurnId(),
+        text,
+        backendQueuePending: true,
+        imageAttachments: snapshot.imageAttachments,
+        fileAttachments: snapshot.fileAttachments ?? [],
+      };
+      // Reserve FIFO order before attachment preparation can yield or the
+      // launchpad can become a thread. The destination follows that handoff.
+      enqueueQueuedTurnInScope(scopeKey, queued);
+      resetComposerDraftAndState(scopeKey);
+      try {
+        const payload = await buildTurnPayload(text, imageAttachments, fileAttachments, skillTokens);
+        updateQueuedTurnInScope(destination.scopeKey, queued, (current) => ({
+          ...current,
+          backendQueuePending: false,
+          input: payload.input,
+        }));
+      } catch (error) {
+        updateQueuedTurnInScope(destination.scopeKey, queued, (current) => ({
+          ...current,
+          backendQueuePending: false,
+          manualReleaseRequired: true,
+          errorMessage: error instanceof Error ? error.message : String(error),
+        }));
+      }
+      return;
+    }
     if (isCompactCommand) {
       await submitCompactThread();
       return;
@@ -7687,6 +7718,9 @@ export function Composer(props: ComposerProps) {
     // pending time so the toggle doesn't reappear after the immediate send.
     setScheduledDraftSendAt(undefined);
     setScheduleArmed(true);
+    const submittedLaunchpad = props.launchpad && props.onMaterializeLaunchpad && !props.disabled
+      ? { scopeKey: composerScopeKey, snapshot: beginLaunchpadSubmission(composerScopeKey) }
+      : undefined;
     const payloadOrPromise = buildTurnPayload(
       canonicalDraft,
       imageAttachments,
@@ -7700,6 +7734,9 @@ export function Composer(props: ComposerProps) {
       try {
         payload = await payloadOrPromise;
       } catch (error) {
+        if (submittedLaunchpad) {
+          restoreSubmittedComposerDraftInScope(submittedLaunchpad.scopeKey, submittedLaunchpad.snapshot);
+        }
         updateSending(false);
         setSendError(error instanceof Error ? error.message : String(error));
         return;
@@ -7719,6 +7756,9 @@ export function Composer(props: ComposerProps) {
       : undefined;
 
     if (payload.input.length === 0 || props.disabled) {
+      if (submittedLaunchpad) {
+        restoreSubmittedComposerDraftInScope(submittedLaunchpad.scopeKey, submittedLaunchpad.snapshot);
+      }
       updateSending(false);
       return;
     }
@@ -7726,9 +7766,9 @@ export function Composer(props: ComposerProps) {
     setSendError(undefined);
     updateSending(true);
 
-    if (props.launchpad && props.onMaterializeLaunchpad) {
-      const submittedScopeKey = composerScopeKey;
-      markComposerDraftSubmitted(submittedScopeKey);
+    if (props.launchpad && props.onMaterializeLaunchpad && submittedLaunchpad) {
+      const submittedScopeKey = submittedLaunchpad.scopeKey;
+      const submittedSnapshot = submittedLaunchpad.snapshot;
       props.onPendingStatusChange?.(
         props.launchpad.codexEnvironmentId &&
           selectedCodexEnvironment?.setupScript
@@ -7749,14 +7789,22 @@ export function Composer(props: ComposerProps) {
             .map((directory) => directory.path)
             .filter((path): path is string => Boolean(path))
         );
-        clearSubmittedComposerDraft(submittedScopeKey);
+
         if (collaborationMode) {
           setPlanModeEnabled(false);
         }
       } catch (error) {
-        unmarkComposerDraftSubmitted(submittedScopeKey);
+        // Never overwrite a follow-up typed while creation was in flight.
+        if (!draftStore.hasDraftContent(submittedScopeKey)
+          && activeComposerScopeKeyRef.current === submittedScopeKey) {
+          restoreSubmittedComposerDraftInScope(submittedScopeKey, submittedSnapshot);
+        } else {
+          draftStore.pushDraft(submittedScopeKey, submittedSnapshot);
+        }
         props.onPendingStatusChange?.(undefined);
-        setSendError(error instanceof Error ? error.message : String(error));
+        if (!launchpadMaterializingRef.current) {
+          setSendError(error instanceof Error ? error.message : String(error));
+        }
       } finally {
         updateSending(false);
       }
@@ -8604,6 +8652,7 @@ export function Composer(props: ComposerProps) {
 
   const attachImages = async (files: ComposerImageFile[]): Promise<void> => {
     const pasteScope = pasteScopeRef.current;
+    const destination = getLaunchpadComposerDestination(draftStore, pasteScope.key);
     const pasteDraft = draft;
     const pasteEditorDocument = editorDocument;
     const pasteImageAttachments = imageAttachments;
@@ -8661,14 +8710,17 @@ export function Composer(props: ComposerProps) {
         })
       );
 
-      if (activeComposerScopeKeyRef.current !== pasteScope.key) {
-        const saved = draftStore.get(pasteScope.key) ?? {
-          draft: pasteDraft,
-          editorDocument: pasteEditorDocument,
-          imageAttachments: pasteImageAttachments,
-          fileAttachments: pasteFileAttachments,
-          skillTokens,
-        };
+      const targetScopeKey = destination.scopeKey;
+      if (targetScopeKey !== pasteScope.key || activeComposerScopeKeyRef.current !== targetScopeKey) {
+        const saved = draftStore.get(targetScopeKey) ?? (targetScopeKey !== pasteScope.key
+          ? createEmptyComposerDraftSnapshot()
+          : {
+              draft: pasteDraft,
+              editorDocument: pasteEditorDocument,
+              imageAttachments: pasteImageAttachments,
+              fileAttachments: pasteFileAttachments,
+              skillTokens,
+            });
         // Drop exact duplicates against the background scope's own attachments
         // (no toast — this composer isn't the one on screen).
         const { unique } = partitionNewImageAttachments(
@@ -8686,8 +8738,9 @@ export function Composer(props: ComposerProps) {
           fileAttachments: saved.fileAttachments,
           skillTokens: saved.skillTokens,
         };
-        saveComposerDraftSnapshot(pasteScope.key, nextSnapshot);
-        persistLaunchpadDraftSnapshot(pasteScope.key, nextSnapshot);
+        saveComposerDraftSnapshot(targetScopeKey, nextSnapshot);
+        persistLaunchpadDraftSnapshot(targetScopeKey, nextSnapshot);
+        notifyLaunchpadAttachmentHandoff(draftStore, targetScopeKey);
         return;
       }
 
@@ -9266,7 +9319,7 @@ export function Composer(props: ComposerProps) {
   const supportsSteering =
     Boolean(backend?.capabilities.steerTurn) &&
     selectedModelOption?.supportsSteering !== false;
-  const launchpadSubmitting = isLaunchpad && sending;
+  const launchpadSubmitting = isLaunchpad && (sending || Boolean(props.launchpadMaterializing));
   const fiveHourResetAt = getFiveHourRateLimitResetAt({
     backend,
     now: scheduleNow,
@@ -9292,12 +9345,13 @@ export function Composer(props: ComposerProps) {
   const sendButtonDisabled =
     props.disabled ||
     steering ||
-    (!activeTurnId && sending) ||
+    (!activeTurnId && sending && !isLaunchpad) ||
     (!hasComposerContent &&
       imageAttachments.length === 0 &&
       fileAttachments.length === 0);
   const scheduleButtonDisabled =
     sendButtonDisabled ||
+    launchpadSubmitting ||
     (!props.thread && !props.launchpad) ||
     Boolean(props.launchpad && !props.onMaterializeLaunchpad) ||
     isCompactCommand;
@@ -9327,6 +9381,7 @@ export function Composer(props: ComposerProps) {
     ? futureScheduledDraftSendAt
     : undefined;
   const submitButtonLabel =
+    launchpadSubmitting ||
     activeTurnId ||
     queuedTurns.some((queued) =>
       Boolean(queued.backendQueuePending || queued.queueEntryId)
@@ -9843,8 +9898,10 @@ export function Composer(props: ComposerProps) {
   // Backend availability gates submission and remote actions, not the draft.
   // Keeping the editor live lets an operator inspect, copy, revise, or remove
   // durable text and attachments while federation reconnects.
-  const composerDisabled = launchpadSubmitting;
-  const composerPlaceholder = isLaunchpad
+  const composerDisabled = false;
+  const composerPlaceholder = launchpadSubmitting
+    ? "Queue a follow-up while this thread starts"
+    : isLaunchpad
     ? `Start a new thread in ${props.launchpad?.directoryLabel ?? "this directory"}`
     : "Reply to this thread";
   const handleComposerChange = (
@@ -9856,7 +9913,6 @@ export function Composer(props: ComposerProps) {
       recoveryCycleRef.current = undefined;
       recoveryEligibilityVersionRef.current += 1;
     }
-    unmarkComposerDraftSubmitted(composerScopeKey);
     const pendingProgrammaticChange =
       pendingProgrammaticComposerChangeRef.current;
     if (pendingProgrammaticChange && nextSkillTokens) {
@@ -10416,7 +10472,11 @@ export function Composer(props: ComposerProps) {
           queued.scheduledSendAt,
           scheduleNow,
         );
-        const queuedLabel = queued.manualReleaseRequired
+        const queuedLabel = queued.waitingForScheduledActionId
+          ? "Waiting for scheduled first message"
+          : queued.steerWhenReady
+          ? "Steer when ready"
+          : queued.manualReleaseRequired
           ? "Held for retry"
           : queued.errorMessage
           ? "Failed to send"
@@ -10476,7 +10536,24 @@ export function Composer(props: ComposerProps) {
               load={() => readQueuedMessage(queued)}
               desktopApi={props.desktopApi}
             >
-              {queued.manualReleaseRequired && index === 0 ? (
+              {isLaunchpad ? (
+                supportsSteering ? (
+                  <button
+                    className="composer__secondary-action"
+                    aria-pressed={Boolean(queued.steerWhenReady)}
+                    disabled={queued.backendQueuePending}
+                    type="button"
+                    onClick={() => {
+                      updateQueuedTurnInScope(queuedScopeKey, queued, (current) => ({
+                        ...current,
+                        steerWhenReady: !current.steerWhenReady,
+                      }));
+                    }}
+                  >
+                    Steer when ready
+                  </button>
+                ) : null
+              ) : queued.manualReleaseRequired && index === 0 ? (
                 <button
                   className="composer__secondary-action"
                   disabled={
@@ -10518,7 +10595,7 @@ export function Composer(props: ComposerProps) {
                     {steering ? "Steering..." : "Steer"}
                   </button>
                 ) : null
-              ) : !backendOwned ? (
+              ) : !backendOwned && !queued.waitingForScheduledActionId ? (
                 <button
                   className="composer__secondary-action"
                   disabled={props.disabled || sending}
@@ -12348,7 +12425,7 @@ export function Composer(props: ComposerProps) {
           {props.launchpad && props.onCancelLaunchpad ? (
             <button
               className="button button--ghost"
-              disabled={sending}
+              disabled={launchpadSubmitting}
               type="button"
               onClick={() => {
                 // Cancel empties the launchpad without losing what was typed:

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -1,3 +1,4 @@
+import { handoffLaunchpadComposer } from "../launchpad-composer-handoff";
 import "@testing-library/jest-dom/vitest";
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { StrictMode, useState, type ComponentProps } from "react";
@@ -586,6 +587,103 @@ function createScheduledActionApi(options?: {
 }
 
 describe("Composer", () => {
+  it.each([false, true])("preserves follow-up edits while the first launchpad payload is inspected (scheduled: %s)", async (scheduled) => {
+    const inspection = createDeferred<{ filePaths: string[]; pdfPaths: string[] }>();
+    const inspectPdfReferencePaths = vi.fn(() => inspection.promise);
+    const onMaterializeLaunchpad = vi.fn<NonNullable<ComponentProps<typeof Composer>["onMaterializeLaunchpad"]>>(async () => undefined);
+    const launchpad = createRetargetingLaunchpad(retargetingPwrSnap, "Read [@notes](/repo/notes.txt)");
+    render(<Composer backends={[backendSummary("codex")]}
+      directory={retargetingPwrSnap} launchpad={launchpad} skills={[]}
+      desktopApi={{ inspectPdfReferencePaths }} onMaterializeLaunchpad={onMaterializeLaunchpad} />);
+    if (scheduled) {
+      fireEvent.click(screen.getByRole("button", { name: "Schedule thread" }));
+      fireEvent.click(screen.getByRole("menuitem", { name: "Start in 1h" }));
+    } else {
+      fireEvent.click(screen.getByRole("button", { name: "Start thread" }));
+    }
+    await waitFor(() => expect(inspectPdfReferencePaths).toHaveBeenCalled());
+    fireEvent.change(screen.getByLabelText("New thread"), { target: { value: "Keep this follow-up" } });
+    await act(async () => {
+      inspection.resolve({ filePaths: ["/repo/notes.txt"], pdfPaths: [] });
+      await inspection.promise;
+    });
+    await waitFor(() => expect(onMaterializeLaunchpad).toHaveBeenCalledTimes(1));
+    expect(onMaterializeLaunchpad.mock.calls[0]?.[1]).toEqual(expect.arrayContaining([
+      { type: "text", text: "Read [@notes](/repo/notes.txt)" },
+    ]));
+    expect(screen.getByLabelText("New thread")).toHaveValue("Keep this follow-up");
+  });
+
+  it("retargets an image that finishes normalizing after launchpad handoff", async () => {
+    const normalization = createDeferred<Awaited<ReturnType<typeof normalizeImageFile>>>();
+    vi.mocked(normalizeImageFile).mockImplementationOnce(() => normalization.promise);
+    const store = createComposerDraftStore();
+    const launchpad = createRetargetingLaunchpad(retargetingPwrSnap, "First message");
+    const view = render(<Composer backends={[backendSummary("codex")]}
+      directory={retargetingPwrSnap} launchpad={launchpad} launchpadMaterializing
+      draftStore={store} skills={[]} />);
+    fireEvent.change(screen.getByLabelText("New thread"), { target: { value: "Follow-up image" } });
+    const file = new File([new Uint8Array([1, 2, 3])], "follow-up.png", { type: "image/png" });
+    fireEvent.paste(screen.getByLabelText("New thread"), {
+      clipboardData: { files: [file], items: [{ kind: "file", type: "image/png", getAsFile: () => file }] },
+    });
+    await waitFor(() => expect(normalizeImageFile).toHaveBeenCalledTimes(1));
+    const thread: NavigationThreadSummary = {
+      id: "materialized", source: "codex", title: "First message", titleSource: "explicit",
+      linkedDirectories: [], inbox: { inInbox: false }, optimisticActiveTurn: { id: "first-turn" },
+    };
+    act(() => handoffLaunchpadComposer(store, launchpad.directoryKey, thread));
+    view.rerender(<Composer backends={[backendSummary("codex")]} thread={thread}
+      activeTurnId="first-turn" draftStore={store} skills={[]} />);
+    await act(async () => {
+      normalization.resolve({
+        dataUrl: "data:image/png;base64,AQID", height: 24, width: 24, size: 3,
+        mimeType: "image/png", conversionPath: "renderer",
+        original: { height: 24, width: 24, size: 3, mimeType: "image/png", name: "follow-up.png" },
+      });
+      await normalization.promise;
+    });
+    expect(await screen.findByAltText("follow-up.png")).toBeInTheDocument();
+    expect(store.get("thread:codex:materialized")?.imageAttachments).toHaveLength(1);
+    expect(store.get("thread:codex:materialized")?.draft).toBe("Follow-up image");
+    expect(store.get(`launchpad:${launchpad.directoryKey}`)).toBeUndefined();
+  });
+
+  it("keeps follow-ups and steering intent when a starting launchpad is remounted", async () => {
+    const draftStore = createComposerDraftStore();
+    const backend = backendSummary("codex");
+    backend.capabilities.steerTurn = true;
+    const launchpad = createRetargetingLaunchpad(retargetingPwrSnap, "Already submitted");
+    const onMaterializeLaunchpad = vi.fn();
+    const composer = (
+      <Composer
+        backends={[backend]}
+        directory={retargetingPwrSnap}
+        draftStore={draftStore}
+        launchpad={launchpad}
+        launchpadMaterializing
+        onMaterializeLaunchpad={onMaterializeLaunchpad}
+        skills={[]}
+      />
+    );
+    const first = render(composer);
+    expect(screen.getByLabelText("New thread")).toHaveValue("");
+    expect(screen.getByLabelText("New thread")).toBeEnabled();
+    fireEvent.change(screen.getByLabelText("New thread"), { target: { value: "Correction" } });
+    await clickButton("Queue");
+    const queued = screen.getByLabelText("Queued message");
+    fireEvent.click(within(queued).getByRole("button", { name: "Steer when ready" }));
+    fireEvent.change(screen.getByLabelText("New thread"), { target: { value: "Still composing" } });
+    first.unmount();
+    render(composer);
+    expect(screen.getByLabelText("New thread")).toHaveValue("Still composing");
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent("Correction");
+    expect(within(screen.getByLabelText("Queued message")).getByRole("button", {
+      name: "Steer when ready",
+    })).toHaveAttribute("aria-pressed", "true");
+    expect(onMaterializeLaunchpad).not.toHaveBeenCalled();
+  });
+
   it("persists the Auto-fix PR toggle and shows its global polling gate", async () => {
     const onSetThreadPrAutoDispatch = vi.fn(async () => undefined);
     const thread: NavigationThreadSummary = {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/launchpad-composer-handoff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/launchpad-composer-handoff.test.tsx
@@ -1,0 +1,143 @@
+import { applyScheduledActionProjection, syncScheduledActionProjections } from "../../../lib/useScheduledThreadActionProjection";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { NavigationThreadSummary, ScheduledThreadAction } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { beginLaunchpadComposition, getLaunchpadComposerDestination, handoffLaunchpadComposer, resolveLaunchpadComposerScope } from "../launchpad-composer-handoff";
+import { getNextReleasableQueuedTurn, useComposerDraftStore } from "../useComposerDraftStore";
+
+const thread: NavigationThreadSummary = {
+  id: "new-thread",
+  source: "codex",
+  title: "Initial message",
+  titleSource: "explicit",
+  linkedDirectories: [],
+  inbox: { inInbox: false },
+  optimisticActiveTurn: { id: "first-turn" },
+};
+const source = "launchpad:project";
+const target = "thread:codex:new-thread";
+const draft = (text: string) => ({
+  draft: text,
+  imageAttachments: [],
+  fileAttachments: [],
+  skillTokens: [],
+});
+const queued = (text: string) => ({
+  id: text,
+  text,
+  input: [{ type: "text" as const, text }],
+  imageAttachments: [],
+  fileAttachments: [],
+});
+
+describe("launchpad composer handoff", () => {
+  it("moves the latest draft, parked drafts, and ordered follow-ups before selecting the thread", () => {
+    const { result } = renderHook(useComposerDraftStore);
+    const store = result.current;
+    store.set(source, draft("Still typing"));
+    store.pushDraft(source, draft("Older draft"));
+    store.setQueuedTurns(source, [queued("second"), queued("third")]);
+    act(() => handoffLaunchpadComposer(store, "project", thread));
+    expect(store.get(target)?.draft).toBe("Still typing");
+    expect(store.popDraft(target)?.draft).toBe("Older draft");
+    expect(store.getQueuedTurns(target).map((entry) => entry.text)).toEqual(["second", "third"]);
+    expect(store.get(source)).toBeUndefined();
+    expect(store.getQueuedTurns(source)).toEqual([]);
+    expect(resolveLaunchpadComposerScope(store, source)).toBe(target);
+  });
+
+  it("retains the destination for an attachment finishing after another launchpad opens", () => {
+    const { result } = renderHook(useComposerDraftStore);
+    const destination = getLaunchpadComposerDestination(result.current, source);
+    act(() => handoffLaunchpadComposer(result.current, "project", thread));
+    beginLaunchpadComposition(result.current, source);
+    expect(destination.scopeKey).toBe(target);
+    expect(getLaunchpadComposerDestination(result.current, source).scopeKey).toBe(source);
+  });
+
+  it("steers the created thread even if another conversation is selected", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    const steerTurn = vi.fn<NonNullable<DesktopApi["steerTurn"]>>().mockResolvedValue({
+      backend: "codex", threadId: thread.id, turnId: "first-turn", disposition: "steered",
+    });
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", thread, { steerTurn }));
+    expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({
+      threadId: thread.id,
+      expectedTurnId: "first-turn",
+      input: [{ type: "text", text: "correction" }],
+    }));
+    await waitFor(() => expect(result.current.getQueuedTurns(target)).toEqual([]));
+  });
+
+  it("holds a failed steer for explicit recovery without losing its content", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    const steerTurn = vi.fn().mockRejectedValue(new Error("Connection lost"));
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", thread, { steerTurn }));
+    await waitFor(() => expect(result.current.getQueuedTurns(target)[0]).toMatchObject({
+      text: "correction", manualReleaseRequired: true, backendQueuePending: false,
+      errorMessage: "Connection lost",
+    }));
+    expect(getNextReleasableQueuedTurn(result.current.getQueuedTurns(target))).toBeUndefined();
+  });
+
+  it.each(["event", "refresh", "early event"])("releases scheduled follow-ups only after positive admission (%s)", (delivery) => {
+    const { result } = renderHook(useComposerDraftStore);
+    const store = result.current;
+    const action: ScheduledThreadAction = {
+      id: "scheduled-first", backend: "codex", threadId: thread.id, kind: "turn", origin: "desktop",
+      status: "started", scheduledFor: 100, createdAt: 1, updatedAt: 101,
+      turnId: "scheduled-turn", displayText: "First message",
+    };
+    if (delivery === "early event") act(() => applyScheduledActionProjection(store, action));
+    store.setQueuedTurns(source, [queued("second"), queued("third")]);
+    act(() => handoffLaunchpadComposer(store, "project", {
+      ...thread, optimisticActiveTurn: undefined,
+      scheduledStart: { actionId: action.id, scheduledFor: 100, state: "scheduled" },
+    }));
+    if (delivery !== "early event") {
+      expect(store.getQueuedTurns(target)[0].manualReleaseRequired).not.toBe(true);
+      expect(getNextReleasableQueuedTurn(store.getQueuedTurns(target), 1000)).toBeUndefined();
+      // Neither the due time nor a stale/empty refresh proves admission.
+      act(() => syncScheduledActionProjections(store, [], new Set([target])));
+      expect(getNextReleasableQueuedTurn(store.getQueuedTurns(target), 1000)).toBeUndefined();
+      act(() => delivery === "event"
+        ? applyScheduledActionProjection(store, action)
+        : syncScheduledActionProjections(store, [action]));
+    }
+    expect(getNextReleasableQueuedTurn(store.getQueuedTurns(target))?.text).toBe("second");
+    expect(store.getQueuedTurns(target).map((entry) => entry.text)).toEqual(["second", "third"]);
+  });
+
+  it("delivers a scheduled steer when the first action starts", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    const steerTurn = vi.fn<NonNullable<DesktopApi["steerTurn"]>>().mockResolvedValue({
+      backend: "codex", threadId: thread.id, turnId: "scheduled-turn", disposition: "steered",
+    });
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", {
+      ...thread, optimisticActiveTurn: undefined,
+      scheduledStart: { actionId: "first", scheduledFor: 100, state: "scheduled" },
+    }, { steerTurn }));
+    expect(steerTurn).not.toHaveBeenCalled();
+    act(() => applyScheduledActionProjection(result.current, {
+      id: "first", backend: "codex", threadId: thread.id, kind: "turn", origin: "desktop",
+      status: "started", scheduledFor: 100, createdAt: 1, updatedAt: 101,
+      turnId: "scheduled-turn", displayText: "First message",
+    }));
+    expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({ expectedTurnId: "scheduled-turn" }));
+    await waitFor(() => expect(result.current.getQueuedTurns(target)).toEqual([]));
+  });
+
+  it("does not release follow-ups ahead of a first message whose setup failed", () => {
+    const { result } = renderHook(useComposerDraftStore);
+    result.current.setQueuedTurns(source, [queued("second")]);
+    act(() => handoffLaunchpadComposer(result.current, "project", {
+      ...thread, optimisticActiveTurn: undefined,
+    }));
+    expect(result.current.getQueuedTurns(target)[0].manualReleaseRequired).toBe(true);
+    expect(getNextReleasableQueuedTurn(result.current.getQueuedTurns(target))).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/composer/launchpad-composer-handoff.ts
+++ b/apps/desktop/src/renderer/src/features/composer/launchpad-composer-handoff.ts
@@ -1,0 +1,222 @@
+import type { NavigationThreadSummary, ScheduledThreadAction } from "@pwragent/shared";
+import type { DesktopApi } from "../../lib/desktop-api";
+import { readRendererFederationTarget } from "../../lib/federation-window";
+import {
+  buildThreadComposerScopeKey,
+  type ComposerDraftStore,
+  type ComposerQueuedTurnSnapshot,
+} from "./useComposerDraftStore";
+
+type ComposerDestination = { scopeKey: string };
+const handoffTargets = new WeakMap<ComposerDraftStore, Map<string, ComposerDestination>>();
+const attachmentListeners = new WeakMap<ComposerDraftStore, Set<(scopeKey: string) => void>>();
+
+export function subscribeLaunchpadAttachmentHandoffs(
+  store: ComposerDraftStore,
+  listener: (scopeKey: string) => void,
+): () => void {
+  let listeners = attachmentListeners.get(store);
+  if (!listeners) {
+    listeners = new Set();
+    attachmentListeners.set(store, listeners);
+  }
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+export function notifyLaunchpadAttachmentHandoff(store: ComposerDraftStore, scopeKey: string): void {
+  for (const listener of attachmentListeners.get(store) ?? []) listener(scopeKey);
+}
+
+type ScheduledFirstActionEvidence = Pick<
+  ScheduledThreadAction, "status" | "turnId" | "errorMessage" | "updatedAt"
+>;
+type ScheduledFirstActionState = {
+  observed: Map<string, ScheduledFirstActionEvidence>;
+  waiting: Map<string, (action: ScheduledFirstActionEvidence) => void>;
+};
+const scheduledFirstActions = new WeakMap<ComposerDraftStore, ScheduledFirstActionState>();
+
+function scheduledFirstActionState(store: ComposerDraftStore): ScheduledFirstActionState {
+  let state = scheduledFirstActions.get(store);
+  if (!state) {
+    state = { observed: new Map(), waiting: new Map() };
+    scheduledFirstActions.set(store, state);
+  }
+  return state;
+}
+
+/** Retain positive admission evidence even if it arrives before materialization returns. */
+export function observeLaunchpadScheduledAction(store: ComposerDraftStore, action: ScheduledThreadAction): void {
+  if (!["started", "failed", "cancelled", "held"].includes(action.status)) return;
+  const state = scheduledFirstActionState(store);
+  const key = `${buildThreadComposerScopeKey(action.backend, action.threadId)}:${action.id}`;
+  const previous = state.observed.get(key);
+  if (previous && previous.updatedAt > action.updatedAt) return;
+  state.observed.set(key, {
+    status: action.status,
+    turnId: action.turnId,
+    errorMessage: action.errorMessage,
+    updatedAt: action.updatedAt,
+  });
+  state.waiting.get(key)?.(action);
+}
+
+export function getLaunchpadComposerDestination(
+  store: ComposerDraftStore,
+  scopeKey: string,
+): ComposerDestination {
+  let targets = handoffTargets.get(store);
+  if (!targets) {
+    targets = new Map();
+    handoffTargets.set(store, targets);
+  }
+  let destination = targets.get(scopeKey);
+  if (!destination) {
+    destination = { scopeKey };
+    targets.set(scopeKey, destination);
+  }
+  return destination;
+}
+
+export function beginLaunchpadComposition(store: ComposerDraftStore, scopeKey: string): void {
+  handoffTargets.get(store)?.delete(scopeKey);
+  getLaunchpadComposerDestination(store, scopeKey);
+}
+
+export function resolveLaunchpadComposerScope(store: ComposerDraftStore, scopeKey: string): string {
+  return handoffTargets.get(store)?.get(scopeKey)?.scopeKey ?? scopeKey;
+}
+
+/** Move local composition before navigation exposes the new thread. */
+export function handoffLaunchpadComposer(
+  store: ComposerDraftStore,
+  directoryKey: string,
+  thread: NavigationThreadSummary,
+  desktopApi?: DesktopApi,
+): void {
+  const source = `launchpad:${directoryKey}`;
+  const target = buildThreadComposerScopeKey(thread.source, thread.id);
+  getLaunchpadComposerDestination(store, source).scopeKey = target;
+  const draft = store.get(source);
+  if (draft) {
+    store.set(target, draft);
+    store.delete(source);
+  }
+  const parked = [];
+  for (let snapshot = store.popDraft(source); snapshot; snapshot = store.popDraft(source)) {
+    parked.push(snapshot);
+  }
+  for (const snapshot of parked.reverse()) store.pushDraft(target, snapshot);
+
+  const turnId = thread.optimisticActiveTurn?.id;
+  const queued = store.getQueuedTurns(source).map((entry) => ({
+    ...entry,
+    // A failed first turn must be resolved before follow-ups can run.
+    ...(!turnId && !thread.scheduledStart ? {
+      manualReleaseRequired: true,
+      holdReason: "Start the first message before releasing this follow-up.",
+    } : {}),
+    ...(!turnId && thread.scheduledStart ? {
+      waitingForScheduledActionId: thread.scheduledStart.actionId,
+    } : {}),
+    ...(entry.steerWhenReady && turnId ? { backendQueuePending: true } : {}),
+  }));
+  store.setQueuedTurns(target, [...store.getQueuedTurns(target), ...queued]);
+  store.deleteQueuedTurn(source);
+
+  // Capture the owning thread, never the current selection. The operator may
+  // have navigated away while setup ran. Failed/ambiguous submissions stay
+  // held for explicit recovery rather than being sent a second time.
+  const steer = async (entry: ComposerQueuedTurnSnapshot, expectedTurnId = turnId): Promise<void> => {
+    const update = (patch: Partial<ComposerQueuedTurnSnapshot>): void => {
+      store.setQueuedTurns(target, store.getQueuedTurns(target).map((current) =>
+        current.id === entry.id ? { ...current, ...patch } : current,
+      ));
+    };
+    try {
+      if (!desktopApi?.steerTurn || !expectedTurnId || !entry.input?.length) {
+        throw new Error("Steering is unavailable. Edit this message to send it again.");
+      }
+      const response = await desktopApi.steerTurn({
+        backend: thread.source,
+        federationTarget: thread.federation?.ref.target ?? readRendererFederationTarget(),
+        threadId: thread.id,
+        expectedTurnId,
+        requestId: entry.id,
+        input: entry.input,
+        fallback: {
+          displayText: entry.text,
+          imageAttachments: entry.imageAttachments,
+          fileAttachments: entry.fileAttachments,
+          turn: {
+            input: entry.input,
+            executionMode: thread.executionMode,
+            model: thread.model,
+            reasoningEffort: thread.reasoningEffort,
+            serviceTier: thread.serviceTier,
+            fastMode: thread.fastMode,
+          },
+        },
+      });
+      if (response.scheduledAction?.status === "failed") {
+        throw new Error(response.scheduledAction.errorMessage ?? "The follow-up could not be dispatched.");
+      }
+      if (response.disposition === "held" || response.disposition === "scheduled") {
+        update({
+          backendQueuePending: false,
+          steerWhenReady: false,
+          queueEntryId: response.queueEntryId,
+          scheduledActionId: response.scheduledAction?.id,
+          manualReleaseRequired: response.disposition === "held",
+          holdReason: response.holdReason,
+        });
+      } else {
+        store.removeQueuedTurnById(target, entry.id);
+      }
+    } catch (error) {
+      update({
+        backendQueuePending: false,
+        steerWhenReady: false,
+        manualReleaseRequired: true,
+        errorMessage: error instanceof Error ? error.message : String(error),
+      });
+    }
+  };
+  if (!turnId && thread.scheduledStart && queued.length > 0) {
+    const state = scheduledFirstActionState(store);
+    const actionId = thread.scheduledStart.actionId;
+    const key = `${target}:${actionId}`;
+    const settle = (action: ScheduledFirstActionEvidence): void => {
+      const steers: ComposerQueuedTurnSnapshot[] = [];
+      store.setQueuedTurns(target, store.getQueuedTurns(target).map((entry) => {
+        if (entry.waitingForScheduledActionId !== actionId) return entry;
+        const admitted = action.status === "started";
+        const steerReady = admitted && entry.steerWhenReady && action.turnId;
+        const next = {
+          ...entry,
+          waitingForScheduledActionId: undefined,
+          ...(steerReady ? { backendQueuePending: true } : {}),
+          ...(!admitted ? {
+            manualReleaseRequired: true,
+            holdReason: action.errorMessage ?? "The scheduled first message did not start. Edit this follow-up to send it.",
+          } : {}),
+        };
+        if (steerReady) steers.push(next);
+        return next;
+      }));
+      state.waiting.delete(key);
+      void (async () => {
+        for (const entry of steers) await steer(entry, action.turnId);
+      })();
+    };
+    state.waiting.set(key, settle);
+    const observed = state.observed.get(key);
+    if (observed) settle(observed);
+  }
+  void (async () => {
+    for (const entry of queued) {
+      if (entry.steerWhenReady && turnId) await steer(entry);
+    }
+  })();
+}

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -25,6 +25,10 @@ export type ComposerDraftSnapshot = {
 
 export type ComposerQueuedTurnSnapshot = {
   id: string;
+  /** Apply this follow-up to the first turn once launchpad setup finishes. */
+  steerWhenReady?: boolean;
+  /** Wait for positive admission of the scheduled first action, not its due time. */
+  waitingForScheduledActionId?: string;
   /** Submission is in flight to the main-process FIFO. */
   backendQueuePending?: boolean;
   /** Main-process FIFO entry once the renderer has handed off dispatch ownership. */
@@ -184,13 +188,17 @@ export function getNextReleasableQueuedTurn<
     | "queueEntryId"
     | "scheduledActionId"
     | "scheduledSendAt"
+    | "manualReleaseRequired"
+    | "waitingForScheduledActionId"
   >,
 >(queuedTurns: readonly T[], now = Date.now()): T | undefined {
   for (const queuedTurn of queuedTurns) {
     // A backend-owned entry is already in the authoritative FIFO. Local
     // scheduled turns and reviews behind it must not leapfrog that entry.
     if (
-      queuedTurn.backendQueuePending
+      queuedTurn.waitingForScheduledActionId
+      || queuedTurn.manualReleaseRequired
+      || queuedTurn.backendQueuePending
       || queuedTurn.queueEntryId
       || queuedTurn.scheduledActionId
     ) {

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1,3 +1,4 @@
+import type { PendingLaunchpadCreation } from "../../lib/useThreadNavigation";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type {
   MouseEvent as ReactMouseEvent,
@@ -250,6 +251,8 @@ type SidebarProps = {
   revealSelectedThreadRequest?: number;
   onRevealSelectedThreadComplete?: (request: number) => void;
   selectedItemKey?: string;
+  pendingLaunchpadCreations?: PendingLaunchpadCreation[];
+  onSelectPendingLaunchpad?: (creation: PendingLaunchpadCreation) => void;
   thinkingThreadKeys?: Record<string, boolean>;
   threads: NavigationThreadSummary[];
   onBrowseModeChange: (browseMode: BrowseMode) => void;
@@ -2062,6 +2065,19 @@ export function Sidebar(props: SidebarProps) {
           onPointerOut={hoverStableSnapshot.onPointerOut}
           onPointerOver={hoverStableSnapshot.onPointerOver}
         >
+          {props.pendingLaunchpadCreations?.map((creation) => (
+            <button
+              key={creation.selectionKey}
+              className="sidebar-pending-thread"
+              aria-current={props.selectedItemKey === creation.selectionKey ? "true" : undefined}
+              onClick={() => props.onSelectPendingLaunchpad?.(creation)}
+              type="button"
+            >
+              <span className="pending-spinner" aria-hidden="true" />
+              <span className="sidebar-pending-thread__title">{creation.title || "New thread"}</span>
+              <span>Starting</span>
+            </button>
+          ))}
           {props.loading ? (
             <p className="sidebar-empty">Loading threads…</p>
           ) : props.providerRefresh?.state === "checking"

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -1,3 +1,4 @@
+import { applyLaunchpadEnvironmentSetupProgress, type LaunchpadEnvironmentSetupProgress } from "../../lib/launchpad-setup-progress";
 import {
   useCallback,
   useEffect,
@@ -27,7 +28,6 @@ import type {
   AppServerThreadReplayPagination,
   AppServerSkillSummary,
   BackendSummary,
-  CodexEnvironmentSetupProgressEvent,
   CodexEnvironmentActionRun,
   DesktopApplicationsSnapshot,
   DesktopChatReplyComposer,
@@ -69,7 +69,7 @@ import type {
   IntegratedTerminalsController,
 } from "../../lib/useIntegratedTerminals";
 import type { ThreadContextWindowState } from "../../lib/useThreadSessionState";
-import type { PendingForkEnvironmentSetup } from "../../lib/useThreadNavigation";
+import type { PendingForkEnvironmentSetup, PendingLaunchpadCreation } from "../../lib/useThreadNavigation";
 import { useTranscriptWindow } from "./useTranscriptWindow";
 import { formatBackendLabel } from "../../lib/backend-label";
 import { resolvePreferredEditor } from "../../lib/preferred-application";
@@ -122,19 +122,6 @@ import {
   summarizeActivityStatus,
 } from "./live-transcript-activity";
 import { findTranscriptCommandDetailEntryIndex } from "./tool-call-details";
-
-type LaunchpadEnvironmentSetupProgress = {
-  command: string;
-  cwd?: string;
-  directoryKey: string;
-  durationMs?: number;
-  environmentId: string;
-  environmentName: string;
-  error?: string;
-  exitCode?: number;
-  output: string;
-  status: "starting" | "running" | "completed" | "failed";
-};
 
 function collectThreadImageGallery(
   entries: Array<AppServerThreadEntry | undefined>,
@@ -201,58 +188,6 @@ const LazyIntegratedTerminal = lazy(async () => {
 
 const noop = (): void => {};
 
-function applyLaunchpadEnvironmentSetupProgress(
-  current: LaunchpadEnvironmentSetupProgress | undefined,
-  event: CodexEnvironmentSetupProgressEvent,
-): LaunchpadEnvironmentSetupProgress {
-  const base =
-    current?.directoryKey === event.directoryKey &&
-    current.environmentId === event.environmentId
-      ? current
-      : {
-          command: event.command,
-          cwd: event.cwd,
-          directoryKey: event.directoryKey,
-          environmentId: event.environmentId,
-          environmentName: event.environmentName,
-          output: "",
-          status: "starting" as const,
-        };
-
-  if (event.phase === "stdout" || event.phase === "stderr") {
-    return {
-      ...base,
-      output: `${base.output}${event.chunk ?? ""}`.slice(-32_000),
-      status: "running",
-    };
-  }
-
-  if (event.phase === "completed") {
-    return {
-      ...base,
-      durationMs: event.durationMs,
-      exitCode: event.exitCode,
-      output: event.output ?? base.output,
-      status: "completed",
-    };
-  }
-
-  if (event.phase === "failed") {
-    return {
-      ...base,
-      durationMs: event.durationMs,
-      error: event.error,
-      exitCode: event.exitCode,
-      output: event.output ?? base.output,
-      status: "failed",
-    };
-  }
-
-  return {
-    ...base,
-    status: "running",
-  };
-}
 
 function formatSetupStatus(progress?: LaunchpadEnvironmentSetupProgress): {
   heading: string;
@@ -383,8 +318,8 @@ function LaunchpadEnvironmentSetupPending(props: {
             <code>{props.command ? `$ ${props.command}` : "$"}</code>
           </pre>
         </div>
-        <div className="launchpad-pending__output" aria-label="Setup output">
-          <div className="launchpad-pending__section-header">
+        <details className="launchpad-pending__output" aria-label="Setup output" open>
+          <summary className="launchpad-pending__section-header">
             <div className="launchpad-pending__command-label">
               {error ? "Output and errors" : "Output"}
             </div>
@@ -396,11 +331,11 @@ function LaunchpadEnvironmentSetupPending(props: {
                 text={renderedOutput}
               />
             ) : null}
-          </div>
+          </summary>
           <pre ref={outputRef}>
             <code>{renderedOutput || "Waiting for output..."}</code>
           </pre>
-        </div>
+        </details>
       </div>
     </section>
   );
@@ -1059,6 +994,7 @@ export type ThreadViewProps = {
   onRefreshNavigation?: () => Promise<void>;
   onReloadThread?: () => Promise<void>;
   onLiveTranscriptEntry?: (entry: AppServerThreadEntry) => void;
+  pendingLaunchpadCreation?: PendingLaunchpadCreation;
   onMaterializeLaunchpad?: (
     directoryKey: string,
     input?: AppServerTurnInputItem[],
@@ -1320,7 +1256,9 @@ export function ThreadView(props: ThreadViewProps) {
   const [transcriptTurnPageRequestPending, setTranscriptTurnPageRequestPending] =
     useState(false);
   const [contextRailWidth, setContextRailWidth] = useState(380);
-  const [launchpadMaterializing, setLaunchpadMaterializing] = useState(false);
+  const [localLaunchpadMaterializing, setLaunchpadMaterializing] = useState(false);
+  const launchpadMaterializing = Boolean(props.pendingLaunchpadCreation) || localLaunchpadMaterializing;
+  const [launchpadSubmittedInput, setLaunchpadSubmittedInput] = useState<AppServerTurnInputItem[]>([]);
   // Terminal state is owned by `useIntegratedTerminals` up in App, mirroring
   // the main process's registry. It cannot live here: ThreadView unmounts on
   // search and on any refresh that flips `threadDetailPending`, which used to
@@ -1340,8 +1278,9 @@ export function ThreadView(props: ThreadViewProps) {
   const [setupFailureContinuing, setSetupFailureContinuing] = useState(false);
   const [setupFailureContinueError, setSetupFailureContinueError] =
     useState<string>();
-  const [launchpadSetupProgress, setLaunchpadSetupProgress] =
+  const [localLaunchpadSetupProgress, setLaunchpadSetupProgress] =
     useState<LaunchpadEnvironmentSetupProgress>();
+  const launchpadSetupProgress = props.pendingLaunchpadCreation?.setupProgress ?? localLaunchpadSetupProgress;
   const [dismissedEnvActionRunIds, setDismissedEnvActionRunIds] = useState<
     Set<string>
   >(() => new Set());
@@ -1388,6 +1327,7 @@ export function ThreadView(props: ThreadViewProps) {
     transcriptTurnPageRequestGenerationRef.current += 1;
     setTranscriptTurnPageRequestPending(false);
     setLaunchpadMaterializing(false);
+    setLaunchpadSubmittedInput([]);
     setLaunchpadMaterializeError(undefined);
     setLaunchpadSetupProgress(undefined);
     setSetupFailureContinuing(false);
@@ -3302,6 +3242,7 @@ export function ThreadView(props: ThreadViewProps) {
       }
 
       setLaunchpadMaterializing(true);
+      setLaunchpadSubmittedInput(input ?? []);
       setLaunchpadMaterializeError(undefined);
       try {
         await props.onMaterializeLaunchpad(
@@ -3386,96 +3327,107 @@ export function ThreadView(props: ThreadViewProps) {
                 }}
               />
             ) : null}
-            <div className="thread-view__launchpad-composer">
-              {launchpadMaterializing && launchpadMaterializeError ? (
-                <LaunchpadMaterializeFailure
-                  directoryLabel={selectedLaunchpad.directoryLabel}
-                  error={launchpadMaterializeError}
-                  onClose={() => {
-                    setLaunchpadMaterializing(false);
-                    setLaunchpadMaterializeError(undefined);
-                  }}
-                />
-              ) : launchpadMaterializing && launchpadRunningCodexEnvironmentSetup ? (
-                <LaunchpadEnvironmentSetupPending
-                  command={
-                    launchpadSetupProgress?.command ??
-                    selectedLaunchpadCodexEnvironment?.setupScript
-                  }
-                  confirmedCwd={launchpadSetupProgress?.cwd}
-                  cwd={
-                    launchpadSetupProgress?.cwd ?? selectedLaunchpad.directoryPath
-                  }
-                  desktopApi={props.desktopApi}
-                  directoryLabel={selectedLaunchpad.directoryLabel}
-                  environmentName={
-                    launchpadSetupProgress?.environmentName ??
-                    selectedLaunchpadCodexEnvironment?.name
-                  }
-                  progress={launchpadSetupProgress}
-                />
-              ) : launchpadMaterializing ? (
-                <section
-                  className="transcript-panel transcript-panel--pending"
-                  aria-label="Preparing transcript"
-                >
-                  <div className="launchpad-pending">
-                    <p className="eyebrow">Preparing transcript</p>
-                    <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
-                    <p>
-                      Your prompt was sent. The transcript will appear here when
-                      the thread is ready.
-                    </p>
-                  </div>
-                </section>
-              ) : (
-                <Composer
-                  backends={props.backends}
-                  applications={props.applications}
-                  codexFastAllowed={props.codexFastAllowed}
-                  providerModelDefaults={props.providerModelDefaults}
-                  desktopApi={props.desktopApi}
-                  onShowNotice={props.onShowNotice}
-                  onProviderSelected={props.onProviderSelected}
-                  composerImplementation={props.composerImplementation}
-                  draftStore={props.composerDraftStore}
-                  directory={props.selectedDirectory}
-                  directories={props.directories}
-                  disabled={launchpadBackend ? !launchpadBackend.available : false}
-                  unavailableReason={launchpadBackend?.unavailableReason}
-                  launchpad={selectedLaunchpad}
-                  launchpadError={props.launchpadError}
-                  pastedImageMaxPatches={props.pastedImageMaxPatches}
-                  pdfAnalysisEnabled={props.pdfAnalysisEnabled}
-            tokenMiserEnabled={props.tokenMiserEnabled}
-            tokenMiserDefaultEnabled={props.tokenMiserDefaultEnabled}
-                  fullAccessRiskWarningDismissed={
-                    props.fullAccessRiskWarningDismissed
-                  }
-                  onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
-                  onDismissFullAccessRiskWarning={
-                    props.onDismissFullAccessRiskWarning
-                  }
-                  onMaterializeLaunchpad={handleMaterializeLaunchpad}
-                  onCancelLaunchpad={props.onCancelLaunchpad}
-                  onUpdateLaunchpad={props.onUpdateLaunchpad}
-                  onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
-                  onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
-                  onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
-                  threads={props.threads}
-                  onPickAndAttachDirectoryToThread={
-                    props.onPickAndAttachDirectoryToThread
-                  }
-                  onPickDirectoryForReference={props.onPickDirectoryForReference}
-                  onClearPickDirectoryError={props.onClearPickDirectoryError}
-                  pickDirectoryError={props.pickDirectoryError}
-                  pickingDirectory={props.pickingDirectory}
-                  skillError={props.skillError}
-                  skillLoading={props.skillLoading}
-                  providerCommands={props.providerCommands ?? []}
-                  skills={props.skills}
-                />
-              )}
+            <div className={`thread-view__launchpad-composer${launchpadMaterializing ? " is-materializing" : ""}`}>
+              {launchpadMaterializing ? (
+                <div className="thread-view__launchpad-transcript">
+                  <article className="launchpad-submitted-message" aria-label="Submitted message">
+                    {(props.pendingLaunchpadCreation?.input ?? launchpadSubmittedInput).map((item, index) =>
+                      item.type === "text" ? <p key={index}>{item.text}</p>
+                        : item.type === "image" ? <img key={index} src={item.url} alt="Submitted attachment" />
+                        : null,
+                    )}
+                  </article>
+                  {launchpadMaterializing && launchpadMaterializeError ? (
+                    <LaunchpadMaterializeFailure
+                      directoryLabel={selectedLaunchpad.directoryLabel}
+                      error={launchpadMaterializeError}
+                      onClose={() => {
+                        setLaunchpadMaterializing(false);
+                        setLaunchpadMaterializeError(undefined);
+                      }}
+                    />
+                  ) : launchpadMaterializing && launchpadRunningCodexEnvironmentSetup ? (
+                    <LaunchpadEnvironmentSetupPending
+                      command={
+                        launchpadSetupProgress?.command ??
+                        selectedLaunchpadCodexEnvironment?.setupScript
+                      }
+                      confirmedCwd={launchpadSetupProgress?.cwd}
+                      cwd={
+                        launchpadSetupProgress?.cwd ?? selectedLaunchpad.directoryPath
+                      }
+                      desktopApi={props.desktopApi}
+                      directoryLabel={selectedLaunchpad.directoryLabel}
+                      environmentName={
+                        launchpadSetupProgress?.environmentName ??
+                        selectedLaunchpadCodexEnvironment?.name
+                      }
+                      progress={launchpadSetupProgress}
+                    />
+                  ) : launchpadMaterializing ? (
+                    <section
+                      className="transcript-panel transcript-panel--pending"
+                      aria-label="Preparing transcript"
+                    >
+                      <div className="launchpad-pending">
+                        <p className="eyebrow">Preparing transcript</p>
+                        <h3>Starting {selectedLaunchpad.directoryLabel}</h3>
+                        <p>
+                          Your prompt was sent. The transcript will appear here when
+                          the thread is ready.
+                        </p>
+                      </div>
+                    </section>
+                  ) : null}
+                </div>
+              ) : null}
+              <Composer
+                backends={props.backends}
+                applications={props.applications}
+                codexFastAllowed={props.codexFastAllowed}
+                providerModelDefaults={props.providerModelDefaults}
+                desktopApi={props.desktopApi}
+                onShowNotice={props.onShowNotice}
+                onProviderSelected={props.onProviderSelected}
+                composerImplementation={props.composerImplementation}
+                draftStore={props.composerDraftStore}
+                directory={props.selectedDirectory}
+                directories={props.directories}
+                disabled={launchpadBackend ? !launchpadBackend.available : false}
+                unavailableReason={launchpadBackend?.unavailableReason}
+                launchpad={selectedLaunchpad}
+                launchpadMaterializing={launchpadMaterializing}
+                launchpadError={props.launchpadError}
+                pastedImageMaxPatches={props.pastedImageMaxPatches}
+                pdfAnalysisEnabled={props.pdfAnalysisEnabled}
+                tokenMiserEnabled={props.tokenMiserEnabled}
+                tokenMiserDefaultEnabled={props.tokenMiserDefaultEnabled}
+                fullAccessRiskWarningDismissed={
+                  props.fullAccessRiskWarningDismissed
+                }
+                onEnsureSkillsLoaded={props.onEnsureSkillsLoaded}
+                onDismissFullAccessRiskWarning={
+                  props.onDismissFullAccessRiskWarning
+                }
+                onMaterializeLaunchpad={handleMaterializeLaunchpad}
+                onCancelLaunchpad={props.onCancelLaunchpad}
+                onUpdateLaunchpad={props.onUpdateLaunchpad}
+                onSelectDirectoryFromPicker={props.onSelectDirectoryFromPicker}
+                onSelectNoDirectoryFromPicker={props.onSelectNoDirectoryFromPicker}
+                onPickAndRegisterDirectory={props.onPickAndRegisterDirectory}
+                threads={props.threads}
+                onPickAndAttachDirectoryToThread={
+                  props.onPickAndAttachDirectoryToThread
+                }
+                onPickDirectoryForReference={props.onPickDirectoryForReference}
+                onClearPickDirectoryError={props.onClearPickDirectoryError}
+                pickDirectoryError={props.pickDirectoryError}
+                pickingDirectory={props.pickingDirectory}
+                skillError={props.skillError}
+                skillLoading={props.skillLoading}
+                providerCommands={props.providerCommands ?? []}
+                skills={props.skills}
+              />
             </div>
           </div>
           <ThreadContextPanel

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2258,6 +2258,16 @@ describe("ThreadView", () => {
       await screen.findByRole("heading", { name: "Running environment setup" }),
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Setup command")).toHaveTextContent("pnpm install");
+    const followup = screen.getByRole("textbox", { name: "New thread" });
+    expect(followup).toBeEnabled();
+    expect(followup).toHaveValue("");
+    expect(screen.getByLabelText("Submitted message")).toHaveTextContent("Investigate clipboard filenames");
+    fireEvent.change(followup, { target: { value: "Also check the tests" } });
+    fireEvent.click(screen.getByRole("button", { name: "Queue" }));
+    expect(await screen.findByLabelText("Queued message")).toHaveTextContent("Also check the tests");
+    expect(onMaterializeLaunchpad).toHaveBeenCalledTimes(1);
+    expect(followup).toHaveValue("");
+
     expect(screen.getAllByText("PwrSnap").length).toBeGreaterThan(0);
     expect(screen.getByText("/repo")).toBeInTheDocument();
     expect(
@@ -2469,7 +2479,7 @@ describe("ThreadView", () => {
     expect(await screen.findByRole("heading", { name: "Could not start PwrAgent" }))
       .toBeInTheDocument();
     expect(
-      screen.getByText(
+      within(screen.getByLabelText("Launch error")).getByText(
         "json-rpc error (500): You have exhausted your capacity on this model.",
       ),
     ).toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -5948,12 +5948,8 @@ describe("useThreadNavigation", () => {
         executionMode: "default" as const,
       },
     }));
-    const materializeDirectoryLaunchpad = vi.fn(async () => ({
-      backend: "codex" as const,
-      threadId: "thread-new",
-      executionMode: "default" as const,
-      workMode: "worktree" as const,
-    }));
+    const creation = createDeferred<Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>>();
+    const materializeDirectoryLaunchpad = vi.fn(() => creation.promise);
     const setThreadPin: NonNullable<DesktopApi["setThreadPin"]> = vi.fn(
       async (request) => ({
         backend: request.backend ?? "codex",
@@ -5977,11 +5973,29 @@ describe("useThreadNavigation", () => {
       );
     });
 
-    await act(async () => {
-      await result.current.materializeDirectoryLaunchpad(
-        "directory:/Users/fixture-user/github/PwrAgent"
+    const onMaterialized = vi.fn((thread: NavigationThreadSummary) => {
+      expect(thread.id).toBe("thread-new");
+      expect(result.current.selectedThread).toBeUndefined();
+    });
+    let pending: Promise<void>;
+    act(() => {
+      pending = result.current.materializeDirectoryLaunchpad(
+        "directory:/Users/fixture-user/github/PwrAgent",
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        onMaterialized,
       );
     });
+    expect(result.current.pendingLaunchpadCreations).toHaveLength(1);
+    act(() => result.current.selectPendingLaunchpad(result.current.pendingLaunchpadCreations[0]!.selectionKey));
+    expect(result.current.selectedLaunchpad?.directoryLabel).toBe("PwrAgent");
+    await act(async () => {
+      creation.resolve({
+        backend: "codex", threadId: "thread-new", executionMode: "default", workMode: "worktree",
+      });
+      await pending;
+    });
+    expect(onMaterialized).toHaveBeenCalledTimes(1);
+    expect(result.current.pendingLaunchpadCreations).toEqual([]);
 
     expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith({
       directoryKey: "directory:/Users/fixture-user/github/PwrAgent",

--- a/apps/desktop/src/renderer/src/lib/launchpad-setup-progress.ts
+++ b/apps/desktop/src/renderer/src/lib/launchpad-setup-progress.ts
@@ -1,0 +1,67 @@
+import type { CodexEnvironmentSetupProgressEvent } from "@pwragent/shared";
+
+export type LaunchpadEnvironmentSetupProgress = {
+  command: string;
+  cwd?: string;
+  directoryKey: string;
+  durationMs?: number;
+  environmentId: string;
+  environmentName: string;
+  error?: string;
+  exitCode?: number;
+  output: string;
+  status: "starting" | "running" | "completed" | "failed";
+};
+
+export function applyLaunchpadEnvironmentSetupProgress(
+  current: LaunchpadEnvironmentSetupProgress | undefined,
+  event: CodexEnvironmentSetupProgressEvent,
+): LaunchpadEnvironmentSetupProgress {
+  const base =
+    current?.directoryKey === event.directoryKey &&
+    current.environmentId === event.environmentId
+      ? current
+      : {
+          command: event.command,
+          cwd: event.cwd,
+          directoryKey: event.directoryKey,
+          environmentId: event.environmentId,
+          environmentName: event.environmentName,
+          output: "",
+          status: "starting" as const,
+        };
+
+  if (event.phase === "stdout" || event.phase === "stderr") {
+    return {
+      ...base,
+      output: `${base.output}${event.chunk ?? ""}`.slice(-32_000),
+      status: "running",
+    };
+  }
+
+  if (event.phase === "completed") {
+    return {
+      ...base,
+      durationMs: event.durationMs,
+      exitCode: event.exitCode,
+      output: event.output ?? base.output,
+      status: "completed",
+    };
+  }
+
+  if (event.phase === "failed") {
+    return {
+      ...base,
+      durationMs: event.durationMs,
+      error: event.error,
+      exitCode: event.exitCode,
+      output: event.output ?? base.output,
+      status: "failed",
+    };
+  }
+
+  return {
+    ...base,
+    status: "running",
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/useScheduledThreadActionProjection.ts
@@ -1,3 +1,4 @@
+import { observeLaunchpadScheduledAction } from "../features/composer/launchpad-composer-handoff";
 import { useEffect } from "react";
 import type { FederationTarget, ScheduledThreadAction } from "@pwragent/shared";
 import type { ComposerDraftStore } from "../features/composer/useComposerDraftStore";
@@ -176,6 +177,7 @@ export function syncScheduledActionProjections(
 ): Set<string> {
   const byScope = new Map<string, ScheduledThreadAction[]>();
   for (const action of actions) {
+    observeLaunchpadScheduledAction(store, action);
     if (!isProjectableAction(action)) continue;
     const scopeKey = scopeKeyForAction(action);
     const current = byScope.get(scopeKey) ?? [];
@@ -253,6 +255,7 @@ export function applyScheduledActionProjection(
   store: ComposerDraftStore,
   action: ScheduledThreadAction,
 ): void {
+  observeLaunchpadScheduledAction(store, action);
   const scopeKey = scopeKeyForAction(action);
   const current = store.getQueuedTurns(scopeKey);
   const withoutAction = current.filter(

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -1,3 +1,4 @@
+import { applyLaunchpadEnvironmentSetupProgress, type LaunchpadEnvironmentSetupProgress } from "./launchpad-setup-progress";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type {
   AppServerBackendKind,
@@ -2939,6 +2940,15 @@ function reviewDisplayTextFromTarget(
   }
 }
 
+export type PendingLaunchpadCreation = {
+  federatedSession?: FederatedLaunchpadSession;
+  setupProgress?: LaunchpadEnvironmentSetupProgress;
+  selectionKey: string;
+  directoryKey: string;
+  title: string;
+  input: AppServerTurnInputItem[];
+};
+
 type UseThreadNavigationOptions = {
   enabled?: boolean;
   lightweightNavigationRefresh?: boolean;
@@ -2989,6 +2999,8 @@ export function useThreadNavigation(
   inboxThreads: NavigationThreadSummary[];
   recentThreads: NavigationThreadSummary[];
   launchpadError?: string;
+  pendingLaunchpadCreations: PendingLaunchpadCreation[];
+  selectPendingLaunchpad: (selectionKey: string) => void;
   archiveThreadNotice?: ArchiveThreadNotice;
   dismissArchiveThreadNotice: () => void;
   worktreeArchiveError?: string;
@@ -3005,6 +3017,7 @@ export function useThreadNavigation(
     parentThreadId?: string,
     extraDirectoryPaths?: string[],
     scheduledFor?: number,
+    onMaterialized?: (thread: NavigationThreadSummary) => void,
   ) => Promise<void>;
   /** Directory the New Thread button resolves to by default, or undefined for the directory-less workspace. */
   newThreadDirectoryLabel?: string;
@@ -3240,6 +3253,21 @@ export function useThreadNavigation(
   // `onThreadActionError`.
   const [createThreadError, setCreateThreadError] = useState<string>();
   const [launchpadError, setLaunchpadError] = useState<string>();
+  const pendingLaunchpadCreationsRef = useRef(new Map<string, PendingLaunchpadCreation>());
+  const [pendingLaunchpadCreations, setPendingLaunchpadCreations] =
+    useState<PendingLaunchpadCreation[]>([]);
+  useEffect(() => desktopApi?.onCodexEnvironmentSetupProgress?.((event) => {
+    let changed = false;
+    for (const [key, creation] of pendingLaunchpadCreationsRef.current) {
+      if (creation.directoryKey !== event.directoryKey) continue;
+      pendingLaunchpadCreationsRef.current.set(key, {
+        ...creation,
+        setupProgress: applyLaunchpadEnvironmentSetupProgress(creation.setupProgress, event),
+      });
+      changed = true;
+    }
+    if (changed) setPendingLaunchpadCreations([...pendingLaunchpadCreationsRef.current.values()]);
+  }), [desktopApi]);
   const [archiveThreadError, setArchiveThreadError] = useState<string>();
   const [archiveThreadNotice, setArchiveThreadNotice] = useState<ArchiveThreadNotice>();
   const [worktreeArchiveError, setWorktreeArchiveError] = useState<string>();
@@ -5597,6 +5625,13 @@ export function useThreadNavigation(
     setSelectedItemKey(buildLaunchpadSelectionKey(directoryKey));
   }, []);
 
+  const selectPendingLaunchpad = useCallback((selectionKey: string): void => {
+    const creation = pendingLaunchpadCreationsRef.current.get(selectionKey);
+    if (!creation) return;
+    if (creation.federatedSession) setFederatedLaunchpad(creation.federatedSession);
+    setSelectedItemKey(creation.selectionKey);
+  }, []);
+
   const createThread = useCallback(
     async (
       backend?: AppServerBackendKind,
@@ -7029,6 +7064,7 @@ export function useThreadNavigation(
       parentThreadId?: string,
       extraDirectoryPaths?: string[],
       scheduledFor?: number,
+      onMaterialized?: (thread: NavigationThreadSummary) => void,
     ): Promise<void> => {
       if (!desktopApi?.materializeDirectoryLaunchpad) {
         setLaunchpadError("Desktop bridge is missing materializeDirectoryLaunchpad().");
@@ -7056,262 +7092,281 @@ export function useThreadNavigation(
       const launchpadSelectionKey = federatedSelection
         ? buildFederatedLaunchpadSelectionKey(federatedSelection.target)
         : buildLaunchpadSelectionKey(directoryKey);
-      const selectionKeyAtMaterializationStart = selectedItemKeyRef.current;
-      const materializeParentThreadId =
-        parentThreadId ??
-        launchpad.parentThreadId ??
-        getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
-      const materializeParentThreadBackend =
-        launchpad.parentThreadBackend ?? launchpad.backend;
-      const materializeParentThreadInstanceId =
-        launchpad.parentThreadInstanceId;
-      const federationTarget =
-        launchpad.federationTarget ?? readRendererFederationTarget();
-      let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
+      if (pendingLaunchpadCreationsRef.current.has(launchpadSelectionKey)) {
+        throw new Error("This thread is already starting.");
+      }
+      const pendingCreation: PendingLaunchpadCreation = {
+        federatedSession: federatedSelection,
+        selectionKey: launchpadSelectionKey,
+        directoryKey,
+        title: input?.find((item) => item.type === "text")?.text
+          ?? launchpad.prompt ?? "New thread",
+        input: input ?? [],
+      };
+      pendingLaunchpadCreationsRef.current.set(launchpadSelectionKey, pendingCreation);
+      setPendingLaunchpadCreations([...pendingLaunchpadCreationsRef.current.values()]);
       try {
-        response = await desktopApi.materializeDirectoryLaunchpad({
-          directoryKey,
-          federationTarget,
+        const selectionKeyAtMaterializationStart = selectedItemKeyRef.current;
+        const materializeParentThreadId =
+          parentThreadId ??
+          launchpad.parentThreadId ??
+          getParentThreadIdFromSubthreadLaunchpadKey(directoryKey);
+        const materializeParentThreadBackend =
+          launchpad.parentThreadBackend ?? launchpad.backend;
+        const materializeParentThreadInstanceId =
+          launchpad.parentThreadInstanceId;
+        const federationTarget =
+          launchpad.federationTarget ?? readRendererFederationTarget();
+        let response: Awaited<ReturnType<NonNullable<DesktopApi["materializeDirectoryLaunchpad"]>>>;
+        try {
+          response = await desktopApi.materializeDirectoryLaunchpad({
+            directoryKey,
+            federationTarget,
+            launchpad,
+            input,
+            collaborationMode,
+            reviewTarget,
+            scheduledFor,
+            ...(materializeParentThreadId
+              ? {
+                  parentThreadId: materializeParentThreadId,
+                  parentThreadBackend: materializeParentThreadBackend,
+                  ...(materializeParentThreadInstanceId
+                    ? { parentThreadInstanceId: materializeParentThreadInstanceId }
+                    : {}),
+                }
+              : {}),
+          });
+        } catch (error) {
+          setLaunchpadError(error instanceof Error ? error.message : String(error));
+          throw error;
+        }
+        let localDraftResetFailure: string | undefined;
+        if (federationTarget && desktopApi.resetDirectoryLaunchpad) {
+          try {
+            // Remote launchpads are composed and persisted on the viewer, then
+            // sent in full to the owning instance for materialization. The owner
+            // clears its overlay row as part of that operation, but it cannot
+            // clear the viewer's local copy. Remove that copy after success so
+            // reopening the launchpad cannot resurrect the submitted message.
+            await desktopApi.resetDirectoryLaunchpad({ directoryKey });
+          } catch (error) {
+            localDraftResetFailure =
+              error instanceof Error ? error.message : String(error);
+          }
+        }
+        const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
+          directory,
           launchpad,
-          input,
-          collaborationMode,
-          reviewTarget,
-          scheduledFor,
-          ...(materializeParentThreadId
+          backend: response.backend,
+          threadId: response.threadId,
+          federation: federationTarget
+            && isRemoteFederationTarget(federationTarget)
             ? {
-                parentThreadId: materializeParentThreadId,
-                parentThreadBackend: materializeParentThreadBackend,
-                ...(materializeParentThreadInstanceId
-                  ? { parentThreadInstanceId: materializeParentThreadInstanceId }
+                ref: {
+                  backend: response.backend,
+                  target: federationTarget,
+                  threadId: response.threadId,
+                },
+                instanceLabel:
+                  readRendererFederationLabel() ?? federationTarget.instanceId,
+              }
+            : undefined,
+          executionMode: response.executionMode,
+          workMode: response.workMode,
+          codexEnvironmentRuntime: response.codexEnvironmentRuntime,
+          optimisticUserMessage: response.turnStartFailure
+            || response.scheduledAction
+            ? undefined
+            : buildOptimisticUserMessage(input),
+          optimisticActiveTurn: response.turnId && !response.turnStartFailure
+            ? {
+                id: response.turnId,
+                statusText: reviewTarget
+                  ? "Reviewing"
+                  : collaborationMode
+                    ? "Planning"
+                    : "Thinking",
+                startedAt: Date.now(),
+                ...(reviewTarget
+                  ? { reviewDisplayText: reviewDisplayTextFromTarget(reviewTarget) }
                   : {}),
               }
-            : {}),
+            : undefined,
+          parentThreadId: materializeParentThreadId,
+          parentThreadBackend: materializeParentThreadId
+            ? materializeParentThreadBackend
+            : undefined,
+          parentThreadInstanceId: materializeParentThreadId
+            ? materializeParentThreadInstanceId
+            : undefined,
+          pinnedRank: response.pinnedRank,
+          scheduledStart: response.scheduledAction
+            ? {
+                actionId: response.scheduledAction.id,
+                scheduledFor: response.scheduledAction.scheduledFor,
+                state: "scheduled",
+              }
+            : undefined,
         });
-      } catch (error) {
-        setLaunchpadError(error instanceof Error ? error.message : String(error));
-        throw error;
-      }
-      let localDraftResetFailure: string | undefined;
-      if (federationTarget && desktopApi.resetDirectoryLaunchpad) {
-        try {
-          // Remote launchpads are composed and persisted on the viewer, then
-          // sent in full to the owning instance for materialization. The owner
-          // clears its overlay row as part of that operation, but it cannot
-          // clear the viewer's local copy. Remove that copy after success so
-          // reopening the launchpad cannot resurrect the submitted message.
-          await desktopApi.resetDirectoryLaunchpad({ directoryKey });
-        } catch (error) {
-          localDraftResetFailure =
-            error instanceof Error ? error.message : String(error);
-        }
-      }
-      const optimisticMaterializedThread = buildOptimisticThreadFromLaunchpad({
-        directory,
-        launchpad,
-        backend: response.backend,
-        threadId: response.threadId,
-        federation: federationTarget
-          && isRemoteFederationTarget(federationTarget)
+        const observedThreadNameEntry = threadNameObservationsRef.current.get(
+          federationTarget
+            ? federatedThreadIdentityKey({
+                backend: response.backend,
+                target: federationTarget,
+                threadId: response.threadId,
+              })
+            : buildThreadIdentityKey(response.backend, response.threadId),
+        );
+        const namedOptimisticMaterializedThread = observedThreadNameEntry
           ? {
+              ...optimisticMaterializedThread,
+              title: observedThreadNameEntry.threadName,
+              titleSource: observedThreadNameEntry.titleSource,
+            }
+          : optimisticMaterializedThread;
+        if (
+          federationTarget
+          && isRemoteFederationTarget(federationTarget)
+          && !readRendererFederationTarget()
+        ) {
+          try {
+            await desktopApi.addRemoteThreadPin?.({
               ref: {
                 backend: response.backend,
                 target: federationTarget,
                 threadId: response.threadId,
               },
+              summary: namedOptimisticMaterializedThread,
               instanceLabel:
-                readRendererFederationLabel() ?? federationTarget.instanceId,
-            }
-          : undefined,
-        executionMode: response.executionMode,
-        workMode: response.workMode,
-        codexEnvironmentRuntime: response.codexEnvironmentRuntime,
-        optimisticUserMessage: response.turnStartFailure
-          || response.scheduledAction
-          ? undefined
-          : buildOptimisticUserMessage(input),
-        optimisticActiveTurn: response.turnId && !response.turnStartFailure
-          ? {
-              id: response.turnId,
-              statusText: reviewTarget
-                ? "Reviewing"
-                : collaborationMode
-                  ? "Planning"
-                  : "Thinking",
-              startedAt: Date.now(),
-              ...(reviewTarget
-                ? { reviewDisplayText: reviewDisplayTextFromTarget(reviewTarget) }
-                : {}),
-            }
-          : undefined,
-        parentThreadId: materializeParentThreadId,
-        parentThreadBackend: materializeParentThreadId
-          ? materializeParentThreadBackend
-          : undefined,
-        parentThreadInstanceId: materializeParentThreadId
-          ? materializeParentThreadInstanceId
-          : undefined,
-        pinnedRank: response.pinnedRank,
-        scheduledStart: response.scheduledAction
-          ? {
-              actionId: response.scheduledAction.id,
-              scheduledFor: response.scheduledAction.scheduledFor,
-              state: "scheduled",
-            }
-          : undefined,
-      });
-      const observedThreadNameEntry = threadNameObservationsRef.current.get(
-        federationTarget
-          ? federatedThreadIdentityKey({
-              backend: response.backend,
-              target: federationTarget,
-              threadId: response.threadId,
-            })
-          : buildThreadIdentityKey(response.backend, response.threadId),
-      );
-      const namedOptimisticMaterializedThread = observedThreadNameEntry
-        ? {
-            ...optimisticMaterializedThread,
-            title: observedThreadNameEntry.threadName,
-            titleSource: observedThreadNameEntry.titleSource,
-          }
-        : optimisticMaterializedThread;
-      if (
-        federationTarget
-        && isRemoteFederationTarget(federationTarget)
-        && !readRendererFederationTarget()
-      ) {
-        try {
-          await desktopApi.addRemoteThreadPin?.({
-            ref: {
-              backend: response.backend,
-              target: federationTarget,
-              threadId: response.threadId,
-            },
-            summary: namedOptimisticMaterializedThread,
-            instanceLabel:
-              namedOptimisticMaterializedThread.federation?.instanceLabel
-              ?? federationTarget.instanceId,
-          });
-        } catch (error) {
-          // Materialization already succeeded on the owner. Keep the created
-          // thread selected even if this viewer cannot persist its list entry.
-          console.warn("Could not add the remote thread to this thread list:", error);
-        }
-      }
-      const nextThreadKey = threadSummaryIdentityKey(
-        namedOptimisticMaterializedThread,
-      );
-      // Sub-thread launchpads drop the new child directly below their source
-      // card. Plain new-thread launchpads have no parent and skip this. Await
-      // so the order write commits before the refresh below reads it back.
-      if (materializeParentThreadId) {
-        const groupRoot = stateRef.current.response?.threads.find(
-          (thread) =>
-            thread.source === materializeParentThreadBackend
-            && thread.id === materializeParentThreadId,
-        );
-        const subthreadOrderTarget = groupRoot
-          ? groupRoot.federation?.ref.target
-          : materializeParentThreadInstanceId
-            ? {
-                scope: "remote" as const,
-                instanceId: materializeParentThreadInstanceId,
-              }
-            : federationTarget;
-        await insertSubthreadBelowSource(
-          materializeParentThreadBackend,
-          materializeParentThreadId,
-          launchpad.sourceThreadId ?? materializeParentThreadId,
-          response.threadId,
-          subthreadOrderTarget,
-        );
-      }
-      if (federatedSelection) {
-        setFederatedLaunchpad((current) =>
-          current
-          && federationTargetsEqual(current.target, federatedSelection.target)
-          && current.launchpad.directoryKey === directoryKey
-            ? undefined
-            : current,
-        );
-      } else {
-        setLocalLaunchpads((current) => {
-          if (!current[directoryKey]) {
-            return current;
-          }
-          const next = { ...current };
-          delete next[directoryKey];
-          return next;
-        });
-      }
-      const shouldSelectMaterializedThread =
-        selectionKeyAtMaterializationStart !== launchpadSelectionKey ||
-        selectedItemKeyRef.current === launchpadSelectionKey;
-      const shouldProjectOptimisticThread =
-        shouldSelectMaterializedThread || !optimisticThreadRef.current;
-      setOptimisticThread((current) =>
-        shouldSelectMaterializedThread || !current
-          ? namedOptimisticMaterializedThread
-          : current
-      );
-      if (shouldSelectMaterializedThread) {
-        setSelectedItemKey(nextThreadKey);
-        setPendingSeenThreadKey(nextThreadKey);
-      }
-      if (response.turnStartFailure) {
-        setLaunchpadError(response.turnStartFailure.message);
-      } else if (response.autoPinFailure) {
-        setLaunchpadError(response.autoPinFailure.message);
-      } else if (localDraftResetFailure) {
-        setLaunchpadError(
-          `Thread started, but the saved launchpad draft could not be cleared: ${localDraftResetFailure}`,
-        );
-      }
-      // Link composer `@`-referenced directories to the just-created
-      // thread before the refresh below so the snapshot comes back with
-      // them. Non-fatal per path — the turn already carries the path as
-      // text, so a failed link only loses the sidebar association.
-      if (extraDirectoryPaths && extraDirectoryPaths.length > 0) {
-        for (const path of extraDirectoryPaths) {
-          try {
-            const attachResult = await desktopApi.attachDirectoryToThread?.({
-              backend: response.backend,
-              federationTarget,
-              threadId: response.threadId,
-              path,
-              preferredBackend: response.backend,
+                namedOptimisticMaterializedThread.federation?.instanceLabel
+                ?? federationTarget.instanceId,
             });
-            if (attachResult && !attachResult.ok) {
-              console.warn(
-                `Could not link referenced directory ${path}: ${attachResult.message}`,
-              );
-            }
           } catch (error) {
-            console.warn(`Could not link referenced directory ${path}:`, error);
+            // Materialization already succeeded on the owner. Keep the created
+            // thread selected even if this viewer cannot persist its list entry.
+            console.warn("Could not add the remote thread to this thread list:", error);
           }
         }
-      }
-      if (!federatedSelection) {
-        setState((current) => ({
-          ...current,
-          response: current.response
-            ? applyLaunchpadReset(
-                current.response,
-                directoryKey,
-                current.response.launchpadDefaults
-              )
-            : current.response,
-        }));
-      }
-      try {
-        await refresh(
-          shouldSelectMaterializedThread ? nextThreadKey : undefined,
-          shouldProjectOptimisticThread
-            ? namedOptimisticMaterializedThread
-            : undefined,
+        const nextThreadKey = threadSummaryIdentityKey(
+          namedOptimisticMaterializedThread,
         );
-      } catch (error) {
-        setLaunchpadError(error instanceof Error ? error.message : String(error));
+        // Sub-thread launchpads drop the new child directly below their source
+        // card. Plain new-thread launchpads have no parent and skip this. Await
+        // so the order write commits before the refresh below reads it back.
+        if (materializeParentThreadId) {
+          const groupRoot = stateRef.current.response?.threads.find(
+            (thread) =>
+              thread.source === materializeParentThreadBackend
+              && thread.id === materializeParentThreadId,
+          );
+          const subthreadOrderTarget = groupRoot
+            ? groupRoot.federation?.ref.target
+            : materializeParentThreadInstanceId
+              ? {
+                  scope: "remote" as const,
+                  instanceId: materializeParentThreadInstanceId,
+                }
+              : federationTarget;
+          await insertSubthreadBelowSource(
+            materializeParentThreadBackend,
+            materializeParentThreadId,
+            launchpad.sourceThreadId ?? materializeParentThreadId,
+            response.threadId,
+            subthreadOrderTarget,
+          );
+        }
+        if (federatedSelection) {
+          setFederatedLaunchpad((current) =>
+            current
+            && federationTargetsEqual(current.target, federatedSelection.target)
+            && current.launchpad.directoryKey === directoryKey
+              ? undefined
+              : current,
+          );
+        } else {
+          setLocalLaunchpads((current) => {
+            if (!current[directoryKey]) {
+              return current;
+            }
+            const next = { ...current };
+            delete next[directoryKey];
+            return next;
+          });
+        }
+        onMaterialized?.(namedOptimisticMaterializedThread);
+        const shouldSelectMaterializedThread =
+          selectionKeyAtMaterializationStart !== launchpadSelectionKey ||
+          selectedItemKeyRef.current === launchpadSelectionKey;
+        const shouldProjectOptimisticThread =
+          shouldSelectMaterializedThread || !optimisticThreadRef.current;
+        setOptimisticThread((current) =>
+          shouldSelectMaterializedThread || !current
+            ? namedOptimisticMaterializedThread
+            : current
+        );
+        if (shouldSelectMaterializedThread) {
+          setSelectedItemKey(nextThreadKey);
+          setPendingSeenThreadKey(nextThreadKey);
+        }
+        if (response.turnStartFailure) {
+          setLaunchpadError(response.turnStartFailure.message);
+        } else if (response.autoPinFailure) {
+          setLaunchpadError(response.autoPinFailure.message);
+        } else if (localDraftResetFailure) {
+          setLaunchpadError(
+            `Thread started, but the saved launchpad draft could not be cleared: ${localDraftResetFailure}`,
+          );
+        }
+        // Link composer `@`-referenced directories to the just-created
+        // thread before the refresh below so the snapshot comes back with
+        // them. Non-fatal per path — the turn already carries the path as
+        // text, so a failed link only loses the sidebar association.
+        if (extraDirectoryPaths && extraDirectoryPaths.length > 0) {
+          for (const path of extraDirectoryPaths) {
+            try {
+              const attachResult = await desktopApi.attachDirectoryToThread?.({
+                backend: response.backend,
+                federationTarget,
+                threadId: response.threadId,
+                path,
+                preferredBackend: response.backend,
+              });
+              if (attachResult && !attachResult.ok) {
+                console.warn(
+                  `Could not link referenced directory ${path}: ${attachResult.message}`,
+                );
+              }
+            } catch (error) {
+              console.warn(`Could not link referenced directory ${path}:`, error);
+            }
+          }
+        }
+        if (!federatedSelection) {
+          setState((current) => ({
+            ...current,
+            response: current.response
+              ? applyLaunchpadReset(
+                  current.response,
+                  directoryKey,
+                  current.response.launchpadDefaults
+                )
+              : current.response,
+          }));
+        }
+        try {
+          await refresh(
+            shouldSelectMaterializedThread ? nextThreadKey : undefined,
+            shouldProjectOptimisticThread
+              ? namedOptimisticMaterializedThread
+              : undefined,
+          );
+        } catch (error) {
+          setLaunchpadError(error instanceof Error ? error.message : String(error));
+        }
+      } finally {
+        pendingLaunchpadCreationsRef.current.delete(launchpadSelectionKey);
+        setPendingLaunchpadCreations([...pendingLaunchpadCreationsRef.current.values()]);
       }
     },
     [
@@ -8659,6 +8714,7 @@ export function useThreadNavigation(
     inboxThreads,
     recentThreads,
     launchpadError,
+    pendingLaunchpadCreations,
     archiveThreadNotice,
     dismissArchiveThreadNotice,
     worktreeArchiveError,
@@ -8685,6 +8741,7 @@ export function useThreadNavigation(
     resetDirectoryLaunchpad,
     removeDirectory,
     selectDirectoryLaunchpad,
+    selectPendingLaunchpad,
     selectedDirectory,
     selectedItemKey: displaySelectionKey,
     selectedLaunchpad,

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -697,14 +697,23 @@ describe("Tangerine Terminal theme contract", () => {
     expect(titleButtonRule).not.toMatch(/(?:^|\n)\s*width:\s*100%;/);
   });
 
-  it("keeps launchpad setup output from shrinking the header summary", () => {
+  it("scrolls launchpad setup output while preserving the header and composer", () => {
     const setupComposerRule = extractRuleBody(
       css,
-      ".thread-view__launchpad-composer:has(.transcript-panel--setup)"
+      ".thread-view__launchpad-composer.is-materializing"
+    );
+    const setupTranscriptRule = extractRuleBody(css, ".thread-view__launchpad-transcript");
+    const composerRule = extractRuleBody(
+      css,
+      ".thread-view__launchpad-composer.is-materializing > .composer"
     );
 
     expect(setupComposerRule).toContain("flex: 1 1 0;");
     expect(setupComposerRule).toContain("min-height: 0;");
+    expect(setupTranscriptRule).toContain("flex: 1 1 0;");
+    expect(setupTranscriptRule).toContain("min-height: 0;");
+    expect(setupTranscriptRule).toContain("overflow-y: auto;");
+    expect(composerRule).toContain("flex-shrink: 0;");
   });
 
   it("keeps environment setup status, copying, and path wrapping on theme tokens", () => {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -15996,10 +15996,42 @@ a.button {
   margin-top: auto;
 }
 
-.thread-view__launchpad-composer:has(.transcript-panel--setup) {
+.thread-view__launchpad-composer:has(.transcript-panel--setup),
+.thread-view__launchpad-composer.is-materializing {
   flex: 1 1 0;
   min-height: 0;
   margin-top: 0;
+}
+
+.thread-view__launchpad-transcript {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.thread-view__launchpad-transcript .transcript-panel--setup {
+  min-height: 0;
+}
+
+.thread-view__launchpad-composer.is-materializing > .composer {
+  flex-shrink: 0;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.launchpad-submitted-message {
+  width: calc(100% - 32px);
+  max-width: var(--chat-column-max);
+  margin: 16px auto;
+  color: var(--text-primary);
+  font-size: var(--transcript-text-size);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.launchpad-submitted-message img {
+  max-width: 160px;
+  max-height: 120px;
+  object-fit: contain;
 }
 
 .thread-view__launchpad-composer > .composer,
@@ -33917,4 +33949,65 @@ button.pricing-token-miser__folded:focus-visible {
   max-width: 100%;
   max-height: 240px;
   object-fit: contain;
+}
+
+.sidebar-pending-thread {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-muted);
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.sidebar-pending-thread[aria-current="true"] {
+  background: var(--bg-row-active);
+}
+
+.sidebar-pending-thread__title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+details.launchpad-pending__output {
+  display: block;
+  flex: 0 0 auto;
+  min-height: 0;
+}
+
+details.launchpad-pending__output > summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+details.launchpad-pending__output > summary::-webkit-details-marker {
+  display: none;
+}
+
+details.launchpad-pending__output > summary::before {
+  content: "▸";
+  color: var(--text-muted);
+}
+
+details.launchpad-pending__output[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+details.launchpad-pending__output pre {
+  max-height: 320px;
+}
+
+details.launchpad-pending__output > summary .launchpad-pending__command-label {
+  flex: 1;
+  margin-left: 8px;
 }


### PR DESCRIPTION
## Summary

- Keep the submitted message, environment setup progress, and an editable composer visible while a thread starts. Add a selectable pending thread to the sidebar.
- Let users queue follow-ups or mark them to steer when the first turn is ready. Preserve drafts and images across asynchronous payload preparation and the new thread handoff.
- Keep follow-ups behind scheduled first messages until the scheduled turn is admitted, including when its start event arrives before thread creation returns.

## Verification

- 582 focused tests passed across composer, handoff, thread view, navigation, scheduled actions, and queue projection/release suites.
- Workspace typecheck, ESLint (zero errors), dependency boundaries, and color checks passed.
- Verified the real thread view in a headless fixture at 1100×800 and 900×600: editable composer, queued follow-ups, steer toggle, and collapsible setup output.

## Notes

The screenshot uses entirely synthetic fixture data.

![Thread setup with an editable composer and a follow-up marked to steer](https://github.com/user-attachments/assets/cf9247ed-aa29-4c57-accb-9d851a512e90)
