### PR TITLE
fix(desktop): render pending prompts as transcript messages

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3231,6 +3231,32 @@ export function ThreadView(props: ThreadViewProps) {
     );
   }
 
+  const imageLightbox = expandedImage ? (
+    <ImageLightbox
+      src={expandedImage.url}
+      alt={expandedImage.alt ?? "Expanded image"}
+      position={expandedImageIndex >= 0 ? expandedImageIndex + 1 : undefined}
+      total={expandedImageIndex >= 0 ? threadImageGallery.length : undefined}
+      onClose={() => {
+        setExpandedImage(undefined);
+      }}
+      onNext={
+        expandedImageIndex >= 0 && expandedImageIndex < threadImageGallery.length - 1
+          ? () => {
+              setExpandedImage(threadImageGallery[expandedImageIndex + 1]);
+            }
+          : undefined
+      }
+      onPrevious={
+        expandedImageIndex > 0
+          ? () => {
+              setExpandedImage(threadImageGallery[expandedImageIndex - 1]);
+            }
+          : undefined
+      }
+    />
+  ) : null;
+
   if (selectedLaunchpad && props.selectedDirectory) {
     const launchpadBackend = props.backends.find(
       (backend) => backend.kind === selectedLaunchpad.backend
@@ -3463,6 +3489,7 @@ export function ThreadView(props: ThreadViewProps) {
             pinned={contextRailPinned}
           />
         </div>
+        {imageLightbox}
       </section>
     );
   }
@@ -3882,31 +3909,7 @@ export function ThreadView(props: ThreadViewProps) {
         />
       </div>
 
-      {expandedImage ? (
-        <ImageLightbox
-          src={expandedImage.url}
-          alt={expandedImage.alt ?? "Expanded image"}
-          position={expandedImageIndex >= 0 ? expandedImageIndex + 1 : undefined}
-          total={expandedImageIndex >= 0 ? threadImageGallery.length : undefined}
-          onClose={() => {
-            setExpandedImage(undefined);
-          }}
-          onNext={
-            expandedImageIndex >= 0 && expandedImageIndex < threadImageGallery.length - 1
-              ? () => {
-                  setExpandedImage(threadImageGallery[expandedImageIndex + 1]);
-                }
-              : undefined
-          }
-          onPrevious={
-            expandedImageIndex > 0
-              ? () => {
-                  setExpandedImage(threadImageGallery[expandedImageIndex - 1]);
-                }
-              : undefined
-          }
-        />
-      ) : null}
+      {imageLightbox}
 
       {rewindDialog ? (
         <div className="workspace-handoff-modal">

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -20,6 +20,7 @@ import type {
   AppServerThreadEntry,
   AppServerThreadImagePart,
   AppServerThreadMessageEntry,
+  AppServerThreadMessagePart,
   AppServerThreadPlanEntry,
   AppServerThreadPlanStep,
   AppServerThreadTurnMetadata,
@@ -99,6 +100,7 @@ import { ThreadPlaceholderHeader } from "./ThreadPlaceholderHeader";
 import { ImageLightbox } from "./ImageLightbox";
 import { TranscriptCopyButton } from "./TranscriptCopyButton";
 import { TranscriptList } from "./TranscriptList";
+import { TranscriptMessage } from "./TranscriptMessage";
 import { LiveWorkRail } from "./LiveWorkRail";
 import {
   McpInventoryPanel,
@@ -1259,6 +1261,19 @@ export function ThreadView(props: ThreadViewProps) {
   const [localLaunchpadMaterializing, setLaunchpadMaterializing] = useState(false);
   const launchpadMaterializing = Boolean(props.pendingLaunchpadCreation) || localLaunchpadMaterializing;
   const [launchpadSubmittedInput, setLaunchpadSubmittedInput] = useState<AppServerTurnInputItem[]>([]);
+  const launchpadSubmittedMessage = useMemo<AppServerThreadMessageEntry>(() => {
+    const parts = (props.pendingLaunchpadCreation?.input ?? launchpadSubmittedInput)
+      .flatMap<AppServerThreadMessagePart>((item) =>
+        item.type === "text" || item.type === "image" ? [item] : [],
+      );
+    return {
+      id: "launchpad-submitted-message",
+      type: "message",
+      role: "user",
+      text: parts.flatMap((part) => part.type === "text" ? [part.text] : []).join("\n\n"),
+      parts,
+    };
+  }, [launchpadSubmittedInput, props.pendingLaunchpadCreation?.input]);
   // Terminal state is owned by `useIntegratedTerminals` up in App, mirroring
   // the main process's registry. It cannot live here: ThreadView unmounts on
   // search and on any refresh that flips `threadDetailPending`, which used to
@@ -3331,11 +3346,16 @@ export function ThreadView(props: ThreadViewProps) {
               {launchpadMaterializing ? (
                 <div className="thread-view__launchpad-transcript">
                   <article className="launchpad-submitted-message" aria-label="Submitted message">
-                    {(props.pendingLaunchpadCreation?.input ?? launchpadSubmittedInput).map((item, index) =>
-                      item.type === "text" ? <p key={index}>{item.text}</p>
-                        : item.type === "image" ? <img key={index} src={item.url} alt="Submitted attachment" />
-                        : null,
-                    )}
+                    <div className="transcript-list__content">
+                      <TranscriptMessage
+                        applications={props.applications}
+                        desktopApi={props.desktopApi}
+                        message={launchpadSubmittedMessage}
+                        parentThreadId=""
+                        skills={props.skills}
+                        onOpenImage={setExpandedImage}
+                      />
+                    </div>
                   </article>
                   {launchpadMaterializing && launchpadMaterializeError ? (
                     <LaunchpadMaterializeFailure

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2841,6 +2841,46 @@ describe("ThreadView", () => {
     );
   });
 
+  it("opens submitted image previews while the launchpad is materializing", () => {
+    const dataUrl = "data:image/png;base64,aGVsbG8=";
+    render(
+      <ThreadView
+        addOptimisticUserMessage={() => "optimistic-1"}
+        backends={[]}
+        clearPendingRequest={() => undefined}
+        composerDisabled={false}
+        loading={false}
+        loadingMore={false}
+        messageCount={0}
+        selectedDirectory={{
+          key: "directory:/repo", kind: "directory", label: "Example", path: "/repo",
+          threadKeys: [], needsAttentionCount: 0,
+        }}
+        selectedLaunchpad={{
+          backend: "codex", directoryKey: "directory:/repo", directoryKind: "directory",
+          directoryLabel: "Example", directoryPath: "/repo", executionMode: "default",
+          prompt: "Inspect this screenshot", workMode: "worktree", createdAt: 1, updatedAt: 1,
+        }}
+        pendingLaunchpadCreation={{
+          selectionKey: "launchpad:directory:/repo", directoryKey: "directory:/repo",
+          title: "Inspect this screenshot",
+          input: [{ type: "image", url: dataUrl }],
+        }}
+        skills={[]}
+        transcriptEntries={[]}
+        onLoadOlder={async () => undefined}
+        removeOptimisticMessage={() => undefined}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand transcript image 1" }));
+    const dialog = screen.getByRole("dialog", { name: "Expanded image" });
+    expect(within(dialog).getByRole("img")).toHaveAttribute("src", "blob:expanded-transcript-image");
+    expect(screen.getByRole("textbox", { name: "New thread" })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Expanded image" })).not.toBeInTheDocument();
+  });
+
   it("opens transcript image previews in a lightbox and dismisses them with Escape", () => {
     const dataUrl = "data:image/png;base64,aGVsbG8=";
 

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2185,7 +2185,7 @@ describe("ThreadView", () => {
       directoryLabel: selectedDirectory.label,
       directoryPath: selectedDirectory.path,
       executionMode: "full-access",
-      prompt: "Investigate clipboard filenames",
+      prompt: "Investigate **clipboard filenames**\n\n> Keep the original name.\n\n| File | Status |\n| --- | --- |\n| capture.png | Ready |",
       updatedAt: 1000,
       workMode: "worktree",
       codexEnvironmentId: "environment",
@@ -2261,7 +2261,13 @@ describe("ThreadView", () => {
     const followup = screen.getByRole("textbox", { name: "New thread" });
     expect(followup).toBeEnabled();
     expect(followup).toHaveValue("");
-    expect(screen.getByLabelText("Submitted message")).toHaveTextContent("Investigate clipboard filenames");
+    const submittedMessage = screen.getByLabelText("Submitted message");
+    expect(submittedMessage).toHaveTextContent("Investigate clipboard filenames");
+    expect(within(submittedMessage).getByText("clipboard filenames").tagName).toBe("STRONG");
+    expect(within(submittedMessage).getByText("Keep the original name.").closest("blockquote"))
+      .toBeInTheDocument();
+    expect(within(submittedMessage).getByRole("table")).toHaveTextContent("capture.png");
+    expect(submittedMessage.querySelector(".transcript-message--user")).toBeInTheDocument();
     fireEvent.change(followup, { target: { value: "Also check the tests" } });
     fireEvent.click(screen.getByRole("button", { name: "Queue" }));
     expect(await screen.findByLabelText("Queued message")).toHaveTextContent("Also check the tests");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16022,16 +16022,6 @@ a.button {
   width: calc(100% - 32px);
   max-width: var(--chat-column-max);
   margin: 16px auto;
-  color: var(--text-primary);
-  font-size: var(--transcript-text-size);
-  white-space: pre-wrap;
-  overflow-wrap: anywhere;
-}
-
-.launchpad-submitted-message img {
-  max-width: 160px;
-  max-height: 120px;
-  object-fit: contain;
 }
 
 .thread-view__launchpad-composer > .composer,


### PR DESCRIPTION
## Summary

Render the submitted launchpad prompt with the existing `TranscriptMessage` component during environment setup. Markdown, user-message styling, copy controls, and image previews now use the same rendering as the regular transcript. Remove the plain-text and thumbnail-specific styling.

## Verification

- 198 focused tests passed, including bold text, blockquotes, and tables in the pending message.
- Desktop typecheck, ESLint, and dependency-boundary checks passed.
- Checked the real thread view in a headless fixture at 1100×800 and 900×600; the composer remains visible and editable.

## Notes

Screenshot uses entirely synthetic fixture data.

![Formatted pending user message above environment setup and the editable composer](https://github.com/user-attachments/assets/c907a094-cdfc-40de-b0e1-e1ab2bc60cd4)
