### PR TITLE
fix(desktop): isolate side-panel clocks and memoize rendering

### DIFF
--- a/apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/automations/ThreadAutomationsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import type {
   AppServerThreadEntry,
   AutomationDetail,
@@ -43,7 +43,7 @@ type ThreadAutomationsPanelProps = {
   onRefreshNavigation?: () => Promise<void>;
 };
 
-export function ThreadAutomationsPanel(props: ThreadAutomationsPanelProps) {
+export const ThreadAutomationsPanel = memo(function ThreadAutomationsPanel(props: ThreadAutomationsPanelProps) {
   const isAgentThread = Boolean(props.thread.agent);
   const automations = useAutomations(props.desktopApi, {
     backend: props.thread.source,
@@ -181,7 +181,7 @@ export function ThreadAutomationsPanel(props: ThreadAutomationsPanelProps) {
       )}
     </section>
   );
-}
+});
 
 function AutomationSummary(props: {
   automation: AutomationDetail;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadContextPanel.tsx
@@ -1,6 +1,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ComponentType,
@@ -168,6 +169,40 @@ const RAIL_MIN_WIDTH = 300;
 const RAIL_MAX_WIDTH = 560;
 
 export function ThreadContextPanel(props: ThreadContextPanelProps) {
+  const {
+    onOpenToolOutputIncidentExplorer,
+    onActionRunsDockChange,
+    onShowActionRunsAboveComposer,
+  } = props;
+  const threadBackend = props.thread?.source;
+  const openIncidentExplorer = useCallback(() => {
+    onOpenToolOutputIncidentExplorer?.();
+  }, [onOpenToolOutputIncidentExplorer]);
+  const changeActionRunsDock = useCallback((dock: ActionRunsDock) => {
+    onActionRunsDockChange?.(dock);
+    if (dock === "above") {
+      onShowActionRunsAboveComposer?.();
+    }
+  }, [onActionRunsDockChange, onShowActionRunsAboveComposer]);
+  const editedFileGroups = useMemo(
+    () => props.editedFileGroups ?? [],
+    [props.editedFileGroups],
+  );
+  const actionRuns = useMemo(() => props.actionRuns ?? [], [props.actionRuns]);
+  const toolCallsFederationTarget = props.thread?.federation?.ref.target
+    ?? readRendererFederationTarget();
+  const toolCallsInstanceId = toolCallsFederationTarget?.scope === "remote"
+    ? toolCallsFederationTarget.instanceId
+    : undefined;
+  const threadLinkSource = useMemo(() =>
+    threadBackend && toolCallsInstanceId
+      ? { backend: threadBackend, instanceId: toolCallsInstanceId }
+      : undefined,
+    [threadBackend, toolCallsInstanceId],
+  );
+  const openTokenMiserSavings = useCallback(() => {
+    onOpenToolOutputIncidentExplorer?.("savings");
+  }, [onOpenToolOutputIncidentExplorer]);
   const railRef = useRef<HTMLElement>(null);
   const [revealed, setRevealed] = useState(false);
   // A modal portaled to document.body is outside the rail in DOM and pointer
@@ -180,6 +215,20 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
   const railWidth = props.width ?? 380;
   const [resizing, setResizing] = useState(false);
   const railTooltip = useViewportTooltip({ className: "context-rail__tooltip" });
+  const showTooltip = railTooltip.show;
+  const showRailTooltip = useCallback((
+    event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
+    path: string,
+    maxLength?: number,
+    copyHint = true
+  ): void => {
+    showTooltip(
+      event.currentTarget,
+      buildRailTooltipText(path, maxLength, copyHint),
+    );
+  }, [showTooltip]);
+
+  const hideRailTooltip = railTooltip.hide;
   const pinned = props.pinned;
   const open = pinned || revealed || portaledInteractionOpen;
   const hideTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -676,7 +725,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         return (
           <EditsPanel
             backend={props.thread.source}
-            groups={props.editedFileGroups ?? []}
+            groups={editedFileGroups}
             commitStatesByKey={props.editedFileCommitStates}
             worktreeRoot={editsWorktreeRoot}
             desktopApi={props.desktopApi}
@@ -701,7 +750,7 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
             displayOptions={props.pricingDisplayOptions}
             onOpenTokenMiserSavings={
               props.onOpenToolOutputIncidentExplorer
-                ? () => props.onOpenToolOutputIncidentExplorer?.("savings")
+                ? openTokenMiserSavings
                 : undefined
             }
             onScrollToTurn={props.onScrollToTurn}
@@ -713,9 +762,6 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
         );
       case "tool-calls": {
         if (!props.thread) return null;
-        const toolCallsFederationTarget =
-          props.thread.federation?.ref.target
-          ?? readRendererFederationTarget();
         return (
           <ToolCallsPanel
             entries={props.toolCallEntries}
@@ -727,19 +773,12 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
                a lens inside the window, asks for one. */
             onOpenIncidentExplorer={
               props.onOpenToolOutputIncidentExplorer
-                ? () => props.onOpenToolOutputIncidentExplorer?.()
+                ? openIncidentExplorer
                 : undefined
             }
             onRequestInvocationDetails={props.onRequestToolCallDetails}
             onScrollToTurn={props.onScrollToTurn}
-            threadLinkSource={
-              toolCallsFederationTarget?.scope === "remote"
-                ? {
-                    backend: props.thread.source,
-                    instanceId: toolCallsFederationTarget.instanceId,
-                  }
-                : undefined
-            }
+            threadLinkSource={threadLinkSource}
             toolAccounting={props.toolAccounting}
           />
         );
@@ -750,15 +789,10 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
           <ActionRunsPanel
             dock={props.actionRunsDock ?? "above"}
             environmentName={props.actionRunsEnvironmentName}
-            onDockChange={(dock) => {
-              props.onActionRunsDockChange?.(dock);
-              if (dock === "above") {
-                props.onShowActionRunsAboveComposer?.();
-              }
-            }}
+            onDockChange={changeActionRunsDock}
             onDismissRun={props.onDismissEnvActionRun}
             onStopRun={props.onStopEnvActionRun}
-            runs={props.actionRuns ?? []}
+            runs={actionRuns}
           />
         );
       case "subagents":
@@ -814,19 +848,5 @@ export function ThreadContextPanel(props: ThreadContextPanelProps) {
     }
   }
 
-  function showRailTooltip(
-    event: FocusEvent<HTMLElement> | MouseEvent<HTMLElement>,
-    path: string,
-    maxLength?: number,
-    copyHint = true
-  ): void {
-    railTooltip.show(
-      event.currentTarget,
-      buildRailTooltipText(path, maxLength, copyHint),
-    );
-  }
 
-  function hideRailTooltip(): void {
-    railTooltip.hide();
-  }
 }

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/PricingPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/PricingPanel.test.tsx
@@ -1,0 +1,118 @@
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { ThreadUsageLineRecord } from "@pwragent/shared";
+import { ThreadContextPanel } from "../ThreadContextPanel";
+import type { ComponentProps } from "react";
+import { PricingPanel } from "../context-panels/PricingPanel";
+import * as spend from "../pricing-spend-by-model";
+import * as formatting from "../context-panels/subagent-format";
+import * as rail from "../context-panels/context-rail-shared";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+function buildMonitorLine(
+  overrides: Partial<ThreadUsageLineRecord> = {},
+): ThreadUsageLineRecord {
+  return {
+    backend: "codex",
+    cachedInputCostMicros: 0,
+    cachedInputTokens: 0,
+    createdAt: 1_800_000_000_000,
+    currency: "USD",
+    inputTokens: 100,
+    model: "gpt-5.5",
+    outputCostMicros: 0,
+    outputTokens: 10,
+    priceStatus: "priced",
+    provider: "openai",
+    reasoningOutputTokens: 0,
+    scope: "monitor",
+    source: "monitor",
+    sourceItemId: "mon-1",
+    status: "finalized",
+    threadId: "thread-1",
+    totalCostMicros: 1_000,
+    totalTokens: 110,
+    uncachedInputCostMicros: 0,
+    uncachedInputTokens: 100,
+    usageLineId: "mon-line-1",
+    ...overrides,
+  };
+}
+
+it("ticks only live timestamps and keeps completed cards and pricing calculations static", () => {
+  vi.useFakeTimers();
+  const startedAt = 1_800_000_000_000;
+  vi.setSystemTime(startedAt + 10_000);
+  const calculate = vi.spyOn(spend, "buildPricingSpendByModel");
+  const formatTokens = vi.spyOn(formatting, "formatTokenCount");
+  const formatTimestamp = vi.spyOn(rail, "formatTimestamp");
+  const active = buildMonitorLine({
+    usageLineId: "active", scope: "turn", source: "live",
+    turnId: "turn-active", startedAt, status: "pending",
+  });
+  const completed = buildMonitorLine({
+    usageLineId: "completed", scope: "turn", source: "live",
+    turnId: "turn-completed", startedAt: startedAt - 60_000,
+    completedAt: startedAt - 50_000,
+  });
+  const pricing = { lines: [active, completed], summaries: [] };
+  const view = render(<PricingPanel activeTurnId="turn-active" pricing={pricing} />);
+  const durations = () => Array.from(view.container.querySelectorAll(".rail-card__duration"))
+    .map((element) => element.textContent);
+  const before = durations();
+  calculate.mockClear();
+  formatTokens.mockClear();
+  formatTimestamp.mockClear();
+
+  act(() => { vi.advanceTimersByTime(3_000); });
+  expect(durations()).not.toEqual(before);
+  expect(calculate).not.toHaveBeenCalled();
+  expect(formatTokens).not.toHaveBeenCalled();
+  expect(formatTimestamp.mock.calls.every(([timestamp]) => timestamp === startedAt)).toBe(true);
+
+  // An unrelated parent update must not rebuild the pricing cards either.
+  formatTimestamp.mockClear();
+  view.rerender(<PricingPanel activeTurnId="turn-active" pricing={pricing} />);
+  expect(formatTimestamp).not.toHaveBeenCalled();
+  expect(formatTokens).not.toHaveBeenCalled();
+
+  // A real usage update invalidates cached calculations and updates the cards.
+  view.rerender(<PricingPanel activeTurnId="turn-active" pricing={{
+    ...pricing,
+    lines: [{ ...active, uncachedInputTokens: 987654 }, completed],
+  }} />);
+  expect(calculate).toHaveBeenCalledTimes(1);
+  expect(formatTokens).toHaveBeenCalledWith(987654);
+
+  view.rerender(<PricingPanel pricing={pricing} />);
+  formatTimestamp.mockClear();
+  act(() => { vi.advanceTimersByTime(3_000); });
+  expect(formatTimestamp).not.toHaveBeenCalled();
+});
+
+it("keeps pricing cards cached across rail updates even with an Explorer callback", () => {
+  const formatTokens = vi.spyOn(formatting, "formatTokenCount");
+  const props: ComponentProps<typeof ThreadContextPanel> = {
+    activeTab: "pricing",
+    backends: [],
+    onActiveTabChange: vi.fn(),
+    onOpenToolOutputIncidentExplorer: vi.fn(),
+    pinned: true,
+    pricing: { lines: [buildMonitorLine()], summaries: [] },
+    thread: {
+      id: "thread-1", title: "Fixture", titleSource: "explicit", source: "codex",
+      linkedDirectories: [], inbox: { inInbox: true },
+    },
+  };
+  const view = render(<ThreadContextPanel {...props} width={380} />);
+  expect(formatTokens).toHaveBeenCalled();
+  formatTokens.mockClear();
+  view.rerender(<ThreadContextPanel {...props} width={420} />);
+  expect(formatTokens).not.toHaveBeenCalled();
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ActionRunsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ActionRunsPanel.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import type { CodexEnvironmentActionRun } from "@pwragent/shared";
 import { EnvActionRunsView } from "../EnvActionRunsView";
 import type { ActionRunsDock } from "./context-tab";
@@ -14,7 +15,7 @@ type ActionRunsPanelProps = {
   runs: CodexEnvironmentActionRun[];
 };
 
-export function ActionRunsPanel(props: ActionRunsPanelProps) {
+export const ActionRunsPanel = memo(function ActionRunsPanel(props: ActionRunsPanelProps) {
   return (
     <section className="context-panel__section context-panel__section--env-actions">
       {props.runs.length > 0 ? (
@@ -44,4 +45,4 @@ export function ActionRunsPanel(props: ActionRunsPanelProps) {
       )}
     </section>
   );
-}
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/EditsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useMemo, useState } from "react";
+import { memo, useEffect, useId, useMemo, useState } from "react";
 import type {
   AppServerBackendKind,
   AppServerThreadActivityDetail,
@@ -427,7 +427,7 @@ function FileSizeStat(props: { bytes: number }) {
  * translates with the list — only the groups scroll, their sticky
  * headers pinning to the body's top edge.
  */
-export function EditsPanel(props: EditsPanelProps) {
+export const EditsPanel = memo(function EditsPanel(props: EditsPanelProps) {
   const [view, setView] = useState<EditedFileGroupView>("turns");
   const hasGroups = props.groups.length > 0;
   const showViewToggle = props.groups.length > 1;
@@ -540,7 +540,7 @@ export function EditsPanel(props: EditsPanelProps) {
       </div>
     </section>
   );
-}
+});
 
 function unpublishedCommitsSummary(totalCommits: number): string {
   return `Unpublished ${totalCommits.toLocaleString()} ${

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/LinkedProjectsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import { FolderIcon, WorktreeIcon } from "../../../icons";
 import type { DesktopApi } from "../../../lib/desktop-api";
@@ -38,7 +38,7 @@ type LinkedProjectsPanelProps = {
  * to it. Worktree dirty/clean status is a placeholder pending a
  * main-process `git status --porcelain` IPC (see TODO below).
  */
-export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
+export const LinkedProjectsPanel = memo(function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
   const [attachError, setAttachError] = useState<string>();
   const [attaching, setAttaching] = useState(false);
   const [detachError, setDetachError] = useState<string>();
@@ -350,7 +350,7 @@ export function LinkedProjectsPanel(props: LinkedProjectsPanelProps) {
       ) : null}
     </section>
   );
-}
+});
 
 function dedupeLinkedProjectDirectories(
   directories: NavigationThreadSummary["linkedDirectories"],

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -13,7 +13,7 @@ import {
   estimateHistoricalThreadUsageGapLines,
   formatTokenUsageMicrosAsUsd,
 } from "@pwragent/shared";
-import { useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   ChipContextMenu,
   type ChipContextMenuItem,
@@ -91,19 +91,29 @@ const DEFAULT_PRICING_DISPLAY_OPTIONS: PricingDisplayOptions = {
 };
 const PRICING_USAGE_PAGE_SIZE = 20;
 
-export function PricingPanel(props: PricingPanelProps) {
-  const summaries = props.pricing?.summaries ?? [];
-  const lines = props.pricing?.lines ?? [];
-  const allDisplayLines = buildPricingDisplayLines(lines);
-  const subAgentsById = new Map(
-    (props.subAgents ?? []).map((subAgent) => [subAgent.monitorId, subAgent]),
+export const PricingPanel = memo(function PricingPanel(props: PricingPanelProps) {
+  // These derivations cover the entire history, including folded gate rows.
+  // Reuse them for presentation updates when their source data is unchanged.
+  const summaries = useMemo(
+    () => props.pricing?.summaries ?? [],
+    [props.pricing?.summaries],
   );
+  const lines = useMemo(
+    () => props.pricing?.lines ?? [],
+    [props.pricing?.lines],
+  );
+  const allDisplayLines = useMemo(() => buildPricingDisplayLines(lines), [lines]);
+  const subAgentsById = useMemo(() => new Map(
+    (props.subAgents ?? []).map((subAgent) => [subAgent.monitorId, subAgent]),
+  ), [props.subAgents]);
   // Gate rows nest under the turn they happened in. Left in the flat list they
   // sort *above* their turn — a gate is created mid-turn, after the turn's
   // first usage flush — and each one is a full card, so a turn with 25 gates
   // pushed its own row a screen below the noise it produced.
-  const { gateLinesByTurn, displayLines, orphanGroupsByAnchor } =
-    partitionTokenMiserGateLines(allDisplayLines, subAgentsById);
+  const { gateLinesByTurn, displayLines, orphanGroupsByAnchor } = useMemo(
+    () => partitionTokenMiserGateLines(allDisplayLines, subAgentsById),
+    [allDisplayLines, subAgentsById],
+  );
   const pricingHistoryKey = summaries[0]
     ? `${summaries[0].backend}:${summaries[0].threadId}`
     : displayLines[0]
@@ -119,15 +129,16 @@ export function PricingPanel(props: PricingPanelProps) {
       : PRICING_USAGE_PAGE_SIZE;
   const visibleDisplayLines = displayLines.slice(0, visibleUsageRowCount);
   const hiddenUsageRowCount = displayLines.length - visibleDisplayLines.length;
-  const estimatedLines = allDisplayLines.filter(isEstimatedUsageGap);
-  const displaySummaries = addEstimatedLinesToSummaries(summaries, estimatedLines);
-  const summary =
-    aggregateSummaries(displaySummaries) ?? aggregateUsageLines(allDisplayLines);
+  const summary = useMemo(() => {
+    const estimatedLines = allDisplayLines.filter(isEstimatedUsageGap);
+    const displaySummaries = addEstimatedLinesToSummaries(summaries, estimatedLines);
+    return aggregateSummaries(displaySummaries) ?? aggregateUsageLines(allDisplayLines);
+  }, [summaries, allDisplayLines]);
   // The headline is the all-in bill, including naming, reviews, monitors and
   // Token Miser. Underneath it, the same bill split by the model that spent
   // it: a turn that sends four reviewers to four models bills three providers,
   // and a per-provider split answers none of the questions that raises.
-  const spendByModel = buildPricingSpendByModel({
+  const spendByModel = useMemo(() => buildPricingSpendByModel({
     lines: allDisplayLines,
     resolveModel: (line) =>
       resolveUsageLineModel(
@@ -136,7 +147,7 @@ export function PricingPanel(props: PricingPanelProps) {
           ? subAgentsById.get(line.sourceItemId)
           : undefined,
       ),
-  });
+  }), [allDisplayLines, subAgentsById]);
   const spendModelCount = spendByModel.reduce(
     (total, group) => total + group.models.length,
     0,
@@ -215,14 +226,11 @@ export function PricingPanel(props: PricingPanelProps) {
   const displayOptions = props.displayOptions ?? DEFAULT_PRICING_DISPLAY_OPTIONS;
   // Totals run over every line, nested gates included: a gate's helper cost is
   // still part of the running total of every turn after it.
-  const pricingTotals = buildPricingRunningTotals(allDisplayLines);
-  const activeTurnId = props.activeTurnId;
-  const hasActiveRow = allDisplayLines.some((line) =>
-    isActiveUsageLine({ activeTurnId, line, subAgentsById }),
+  const pricingTotals = useMemo(
+    () => buildPricingRunningTotals(allDisplayLines),
+    [allDisplayLines],
   );
-  // Tick while any row is live — the main turn or any still-running sub-agent —
-  // so completed threads render static and never spin a 1s interval.
-  const now = useNowWhileActive(hasActiveRow);
+  const activeTurnId = props.activeTurnId;
   const compactionsByRow = useMemo(
     () => groupCompactionsByRow(props.pricing?.compactions ?? []),
     [props.pricing?.compactions],
@@ -376,7 +384,6 @@ export function PricingPanel(props: PricingPanelProps) {
         <PricingUsageTimestamp
           isActive={isActive}
           line={line}
-          now={now}
           onScrollToTurn={props.onScrollToTurn}
           subAgent={subAgent}
         />
@@ -557,7 +564,7 @@ export function PricingPanel(props: PricingPanelProps) {
       ) : null}
     </section>
   );
-}
+});
 
 /**
  * One model's share of the bill, closed by default, opening onto the token
@@ -1639,10 +1646,11 @@ function isActiveUsageLine(params: {
 function PricingUsageTimestamp(props: {
   isActive: boolean;
   line: ThreadUsageLineRecord;
-  now: number;
   onScrollToTurn?: (turnId: string, turnTimeMs?: number) => void;
   subAgent?: ThreadSubAgentSummary;
 }) {
+  // Only this timestamp subscribes to the clock; completed cards stay static.
+  const now = useNowWhileActive(props.isActive);
   const startedAt =
     props.subAgent?.createdAt ?? props.line.startedAt ?? props.line.createdAt;
   const completedAt =
@@ -1658,7 +1666,7 @@ function PricingUsageTimestamp(props: {
   return (
     <RailCardTiming
       completedAt={completedAt}
-      now={props.now}
+      now={now}
       running={props.isActive}
       startedAt={startedAt}
       {...(canScrollToTurn

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ProviderStatusPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { memo, useEffect } from "react";
 import type { BackendRuntimeBuild, BackendSummary } from "@pwragent/shared";
 import {
   formatBackendAccountText,
@@ -17,7 +17,7 @@ type ProviderStatusPanelProps = {
  * plan, and rate-limit lines for every configured agent backend.
  * Moved out of the old single-scroll context panel into its own tab.
  */
-export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
+export const ProviderStatusPanel = memo(function ProviderStatusPanel(props: ProviderStatusPanelProps) {
   useEffect(() => {
     window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
   }, []);
@@ -100,7 +100,7 @@ export function ProviderStatusPanel(props: ProviderStatusPanelProps) {
       )}
     </section>
   );
-}
+});
 
 function hasProviderMetadata(backend: BackendSummary): boolean {
   return hasIdentityMetadata(backend) || Boolean(backend.rateLimits?.length);

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PullRequestsPanel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { NavigationThreadSummary, PrSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../../lib/federation-window";
@@ -27,7 +27,7 @@ type CheckState = NonNullable<PrSummary["checkState"]>;
  * (#number, tooltip, status dot — identical to the sidebar) leads a row of
  * status pills (lifecycle, merge conflict, checks), above the title + repo.
  */
-export function PullRequestsPanel(props: PullRequestsPanelProps) {
+export const PullRequestsPanel = memo(function PullRequestsPanel(props: PullRequestsPanelProps) {
   const [pendingDetachPr, setPendingDetachPr] = useState<PrSummary>();
   // Newest first. `PrSummary` carries no creation timestamp, so sort by PR
   // number (monotonic with creation within a repo); for the rare multi-repo
@@ -132,7 +132,7 @@ export function PullRequestsPanel(props: PullRequestsPanelProps) {
       ) : null}
     </section>
   );
-}
+});
 
 function prKey(pr: PrSummary): string {
   return `${pr.provider}/${pr.org}/${pr.repo}#${pr.number}`;

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/RailCardTiming.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/RailCardTiming.tsx
@@ -16,6 +16,12 @@ type RailCardTimingProps = {
   startedAt: number;
 };
 
+/** Live clocks belong to the timing display, never to its containing panel. */
+export function LiveRailCardTiming(props: Omit<RailCardTimingProps, "now">) {
+  const now = useNowWhileActive(props.running);
+  return <RailCardTiming {...props} now={now} />;
+}
+
 /**
  * Shared start + duration treatment for Pricing and Sub-agent rail cards.
  *

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -20,7 +20,7 @@ import {
   subAgentStatusLabel,
   subAgentTone,
 } from "./subagent-format";
-import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
+import { LiveRailCardTiming } from "./RailCardTiming";
 import { RailStatusChip } from "./RailStatusChip";
 import { subAgentOriginLabel } from "./subagent-kind";
 
@@ -124,7 +124,6 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
   const fastMode = subAgent.preferredFastMode ?? usage?.fastMode;
   const running = !isTerminalSubAgent(subAgent);
-  const now = useNowWhileActive(running);
   const transcriptThreadId =
     subAgent.monitorThreadId &&
     subAgent.monitorThreadId !== props.parentThreadId
@@ -186,9 +185,8 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
                 </span>
               ) : null}
             </p>
-            <RailCardTiming
+            <LiveRailCardTiming
               completedAt={subAgentCompletedAt(subAgent)}
-              now={now}
               running={running}
               startedAt={subAgent.createdAt}
             />

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentsPanel.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useEffect,
   useId,
   useState,
@@ -20,7 +21,7 @@ import {
   subAgentTone,
 } from "./subagent-format";
 import { RailStatusChip } from "./RailStatusChip";
-import { RailCardTiming, useNowWhileActive } from "./RailCardTiming";
+import { LiveRailCardTiming } from "./RailCardTiming";
 import { SubAgentDetailsModal } from "./SubAgentDetailsModal";
 import {
   type SubAgentLens,
@@ -49,7 +50,7 @@ const SUB_AGENT_LENSES: Array<{
 ];
 
 /** Sub-Agents tab: durable task-monitor cards spawned from this thread. */
-export function SubAgentsPanel(props: SubAgentsPanelProps) {
+export const SubAgentsPanel = memo(function SubAgentsPanel(props: SubAgentsPanelProps) {
   const { subAgents, loading } = useSubAgents(props.thread);
   const { onDetailsModalOpenChange } = props;
   const lensControlId = useId();
@@ -91,10 +92,6 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
   const [detailsForId, setDetailsForId] = useState<string | null>(null);
   const detailsFor =
     subAgents.find((subAgent) => subAgent.monitorId === detailsForId) ?? null;
-  const hasRunningSubAgent = subAgents.some(
-    (subAgent) => !isTerminalSubAgent(subAgent),
-  );
-  const now = useNowWhileActive(hasRunningSubAgent);
   const [stoppingIds, setStoppingIds] = useState<Set<string>>(() => new Set());
   const [stopErrors, setStopErrors] = useState<Record<string, string>>({});
 
@@ -297,9 +294,8 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
                     </span>
                   ) : null}
                 </p>
-                <RailCardTiming
+                <LiveRailCardTiming
                   completedAt={subAgentCompletedAt(subAgent)}
-                  now={now}
                   running={running}
                   startedAt={subAgent.createdAt}
                 />
@@ -374,4 +370,4 @@ export function SubAgentsPanel(props: SubAgentsPanelProps) {
       ) : null}
     </section>
   );
-}
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ThreadInfoPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { memo, useEffect, useState } from "react";
 import type { BackendSummary, NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../lib/desktop-api";
 import { formatBackendLabel } from "../../../lib/backend-label";
@@ -34,7 +34,7 @@ type ThreadInfoPanelProps = {
  * Owns its own Agent-save state; tooltip portal state is owned by the rail
  * and threaded in via `showTooltip` / `hideTooltip`.
  */
-export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
+export const ThreadInfoPanel = memo(function ThreadInfoPanel(props: ThreadInfoPanelProps) {
   const [agentSaving, setAgentSaving] = useState(false);
   const [agentError, setAgentError] = useState<string>();
   const canChangeAgentDesignation = canChangeExistingThreadAgentDesignation(
@@ -193,4 +193,4 @@ export function ThreadInfoPanel(props: ThreadInfoPanelProps) {
       </section>
     </>
   );
-}
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/ToolCallsPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { memo, useMemo, useState } from "react";
 import type {
   AppServerThreadActivityDetail,
   AppServerThreadEntry,
@@ -38,7 +38,7 @@ type ToolAccountingTotals = {
   warningLines: number;
 };
 
-export function ToolCallsPanel(props: ToolCallsPanelProps) {
+export const ToolCallsPanel = memo(function ToolCallsPanel(props: ToolCallsPanelProps) {
   const [expandedSummary, setExpandedSummary] = useState<string>();
   const [expandedInvocation, setExpandedInvocation] = useState<string>();
   const accounting = props.toolAccounting;
@@ -199,7 +199,7 @@ export function ToolCallsPanel(props: ToolCallsPanelProps) {
       ) : null}
     </section>
   );
-}
+});
 
 function ToolInvocationList(props: {
   detailsByItemId: Map<string, AppServerThreadActivityDetail>;

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentsPanel.test.tsx
@@ -1,5 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -10,10 +11,14 @@ import {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { NavigationThreadSummary } from "@pwragent/shared";
 import type { DesktopApi } from "../../../../lib/desktop-api";
+import * as subAgentFormatting from "../subagent-format";
+import * as railFormatting from "../context-rail-shared";
 import { SubAgentsPanel } from "../SubAgentsPanel";
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
 });
 
 const thread: NavigationThreadSummary = {
@@ -491,4 +496,22 @@ describe("SubAgentsPanel", () => {
       });
     });
   });
+});
+
+it("updates live timing without rendering the sub-agent list or completed timing", () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_800_000_010_000);
+  const status = vi.spyOn(subAgentFormatting, "subAgentStatusLabel");
+  const timestamp = vi.spyOn(railFormatting, "formatTimestamp");
+  const view = render(<SubAgentsPanel thread={thread} />);
+  const before = view.container.querySelector(".rail-card__duration")?.textContent;
+  status.mockClear();
+  timestamp.mockClear();
+  act(() => { vi.advanceTimersByTime(3_000); });
+  expect(view.container.querySelector(".rail-card__duration")?.textContent).not.toBe(before);
+  expect(status).not.toHaveBeenCalled();
+  expect(timestamp.mock.calls.every(([time]) => time === 1_800_000_000_000)).toBe(true);
+  timestamp.mockClear();
+  view.rerender(<SubAgentsPanel thread={thread} />);
+  expect(timestamp).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Problem and change

While a turn or sub-agent was active, a one-second duration timer rerendered the entire Pricing panel, including completed cards, Token Miser groups, and history-wide cost calculations. Move clock updates into the active timestamp display and cache pricing derivations by their source inputs.

The side-panel audit found the same timer ownership in Sub-agents and its Details dialog; both now use a local live timing component. Memoize all ten side-panel components (Pricing, Sub-agents, Info, Edits, Tool calls, Actions, Automations, PRs, Projects, Providers). Stabilize rail callbacks, empty arrays, and the remote thread-link source so unchanged inputs can actually skip rendering. Internal state and changed props still update normally.

## Validation

- 159 tests passed across 11 focused pricing, context-rail, and side-panel suites; the subsequently added rail callback regression also passed (160 distinct tests total).
- Regressions verify that live durations advance without rerendering completed cards or recalculating pricing, real usage changes invalidate cached totals, stopped turns stop ticking, and rail resizing preserves pricing cards with an Explorer callback present.
- `pnpm typecheck`, `pnpm lint:eslint` (zero errors; existing warnings), `pnpm lint:boundaries`, and `git diff --check` passed.

No intended visual change. CPU captures motivated the fix, but no before/after runtime CPU percentage has been measured yet. Memoization uses normal shallow prop comparison; genuinely changed thread/data objects still render.
