### PR TITLE
fix(tests): isolate native desktop runtime workers

### DIFF
--- a/apps/desktop/src/main/__tests__/standard-test-process-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/standard-test-process-budget.test.ts
@@ -1,13 +1,9 @@
 // Regression budget for standard Vitest worker-process churn.
 //
-// Vitest 4 defaults to the `forks` pool. In this workspace that produced one
-// fresh Node OS process per test file: 356 fork-worker execs for desktop-main
-// alone. Ten concurrent worktrees therefore multiply ordinary test discovery
-// into thousands of executable provenance events on macOS.
-//
-// `threads` keeps Vitest's default file isolation but does not exec an OS
-// process for each file. Keep the budget explicit so a pool default change or
-// a newly added project cannot quietly restore per-file process scaling.
+// The desktop main suite loads native runtime bindings. Vitest documents that
+// native modules can segfault in the worker-thread pool, so that project owns
+// its bindings in forked OS processes. The pure projects retain `threads` to
+// avoid expanding normal test discovery into per-file process churn.
 import { describe, expect, it } from "vitest";
 import workspaceConfig from "../../../../../vitest.workspace";
 
@@ -17,13 +13,18 @@ const EXPECTED_PROJECTS = [
   "messaging",
   "shared",
 ];
-const OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE = 0;
 const EXPECTED_POOLS = {
-  "desktop-main": process.platform === "win32" ? "forks" : "threads",
+  "desktop-main": "forks",
   "desktop-renderer": "threads",
   messaging: "threads",
   shared: "threads",
 } as const;
+const EXPECTED_OS_WORKER_PROCESSES_PER_TEST_FILE = [
+  { name: "desktop-main", osWorkerProcessesPerTestFile: 1 },
+  { name: "desktop-renderer", osWorkerProcessesPerTestFile: 0 },
+  { name: "messaging", osWorkerProcessesPerTestFile: 0 },
+  { name: "shared", osWorkerProcessesPerTestFile: 0 },
+];
 
 type ConfiguredProject = {
   test?: {
@@ -33,7 +34,7 @@ type ConfiguredProject = {
 };
 
 describe("standard test process budget", () => {
-  it("keeps every project on its production-equivalent worker pool", () => {
+  it("keeps native desktop-main in process-isolated workers", () => {
     const projects = configuredProjects();
 
     expect(projects.map((project) => project.test?.name).sort()).toEqual(
@@ -48,7 +49,7 @@ describe("standard test process budget", () => {
   });
 
   it.runIf(process.platform !== "win32")(
-    "keeps the POSIX OS worker process budget at zero per test file",
+    "keeps the POSIX OS worker process budget explicit per test file",
     () => {
       const projects = configuredProjects();
 
@@ -58,13 +59,7 @@ describe("standard test process budget", () => {
           osWorkerProcessesPerTestFile:
             project.test?.pool === "threads" ? 0 : 1,
         })),
-      ).toEqual(
-        EXPECTED_PROJECTS.map((name) => ({
-          name,
-          osWorkerProcessesPerTestFile:
-            OS_WORKER_PROCESS_BUDGET_PER_TEST_FILE,
-        })),
-      );
+      ).toEqual(EXPECTED_OS_WORKER_PROCESSES_PER_TEST_FILE);
     },
   );
 });

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -8,11 +8,14 @@ import { defineConfig } from "vitest/config";
 const TEST_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 5_000;
 const HOOK_TIMEOUT_MS = process.platform === "win32" ? 30_000 : 10_000;
 
-// A Windows worker thread's process.env is case-sensitive, unlike the real
-// Electron main process and a forked Node process on Windows. Keep desktop-main
-// on forks there so PATH/Path behavior remains production-equivalent. POSIX
-// uses threads to avoid one OS process exec per test file.
-const DESKTOP_MAIN_POOL = process.platform === "win32" ? "forks" : "threads";
+// desktop-main loads native runtime bindings (better-sqlite3,
+// @napi-rs/canvas, and node-pty). A worker thread lets their native teardown
+// share a process with other test files and Vitest itself; on macOS that can
+// crash the entire test host after every assertion has passed. Forks preserve
+// parallel test execution while giving each binding an OS-process ownership
+// boundary. They are also required on Windows, where a worker thread's
+// process.env is case-sensitive unlike the real Electron main process.
+const DESKTOP_MAIN_POOL = "forks";
 
 // Where the desktop suites resolve the PwrAgent root to. `resolvePwragentRoot`
 // falls back to `~/.pwragent` — the operator's live application state — and


### PR DESCRIPTION
## Summary

- I isolate `desktop-main` Vitest workers in forked OS processes so native runtime teardown cannot crash the shared macOS test host.
- I keep the threaded pool for the pure projects and record the desktop-main process-ownership budget.

## Verification

- I ran `PWRAGENT_REQUIRE_ACTOOL=1 pnpm test` on macOS ARM64: 702 files passed; 10,373 tests passed and 6 skipped.
- I ran `pnpm typecheck`.
- I ran `pnpm lint:eslint`.

## Notes

- This addresses release run 34043966978, which ended with `Segmentation fault: 11` immediately after a passing `desktop-main` suite.
