### PR TITLE
fix(desktop): preserve source and evaluate mixed Code Mode output

### DIFF
--- a/apps/desktop/src/main/__tests__/token-miser-agent-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-agent-tools.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { AgentToolRouter } from "../agent-tools/agent-tool-router";
 import { buildTokenMiserToolDefinitions } from "../agent-tools/token-miser-agent-tools";
 import { TokenMiserService } from "../token-miser/token-miser-service";
@@ -269,13 +269,14 @@ describe("Token Miser agent tools", () => {
     expect(dynamicText.text).toContain("RECOGNIZABLE_REQUESTED_LINE");
     expect(dynamicText.text).toContain("pwragent_token_miser_retrieval");
 
+    const generateSummary = vi.fn(async () => ({
+      status: "failed" as const,
+      reason: "ordinary output remains eligible for evaluation",
+    }));
     const service = new TokenMiserService({
       store,
       isEnabled: () => true,
-      generateSummary: async () => ({
-        status: "failed",
-        reason: "retrieval cells must bypass the reducer",
-      }),
+      generateSummary,
       thresholdCharacters: 1,
     });
     const retrievalScript =
@@ -297,6 +298,10 @@ describe("Token Miser agent tools", () => {
     })).toBeUndefined();
     expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters)
       .toBe(0);
+
+    // Calling a retrieval tool without emitting its delivery is not a
+    // retrieval-only cell. The script text cannot exempt ordinary output.
+    expect(generateSummary).toHaveBeenCalledTimes(1);
 
     const deliveredResponse = await router.handleDynamicToolCall({
       backend: "codex",
@@ -334,8 +339,17 @@ describe("Token Miser agent tools", () => {
     expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters)
       .toBeGreaterThanOrEqual("RECOGNIZABLE_REQUESTED_LINE".length);
     expect(await store.summarizeThreadUsage("thread-1")).toMatchObject({
-      codeMode: { retrievalCount: 2 },
+      codeMode: {
+        callCount: 2,
+        directCount: 1,
+        retrievalCount: 1,
+        observations: expect.arrayContaining([
+          expect.objectContaining({ callId: "call-code-mode-empty", retrieval: false, disposition: "direct" }),
+          expect.objectContaining({ callId: "call-code-mode", retrieval: true, disposition: "retrieval" }),
+        ]),
+      },
     });
+    expect(generateSummary).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/token-miser-service.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-service.test.ts
@@ -1545,6 +1545,67 @@ describe("TokenMiserService code-mode reduction", () => {
     expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters).toBe(0);
   });
 
+  it.each([
+    { maxOutputTokens: 10_000, character: "a", summaryLength: 100, canFitReference: true },
+    { maxOutputTokens: 1_000, character: "α", summaryLength: 2_500, canFitReference: true },
+    { maxOutputTokens: 25, character: "a", summaryLength: 100, canFitReference: false },
+  ])("keeps the mixed summary and recovery reference visible at a $maxOutputTokens-token cap", async ({ maxOutputTokens, character, summaryLength, canFitReference }) => {
+    const store = await createStore();
+    const source = character.repeat(30_000 / utf8ByteLength(character));
+    const deliveries: string[] = [];
+    for (const toolUseId of ["first-source", "second-source"]) {
+      const metadata = await store.store({
+        threadId: "thread-1", turnId: "turn-1", toolUseId, toolName: "Code Mode",
+        output: source, replacementCharacters: 1,
+        summary: { summary: "Preserved source", usefulDetails: [] },
+      });
+      const delivery = await store.prepareRetrievalDelivery({
+        objectId: metadata.objectId, threadId: "thread-1", visibleText: source,
+      });
+      deliveries.push(delivery!.text);
+    }
+    const service = new TokenMiserService({
+      store, isEnabled: () => true,
+      generateSummary: async () => ({ status: "ok", object: {
+        disposition: "summarize",
+        summary: `NEW_LOG_RESULT ${"s".repeat(summaryLength)}`,
+        usefulDetails: [],
+      } }),
+    });
+    const prepared = await service.prepareCodeModeOutput({
+      ...codeModePayload([{
+        type: "input_text",
+        text: `${deliveries[0]}\n${deliveries[1]}\n${"new logs\n".repeat(2_000)}`,
+      }]),
+      max_output_tokens: maxOutputTokens,
+    });
+    if (!canFitReference) {
+      expect(prepared).toBeUndefined();
+      expect(await store.listMetadata()).toHaveLength(2);
+      return;
+    }
+    expect(prepared).toBeDefined();
+    const replacement = prepared!.response.replacement![0]!.text;
+    for (const delivery of deliveries) expect(replacement).toContain(delivery);
+    // Independently simulate Codex's head/tail truncation. Both the new result
+    // and its full recovery reference must survive, not just the old sources.
+    const bytes = Buffer.from(replacement);
+    const maxBytes = maxOutputTokens * TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN;
+    expect(bytes.length).toBeGreaterThan(maxBytes);
+    const visible = Buffer.concat([
+      bytes.subarray(0, Math.floor(maxBytes / 2)),
+      bytes.subarray(bytes.length - Math.ceil(maxBytes / 2)),
+    ]).toString("utf8");
+    expect(visible).toContain("NEW_LOG_RESULT");
+    expect(visible).toContain(`Output reference: ${prepared!.staged.metadata.objectId}`);
+    expect(prepared!.staged.metadata.replacementCharacters).toBeGreaterThan(100);
+    await prepared!.staged.persist();
+    await prepared!.staged.commit();
+    expect((await store.readAll({
+      objectId: prepared!.staged.metadata.objectId, threadId: "thread-1",
+    }))?.text).toContain("new logs");
+  });
+
   it("shares the outer cap between novel output and preserved retrievals", async () => {
     const store = await createStore();
     const original = "α".repeat(15_000);

--- a/apps/desktop/src/main/__tests__/token-miser-service.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-service.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   TokenMiserService,
   type TokenMiserStructuredGenerationResult,
+  type TokenMiserServiceOptions,
 } from "../token-miser/token-miser-service";
 import { TokenMiserStore } from "../token-miser/token-miser-store";
 import type {
@@ -1349,15 +1350,191 @@ describe("TokenMiserService code-mode reduction", () => {
       thresholdCharacters: 1,
     });
 
+    const metadata = await store.store({
+      threadId: "thread-1", turnId: "turn-1", toolUseId: "original", toolName: "Code Mode",
+      output: "deliberately retrieved output", replacementCharacters: 1,
+      summary: { summary: "original", usefulDetails: [] },
+    });
+    const delivery = await store.prepareRetrievalDelivery({
+      objectId: metadata.objectId, threadId: "thread-1", visibleText: "deliberately retrieved output",
+    });
     expect(await service.prepareCodeModeOutput({
       ...codeModePayload([{
         type: "input_text",
-        text: "deliberately retrieved output",
+        text: delivery!.text,
       }]),
       script,
     })).toBeUndefined();
     expect(generateSummary).not.toHaveBeenCalled();
-    expect(await store.listMetadata()).toEqual([]);
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters).toBe("deliberately retrieved output".length);
+  });
+
+  it.each([
+    "text(await tools.pwragent__read_all_token_miser_output({})); text(await tools.exec_command({cmd: 'rg needle'}));",
+    "const results = await Promise.all([tools.pwragent__read_all_token_miser_output({}), tools.exec_command({cmd: 'rg needle'})]); results.forEach(text);",
+    "const read = tools.pwragent__read_all_token_miser_output; text(await read({})); text((await tools.exec_command({cmd: 'rg needle'})).output);",
+  ])("preserves retrievals while evaluating new output in a mixed cell: %s", async (script) => {
+    const store = await createStore();
+    const original = "requested source α\n".repeat(60);
+    const novel = "unrelated search matches β\n".repeat(400);
+    const metadata = await store.store({
+      threadId: "thread-1", turnId: "turn-1", toolUseId: "original", toolName: "Code Mode",
+      output: original, replacementCharacters: 1,
+      summary: { summary: "original", usefulDetails: [] },
+    });
+    const delivery = await store.prepareRetrievalDelivery({
+      objectId: metadata.objectId, threadId: "thread-1", visibleText: original,
+    });
+    const generateSummary = vi.fn<TokenMiserServiceOptions["generateSummary"]>(async () => ({
+      status: "ok" as const,
+      object: { disposition: "summarize", summary: "Search matched three files.", usefulDetails: [] },
+    }));
+    const service = new TokenMiserService({ store, isEnabled: () => true, generateSummary });
+    const prepared = await service.prepareCodeModeOutput({
+      ...codeModePayload([{ type: "input_text", text: delivery!.text + novel }]), script,
+    });
+    expect(prepared).toBeDefined();
+    expect(generateSummary).toHaveBeenCalledTimes(1);
+    expect(generateSummary.mock.calls[0]?.[0].prompt).toContain(novel.slice(0, 100));
+    expect(generateSummary.mock.calls[0]?.[0].prompt).not.toContain(original);
+    const replacement = prepared!.response.replacement![0]!.text;
+    expect(replacement).toContain(delivery!.text);
+    expect(replacement).not.toContain(novel);
+    expect(prepared!.staged.metadata.originalCharacters).toBe(utf8ByteLength(novel));
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters).toBe(0);
+    await prepared!.staged.persist();
+    await prepared!.staged.commit();
+    await prepared!.staged.commit();
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters).toBe(utf8ByteLength(original));
+    const [observation] = await store.listCodeModeObservations("thread-1");
+    expect(observation).toMatchObject({ retrieval: false, capturedNestedInvocationCount: null });
+    expect((await store.summarizeThreadUsage("thread-1")).codeMode).toMatchObject({
+      commandCellCount: null, otherCellCount: null, unclassifiedCellCount: 1,
+      summarizedCount: 1, retrievalCount: 0,
+    });
+  });
+
+  it.each([
+    "// tools.pwragent__read_all_token_miser_output({})\ntext(await tools.exec_command({cmd: 'rg needle'}));",
+    "const example = 'tools.pwragent__read_all_token_miser_output({})'; text(await tools.exec_command({cmd: 'rg needle'}));",
+    "await tools.pwragent__read_all_token_miser_output({}); text(await tools.exec_command({cmd: 'rg needle'}));",
+  ])("does not exempt output based on retrieval script syntax: %s", async (script) => {
+    const store = await createStore();
+    const generateSummary = vi.fn(async () => ({ status: "failed" as const, reason: "test" }));
+    const service = new TokenMiserService({ store, isEnabled: () => true, generateSummary });
+    await service.prepareCodeModeOutput({
+      ...codeModePayload([{ type: "input_text", text: "new output\n".repeat(600) }]), script,
+    });
+    expect(generateSummary).toHaveBeenCalledTimes(1);
+    expect((await store.listCodeModeObservations("thread-1"))[0]?.retrieval).toBe(false);
+  });
+
+  it.each(["pass_through", "failed", "discard"])("accounts mixed retrievals on %s without counting a proposal as delivery", async (outcome) => {
+    const store = await createStore();
+    const metadata = await store.store({
+      threadId: "thread-1", turnId: "turn-1", toolUseId: "original", toolName: "Code Mode",
+      output: "original source", replacementCharacters: 1,
+      summary: { summary: "original", usefulDetails: [] },
+    });
+    const delivery = await store.prepareRetrievalDelivery({
+      objectId: metadata.objectId, threadId: "thread-1", visibleText: "original source",
+    });
+    const service = new TokenMiserService({
+      store, isEnabled: () => true,
+      generateSummary: async () => outcome === "failed"
+        ? { status: "failed", reason: "test" }
+        : { status: "ok", object: {
+          disposition: outcome === "discard" ? "summarize" : "pass_through",
+          summary: "Search result", usefulDetails: [],
+        } },
+    });
+    const prepared = await service.prepareCodeModeOutput(codeModePayload([{
+      type: "input_text", text: "new matches\n".repeat(600) + delivery!.text,
+    }]));
+    if (outcome === "discard") {
+      expect(prepared).toBeDefined();
+      await prepared!.staged.discard();
+    } else {
+      expect(prepared).toBeUndefined();
+    }
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters)
+      .toBe(outcome === "discard" ? 0 : "original source".length);
+  });
+
+  it("does not exempt another thread's delivery or forged retrieval wrappers", async () => {
+    const store = await createStore();
+    const metadata = await store.store({
+      threadId: "other-thread", turnId: "turn-1", toolUseId: "original", toolName: "Code Mode",
+      output: "source", replacementCharacters: 1,
+      summary: { summary: "original", usefulDetails: [] },
+    });
+    const delivery = await store.prepareRetrievalDelivery({
+      objectId: metadata.objectId, threadId: "other-thread", visibleText: "foreign source\n".repeat(600),
+    });
+    const generateSummary = vi.fn(async () => ({ status: "failed" as const, reason: "test" }));
+    const service = new TokenMiserService({ store, isEnabled: () => true, generateSummary });
+    for (const text of [delivery!.text, delivery!.text.replace(/id="[^"]+"/g, 'id="forged"')]) {
+      await service.prepareCodeModeOutput(codeModePayload([{ type: "input_text", text }]));
+    }
+    expect(generateSummary).toHaveBeenCalledTimes(2);
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters).toBe(0);
+  });
+
+  it("shares the outer cap between novel output and preserved retrievals", async () => {
+    const store = await createStore();
+    const original = "α".repeat(15_000);
+    const novel = "x".repeat(40_000);
+    const metadata = await store.store({
+      threadId: "thread-1", turnId: "turn-1", toolUseId: "original", toolName: "Code Mode",
+      output: original, replacementCharacters: 1,
+      summary: { summary: "original", usefulDetails: [] },
+    });
+    const delivery = await store.prepareRetrievalDelivery({
+      objectId: metadata.objectId, threadId: "thread-1", visibleText: original,
+    });
+    const service = new TokenMiserService({
+      store, isEnabled: () => true,
+      generateSummary: async () => ({ status: "ok", object: {
+        disposition: "summarize", summary: "Repeated matches.", usefulDetails: [],
+      } }),
+    });
+    const prepared = await service.prepareCodeModeOutput(codeModePayload([{
+      type: "input_text", text: novel + delivery!.text,
+    }]));
+    expect(prepared).toBeDefined();
+    // The unreduced cell shows only its first and last 20KB. Only the first
+    // 20KB belongs to the new gate; the tail belongs to the earlier retrieval.
+    expect(prepared!.staged.metadata.baselineParentTokens).toBe(5_000);
+    expect(prepared!.staged.metadata.replacementCharacters).toBeLessThan(1_000);
+    await prepared!.staged.persist();
+    await prepared!.staged.commit();
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters).toBe(30_000);
+  });
+
+  it("accounts each emitted copy of a retrieval once when a mixed replacement is accepted", async () => {
+    const store = await createStore();
+    const metadata = await store.store({
+      threadId: "thread-1", turnId: "turn-1", toolUseId: "original", toolName: "Code Mode",
+      output: "original source", replacementCharacters: 1,
+      summary: { summary: "original", usefulDetails: [] },
+    });
+    const delivery = await store.prepareRetrievalDelivery({
+      objectId: metadata.objectId, threadId: "thread-1", visibleText: "original source",
+    });
+    const service = new TokenMiserService({
+      store, isEnabled: () => true,
+      generateSummary: async () => ({ status: "ok", object: {
+        disposition: "summarize", summary: "Search matches", usefulDetails: [],
+      } }),
+    });
+    const prepared = await service.prepareCodeModeOutput(codeModePayload([{
+      type: "input_text", text: delivery!.text + "new matches\n".repeat(600) + delivery!.text,
+    }]));
+    await prepared!.staged.persist();
+    await prepared!.staged.commit();
+    await prepared!.staged.commit();
+    expect((await store.readMetadata(metadata.objectId))?.retrievedCharacters)
+      .toBe("original source".length * 2);
   });
 
   it("shares the 10k parent cap across multiple retrievals in one Code Mode cell", async () => {

--- a/apps/desktop/src/main/__tests__/token-miser-service.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-service.test.ts
@@ -720,7 +720,72 @@ describe("TokenMiserService code-mode reduction", () => {
     expect(onInterceptionStored).toHaveBeenCalledWith(metadata);
   });
 
-  it("passes a bounded exact source read through without evaluation", async () => {
+  it.each([
+    { name: "missing narration", command: "sed -n '1,220p' source.ts", intent: undefined },
+    { name: "mixed discovery and source", command: "rg -n 'handler' src; sed -n '1,220p' source.ts", intent: "Investigate the handler." },
+    { name: "test source and diffs", command: "git diff -- source.test.ts; cat source.test.ts", intent: "Review the changes." },
+  ])("provides passthrough-default source policy for $name", async ({ command, intent }) => {
+    const store = await createStore();
+    const source = Array.from({ length: 600 }, (_, index) =>
+      `export function handler${index}() { return ${index}; }`,
+    ).join("\n");
+    expect(source.length).toBeGreaterThan(20_000);
+    const generateSummary = vi.fn<TokenMiserServiceOptions["generateSummary"]>(async () => ({
+      status: "ok",
+      object: { disposition: "pass_through", summary: "The requested source was returned.", usefulDetails: [] },
+    }));
+    const service = new TokenMiserService({ store, isEnabled: () => true, generateSummary });
+    expect(await service.prepareCodeModeOutput({
+      ...codeModePayload([{ type: "input_text", text: source }]),
+      script: `text(await tools.exec_command({ cmd: ${JSON.stringify(command)} }));`,
+      parent_intent: intent,
+    })).toBeUndefined();
+    const request = generateSummary.mock.calls[0]?.[0];
+    expect(request?.prompt).toContain(command);
+    expect(request?.prompt).toContain("handler599");
+    expect(request?.system).toContain("Default to pass_through for source code, test source, diffs, and requested file content.");
+    expect(request?.system).toContain("Missing intent, uncertain relevance, a large result, multiple source ranges, incomplete surrounding functions, or a nearby search are not evidence of a miss");
+    expect(request?.system).toContain("Test source is source code; it is not test execution output.");
+    expect(request?.system).toContain("Minor noise or failed companion commands do not justify discarding useful source.");
+    expect(request?.system).not.toContain("When intent is absent or the choice is uncertain, choose summarize.");
+    const [metadata] = await store.listMetadata();
+    expect(metadata).toMatchObject({ disposition: "passed_through", replacementCharacters: utf8ByteLength(source) });
+  });
+
+  it.each(["direct", "code-mode"])("evaluates a degenerate source read before deciding its %s disposition", async (surface) => {
+    const store = await createStore();
+    const generateSummary = vi.fn<TokenMiserServiceOptions["generateSummary"]>(async () => ({
+      status: "ok",
+      object: {
+        disposition: "summarize",
+        summary: "The requested source range contained only blank space.",
+        usefulDetails: [],
+      },
+    }));
+    const service = new TokenMiserService({
+      store, isEnabled: () => true, generateSummary,
+      postToolUseExactOutputVersion: () => 1,
+    });
+    const output = " \n".repeat(3_000);
+    const parent_intent = "Read the exact source implementation before patching it.";
+    const prepared = surface === "direct"
+      ? await service.preparePostToolUse({
+        ...payload(output), parent_intent,
+        tool_input: { command: "sed -n '1,3000p' source.ts" },
+      })
+      : await service.prepareCodeModeOutput({
+        ...codeModePayload([{ type: "input_text", text: output }]), parent_intent,
+        script: 'text(await tools.exec_command({ cmd: "sed -n 1,3000p source.ts" }));',
+      });
+    expect(generateSummary).toHaveBeenCalledTimes(1);
+    expect(generateSummary.mock.calls[0]?.[0].system).toContain("State the concrete mismatch or degeneration in the audit summary.");
+    expect(prepared).toBeDefined();
+    await prepared!.staged.persist();
+    await prepared!.staged.commit();
+    expect((await store.listMetadata())[0]?.disposition).toBe("summarized");
+  });
+
+  it("passes a source read through after evaluating its actual content", async () => {
     const store = await createStore();
     const generateSummary = vi.fn(async () => ({
       status: "ok" as const,
@@ -750,14 +815,14 @@ describe("TokenMiserService code-mode reduction", () => {
     };
 
     expect(await service.prepareCodeModeOutput(request)).toBeUndefined();
-    expect(generateSummary).not.toHaveBeenCalled();
+    expect(generateSummary).toHaveBeenCalledTimes(1);
     const [metadata] = await store.listMetadata();
     expect(metadata).toMatchObject({
       disposition: "passed_through",
       baselineParentTokens: 6,
       replacementCharacters: 24,
     });
-    expect(metadata?.helperUsage).toBeUndefined();
+    expect(metadata?.helperUsage?.helperThreadId).toBe("helper-code-pass-through");
   });
 
   it("accounts only the original 10k-token result when Luna passes through", async () => {

--- a/apps/desktop/src/main/__tests__/token-miser-store.test.ts
+++ b/apps/desktop/src/main/__tests__/token-miser-store.test.ts
@@ -163,6 +163,35 @@ describe("TokenMiserStore", () => {
     ]));
   });
 
+  it("distinguishes unavailable and legacy capture from captured zero command counts", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-token-miser-"));
+    temporaryDirectories.push(root);
+    const store = new TokenMiserStore(root);
+    const observation = {
+      threadId: "thread-owner", turnId: "turn-1", cellId: "cell-1",
+      outputCharacters: 100, maxOutputTokens: 10_000, scriptStatus: "completed", retrieval: false,
+    };
+    await store.recordCodeModeObservation({
+      ...observation, callId: "unavailable", capturedNestedInvocationCount: null,
+    });
+    await store.recordCodeModeObservation({
+      ...observation, callId: "legacy", capturedNestedInvocationCount: 0,
+      capturedCommandInvocationCount: 0, capturedOtherInvocationCount: 0,
+    });
+    expect((await store.summarizeThreadUsage("thread-owner")).codeMode).toMatchObject({
+      callCount: 2, unclassifiedCellCount: 2, commandCellCount: null,
+      capturedNestedInvocationCount: null, otherCellCount: null, pollingCellCount: null,
+    });
+    await store.recordCodeModeObservation({
+      ...observation, callId: "patch", capturedNestedInvocationCount: 1,
+      capturedCommandInvocationCount: 0, capturedPatchInvocationCount: 1,
+    });
+    expect((await store.summarizeThreadUsage("thread-owner")).codeMode).toMatchObject({
+      callCount: 3, unclassifiedCellCount: 2, commandCellCount: 0,
+      capturedNestedInvocationCount: 1, patchCellCount: 1, otherCellCount: 0,
+    });
+  });
+
   it("counts every Code Mode reducer request separately from gate decisions", async () => {
     const root = await fs.mkdtemp(path.join(os.tmpdir(), "pwragent-token-miser-"));
     temporaryDirectories.push(root);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -4973,6 +4973,7 @@ function toThreadReadEvaluationTokenMiser(
       ? {
           codeMode: {
             callCount: accounting.codeMode.callCount,
+            unclassifiedCellCount: accounting.codeMode.unclassifiedCellCount,
             commandCellCount: accounting.codeMode.commandCellCount,
             directCommandCellCount: accounting.codeMode.directCommandCellCount,
             dispatchClusterCount: accounting.codeMode.dispatchClusterCount,

--- a/apps/desktop/src/main/token-miser/token-miser-service.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-service.ts
@@ -77,12 +77,14 @@ const TOKEN_MISER_GROUP_SUMMARY_SCHEMA = {
 
 const TOKEN_MISER_SYSTEM_PROMPT = [
   "You are Token Miser, the first gate on completed coding-tool output before it enters a parent coding agent's context.",
-  "Choose pass_through when the visible parent intent and tool/script input show a deliberate, well-targeted request for exact content and the result is coherent, relevant, and likely to be consumed substantially as-is.",
-  "Examples that often deserve pass_through are a bounded read of a requested source or instruction file, a concise exact query result, or a focused diagnostic whose details are all material.",
-  "Treat a sed range read as a strong pass_through candidate when its lines are distinct, coherent source code or prose from the requested file or range, even when the result is large.",
-  "Choose summarize for a sed result that is primarily repetitive data, duplicated records, repeated error or log messages, or content that missed the requested file or range.",
-  "Choose summarize for broad or exploratory searches, repetitive matches, verbose logs, test/build output, noisy failures, accidental directory-wide reads, or results that missed the stated intent.",
-  "When intent is absent or the choice is uncertain, choose summarize.",
+  "Default to pass_through for source code, test source, diffs, and requested file content. The parent usually needs the exact bytes to inspect, review, or patch it; a description of the code is not a substitute.",
+  "For a sed range read containing distinct, coherent source code or prose, choose pass_through. Apply the same rule to cat, head/tail, file-reading tools, git diff, and targeted search results containing source lines.",
+  "Judge source using the visible parent intent, the command or script, and the actual result together. Missing intent, uncertain relevance, a large result, multiple source ranges, incomplete surrounding functions, or a nearby search are not evidence of a miss; choose pass_through in these cases.",
+  "Summarize source or requested file content only when that evidence establishes a substantial miss or a degenerate result, such as mostly blank space, generated repetitive data instead of the requested implementation, or an unrelated embedded transcript. State the concrete mismatch or degeneration in the audit summary.",
+  "If a sed result is primarily repetitive data or repeated error/log messages rather than coherent requested source, choose summarize. Do not confuse repeated code syntax, similar tests, or diff context with redundant noise.",
+  "Choose summarize for broad file/reference discovery listings, repetitive matches without material source context, verbose logs, test/build execution output, and noisy failures. Test source is source code; it is not test execution output.",
+  "For mixed results containing useful source or diffs plus search listings or diagnostics, choose pass_through unless the source itself clearly satisfies the substantial-miss or degenerate-result exception. Minor noise or failed companion commands do not justify discarding useful source.",
+  "For other exact query results or focused diagnostics whose details are material, choose pass_through. When uncertain whether source should be summarized, choose pass_through.",
   "The host returns the original bytes itself for pass_through. Never copy or reconstruct the full output in your response.",
   "For pass_through, keep the audit summary under 50 words and omit usefulDetails unless one short fact explains the decision.",
   "Summarize only what is present. Preserve exact filenames, identifiers, errors, counts, and commands that materially describe the result.",
@@ -290,7 +292,6 @@ export class TokenMiserService {
     const deterministicPassThrough = classifyDeterministicPassThrough({
       parentIntent: payload.parent_intent,
       request: serializeToolResponse(payload.tool_input),
-      outputCharacters: output.length,
     });
     if (deterministicPassThrough) {
       await this.recordPassThroughDecision({
@@ -460,7 +461,6 @@ export class TokenMiserService {
     const deterministicPassThrough = classifyDeterministicPassThrough({
       parentIntent: payload.parent_intent,
       request: payload.script ?? "",
-      outputCharacters: output.length,
     });
     if (deterministicPassThrough) {
       await this.recordPassThroughDecision({
@@ -930,17 +930,13 @@ function hasActionableNonterminalState(member: CapturedGroupMember): boolean {
 }
 
 const INSTRUCTION_FILE_PATTERN = /(?:^|[/\\])(?:AGENTS|CLAUDE|SKILL)\.md\b|(?:^|[/\\])UI-THEME\.md\b|(?:^|[/\\])[^\s"']*style-guide\.md\b/i;
-const SOURCE_FILE_PATTERN = /(?:^|[\s"'=:])[^\s"']+\.(?:c|cc|cpp|css|go|h|hpp|html|java|js|jsx|json|md|mjs|py|rb|rs|swift|toml|ts|tsx|yaml|yml)\b/i;
 const EXACT_READ_PATTERN = /\b(?:cat|head|tail|sed|readFile|read_text_file|read_file)\b/i;
 const BROAD_DISCOVERY_PATTERN = /\b(?:find|grep|rg|search)\b/i;
 const READ_INTENT_PATTERN = /\b(?:read|inspect|review|load|follow)\b[\s\S]{0,120}\b(?:instruction|guidance|guide|AGENTS|CLAUDE|SKILL|theme)\b|\b(?:instruction|guidance|guide|AGENTS|CLAUDE|SKILL|theme)\b[\s\S]{0,120}\b(?:read|inspect|review|load|follow)\b/i;
-const EXACT_SOURCE_INTENT_PATTERN = /\b(?:read|inspect|review|open|examine|look at)\b[\s\S]{0,160}\b(?:exact|source|file|range|implementation|code)\b|\b(?:exact|source|file|range|implementation|code)\b[\s\S]{0,160}\b(?:read|inspect|review|open|examine|look at)\b/i;
-const TARGETED_SOURCE_PASS_THROUGH_MAX_CHARACTERS = 20_000;
 
 function classifyDeterministicPassThrough(params: {
   parentIntent?: string;
   request: string;
-  outputCharacters: number;
 }): TokenMiserSummary | undefined {
   if (
     !EXACT_READ_PATTERN.test(params.request)
@@ -954,17 +950,6 @@ function classifyDeterministicPassThrough(params: {
   ) {
     return {
       summary: "A deliberate exact instruction-file read passed through unchanged by policy.",
-      usefulDetails: [],
-    };
-  }
-  if (
-    params.parentIntent
-    && params.outputCharacters <= TARGETED_SOURCE_PASS_THROUGH_MAX_CHARACTERS
-    && EXACT_SOURCE_INTENT_PATTERN.test(params.parentIntent)
-    && SOURCE_FILE_PATTERN.test(params.request)
-  ) {
-    return {
-      summary: "A bounded exact source read passed through unchanged by policy.",
       usefulDetails: [],
     };
   }

--- a/apps/desktop/src/main/token-miser/token-miser-service.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-service.ts
@@ -20,6 +20,7 @@ import {
 } from "./token-miser-types.js";
 import {
   TokenMiserStore,
+  codexVisibleStringRanges,
   type TokenMiserGroupStoredOutput,
   type TokenMiserStagedObject,
 } from "./token-miser-store.js";
@@ -343,50 +344,89 @@ export class TokenMiserService {
     if (!await this.isEnabledForThread(payload.thread_id)) {
       return undefined;
     }
-    const output = payload.content_items.map((item) => item.text).join("");
-    const retrieval = isCodeModeTokenMiserRetrievalInvocation(
-      payload.script ?? "",
-    );
+    const originalOutput = payload.content_items.map((item) => item.text).join("");
+    // Exempt only authenticated delivery bytes. A cell can retrieve source
+    // and emit unrelated commands, regardless of what its script calls look like.
+    const parts = await this.options.store.partitionRetrievalOutput({
+      output: originalOutput,
+      threadId: payload.thread_id,
+    });
+    const hasRetrieval = parts.some((part) => part.retrieval);
+    const output = parts.filter((part) => !part.retrieval)
+      .map((part) => part.text).join("");
+    const retrieval = hasRetrieval && output.trim().length === 0;
+    const maxVisibleBytes =
+      payload.max_output_tokens * TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN;
+    const replaceNewParts = (replacement: string) => {
+      let replaced = false;
+      return parts.map((part) => {
+        if (part.retrieval) return part;
+        const text = replaced ? "" : replacement;
+        replaced = true;
+        return { text, retrieval: false };
+      });
+    };
+    const replaceNewOutput = (replacement: string) =>
+      replaceNewParts(replacement).map((part) => part.text).join("");
+    const visibleNewBytes = (visibleParts: typeof parts) => {
+      const text = visibleParts.map((part) => part.text).join("");
+      const visibleRanges = codexVisibleStringRanges(text, maxVisibleBytes);
+      let offset = 0;
+      let bytes = 0;
+      for (const part of visibleParts) {
+        if (!part.retrieval) {
+          for (const range of visibleRanges) {
+            const start = Math.max(offset, range.start);
+            const end = Math.min(offset + part.text.length, range.end);
+            if (end > start) bytes += utf8ByteLength(text.slice(start, end));
+          }
+        }
+        offset += part.text.length;
+      }
+      return bytes;
+    };
+    const baselineBytes = visibleNewBytes(parts);
+    const baselineParentTokenCap = hasRetrieval
+      ? Math.max(1, Math.ceil(baselineBytes / TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN))
+      : payload.max_output_tokens;
+    const confirmRetrievals = (text: string) => this.options.store.confirmModelVisibleRetrievals({
+      maxVisibleBytes,
+      output: text,
+      threadId: payload.thread_id,
+    });
     const nestedKinds = [...(capturedGroup?.members.values() ?? [])].map(
       classifyCapturedGroupMember,
     );
-    const recordObservation = () => this.options.store.recordCodeModeObservation({
-      threadId: payload.thread_id,
-      turnId: payload.turn_id,
-      callId: payload.call_id,
-      cellId: payload.cell_id,
-      outputCharacters: output.length,
-      outputPreview: output.slice(0, 5_000),
-      outputPreviewTruncated: output.length > 5_000,
-      maxOutputTokens: payload.max_output_tokens,
-      scriptStatus: payload.script_status,
-      ...(payload.script ? { script: payload.script } : {}),
-      retrieval,
-      capturedNestedInvocationCount: capturedGroup?.members.size ?? 0,
-      capturedCommandInvocationCount: nestedKinds.filter(
-        (kind) => kind === "command",
-      ).length,
-      capturedPollingInvocationCount: nestedKinds.filter(
-        (kind) => kind === "polling",
-      ).length,
-      capturedPatchInvocationCount: nestedKinds.filter(
-        (kind) => kind === "patch",
-      ).length,
-      capturedOtherInvocationCount: nestedKinds.filter(
-        (kind) => kind === "other",
-      ).length,
-    });
-    if (retrieval) {
-      // The reducer observes exact Code Mode output before Codex applies its
-      // model-visible ceiling. Confirm only the prefix eligible to cross that
-      // boundary; otherwise one minified line can become an unbounded debit.
-      await this.options.store.confirmModelVisibleRetrievals({
-        maxVisibleBytes:
-          payload.max_output_tokens
-          * TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN,
-        output,
+    const recordObservation = async (passedThrough = true) => {
+      if (passedThrough) await confirmRetrievals(originalOutput);
+      return this.options.store.recordCodeModeObservation({
         threadId: payload.thread_id,
+        turnId: payload.turn_id,
+        callId: payload.call_id,
+        cellId: payload.cell_id,
+        outputCharacters: originalOutput.length,
+        outputPreview: originalOutput.slice(0, 5_000),
+        outputPreviewTruncated: originalOutput.length > 5_000,
+        maxOutputTokens: payload.max_output_tokens,
+        scriptStatus: payload.script_status,
+        ...(payload.script ? { script: payload.script } : {}),
+        retrieval,
+        capturedNestedInvocationCount: capturedGroup?.members.size || null,
+        capturedCommandInvocationCount: capturedGroup ? nestedKinds.filter(
+          (kind) => kind === "command",
+        ).length : undefined,
+        capturedPollingInvocationCount: capturedGroup ? nestedKinds.filter(
+          (kind) => kind === "polling",
+        ).length : undefined,
+        capturedPatchInvocationCount: capturedGroup ? nestedKinds.filter(
+          (kind) => kind === "patch",
+        ).length : undefined,
+        capturedOtherInvocationCount: capturedGroup ? nestedKinds.filter(
+          (kind) => kind === "other",
+        ).length : undefined,
       });
+    };
+    if (retrieval || (hasRetrieval && baselineBytes === 0)) {
       await recordObservation();
       return undefined;
     }
@@ -405,7 +445,7 @@ export class TokenMiserService {
         toolName: "Code Mode",
         output,
         signal: options.signal,
-        baselineParentTokenCap: payload.max_output_tokens,
+        baselineParentTokenCap,
         summary: {
           summary:
             "Passed through because the result contains a live process or session handle needed for a follow-up operation.",
@@ -430,14 +470,14 @@ export class TokenMiserService {
         toolName: "Code Mode",
         output,
         signal: options.signal,
-        baselineParentTokenCap: payload.max_output_tokens,
+        baselineParentTokenCap,
         summary: deterministicPassThrough,
       });
       await recordObservation();
       return undefined;
     }
 
-    if (capturedGroup?.members.size && !capturedGroup.overflowed) {
+    if (!hasRetrieval && capturedGroup?.members.size && !capturedGroup.overflowed) {
       const grouped = await this.prepareGroupedCodeModeOutput(
         payload,
         output,
@@ -462,12 +502,13 @@ export class TokenMiserService {
       output,
       prompt: buildCodeModeSummaryPrompt(payload, output),
       signal: options.signal,
-      baselineParentTokenCap: payload.max_output_tokens,
+      baselineParentTokenCap,
       maxReplacementBytes:
         payload.max_output_tokens
         * TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN,
       replacementCharacters: (text) =>
-        utf8ByteLength(text) + payload.model_visible_overhead_characters
+        visibleNewBytes(replaceNewParts(text))
+        + payload.model_visible_overhead_characters
         + this.codeModeActionableStateCharacters(payload),
     });
     if (!prepared) {
@@ -479,7 +520,10 @@ export class TokenMiserService {
       return undefined;
     }
     const response = {
-      replacement: [{ type: "input_text" as const, text: prepared.replacement }],
+      replacement: [{
+        type: "input_text" as const,
+        text: replaceNewOutput(prepared.replacement),
+      }],
       response_id: prepared.staged.metadata.objectId,
       ...(payload.actionable_state
         ? { actionable_state: payload.actionable_state }
@@ -493,10 +537,20 @@ export class TokenMiserService {
       await recordObservation();
       return undefined;
     }
-    await recordObservation();
+    await recordObservation(false);
+    let committed = false;
     return {
       response,
-      staged: prepared.staged,
+      staged: {
+        ...prepared.staged,
+        commit: async () => {
+          await prepared.staged.commit();
+          if (!committed) {
+            committed = true;
+            await confirmRetrievals(response.replacement[0].text);
+          }
+        },
+      },
     };
   }
 
@@ -1361,18 +1415,6 @@ function isDirectTokenMiserRetrievalInvocation(
   return [input.tool, input.name, input.operation].some((value) =>
     typeof value === "string" && isTokenMiserRetrievalToolName(value)
   );
-}
-
-function isCodeModeTokenMiserRetrievalInvocation(script: string): boolean {
-  return TOKEN_MISER_RETRIEVAL_TOOL_NAMES.some((name) => {
-    const directMethod = new RegExp(
-      `\\btools\\s*\\.\\s*(?:pwragent__|pwragent\\s*\\.\\s*)${name}\\s*\\(`,
-    );
-    const namespaceDispatcher = new RegExp(
-      `\\btools\\s*\\.\\s*pwragent\\s*\\(\\s*\\{[\\s\\S]{0,500}?\\btool\\s*:\\s*["']${name}["']`,
-    );
-    return directMethod.test(script) || namespaceDispatcher.test(script);
-  });
 }
 
 function isTokenMiserRetrievalToolName(value: string): boolean {

--- a/apps/desktop/src/main/token-miser/token-miser-service.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-service.ts
@@ -358,15 +358,13 @@ export class TokenMiserService {
     const retrieval = hasRetrieval && output.trim().length === 0;
     const maxVisibleBytes =
       payload.max_output_tokens * TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN;
-    const replaceNewParts = (replacement: string) => {
-      let replaced = false;
-      return parts.map((part) => {
-        if (part.retrieval) return part;
-        const text = replaced ? "" : replacement;
-        replaced = true;
-        return { text, retrieval: false };
-      });
-    };
+    // Codex keeps the head and tail when it caps the combined cell. Put the
+    // new result first, never in whitespace between preserved retrievals.
+    // Limit it to the head budget so its recovery reference survives too.
+    const replaceNewParts = (replacement: string) => [
+      { text: replacement, retrieval: false },
+      ...parts.filter((part) => part.retrieval),
+    ];
     const replaceNewOutput = (replacement: string) =>
       replaceNewParts(replacement).map((part) => part.text).join("");
     const visibleNewBytes = (visibleParts: typeof parts) => {
@@ -503,9 +501,7 @@ export class TokenMiserService {
       prompt: buildCodeModeSummaryPrompt(payload, output),
       signal: options.signal,
       baselineParentTokenCap,
-      maxReplacementBytes:
-        payload.max_output_tokens
-        * TOKEN_MISER_ESTIMATED_BYTES_PER_TOKEN,
+      maxReplacementBytes: hasRetrieval ? Math.floor(maxVisibleBytes / 2) : maxVisibleBytes,
       replacementCharacters: (text) =>
         visibleNewBytes(replaceNewParts(text))
         + payload.model_visible_overhead_characters

--- a/apps/desktop/src/main/token-miser/token-miser-store.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-store.ts
@@ -168,21 +168,22 @@ export type TokenMiserThreadUsageSummary = TokenMiserUsageSummary & {
     summary?: TokenMiserSummary;
   }>;
   codeMode: {
+    unclassifiedCellCount: number;
     callCount: number;
-    commandCellCount: number;
-    directCommandCellCount: number;
-    dispatchClusterCount: number;
-    multiInvocationClusterCount: number;
-    largestDispatchCluster: number;
-    nestedCommandInvocationCount: number;
-    patchCellCount: number;
-    otherCellCount: number;
-    pollingCellCount: number;
+    commandCellCount: number | null;
+    directCommandCellCount: number | null;
+    dispatchClusterCount: number | null;
+    multiInvocationClusterCount: number | null;
+    largestDispatchCluster: number | null;
+    nestedCommandInvocationCount: number | null;
+    patchCellCount: number | null;
+    otherCellCount: number | null;
+    pollingCellCount: number | null;
     directCount: number;
     summarizedCount: number;
     passThroughCount: number;
     retrievalCount: number;
-    capturedNestedInvocationCount: number;
+    capturedNestedInvocationCount: number | null;
     observations: Array<TokenMiserCodeModeObservation & {
       disposition: "direct" | "summarized" | "passed_through" | "retrieval";
     }>;
@@ -623,6 +624,50 @@ export class TokenMiserStore {
     return { deliveryId, text: wrappedText };
   }
 
+  /** Match only live, thread-owned deliveries, never script text or marker syntax. */
+  async partitionRetrievalOutput(params: { output: string; threadId: string }): Promise<Array<{
+    text: string;
+    retrieval: boolean;
+  }>> {
+    if (await this.isArchived(params.threadId)) {
+      return [{ text: params.output, retrieval: false }];
+    }
+    const generation = await this.readRetentionGeneration(params.threadId);
+    const matches = [...this.pendingRetrievalDeliveries.entries()]
+      .filter(([, reference]) => reference.threadId === params.threadId)
+      .flatMap(([deliveryId, reference]) => {
+        const text = this.outputs.get(deliveryId);
+        if (!text || Date.now() - reference.createdAt > RETRIEVAL_DELIVERY_TTL_MS) {
+          this.abandonRetrievalDelivery(deliveryId);
+          return [];
+        }
+        const pending = JSON.parse(text) as PendingRetrievalDelivery;
+        if (pending.generation !== generation) return [];
+        const matches: Array<{ start: number; end: number }> = [];
+        let start = params.output.indexOf(pending.wrappedText);
+        while (start >= 0) {
+          matches.push({ start, end: start + pending.wrappedText.length });
+          start = params.output.indexOf(pending.wrappedText, start + pending.wrappedText.length);
+        }
+        return matches;
+      })
+      .sort((left, right) => left.start - right.start);
+    const parts: Array<{ text: string; retrieval: boolean }> = [];
+    let offset = 0;
+    for (const match of matches) {
+      if (match.start < offset) continue;
+      if (match.start > offset) {
+        parts.push({ text: params.output.slice(offset, match.start), retrieval: false });
+      }
+      parts.push({ text: params.output.slice(match.start, match.end), retrieval: true });
+      offset = match.end;
+    }
+    if (offset < params.output.length) {
+      parts.push({ text: params.output.slice(offset), retrieval: false });
+    }
+    return parts;
+  }
+
   async confirmModelVisibleRetrievals(params: {
     maxVisibleBytes?: number;
     output: string;
@@ -655,15 +700,25 @@ export class TokenMiserStore {
     for (const { deliveryId, outputOffset, pending } of candidates) {
       this.abandonRetrievalDelivery(deliveryId);
       if (pending.generation !== generation) continue;
-      const visibleTextStart = outputOffset + pending.visibleTextOffset;
-      const visibleTextEnd = visibleTextStart + pending.visibleText.length;
-      const visibleCharacters = visibleRanges.reduce((total, range) => {
-        const start = Math.max(visibleTextStart, range.start);
-        const end = Math.min(visibleTextEnd, range.end);
-        return end > start
-          ? total + utf8ByteLength(params.output.slice(start, end))
-          : total;
-      }, 0);
+      let visibleCharacters = 0;
+      let occurrence = outputOffset;
+      // A cell can emit the same delivery more than once. Each visible copy
+      // enters context, but update its metadata only once per delivery.
+      while (occurrence >= 0) {
+        const visibleTextStart = occurrence + pending.visibleTextOffset;
+        const visibleTextEnd = visibleTextStart + pending.visibleText.length;
+        visibleCharacters += visibleRanges.reduce((total, range) => {
+          const start = Math.max(visibleTextStart, range.start);
+          const end = Math.min(visibleTextEnd, range.end);
+          return end > start
+            ? total + utf8ByteLength(params.output.slice(start, end))
+            : total;
+        }, 0);
+        occurrence = params.output.indexOf(
+          pending.wrappedText,
+          occurrence + pending.wrappedText.length,
+        );
+      }
       await this.recordRetrieval(pending.objectId, visibleCharacters);
       confirmedCharacters += visibleCharacters;
     }
@@ -758,11 +813,17 @@ export class TokenMiserStore {
         ? "retrieval" as const
         : metadataByToolUseId.get(observation.callId)?.disposition
           ?? "direct" as const;
-      return { ...observation, disposition };
+      // Legacy zeroes meant no hooks arrived, not that no tools executed.
+      const capturedNestedInvocationCount = observation.capturedNestedInvocationCount || null;
+      return { ...observation, capturedNestedInvocationCount, disposition };
     });
+    const capturedCells = codeModeObservations.filter(
+      (entry) => entry.capturedNestedInvocationCount !== null,
+    );
+    const capturedCount = (count: number) => capturedCells.length > 0 ? count : null;
     const commandCount = (entry: TokenMiserCodeModeObservation) =>
       entry.capturedCommandInvocationCount
-      ?? (entry.retrieval ? 0 : entry.capturedNestedInvocationCount);
+      ?? (entry.retrieval ? 0 : entry.capturedNestedInvocationCount ?? 0);
     const commandCells = codeModeObservations.filter(
       (entry) => commandCount(entry) > 0,
     );
@@ -813,35 +874,38 @@ export class TokenMiserStore {
         };
       }),
       codeMode: {
+        unclassifiedCellCount: codeModeObservations.length - capturedCells.length,
         callCount: codeModeObservations.length,
-        commandCellCount: commandCells.length,
-        directCommandCellCount: commandCells.filter(
+        commandCellCount: capturedCount(commandCells.length),
+        directCommandCellCount: capturedCount(commandCells.filter(
           (entry) => entry.disposition === "direct",
-        ).length,
-        dispatchClusterCount: dispatchClusterSizes.length,
-        multiInvocationClusterCount: dispatchClusterSizes.filter(
+        ).length),
+        dispatchClusterCount: capturedCount(dispatchClusterSizes.length),
+        multiInvocationClusterCount: capturedCount(dispatchClusterSizes.filter(
           (size) => size > 1,
-        ).length,
-        largestDispatchCluster: dispatchClusterSizes.length > 0
-          ? Math.max(...dispatchClusterSizes)
-          : 0,
-        nestedCommandInvocationCount: dispatchClusterSizes.reduce(
+        ).length),
+        largestDispatchCluster: capturedCells.length === 0
+          ? null
+          : dispatchClusterSizes.length > 0
+            ? Math.max(...dispatchClusterSizes)
+            : 0,
+        nestedCommandInvocationCount: capturedCount(dispatchClusterSizes.reduce(
           (total, size) => total + size,
           0,
-        ),
-        patchCellCount: codeModeObservations.filter(
+        )),
+        patchCellCount: capturedCount(capturedCells.filter(
           (entry) => (entry.capturedPatchInvocationCount ?? 0) > 0,
-        ).length,
-        otherCellCount: codeModeObservations.filter(
+        ).length),
+        otherCellCount: capturedCount(capturedCells.filter(
           (entry) => !entry.retrieval
             && (
               entry.capturedNestedInvocationCount === 0
               || (entry.capturedOtherInvocationCount ?? 0) > 0
             ),
-        ).length,
-        pollingCellCount: codeModeObservations.filter(
+        ).length),
+        pollingCellCount: capturedCount(capturedCells.filter(
           (entry) => (entry.capturedPollingInvocationCount ?? 0) > 0,
-        ).length,
+        ).length),
         directCount: codeModeObservations.filter(
           (entry) => entry.disposition === "direct",
         ).length,
@@ -854,10 +918,10 @@ export class TokenMiserStore {
         retrievalCount: codeModeObservations.filter(
           (entry) => entry.disposition === "retrieval",
         ).length,
-        capturedNestedInvocationCount: codeModeObservations.reduce(
-          (total, entry) => total + entry.capturedNestedInvocationCount,
+        capturedNestedInvocationCount: capturedCount(codeModeObservations.reduce(
+          (total, entry) => total + (entry.capturedNestedInvocationCount ?? 0),
           0,
-        ),
+        )),
         observations: codeModeObservations,
       },
     };
@@ -1398,7 +1462,7 @@ function normalizePositiveInteger(
     : fallback;
 }
 
-function codexVisibleStringRanges(
+export function codexVisibleStringRanges(
   text: string,
   maxBytes: number,
 ): Array<{ start: number; end: number }> {

--- a/apps/desktop/src/main/token-miser/token-miser-types.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-types.ts
@@ -208,7 +208,8 @@ export type TokenMiserCodeModeObservation = {
   scriptStatus: string;
   script?: string;
   retrieval: boolean;
-  capturedNestedInvocationCount: number;
+  /** Null means the runtime supplied no nested invocation capture. */
+  capturedNestedInvocationCount: number | null;
   capturedCommandInvocationCount?: number;
   capturedPollingInvocationCount?: number;
   capturedPatchInvocationCount?: number;

--- a/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ToolOutputIncidentExplorerWindow.tsx
@@ -2254,6 +2254,13 @@ function TokenMiserCodeModeStats(props: {
 }) {
   const codeMode = props.tokenMiser.codeMode;
   if (!codeMode || codeMode.callCount === 0) return null;
+  const unclassified = codeMode.unclassifiedCellCount
+    ?? codeMode.observations.filter((entry) => !entry.capturedNestedInvocationCount).length;
+  const captureAvailable = unclassified < codeMode.callCount;
+  const formatCaptured = (count: number | null | undefined) =>
+    !captureAvailable || count == null
+      ? "Unavailable"
+      : `${unclassified > 0 ? "≥" : ""}${count.toLocaleString()}`;
   const commandCells = codeMode.commandCellCount ?? 0;
   const nestedCommands = codeMode.nestedCommandInvocationCount ?? 0;
   const dispatchClusters = codeMode.dispatchClusterCount ?? 0;
@@ -2281,13 +2288,13 @@ function TokenMiserCodeModeStats(props: {
         },
         {
           label: "command cells",
-          value: commandCells.toLocaleString(),
-          zero: commandCells === 0,
+          value: formatCaptured(commandCells),
+          zero: captureAvailable && commandCells === 0,
         },
         {
           label: "dispatch clusters",
-          value: dispatchClusters.toLocaleString(),
-          zero: dispatchClusters === 0,
+          value: formatCaptured(dispatchClusters),
+          zero: captureAvailable && dispatchClusters === 0,
         },
       ]}
       label="Code Mode"
@@ -2295,6 +2302,9 @@ function TokenMiserCodeModeStats(props: {
       open={props.open}
       sectionKey="code-mode"
     >
+      {unclassified > 0 ? (
+        <p>{unclassified.toLocaleString()} cells have no nested tool capture. Command and tool-type counts are unavailable for those cells; their outer output is still inspected.</p>
+      ) : null}
       <SavingsFigureGrid
         figures={[
           {
@@ -2308,37 +2318,37 @@ function TokenMiserCodeModeStats(props: {
             zero: codeMode.passThroughCount === 0,
           },
           {
-            detail: `${nestedCommands.toLocaleString()} nested · `
+            detail: !captureAvailable ? "Nested tool capture was not supplied." : `${nestedCommands.toLocaleString()} nested · `
               + `${commandCells > 0
                 ? (nestedCommands / commandCells).toFixed(2)
                 : "0.00"} per cell`,
             label: "Command-bearing cells",
-            value: commandCells.toLocaleString(),
-            zero: commandCells === 0,
+            value: formatCaptured(commandCells),
+            zero: captureAvailable && commandCells === 0,
           },
           {
-            detail: `${multiInvocation.toLocaleString()} multi-invocation`
+            detail: !captureAvailable ? undefined : `${multiInvocation.toLocaleString()} multi-invocation`
               + (multiInvocation > 0
                 ? ` · largest ${(codeMode.largestDispatchCluster ?? 0).toLocaleString()}`
                 : ""),
             label: "Dispatch clusters",
-            value: dispatchClusters.toLocaleString(),
-            zero: dispatchClusters === 0,
+            value: formatCaptured(dispatchClusters),
+            zero: captureAvailable && dispatchClusters === 0,
           },
           {
             label: "Direct command cells",
-            value: (codeMode.directCommandCellCount ?? 0).toLocaleString(),
-            zero: (codeMode.directCommandCellCount ?? 0) === 0,
+            value: formatCaptured(codeMode.directCommandCellCount),
+            zero: captureAvailable && codeMode.directCommandCellCount === 0,
           },
           {
             label: "Patch cells",
-            value: (codeMode.patchCellCount ?? 0).toLocaleString(),
-            zero: (codeMode.patchCellCount ?? 0) === 0,
+            value: formatCaptured(codeMode.patchCellCount),
+            zero: captureAvailable && codeMode.patchCellCount === 0,
           },
           {
             label: "Other cells",
-            value: (codeMode.otherCellCount ?? 0).toLocaleString(),
-            zero: (codeMode.otherCellCount ?? 0) === 0,
+            value: formatCaptured(codeMode.otherCellCount),
+            zero: captureAvailable && codeMode.otherCellCount === 0,
           },
           {
             label: "Retrieval cells",
@@ -2347,8 +2357,8 @@ function TokenMiserCodeModeStats(props: {
           },
           {
             label: "Polling cells",
-            value: (codeMode.pollingCellCount ?? 0).toLocaleString(),
-            zero: (codeMode.pollingCellCount ?? 0) === 0,
+            value: formatCaptured(codeMode.pollingCellCount),
+            zero: captureAvailable && codeMode.pollingCellCount === 0,
           },
         ]}
       />

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ToolOutputIncidentExplorerWindow.test.tsx
@@ -161,6 +161,33 @@ describe("ToolOutputIncidentExplorerWindow", () => {
     expect(screen.queryByText(/gated \d+ of \d+ flagged/)).not.toBeInTheDocument();
   });
 
+  it("shows unavailable nested capture without implying zero commands", async () => {
+    const response = buildResponse();
+    response.toolAccounting!.tokenMiser = {
+      interceptionCount: 0, originalCharacters: 0, baselineParentTokens: 0,
+      replacementTokens: 0, retrievedTokens: 0, estimatedParentTokensSaved: 0,
+      interceptions: [], codeMode: {
+      callCount: 2, unclassifiedCellCount: 2, commandCellCount: null,
+      directCommandCellCount: null, dispatchClusterCount: null,
+      multiInvocationClusterCount: null, largestDispatchCluster: null,
+      nestedCommandInvocationCount: null, patchCellCount: null, otherCellCount: null,
+      pollingCellCount: null, directCount: 1, summarizedCount: 1, passThroughCount: 0,
+      retrievalCount: 0, capturedNestedInvocationCount: null, observations: [],
+      },
+    };
+    installApi({ readThread: async () => response });
+    window.location.hash = "#tool-output-incidents/codex/thread-1/Noisy%20work";
+    render(<ToolOutputIncidentExplorerWindow />);
+    await screen.findByRole("region", { name: "Code Mode" });
+    expect(savingsSection("Code Mode").getByRole("button"))
+      .toHaveTextContent(/Unavailable command cells.*Unavailable dispatch clusters/);
+    openSavingsSection("Code Mode");
+    expect(savingsSection("Code Mode").getByText("Other cells").nextSibling)
+      .toHaveTextContent("Unavailable");
+    expect(savingsSection("Code Mode").getByText(/2 cells have no nested tool capture/))
+      .toBeInTheDocument();
+  });
+
   it("makes ungated Code Mode calls a filter in the shared results list", async () => {
     const response = buildResponse();
     const observations = Array.from({ length: 2 }, (_, index) => ({

--- a/packages/shared/src/contracts/normalized-app-server.ts
+++ b/packages/shared/src/contracts/normalized-app-server.ts
@@ -1265,7 +1265,8 @@ export type ThreadTokenMiserCodeModeObservation = {
   scriptStatus: string;
   script?: string;
   retrieval: boolean;
-  capturedNestedInvocationCount: number;
+  /** Null means the runtime supplied no nested invocation capture. */
+  capturedNestedInvocationCount: number | null;
   capturedCommandInvocationCount?: number;
   capturedPollingInvocationCount?: number;
   capturedPatchInvocationCount?: number;
@@ -1274,21 +1275,24 @@ export type ThreadTokenMiserCodeModeObservation = {
 };
 
 export type ThreadTokenMiserCodeModeAccounting = {
+  /** Cells without nested capture; classification counts cover only captured cells. */
+  unclassifiedCellCount?: number;
   callCount: number;
-  commandCellCount: number;
-  directCommandCellCount: number;
-  dispatchClusterCount: number;
-  multiInvocationClusterCount: number;
-  largestDispatchCluster: number;
-  nestedCommandInvocationCount: number;
-  patchCellCount: number;
-  otherCellCount: number;
-  pollingCellCount: number;
+  commandCellCount: number | null;
+  directCommandCellCount: number | null;
+  dispatchClusterCount: number | null;
+  multiInvocationClusterCount: number | null;
+  largestDispatchCluster: number | null;
+  nestedCommandInvocationCount: number | null;
+  patchCellCount: number | null;
+  otherCellCount: number | null;
+  pollingCellCount: number | null;
   directCount: number;
   summarizedCount: number;
   passThroughCount: number;
   retrievalCount: number;
-  capturedNestedInvocationCount: number;
+  /** Null means the runtime supplied no nested invocation capture. */
+  capturedNestedInvocationCount: number | null;
   observations: ThreadTokenMiserCodeModeObservation[];
 };
 

--- a/packages/shared/src/contracts/thread-tools.ts
+++ b/packages/shared/src/contracts/thread-tools.ts
@@ -551,21 +551,22 @@ export type ThreadReadEvaluationPricing = {
 };
 
 export type ThreadReadEvaluationTokenMiserCodeMode = {
+  unclassifiedCellCount?: number;
   callCount: number;
-  commandCellCount: number;
-  directCommandCellCount: number;
-  dispatchClusterCount: number;
-  multiInvocationClusterCount: number;
-  largestDispatchCluster: number;
-  nestedCommandInvocationCount: number;
-  patchCellCount: number;
-  otherCellCount: number;
-  pollingCellCount: number;
+  commandCellCount: number | null;
+  directCommandCellCount: number | null;
+  dispatchClusterCount: number | null;
+  multiInvocationClusterCount: number | null;
+  largestDispatchCluster: number | null;
+  nestedCommandInvocationCount: number | null;
+  patchCellCount: number | null;
+  otherCellCount: number | null;
+  pollingCellCount: number | null;
   directCount: number;
   summarizedCount: number;
   passThroughCount: number;
   retrievalCount: number;
-  capturedNestedInvocationCount: number;
+  capturedNestedInvocationCount: number | null;
   observationCount: number;
 };
 


### PR DESCRIPTION
## Summary

Code Mode cells that retrieved a Token Miser result and emitted new command output previously bypassed evaluation for the entire cell. Match live, thread-owned retrieval deliveries in emitted content, preserve those bytes, and evaluate the remaining output. Account retrievals after replacement acceptance and respect the shared output limit, including repeated deliveries and retention checks.

Correct the helper policy that told Luna to summarize when intent was missing or uncertain. Source code, test source, diffs, and coherent requested file content now default to passthrough. Summarizing source requires affirmative evidence of a substantial miss or degenerate result, stated in the audit summary. Large ranges, absent narration, partial surrounding functions, and companion searches or diagnostics do not justify summarizing useful source. Remove the source command/narration shortcut so Luna can inspect the actual result for these exceptions; instruction-file passthrough remains.

Represent missing nested invocation capture as unavailable instead of reporting zero commands or classifying those cells as other tools. Historical zero-capture records are treated as unavailable, and partial capture is labeled in the accounting UI.

Mixed-output summaries and recovery references are placed first and bounded to the portion Codex retains at the beginning. If the recovery reference cannot fit, the original cell passes through. This prevents summaries inserted between large retrievals from disappearing under head/tail truncation.

## Verification

- 181 Token Miser tests passed across 12 files after the source-policy change.
- Earlier rebase validation also passed 156 tests including retention, backend integration, and incident explorer coverage.
- Regression coverage includes independently simulated head/tail truncation at 10k and 1k tokens, Unicode content, too-small-cap fallback, mixed cells, retrieval names in comments/strings, foreign or forged wrappers, helper failure/passthrough, rejected replacements, repeated delivery, UTF-8/output caps, and legacy capture records.
- Source-policy tests cover missing narration, results over 20,000 characters, mixed discovery/source, test source/diffs, and degenerate reads through both direct and Code Mode paths.
- Typecheck, ESLint, dependency boundaries, and git diff checks passed. Codex-storage lint passed for the runtime changes.

## Notes

PwrAgent-only runtime fix using the existing Codex reducer contract. No Codex update, new handshake, or execution ledger is required.

Source reads above the ordinary evaluation threshold now receive semantic evaluation instead of the former narrow deterministic shortcut. This can add helper calls; the policy tests validate instructions and decision handling with mocked helper responses, not live Luna adherence or realized savings. Those require observation after deployment.

