### PR TITLE
fix(desktop): display credit balances as rounded credits

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2143,7 +2143,7 @@ describe("Sidebar", () => {
     expect(tooltip).toHaveTextContent("Codex profile: work3");
     expect(tooltip).toHaveTextContent("Codex account: work@example.com");
     expect(tooltip).toHaveTextContent("Plan: pro");
-    expect(tooltip).toHaveTextContent("Credits: $100");
+    expect(tooltip).toHaveTextContent("Credits: 100");
     expect(tooltip).toHaveTextContent("5h limit");
     expect(tooltip).toHaveTextContent("85% left");
     expect(tooltip).toHaveTextContent("Weekly limit: 60% left");

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/ProviderStatusPanel.test.tsx
@@ -171,7 +171,7 @@ describe("ProviderStatusPanel", () => {
     expect(screen.getByText("Available")).toBeInTheDocument();
     expect(screen.getByText("user@example.com")).toBeInTheDocument();
     expect(screen.getByText("pro")).toBeInTheDocument();
-    expect(screen.getByText(/Credits: \$100/)).toBeInTheDocument();
+    expect(screen.getByText(/Credits: 100/)).toBeInTheDocument();
     expect(screen.getByText(/5h limit: 85% left/)).toBeInTheDocument();
     expect(screen.getByText(/Weekly limit: 91% left/)).toBeInTheDocument();
   });

--- a/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/backend-status-format.test.ts
@@ -220,7 +220,21 @@ describe("backend status formatting", () => {
     ]);
   });
 
-  it("formats a dollar credits balance, unlimited credits, and a hidden amount", () => {
+  it.each([
+    [1226.02, "1,226"],
+    [1226.5, "1,227"],
+    [0.4, "0"],
+    [0, "0"],
+  ])("rounds %s credits to %s without a currency symbol", (remaining, expected) => {
+    expect(formatRateLimitLine({
+      name: "Credits",
+      windowKey: "credits",
+      hasCredits: remaining > 0,
+      remaining,
+    })).toBe(`Credits: ${expected}`);
+  });
+
+  it("formats a credits balance, unlimited credits, and a hidden amount", () => {
     expect(
       formatRateLimitLine({
         name: "Credits",
@@ -228,7 +242,7 @@ describe("backend status formatting", () => {
         hasCredits: true,
         remaining: 100,
       }),
-    ).toBe("Credits: $100");
+    ).toBe("Credits: 100");
     expect(
       formatRateLimitLine({
         name: "Credits",

--- a/apps/desktop/src/renderer/src/lib/backend-status-format.ts
+++ b/apps/desktop/src/renderer/src/lib/backend-status-format.ts
@@ -146,24 +146,12 @@ function formatCreditsLine(limit: BackendRateLimitSummary): string {
     return "Credits: unlimited";
   }
   if (typeof limit.remaining === "number" && limit.remaining > 0) {
-    return `Credits: ${formatUsdBalance(limit.remaining)}`;
+    return `Credits: ${formatWholeNumber(limit.remaining)}`;
   }
   if (limit.hasCredits) {
     return "Credits: available";
   }
-  return "Credits: $0";
-}
-
-function formatUsdBalance(value: number): string {
-  const cents = Math.round(value * 100);
-  const dollars = cents / 100;
-  if (cents % 100 === 0) {
-    return `$${dollars.toLocaleString()}`;
-  }
-  return `$${dollars.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
+  return "Credits: 0";
 }
 
 function isReserveRateLimit(limit: BackendRateLimitSummary): boolean {


### PR DESCRIPTION
Codex account balances are credit counts, but the provider status formatted them as USD. Display balances rounded to the nearest whole credit: `Credits: $1,226.02` becomes `Credits: 1,226`.

Remove currency formatting for zero balances and preserve unlimited/available states. The current Codex App Server CreditsSnapshot schema exposes no currency or monetary value, so no conversion is added.

Validation: all 16 backend status formatter tests passed, including rounding up/down and zero balances; `pnpm lint:eslint` passed.
