### PR TITLE
fix(desktop): retain CPU profiles before hot triggers

### DIFF
--- a/apps/desktop/src/main/__tests__/cpu-profile-history.test.ts
+++ b/apps/desktop/src/main/__tests__/cpu-profile-history.test.ts
@@ -27,22 +27,73 @@ describe("joinCpuProfiles", () => {
     expect(nodes.size).toBe(merged.nodes.length);
     expect(merged.nodes.filter((node) => node.callFrame.functionName === "(root)")).toHaveLength(1);
     expect(merged.samples?.map((id) => nodes.get(id)?.callFrame.functionName)).toEqual([
-      "beforeRotation", "beforeRotation", "afterRotation", "afterRotation",
+      "beforeRotation", "beforeRotation", "(root)", "afterRotation", "afterRotation",
     ]);
     expect(merged.nodes[0].children).toEqual([2, 3]);
-    expect(merged.timeDeltas).toEqual([10, 10, 10, 10]);
+    expect(merged.timeDeltas).toEqual([10, 10, 0, 10, 10]);
     expect(merged.startTime).toBe(100);
     expect(merged.endTime).toBe(140);
     expect(second.samples).toEqual([2, 2]);
   });
 
-  it("marks a stop/start gap instead of charging it to the following function", () => {
-    const merged = joinCpuProfiles([window(100, "before"), window(150, "after")]);
+  it.each([120, 125])("brackets the gap when the preceding recording stops at %s", (endTime) => {
+    const before = window(100, "before");
+    before.endTime = endTime;
+    const merged = joinCpuProfiles([before, window(150, "after")]);
     const names = new Map(merged.nodes.map((node) => [node.id, node.callFrame.functionName]));
-    expect(merged.samples?.map((id) => names.get(id))).toEqual([
-      "before", "before", "(unrecorded)", "after", "after",
+    let timestamp = merged.startTime;
+    const timestamps = merged.timeDeltas!.map((delta) => timestamp += delta);
+    // DevTools renders a sample until the next reconstructed timestamp.
+    const frames = merged.samples!.slice(0, -1).map((id, index) => ({
+      name: names.get(id),
+      start: timestamps[index],
+      end: timestamps[index + 1],
+    }));
+    expect(frames).toEqual([
+      { name: "before", start: 110, end: 120 },
+      { name: "before", start: 120, end: endTime },
+      { name: "(unrecorded)", start: endTime, end: 150 },
+      { name: "(root)", start: 150, end: 160 },
+      { name: "after", start: 160, end: 170 },
     ]);
-    expect(merged.timeDeltas).toEqual([10, 10, 30, 10, 10]);
-    expect(merged.timeDeltas?.reduce((sum, delta) => sum + delta, 0)).toBe(70);
+    expect(merged.timeDeltas).toEqual([10, 10, endTime - 120, 150 - endTime, 10, 10]);
+  });
+
+  it("shares each V8 meta node and its samples across windows without duplicating root edges", () => {
+    function withMetaNodes(start: number, name: string): Profiler.Profile {
+      const profile = window(start, name);
+      for (const [index, functionName] of ["(garbage collector)", "(idle)", "(program)"].entries()) {
+        const id = index + 3;
+        profile.nodes.push({
+          id,
+          callFrame: { ...profile.nodes[0].callFrame, functionName },
+          hitCount: 1,
+        });
+        profile.nodes[0].children!.push(id);
+      }
+      profile.samples = [2, 3, 2, 4, 5];
+      profile.timeDeltas = [2, 2, 2, 2, 2];
+      return profile;
+    }
+    const first = withMetaNodes(100, "firstStack");
+    const second = withMetaNodes(150, "secondStack");
+    const original = structuredClone([first, second]);
+    const merged = joinCpuProfiles([first, second]);
+    for (const name of ["(garbage collector)", "(idle)", "(program)"]) {
+      const meta = merged.nodes.filter((node) => node.callFrame.functionName === name);
+      expect(meta).toHaveLength(1);
+      expect(meta[0].hitCount).toBe(2);
+      expect(merged.nodes[0].children!.filter((id) => id === meta[0].id)).toHaveLength(1);
+      expect(merged.samples!.filter((id) => id === meta[0].id)).toHaveLength(2);
+    }
+    // DevTools selects one GC id. Both collections must be recognized as GC
+    // while preserving their distinct interrupted JavaScript stacks.
+    const gcId = merged.nodes.find((node) => node.callFrame.functionName === "(garbage collector)")!.id;
+    const names = new Map(merged.nodes.map((node) => [node.id, node.callFrame.functionName]));
+    const interrupted = merged.samples!.flatMap((id, index) =>
+      id === gcId ? [names.get(merged.samples![index - 1])] : [],
+    );
+    expect(interrupted).toEqual(["firstStack", "secondStack"]);
+    expect([first, second]).toEqual(original);
   });
 });

--- a/apps/desktop/src/main/__tests__/cpu-profile-history.test.ts
+++ b/apps/desktop/src/main/__tests__/cpu-profile-history.test.ts
@@ -1,0 +1,48 @@
+import type { Profiler } from "node:inspector";
+import { describe, expect, it } from "vitest";
+import { joinCpuProfiles } from "../diagnostics/cpu-profile-history";
+
+function window(startTime: number, name: string): Profiler.Profile {
+  const callFrame = {
+    functionName: "(root)", scriptId: "0", url: "", lineNumber: -1, columnNumber: -1,
+  };
+  return {
+    startTime,
+    endTime: startTime + 20,
+    nodes: [
+      { id: 1, callFrame, children: [2] },
+      { id: 2, callFrame: { ...callFrame, functionName: name }, hitCount: 2 },
+    ],
+    samples: [2, 2],
+    timeDeltas: [10, 10],
+  };
+}
+
+describe("joinCpuProfiles", () => {
+  it("preserves frames from both sides of a rotation with one root and distinct ids", () => {
+    const first = window(100, "beforeRotation");
+    const second = window(120, "afterRotation");
+    const merged = joinCpuProfiles([first, second]);
+    const nodes = new Map(merged.nodes.map((node) => [node.id, node]));
+    expect(nodes.size).toBe(merged.nodes.length);
+    expect(merged.nodes.filter((node) => node.callFrame.functionName === "(root)")).toHaveLength(1);
+    expect(merged.samples?.map((id) => nodes.get(id)?.callFrame.functionName)).toEqual([
+      "beforeRotation", "beforeRotation", "afterRotation", "afterRotation",
+    ]);
+    expect(merged.nodes[0].children).toEqual([2, 3]);
+    expect(merged.timeDeltas).toEqual([10, 10, 10, 10]);
+    expect(merged.startTime).toBe(100);
+    expect(merged.endTime).toBe(140);
+    expect(second.samples).toEqual([2, 2]);
+  });
+
+  it("marks a stop/start gap instead of charging it to the following function", () => {
+    const merged = joinCpuProfiles([window(100, "before"), window(150, "after")]);
+    const names = new Map(merged.nodes.map((node) => [node.id, node.callFrame.functionName]));
+    expect(merged.samples?.map((id) => names.get(id))).toEqual([
+      "before", "before", "(unrecorded)", "after", "after",
+    ]);
+    expect(merged.timeDeltas).toEqual([10, 10, 30, 10, 10]);
+    expect(merged.timeDeltas?.reduce((sum, delta) => sum + delta, 0)).toBe(70);
+  });
+});

--- a/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-hot-cpu-profiler.test.ts
@@ -5,6 +5,7 @@ import type { ProcessMetric } from "electron";
 import { resolveHotCpuProfileConfig } from "../diagnostics/hot-cpu-profile-config";
 import { createHotCpuProfileSession } from "../diagnostics/hot-cpu-profile-session";
 import { HotCpuProfiler } from "../diagnostics/hot-cpu-profiler";
+import { createMainProcessHotCpuTarget } from "../diagnostics/main-process-hot-cpu-target";
 
 function createEnabledConfig(
   repoRoot: string,
@@ -65,7 +66,7 @@ function createTarget() {
       attached = false;
     }),
     isAttached: vi.fn(() => attached),
-    sendCommand: vi.fn(async (method: string) => {
+    sendCommand: vi.fn(async (method: string): Promise<unknown> => {
       if (method === "Profiler.stop") {
         return {
           profile: {
@@ -229,6 +230,175 @@ describe("HotCpuProfiler", () => {
     }
   });
 
+  it("captures a real main-thread burst that finishes before the trigger is evaluated", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_START_DELAY_MS: "0",
+      PWRAGENT_HOT_CPU_PROFILING_TRIGGER_MODE: "spike",
+      PWRAGENT_HOT_CPU_PROFILING_MAX_PROFILES: "1",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      target: "main",
+      versions: { appVersion: "test", electronVersion: "test", chromeVersion: "test", nodeVersion: process.versions.node },
+    });
+    if (!sessionResult.ok) throw new Error(sessionResult.message);
+    const written = deferred();
+    let burstFinished = false;
+    const profiler = createProfiler({
+      config,
+      session: sessionResult.session,
+      target: createMainProcessHotCpuTarget(),
+      getAppMetrics: () => [{
+        ...createMetric(burstFinished ? 90 : 0),
+        pid: process.pid,
+        cpu: { percentCPUUsage: burstFinished ? 90 : 0, idleWakeupsPerSecond: 0 },
+      } as ProcessMetric],
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      onProfileWritten: async () => { written.resolve(); },
+    });
+    await profiler.start();
+    await samplesOf(profiler).waitForCount(1);
+    // The inspector samples this synchronous function, but the timer cannot
+    // evaluate the CPU trigger until the function has returned.
+    function preTriggerCpuBurst(): void {
+      const end = performance.now() + 150;
+      while (performance.now() < end) Math.sqrt(Math.random());
+    }
+    preTriggerCpuBurst();
+    burstFinished = true;
+    await written.promise;
+    await profiler.stop();
+    const profile = JSON.parse(await fs.readFile(sessionResult.session.createProfilePath(1), "utf8"));
+    const burstIds = new Set(profile.nodes
+      .filter((node: { callFrame: { functionName: string } }) => node.callFrame.functionName === "preTriggerCpuBurst")
+      .map((node: { id: number }) => node.id));
+    expect(burstIds.size).toBeGreaterThan(0);
+    expect(profile.samples.some((id: number) => burstIds.has(id))).toBe(true);
+  });
+
+  it.each([false, true])("bounds history across rotations and capture limits (missing metrics: %s)", async (missingMetrics) => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const config = createEnabledConfig(workspace.path, {
+      PWRAGENT_HOT_CPU_PROFILING_START_DELAY_MS: "0",
+      PWRAGENT_HOT_CPU_PROFILING_INTERVAL_MS: "30000",
+      PWRAGENT_HOT_CPU_PROFILING_TRIGGER_MODE: "spike",
+      PWRAGENT_HOT_CPU_PROFILING_MAX_PROFILES: "1",
+    });
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      versions: { appVersion: "test", electronVersion: "test", chromeVersion: "test", nodeVersion: "test" },
+    });
+    if (!sessionResult.ok) throw new Error(sessionResult.message);
+    vi.useFakeTimers();
+    const { target, debuggerApi } = createTarget();
+    let recordingStart = 0;
+    let windowIndex = 0;
+    const frame = { functionName: "(root)", scriptId: "0", url: "", lineNumber: -1, columnNumber: -1 };
+    debuggerApi.sendCommand.mockImplementation(async (method: string) => {
+      if (method === "Profiler.start") recordingStart = Date.now() * 1_000;
+      if (method !== "Profiler.stop") return {};
+      const endTime = Date.now() * 1_000;
+      const name = ["expiredHistory", "burstBeforeRotation", "burstAfterRotation"][windowIndex++];
+      return { profile: {
+        nodes: [
+          { id: 1, callFrame: frame, children: [2] },
+          { id: 2, callFrame: { ...frame, functionName: name } },
+        ],
+        startTime: recordingStart,
+        endTime,
+        samples: [2],
+        timeDeltas: [endTime - recordingStart],
+      } };
+    });
+    let hot = false;
+    const written = deferred();
+    const profiler = createProfiler({
+      config,
+      session: sessionResult.session,
+      target,
+      getAppMetrics: () => missingMetrics && !hot ? [] : [{
+        ...createMetric(0),
+        cpu: { percentCPUUsage: hot ? 80 : 0, idleWakeupsPerSecond: 0 },
+      } as ProcessMetric],
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      onProfileWritten: async () => { written.resolve(); },
+    });
+    await profiler.start();
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.start");
+    await vi.advanceTimersByTimeAsync(0);
+    await samplesOf(profiler).waitForCount(1);
+    for (let count = 2; count <= 3; count += 1) {
+      await vi.advanceTimersByTimeAsync(config.intervalMs);
+      await samplesOf(profiler).waitForCount(count);
+    }
+    expect(windowIndex).toBe(2);
+    expect(await fs.readdir(sessionResult.session.directoryPath)).not.toContain("renderer-hot-0001.cpuprofile");
+    hot = true;
+    await vi.advanceTimersByTimeAsync(config.intervalMs);
+    await samplesOf(profiler).waitForCount(4);
+    // Detection happens before rotation: the still-running window is frozen
+    // for the post-trigger duration, not discarded at the boundary.
+    expect(windowIndex).toBe(2);
+    await vi.advanceTimersByTimeAsync(config.profileDurationMs);
+    await written.promise;
+    await profiler.stop();
+    const profile = JSON.parse(await fs.readFile(sessionResult.session.createProfilePath(1), "utf8"));
+    const names = profile.nodes.map((node: { callFrame: { functionName: string } }) => node.callFrame.functionName);
+    expect(names).toContain("burstBeforeRotation");
+    expect(names).toContain("burstAfterRotation");
+    expect(names).not.toContain("expiredHistory");
+    expect(profile.endTime - profile.startTime).toBe(60_010_000);
+    expect(debuggerApi.sendCommand.mock.calls.filter(([method]) => method === "Profiler.start")).toHaveLength(3);
+    expect(debuggerApi.sendCommand.mock.calls.filter(([method]) => method === "Profiler.stop")).toHaveLength(3);
+    expect(target.debugger.isAttached()).toBe(false);
+  });
+
+  it("discards an untriggered recorder and waits for an in-flight start during shutdown", async () => {
+    const workspace = await createTemporaryTestDirectory();
+    cleanups.push(workspace.cleanup);
+    const config = createEnabledConfig(workspace.path);
+    const sessionResult = await createHotCpuProfileSession({
+      config,
+      versions: { appVersion: "test", electronVersion: "test", chromeVersion: "test", nodeVersion: "test" },
+    });
+    if (!sessionResult.ok) throw new Error(sessionResult.message);
+    const { target, debuggerApi } = createTarget();
+    const startEntered = deferred();
+    const releaseStart = deferred();
+    const sendCommand = debuggerApi.sendCommand.getMockImplementation()!;
+    debuggerApi.sendCommand.mockImplementation(async (method: string) => {
+      if (method === "Profiler.start") {
+        startEntered.resolve();
+        await releaseStart.promise;
+      }
+      return sendCommand(method);
+    });
+    const onProfileWritten = vi.fn();
+    const profiler = createProfiler({
+      config,
+      session: sessionResult.session,
+      target,
+      getAppMetrics: () => [createMetric(0)],
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      onProfileWritten,
+    });
+    const started = profiler.start();
+    await startEntered.promise;
+    let stopped = false;
+    const stopping = profiler.stop().then(() => { stopped = true; });
+    await Promise.resolve();
+    expect(stopped).toBe(false);
+    releaseStart.resolve();
+    await Promise.all([started, stopping]);
+    expect(debuggerApi.sendCommand).toHaveBeenCalledWith("Profiler.stop");
+    expect(target.debugger.isAttached()).toBe(false);
+    expect(onProfileWritten).not.toHaveBeenCalled();
+    expect((await fs.readdir(sessionResult.session.directoryPath)).filter((name) => name.endsWith(".cpuprofile"))).toEqual([]);
+  });
+
   it("records a renderer CPU profile after sustained hot samples", async () => {
     const workspace = await createTemporaryTestDirectory();
     cleanups.push(workspace.cleanup);
@@ -271,10 +441,7 @@ describe("HotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await samplesOf(profiler).waitUntil(
-      () => debuggerApi.attach.mock.calls.length > 0,
-      "debugger attach",
-    );
+    await samplesOf(profiler).waitForCount(config.triggerMode === "spike" ? 2 : 3);
     expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
 
     expect(debuggerApi.sendCommand).toHaveBeenNthCalledWith(1, "Profiler.enable");
@@ -689,10 +856,7 @@ describe("HotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await samplesOf(profiler).waitUntil(
-      () => debuggerApi.attach.mock.calls.length > 0,
-      "debugger attach",
-    );
+    await samplesOf(profiler).waitForCount(config.triggerMode === "spike" ? 2 : 3);
     expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
     await profiler.stop("test-complete");
 
@@ -756,10 +920,7 @@ describe("HotCpuProfiler", () => {
     });
 
     await profiler.start();
-    await samplesOf(profiler).waitUntil(
-      () => debuggerApi.attach.mock.calls.length > 0,
-      "debugger attach",
-    );
+    await samplesOf(profiler).waitForCount(config.triggerMode === "spike" ? 2 : 3);
     expect(debuggerApi.attach).toHaveBeenCalledWith("1.3");
     await profiler.stop("test-complete");
 
@@ -955,6 +1116,9 @@ describe("HotCpuProfiler", () => {
       },
     });
 
+    await (profiler as unknown as {
+      ensureRecording: (startedAtMs: number) => Promise<void>;
+    }).ensureRecording(Date.now());
     await (
       profiler as unknown as {
         startProfile: (options: {
@@ -1189,6 +1353,9 @@ describe("HotCpuProfiler", () => {
       },
     });
 
+    await (profiler as unknown as {
+      ensureRecording: (startedAtMs: number) => Promise<void>;
+    }).ensureRecording(Date.now());
     await (
       profiler as unknown as {
         startProfile: (options: {
@@ -1257,6 +1424,9 @@ describe("HotCpuProfiler", () => {
       },
     });
 
+    await (profiler as unknown as {
+      ensureRecording: (startedAtMs: number) => Promise<void>;
+    }).ensureRecording(Date.now());
     await (
       profiler as unknown as {
         startProfile: (options: {
@@ -1331,6 +1501,9 @@ describe("HotCpuProfiler", () => {
       },
     });
 
+    await (profiler as unknown as {
+      ensureRecording: (startedAtMs: number) => Promise<void>;
+    }).ensureRecording(Date.now());
     await (
       profiler as unknown as {
         startProfile: (options: {

--- a/apps/desktop/src/main/diagnostics/cpu-profile-history.ts
+++ b/apps/desktop/src/main/diagnostics/cpu-profile-history.ts
@@ -19,46 +19,79 @@ export function joinCpuProfiles(
     children: [],
   };
   const nodes = [root];
+  const nodesById = new Map([[root.id, root]]);
+  const metaIds = new Map<string, number>();
+  const metaNames = new Set(["(garbage collector)", "(idle)", "(program)"]);
   const samples: number[] = [];
   const timeDeltas: number[] = [];
   const startTime = profiles[0].startTime;
   let sampleTime = startTime;
   let nextId = 2;
   let gapId: number | undefined;
+  let previousEndTime: number | undefined;
+  const appendSample = (id: number, timestamp: number): void => {
+    samples.push(id);
+    timeDeltas.push(timestamp - sampleTime);
+    sampleTime = timestamp;
+  };
   for (const profile of profiles) {
     const ids = new Map<number, number>();
     const profileRoot = profile.nodes[0];
+    const topLevelIds = new Set(profileRoot.children);
     for (const node of profile.nodes) {
-      ids.set(node.id, node === profileRoot ? root.id : nextId++);
+      if (node === profileRoot) {
+        ids.set(node.id, root.id);
+      } else if (topLevelIds.has(node.id) && metaNames.has(node.callFrame.functionName)) {
+        // DevTools keeps only one reference for each V8 meta node. In
+        // particular, every GC sample must use its selected GC node's id.
+        const name = node.callFrame.functionName;
+        const id = metaIds.get(name) ?? nextId++;
+        metaIds.set(name, id);
+        ids.set(node.id, id);
+      } else {
+        ids.set(node.id, nextId++);
+      }
     }
     for (const node of profile.nodes) {
       const children = node.children?.map((id) => ids.get(id)!);
-      if (node === profileRoot) {
-        root.children!.push(...(children ?? []));
+      const id = ids.get(node.id)!;
+      const existing = nodesById.get(id);
+      if (existing) {
+        existing.children = [...new Set([...(existing.children ?? []), ...(children ?? [])])];
+        if (existing !== root && node.hitCount !== undefined) {
+          existing.hitCount = (existing.hitCount ?? 0) + node.hitCount;
+        }
       } else {
-        nodes.push({ ...node, id: ids.get(node.id)!, children });
+        const merged = { ...node, id, children };
+        nodes.push(merged);
+        nodesById.set(id, merged);
       }
     }
-    if (profile.startTime > sampleTime) {
-      if (gapId === undefined) {
-        gapId = nextId++;
-        nodes.push({
-          id: gapId,
-          callFrame: { ...root.callFrame, functionName: "(unrecorded)" },
-        });
-        root.children!.push(gapId);
+    if (previousEndTime !== undefined) {
+      if (profile.startTime > previousEndTime) {
+        if (gapId === undefined) {
+          gapId = nextId++;
+          nodes.push({
+            id: gapId,
+            callFrame: { ...root.callFrame, functionName: "(unrecorded)" },
+          });
+          root.children!.push(gapId);
+        }
+        // Samples describe the frame FROM their timestamp until the next
+        // sample. Close the preceding stack when its recorder stopped.
+        appendSample(gapId, previousEndTime);
       }
-      samples.push(gapId);
-      timeDeltas.push(profile.startTime - sampleTime);
-      sampleTime = profile.startTime;
+      // End the gap exactly when recording resumed. The root boundary also
+      // prevents a previous window's stack carrying into this window's first
+      // sampling interval (or into a GC sample with no interrupted JS stack).
+      appendSample(root.id, profile.startTime);
     }
     let timestamp = profile.startTime;
     for (let index = 0; index < (profile.samples?.length ?? 0); index += 1) {
       timestamp += profile.timeDeltas![index];
-      samples.push(ids.get(profile.samples![index])!);
-      timeDeltas.push(timestamp - sampleTime);
-      sampleTime = timestamp;
+      appendSample(ids.get(profile.samples![index])!, timestamp);
     }
+    previousEndTime = profile.endTime;
   }
   return { nodes, startTime, endTime: profiles.at(-1)!.endTime, samples, timeDeltas };
 }

--- a/apps/desktop/src/main/diagnostics/cpu-profile-history.ts
+++ b/apps/desktop/src/main/diagnostics/cpu-profile-history.ts
@@ -1,0 +1,64 @@
+import type { Profiler } from "node:inspector";
+
+// CDP returns a new node-id namespace on every Profiler.stop. Keep one root
+// when joining windows, remap every reference, and preserve monotonic sample
+// timestamps. A stop/start gap must not be charged to the next JS function.
+export function joinCpuProfiles(
+  profiles: readonly [Profiler.Profile, ...Profiler.Profile[]],
+): Profiler.Profile {
+  if (profiles.length === 1) return profiles[0];
+  const root: Profiler.ProfileNode = {
+    id: 1,
+    callFrame: {
+      functionName: "(root)",
+      scriptId: "0",
+      url: "",
+      lineNumber: -1,
+      columnNumber: -1,
+    },
+    children: [],
+  };
+  const nodes = [root];
+  const samples: number[] = [];
+  const timeDeltas: number[] = [];
+  const startTime = profiles[0].startTime;
+  let sampleTime = startTime;
+  let nextId = 2;
+  let gapId: number | undefined;
+  for (const profile of profiles) {
+    const ids = new Map<number, number>();
+    const profileRoot = profile.nodes[0];
+    for (const node of profile.nodes) {
+      ids.set(node.id, node === profileRoot ? root.id : nextId++);
+    }
+    for (const node of profile.nodes) {
+      const children = node.children?.map((id) => ids.get(id)!);
+      if (node === profileRoot) {
+        root.children!.push(...(children ?? []));
+      } else {
+        nodes.push({ ...node, id: ids.get(node.id)!, children });
+      }
+    }
+    if (profile.startTime > sampleTime) {
+      if (gapId === undefined) {
+        gapId = nextId++;
+        nodes.push({
+          id: gapId,
+          callFrame: { ...root.callFrame, functionName: "(unrecorded)" },
+        });
+        root.children!.push(gapId);
+      }
+      samples.push(gapId);
+      timeDeltas.push(profile.startTime - sampleTime);
+      sampleTime = profile.startTime;
+    }
+    let timestamp = profile.startTime;
+    for (let index = 0; index < (profile.samples?.length ?? 0); index += 1) {
+      timestamp += profile.timeDeltas![index];
+      samples.push(ids.get(profile.samples![index])!);
+      timeDeltas.push(timestamp - sampleTime);
+      sampleTime = timestamp;
+    }
+  }
+  return { nodes, startTime, endTime: profiles.at(-1)!.endTime, samples, timeDeltas };
+}

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profiler.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import type { Profiler } from "node:inspector";
 import type { ProcessMetric } from "electron";
 import type {
   HotCpuProfileCapturedEvent,
@@ -8,8 +9,12 @@ import type {
 import type { HotCpuProfileConfig } from "./hot-cpu-profile-config";
 import type { HotCpuProfileSession } from "./hot-cpu-profile-session";
 import { getMainLogger } from "../log";
+import { joinCpuProfiles } from "./cpu-profile-history";
 
 const CHROME_DEBUGGER_PROTOCOL_VERSION = "1.3";
+// Rotate only after evaluating the CPU sample, and retain the last complete
+// window as well as the live one. A burst across a rotation stays available.
+const RECORDING_WINDOW_MS = 30_000;
 
 type Logger = Pick<Console, "info" | "warn" | "error">;
 
@@ -61,6 +66,8 @@ function artifactFilename(filePath: string): string {
 export class HotCpuProfiler {
   private readonly detachListener = (_event: unknown, reason: string) => {
     this.debuggerAttached = false;
+    this.recording = false;
+    this.previousRecording = null;
     void this.session.appendEvent({
       capturedAt: this.now().toISOString(),
       type: "debugger-detached",
@@ -85,6 +92,12 @@ export class HotCpuProfiler {
   private readonly session: HotCpuProfileSession;
   private readonly target: HotCpuTarget;
 
+  private startPromise: Promise<void> | null = null;
+  private recording = false;
+  private recordingStartedAtMs = 0;
+  private recordingStartedAtMonotonicMs = 0;
+  private previousRecording: Profiler.Profile | null = null;
+  private previousRecordingStartedAtMs = 0;
   private consecutiveHotSamples = 0;
   private debuggerAttached = false;
   private heapSnapshotLimitReached = false;
@@ -139,12 +152,15 @@ export class HotCpuProfiler {
   }
 
   async start(): Promise<void> {
-    if (this.stopped || this.intervalTimer) {
-      return;
-    }
+    if (this.stopped) return;
+    this.startPromise ??= this.startInner();
+    await this.startPromise;
+  }
 
+  private async startInner(): Promise<void> {
+    const startedAt = this.now();
     await this.session.appendEvent({
-      capturedAt: this.now().toISOString(),
+      capturedAt: startedAt.toISOString(),
       type: "monitor-started",
       detail: {
         intervalMs: this.config.intervalMs,
@@ -156,8 +172,10 @@ export class HotCpuProfiler {
         profileDurationMs: this.config.profileDurationMs,
         captureHeapSnapshot: this.config.captureHeapSnapshot,
         heapSnapshotLimit: this.config.heapSnapshotLimit,
+        recordingWindowMs: this.recordingWindowMs(),
       },
     });
+    await this.ensureRecording(startedAt.getTime());
     this.logger.info("[pwragent:hot-cpu] monitoring started", {
       target: this.session.target ?? "renderer",
       sessionDirectory: this.session.directoryPath,
@@ -182,6 +200,7 @@ export class HotCpuProfiler {
   }
 
   private async stopInner(reason: string): Promise<void> {
+    await this.startPromise?.catch(() => undefined);
     if (this.intervalTimer) {
       clearTimeout(this.intervalTimer);
       this.intervalTimer = null;
@@ -203,6 +222,8 @@ export class HotCpuProfiler {
       await this.stopProfile(reason);
     }
 
+    // An armed recorder without a trigger is discarded, never published.
+    await this.discardRecording();
     this.detachDebugger();
     await this.session.appendEvent({
       capturedAt: this.now().toISOString(),
@@ -254,7 +275,7 @@ export class HotCpuProfiler {
           type: "sample-skipped",
           detail: { reason: "metric-not-found", pid },
         });
-        this.scheduleNextSample();
+        await this.maintainRecording(capturedAtMs);
         return;
       }
 
@@ -298,6 +319,8 @@ export class HotCpuProfiler {
           cpuPercent,
           pid,
         });
+      } else if (!this.stopped && this.profileCount < this.config.maxProfiles) {
+        await this.maintainRecording(capturedAtMs);
       }
     } catch (error) {
       await this.session.appendEvent({
@@ -396,6 +419,90 @@ export class HotCpuProfiler {
     return this.config.triggerMode === "spike" ? 1 : this.config.consecutiveSamples;
   }
 
+  private recordingWindowMs(): number {
+    return Math.max(
+      RECORDING_WINDOW_MS,
+      this.config.intervalMs * this.triggerConsecutiveSamples(),
+    );
+  }
+
+  private async maintainRecording(startedAtMs: number): Promise<void> {
+    await this.ensureRecording(startedAtMs);
+    if (
+      this.recording
+      && performance.now() - this.recordingStartedAtMonotonicMs >= this.recordingWindowMs()
+    ) {
+      await this.rotateRecording(startedAtMs);
+    }
+  }
+
+  private async ensureRecording(startedAtMs: number): Promise<void> {
+    if (
+      this.stopped
+      || this.recording
+      || this.isTargetDestroyed()
+      || this.profileCount >= this.config.maxProfiles
+    ) return;
+    if (this.target.debugger.isAttached()) return;
+    try {
+      this.target.debugger.attach(CHROME_DEBUGGER_PROTOCOL_VERSION);
+      this.debuggerAttached = true;
+      this.target.debugger.on("detach", this.detachListener);
+      await this.target.debugger.sendCommand("Profiler.enable");
+      if (this.stopped) return;
+      await this.target.debugger.sendCommand("Profiler.start");
+      this.recording = true;
+      this.recordingStartedAtMs = startedAtMs;
+      this.recordingStartedAtMonotonicMs = performance.now();
+    } catch (error) {
+      this.recording = false;
+      this.previousRecording = null;
+      this.detachDebugger();
+      await this.session.appendEvent({
+        capturedAt: new Date(startedAtMs).toISOString(),
+        type: "recorder-start-failed",
+        detail: { error: serializeError(error) },
+      });
+    }
+  }
+
+  private async finishRecording(): Promise<Profiler.Profile> {
+    if (!this.recording) throw new Error("CPU recorder is not armed");
+    const result = await this.target.debugger.sendCommand("Profiler.stop") as {
+      profile: Profiler.Profile;
+    };
+    this.recording = false;
+    return result.profile;
+  }
+
+  private async rotateRecording(startedAtMs: number): Promise<void> {
+    try {
+      this.previousRecording = await this.finishRecording();
+      this.previousRecordingStartedAtMs = this.recordingStartedAtMs;
+      if (this.stopped) return;
+      await this.target.debugger.sendCommand("Profiler.start");
+      this.recording = true;
+      this.recordingStartedAtMs = startedAtMs;
+      this.recordingStartedAtMonotonicMs = performance.now();
+    } catch (error) {
+      this.recording = false;
+      this.previousRecording = null;
+      this.detachDebugger();
+      throw error;
+    }
+  }
+
+  private async discardRecording(): Promise<void> {
+    try {
+      if (this.recording && !this.isTargetDestroyed()) await this.finishRecording();
+    } catch (error) {
+      this.logger.warn("[pwragent:hot-cpu] recorder cleanup failed", error);
+    } finally {
+      this.recording = false;
+      this.previousRecording = null;
+    }
+  }
+
   private async startProfile(options: {
     capturedAt: string;
     cpuPercent: number;
@@ -405,29 +512,25 @@ export class HotCpuProfiler {
       return;
     }
 
-    if (this.target.debugger.isAttached()) {
+    if (!this.recording) {
+      // A debugger conflict may have prevented arming. Do not describe a
+      // newly started recording as if it had captured this hot interval.
       await this.session.appendEvent({
         capturedAt: options.capturedAt,
         type: "profile-skipped",
         detail: {
-          reason: "debugger-already-attached",
+          reason: !this.isTargetDestroyed() && this.target.debugger.isAttached()
+            ? "debugger-already-attached"
+            : "recorder-not-armed",
           cpuPercent: options.cpuPercent,
           pid: options.pid,
         },
       });
+      await this.ensureRecording(Date.parse(options.capturedAt));
       return;
     }
 
     try {
-      this.target.debugger.attach(CHROME_DEBUGGER_PROTOCOL_VERSION);
-      this.debuggerAttached = true;
-      this.target.debugger.on("detach", this.detachListener);
-      await this.target.debugger.sendCommand("Profiler.enable");
-      if (this.stopped) {
-        this.detachDebugger();
-        return;
-      }
-      await this.target.debugger.sendCommand("Profiler.start");
       this.profiling = true;
       if (this.stopped) {
         return;
@@ -453,6 +556,12 @@ export class HotCpuProfiler {
           triggerConsecutiveSamples: this.triggerConsecutiveSamples(),
           pid: options.pid,
           durationMs: this.config.profileDurationMs,
+          recordingStartedAt: new Date(this.previousRecording
+            ? this.previousRecordingStartedAtMs
+            : this.recordingStartedAtMs).toISOString(),
+          preTriggerDurationMs: Date.parse(options.capturedAt) - (this.previousRecording
+            ? this.previousRecordingStartedAtMs
+            : this.recordingStartedAtMs),
         },
       });
       this.logger.warn("[pwragent:hot-cpu] CPU profile started", {
@@ -486,6 +595,7 @@ export class HotCpuProfiler {
         detail: { error: serializeError(error) },
       });
       this.logger.error("[pwragent:hot-cpu] CPU profile failed to start", error);
+      await this.discardRecording();
       this.detachDebugger();
     }
   }
@@ -524,12 +634,13 @@ export class HotCpuProfiler {
       };
 
     try {
-      const result = (await this.target.debugger.sendCommand("Profiler.stop")) as {
-        profile?: unknown;
-      };
+      const current = await this.finishRecording();
+      const profile = joinCpuProfiles(this.previousRecording
+        ? [this.previousRecording, current]
+        : [current]);
       await fs.writeFile(
         profilePath,
-        `${JSON.stringify(result.profile ?? {})}\n`,
+        `${JSON.stringify(profile)}\n`,
         "utf8",
       );
       await this.session.registerArtifact(profileFilename);
@@ -576,7 +687,10 @@ export class HotCpuProfiler {
       this.activeProfileTrigger = null;
       this.activeProfileHeapSnapshots = [];
       this.activeProfileHeapSnapshotCaptures.clear();
+      this.previousRecording = null;
+      this.recording = false;
       this.detachDebugger();
+      await this.ensureRecording(this.now().getTime());
       this.resumeSamplingAfterProfile();
     }
   }


### PR DESCRIPTION
## Summary

CPU profiling previously started only after a hot process-CPU sample arrived, so short bursts could finish before recording began. Repeated captures then showed roughly 99% idle time despite a real CPU spike.

Start recording when monitoring is enabled, retain the preceding recording window in memory, and save that history together with the existing post-trigger recording. Rotate windows approximately every 30 seconds, evaluate triggers before rotation, and remap profile nodes and timestamps into one `.cpuprofile`. Explicitly mark stop/start gaps as unrecorded time.

## Verification

- 24 focused tests pass, including a real Node inspector regression that samples a synchronous CPU burst which finishes before the trigger is evaluated. Repeated successfully after rebasing onto current main.
- Coverage includes bounded retention across rotations, missing process metrics, capture limits, debugger conflicts, shutdown during recorder startup, and existing heap-snapshot lifecycle behavior.
- `pnpm lint:eslint` passed with existing warnings and no errors.
- `pnpm typecheck` and `pnpm lint:boundaries` passed; final changed-file lint and desktop typecheck also passed.
- `git diff --check` passed.

## Notes

Continuous sampling adds overhead while CPU monitoring is enabled. Untriggered profile history stays in memory and is discarded; the recorder stops at the capture limit or when monitoring stops. This fixes missing pre-trigger execution in JavaScript CPU profiles; it does not add native browser Performance tracing. The running development app has not been restarted.
