### PR TITLE
fix(desktop): correct transcript message timestamps

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3653,6 +3653,67 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it.each(["inProgress", "completed"])("does not stamp a long %s turn's commentary and work with its start time", async (status) => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-long-turn", {
+      thread: {
+        turns: [{
+          id: "long-turn",
+          status,
+          startedAt: 1_763_500_100,
+          ...(status === "completed" ? { completedAt: 1_763_510_900 } : {}),
+          items: [
+            { type: "userMessage", id: "prompt", content: [{ type: "text", text: "Keep working." }] },
+            { type: "agentMessage", id: "early", phase: "commentary", text: "Starting." },
+            { type: "commandExecution", id: "work", command: "pnpm test", status: "completed" },
+            { type: "agentMessage", id: "late", phase: "commentary", text: "Three hours later." },
+            { type: "plan", id: "plan", plan: [{ step: "Verify", status: "inProgress" }] },
+          ],
+        }],
+      },
+    });
+    const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
+    try {
+      const replay = await client.readThread({ threadId: "thread-long-turn" });
+      expect(replay.entries.map((entry) => entry.id)).toEqual(["prompt", "early", "activity-work", "late", "plan"]);
+      expect(replay.entries[0]?.createdAt).toBe(1_763_500_100_000);
+      for (const entry of replay.entries.slice(1)) {
+        expect(entry.createdAt).toBeUndefined();
+        expect(entry.turn?.startedAt).toBe(1_763_500_100_000);
+      }
+      expect(replay.messages.slice(1).map((message) => message.createdAt)).toEqual([undefined, undefined]);
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("keeps individual replay item times for commentary, work, and plans", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-item-times", {
+      thread: {
+        turns: [{
+          id: "timed-turn",
+          startedAt: 1_763_500_100,
+          items: [
+            { type: "agentMessage", id: "early", phase: "commentary", text: "Starting.", createdAt: 1_763_500_200 },
+            { type: "commandExecution", id: "work", command: "pnpm test", status: "completed", created_at: 1_763_500_300 },
+            { type: "agentMessage", id: "late", phase: "commentary", text: "Later.", timestamp: 1_763_510_800_000 },
+            { type: "plan", id: "plan", plan: [{ step: "Verify", status: "inProgress" }], createdAt: 1_763_510_900 },
+          ],
+        }],
+      },
+    });
+    const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
+    try {
+      const replay = await client.readThread({ threadId: "thread-item-times" });
+      expect(replay.entries.map((entry) => entry.createdAt)).toEqual([
+        1_763_500_200_000, 1_763_500_300_000, 1_763_510_800_000, 1_763_510_900_000,
+      ]);
+    } finally {
+      await client.close();
+    }
+  });
+
   it("uses turn completion time for final assistant entries without item timestamps", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-final-completed-at", {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3487,7 +3487,7 @@ describe("CodexAppServerClient", () => {
           id: "item-2",
           role: "assistant",
           text: "I’m tracing the transcript scroll container.",
-          createdAt: 1_763_500_100_000,
+          createdAt: undefined,
           phase: "commentary",
           turn
         },
@@ -3495,7 +3495,7 @@ describe("CodexAppServerClient", () => {
           type: "activity",
           id: "activity-item-3",
           summary: "Explored 1 file, Ran 1 command, Edited 1 file, +2, -1",
-          createdAt: 1_763_500_100_000,
+          createdAt: undefined,
           status: "completed",
           turn,
           details: [
@@ -3544,7 +3544,7 @@ describe("CodexAppServerClient", () => {
           id: "item-6",
           role: "assistant",
           text: "The desktop shell is live and listing Codex threads.",
-          createdAt: 1_763_500_100_000,
+          createdAt: undefined,
           phase: "final",
           turn
         }
@@ -3566,13 +3566,13 @@ describe("CodexAppServerClient", () => {
           id: "item-2",
           role: "assistant",
           text: "I’m tracing the transcript scroll container.",
-          createdAt: 1_763_500_100_000
+          createdAt: undefined
         },
         {
           id: "item-6",
           role: "assistant",
           text: "The desktop shell is live and listing Codex threads.",
-          createdAt: 1_763_500_100_000
+          createdAt: undefined
         }
       ],
       lastUserMessage: "Show me the current desktop thread shell",
@@ -3667,7 +3667,7 @@ describe("CodexAppServerClient", () => {
             { type: "agentMessage", id: "early", phase: "commentary", text: "Starting." },
             { type: "commandExecution", id: "work", command: "pnpm test", status: "completed" },
             { type: "agentMessage", id: "late", phase: "commentary", text: "Three hours later." },
-            { type: "plan", id: "plan", plan: [{ step: "Verify", status: "inProgress" }] },
+            { type: "plan", plan: [{ step: "Verify", status: "inProgress" }] },
           ],
         }],
       },
@@ -3675,7 +3675,7 @@ describe("CodexAppServerClient", () => {
     const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
     try {
       const replay = await client.readThread({ threadId: "thread-long-turn" });
-      expect(replay.entries.map((entry) => entry.id)).toEqual(["prompt", "early", "activity-work", "late", "plan"]);
+      expect(replay.entries.map((entry) => entry.id)).toEqual(["prompt", "early", "activity-work", "late", "plan-1763500100000"]);
       expect(replay.entries[0]?.createdAt).toBe(1_763_500_100_000);
       for (const entry of replay.entries.slice(1)) {
         expect(entry.createdAt).toBeUndefined();
@@ -3818,7 +3818,7 @@ describe("CodexAppServerClient", () => {
         id: "new-final-answer",
         role: "assistant",
         text: "Same final answer.",
-        createdAt: 1_781_112_452_000,
+        createdAt: undefined,
       }),
     ]);
     expect(replay.messages.at(-1)).toEqual(
@@ -3826,7 +3826,7 @@ describe("CodexAppServerClient", () => {
         id: "new-final-answer",
         role: "assistant",
         text: "Same final answer.",
-        createdAt: 1_781_112_452_000,
+        createdAt: undefined,
       }),
     );
     expect(replay.lastAssistantMessage).toBe("Same final answer.");
@@ -3937,7 +3937,7 @@ describe("CodexAppServerClient", () => {
         type: "activity",
         id: "activity-item-file-change",
         summary: "Edited 6 files, +9, -5",
-        createdAt: 1_763_500_100_000,
+        createdAt: undefined,
         status: "completed",
         turn: {
           id: "turn-file-change-counts",
@@ -4115,7 +4115,7 @@ describe("CodexAppServerClient", () => {
         type: "activity",
         id: "activity-item-metadata-patches",
         summary: "Edited 2 files, +2, -2",
-        createdAt: 1_763_500_150_000,
+        createdAt: undefined,
         status: "completed",
         turn: {
           id: "turn-metadata-patches",
@@ -6135,7 +6135,7 @@ describe("CodexAppServerClient", () => {
       {
         type: "plan",
         id: "plan-1",
-        createdAt: 1_763_500_200_000,
+        createdAt: undefined,
         explanation: "Keep the transcript contract stable.",
         markdown: "## Final plan\n\nShip the transcript renderer in small steps.",
         steps: [
@@ -6583,7 +6583,7 @@ describe("CodexAppServerClient", () => {
         type: "activity",
         id: "activity-tool-1",
         summary: "Used 2 tools",
-        createdAt: 1_763_500_210_000,
+        createdAt: undefined,
         status: "in_progress",
         turn: {
           id: "turn-tools",
@@ -6907,7 +6907,7 @@ describe("CodexAppServerClient", () => {
         id: "message-1",
         role: "assistant",
         text: "I am checking CI.",
-        createdAt: 1_763_500_220_000,
+        createdAt: undefined,
         parts: [{ type: "text", text: "I am checking CI." }],
         phase: "commentary",
         turn: {
@@ -6921,7 +6921,7 @@ describe("CodexAppServerClient", () => {
         type: "activity",
         id: "activity-call-1",
         summary: "Used 2 tools",
-        createdAt: 1_763_500_220_000,
+        createdAt: undefined,
         details: [
           {
             id: "call-1",
@@ -6956,7 +6956,7 @@ describe("CodexAppServerClient", () => {
         id: "message-2",
         role: "assistant",
         text: "CI is green.",
-        createdAt: 1_763_500_220_000,
+        createdAt: undefined,
         parts: [{ type: "text", text: "CI is green." }],
         turn: {
           id: "turn-tools",
@@ -7053,7 +7053,7 @@ describe("CodexAppServerClient", () => {
         id: "message-1",
         role: "assistant",
         text: "Review team:",
-        createdAt: 1_763_500_260_000,
+        createdAt: undefined,
         parts: [{ type: "text", text: "Review team:" }],
         turn: {
           id: "turn-review",
@@ -7066,7 +7066,7 @@ describe("CodexAppServerClient", () => {
         type: "activity",
         id: "activity-collab-spawn-1",
         summary: "Spawned 1 agent, Waited on 1 agent, 1 collaboration tool failed",
-        createdAt: 1_763_500_260_000,
+        createdAt: undefined,
         status: "failed",
         details: [
           expect.objectContaining({
@@ -7785,7 +7785,7 @@ describe("CodexAppServerClient", () => {
       {
         type: "plan",
         id: "item-2",
-        createdAt: 1_763_500_300_000,
+        createdAt: undefined,
         explanation: "Track the desktop work in three steps.",
         steps: [
           { step: "Normalize replay", status: "pending" },
@@ -7866,7 +7866,7 @@ describe("CodexAppServerClient", () => {
       {
         type: "plan",
         id: "item-2",
-        createdAt: 1_763_500_350_000,
+        createdAt: undefined,
         explanation: "Verify the renderer path before changing it.",
         steps: [
           { step: "Read the replay normalizer", status: "completed" },

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2864,7 +2864,7 @@ function extractPlanEntryFromItem(
   const itemType = pickString(item, ["type"]);
   const normalizedItemType = itemType?.trim().toLowerCase();
   const itemId =
-    pickString(item, ["id", "itemId", "item_id", "call_id"]) ?? `plan-${createdAt ?? 0}`;
+    pickString(item, ["id", "itemId", "item_id", "call_id"]) ?? `plan-${createdAt ?? turn?.startedAt ?? 0}`;
   const nestedPlanEntry = extractNestedPlanEntryFromItem(item, createdAt, turn);
   if (nestedPlanEntry) {
     return nestedPlanEntry;
@@ -4268,13 +4268,13 @@ function attachCustomToolOutputImagesToTurn(params: {
   });
 }
 
-function mergeEntryImagePartsIntoReplayMessages(
+function mergeEntryMetadataIntoReplayMessages(
   messages: AppServerThreadReplay["messages"],
   entries: AppServerThreadEntry[],
 ): AppServerThreadReplay["messages"] {
   const entriesById = new Map(
     entries.flatMap((entry) =>
-      entry.type === "message" && entry.parts?.some((part) => part.type === "image")
+      entry.type === "message"
         ? [[entry.id, entry] as const]
         : [],
     ),
@@ -4289,7 +4289,7 @@ function mergeEntryImagePartsIntoReplayMessages(
     const imageParts = entry.parts?.filter(
       (part): part is AppServerThreadImagePart => part.type === "image",
     ) ?? [];
-    return appendImagePartsToMessage(message, imageParts);
+    return appendImagePartsToMessage({ ...message, createdAt: entry.createdAt }, imageParts);
   });
 }
 
@@ -5116,14 +5116,16 @@ function extractThreadEntries(
       suppressedAssistantTexts.add(normalizeSuppressionText(text));
     }
     const pendingActivityItems: Record<string, unknown>[] = [];
+    let pendingActivityCreatedAt: number | undefined;
 
     const flushActivityItems = (): void => {
       const activity = summarizeActivityItems(
         pendingActivityItems,
-        createdAt,
+        pendingActivityCreatedAt,
         turnMetadata
       );
       pendingActivityItems.length = 0;
+      pendingActivityCreatedAt = undefined;
       if (activity) {
         entries.push(activity);
       }
@@ -5143,12 +5145,14 @@ function extractThreadEntries(
           continue;
         }
         const phase = normalizeAgentMessagePhase(pickString(item, ["phase"]));
+        // Turn start is a prompt boundary, not the send time of every
+        // assistant message in a potentially hours-long turn. Leave unknown
+        // item times absent; the renderer can retain times observed live.
         const messageCreatedAt =
           itemCreatedAt ??
-          (role === "assistant" && phase === "final"
-            ? turnMetadata?.completedAt
-            : undefined) ??
-          createdAt;
+          (role === "assistant"
+            ? phase === "final" ? turnMetadata?.completedAt : undefined
+            : createdAt);
         entries.push({
           type: "message",
           id:
@@ -5164,7 +5168,7 @@ function extractThreadEntries(
         continue;
       }
 
-      const planEntry = extractPlanEntryFromItem(item, createdAt, turnMetadata);
+      const planEntry = extractPlanEntryFromItem(item, itemCreatedAt, turnMetadata);
       if (planEntry) {
         flushActivityItems();
         entries.push(planEntry);
@@ -5216,6 +5220,9 @@ function extractThreadEntries(
 
       const activityItem = extractActivityItemFromReplayItem(item);
       if (activityItem) {
+        if (pendingActivityItems.length === 0) {
+          pendingActivityCreatedAt = itemCreatedAt;
+        }
         pendingActivityItems.push(activityItem);
         continue;
       }
@@ -5267,7 +5274,7 @@ export function extractThreadReplayFromReadResult(
   options: { threadId?: string } = {}
 ): AppServerThreadReplay {
   const entries = extractThreadEntries(value, options);
-  const messages = mergeEntryImagePartsIntoReplayMessages(
+  const messages = mergeEntryMetadataIntoReplayMessages(
     extractConversationMessages(value),
     entries,
   );

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -354,6 +354,7 @@ describe("useThreadSessionState", () => {
       .mockResolvedValueOnce(readThreadResponse({ entries, hasPreviousPage: false }))
       .mockResolvedValueOnce(readThreadResponse({
         entries: entries.map(({ createdAt: _createdAt, ...entry }) => entry),
+        fetchedAt: 2_000,
         hasPreviousPage: false,
       }));
     const desktopApi: DesktopApi = { onAgentEvent: () => () => undefined, readThread };
@@ -368,6 +369,7 @@ describe("useThreadSessionState", () => {
     rerender({ updatedAt: 2_000 });
     await waitFor(() => expect(readThread).toHaveBeenCalledTimes(2));
     await waitFor(() => {
+      expect(result.current.response?.fetchedAt).toBe(2_000);
       expect(result.current.entries.map((entry) => entry.createdAt)).toEqual([1_000, 10_801_000]);
       expect(result.current.response?.replay.messages.map((message) => message.createdAt)).toEqual([1_000, 10_801_000]);
     });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadSessionState.test.tsx
@@ -345,6 +345,34 @@ describe("useThreadSessionState", () => {
     });
   });
 
+  it("preserves known message times in both transcript views after an untimed refresh", async () => {
+    const entries = [
+      messageEntry({ id: "early", text: "Starting.", createdAt: 1_000 }),
+      messageEntry({ id: "late", text: "Three hours later.", createdAt: 10_801_000 }),
+    ];
+    const readThread = vi.fn()
+      .mockResolvedValueOnce(readThreadResponse({ entries, hasPreviousPage: false }))
+      .mockResolvedValueOnce(readThreadResponse({
+        entries: entries.map(({ createdAt: _createdAt, ...entry }) => entry),
+        hasPreviousPage: false,
+      }));
+    const desktopApi: DesktopApi = { onAgentEvent: () => () => undefined, readThread };
+    const { result, rerender } = renderHook(
+      ({ updatedAt }: { updatedAt: number }) => useThreadSessionState({
+        desktopApi,
+        thread: buildThread({ id: "thread-1", updatedAt }),
+      }),
+      { initialProps: { updatedAt: 1_000 } },
+    );
+    await waitForThreadHydration(result);
+    rerender({ updatedAt: 2_000 });
+    await waitFor(() => expect(readThread).toHaveBeenCalledTimes(2));
+    await waitFor(() => {
+      expect(result.current.entries.map((entry) => entry.createdAt)).toEqual([1_000, 10_801_000]);
+      expect(result.current.response?.replay.messages.map((message) => message.createdAt)).toEqual([1_000, 10_801_000]);
+    });
+  });
+
   it("preserves loaded older transcript pages across limited refreshes", async () => {
     const initialTail = readThreadResponse({
       entries: [

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -1963,22 +1963,27 @@ function carryForwardTranscriptEntryOrder(
     entries = reorderedEntries;
   }
 
-  const originsByMessageId = new Map(
+  const entriesByMessageId = new Map(
     entries
       .filter(
-        (entry): entry is AppServerThreadMessageEntry =>
-          entry.type === "message" && Boolean(entry.origin)
+        (entry): entry is AppServerThreadMessageEntry => entry.type === "message"
       )
-      .map((entry) => [entry.id, entry.origin] as const)
+      .map((entry) => [entry.id, entry] as const)
   );
   const messages = response.replay.messages.map((message) => {
-    const origin = originsByMessageId.get(message.id);
-    if (!origin || message.origin) {
+    const entry = entriesByMessageId.get(message.id);
+    const origin = !message.origin ? entry?.origin : undefined;
+    const createdAt = entry?.createdAt;
+    if (!origin && (createdAt === undefined || createdAt === message.createdAt)) {
       return message;
     }
 
     changed = true;
-    return { ...message, origin };
+    return {
+      ...message,
+      ...(origin ? { origin } : {}),
+      ...(createdAt !== undefined ? { createdAt } : {}),
+    };
   });
 
   const freshCurrentTurnId = latestTranscriptTurnId(response.replay.entries);


### PR DESCRIPTION
## Summary

- I fixed Codex replay timestamps that made hours of assistant commentary and tool activity appear to have happened at the turn's start. The reported thread's commentary all carried 2:32:56 PM, exactly matching its turn start.
- I now use individual item timestamps for commentary, activity groups, and plans, and leave unavailable times blank. I retain the existing prompt-start and final-answer-completion fallbacks, and preserve generated plan IDs.
- I keep the replay message list consistent with transcript entries, including timestamps retained across a renderer refresh.

## Verification

- I reproduced four failing regression cases before the fixes: running and completed long turns, timestamped activity/plan items, and message-list timestamps lost after refresh.
- I passed all 335 tests across the Codex client, normalizer parity, and thread session state suites.
- I passed ESLint (zero errors), workspace typecheck, dependency boundaries, Codex storage boundaries, SQL and color lint, Electron version policy, and license checks.

## Notes

- I cannot reconstruct historical item times that Codex does not supply. Those labels are now blank instead of displaying a false send time; timestamps observed live remain available while retained by the renderer.
- I made no changes to Codex-owned storage and added no persistence.
