### PR TITLE
fix(desktop): keep MCP action menus visible and open

### DIFF
--- a/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/ChipContextMenu.tsx
@@ -50,7 +50,14 @@ export function ChipContextMenu(props: ChipContextMenuProps) {
   }, [onClose, returnFocusTo]);
 
   useEffect(() => {
-    const closeOnClick = (): void => close(false);
+    const closeOnClick = (event: MouseEvent): void => {
+      // React can mount this listener before the opening click reaches window.
+      // Ignore this menu's invoker, but let that click dismiss any other menu.
+      if (event.target instanceof Node && returnFocusTo.contains(event.target)) {
+        return;
+      }
+      close(false);
+    };
     const closeOnEscape = (event: KeyboardEvent): void => {
       if (event.key === "Escape") {
         close(true);
@@ -66,7 +73,7 @@ export function ChipContextMenu(props: ChipContextMenuProps) {
       window.removeEventListener("contextmenu", closeOnContextMenu, true);
       window.removeEventListener("keydown", closeOnEscape);
     };
-  }, [close]);
+  }, [close, returnFocusTo]);
 
   useLayoutEffect(() => {
     const menu = menuRef.current;

--- a/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/PluginsSettings.tsx
@@ -787,6 +787,7 @@ function McpServerRow(props: {
             </button>
           ) : null}
           <button
+            aria-expanded={Boolean(menuPosition)}
             aria-haspopup="menu"
             aria-label={`More actions for ${server.name}`}
             className="button button--ghost settings-mcp-row__more"
@@ -818,6 +819,7 @@ function McpServerRow(props: {
       ) : null}
       {menuPosition && menuInvokerRef.current ? (
         <ChipContextMenu
+          className="settings-mcp-context-menu"
           items={[
             ...(canSignIn
               ? [{

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
@@ -248,6 +248,29 @@ describe("PluginsSettings", () => {
     expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
+  it("does not dismiss an open menu for clicks on its invoker", async () => {
+    render(
+      <PluginsSettings
+        desktopApi={createDesktopApi([
+          server({ name: "pwrsnap" }),
+          server({ name: "context7" }),
+        ])}
+        snapshot={createSnapshot()}
+      />,
+    );
+
+    const trigger = await screen.findByRole("button", { name: "More actions for pwrsnap" });
+    fireEvent.click(trigger);
+    // Exercise an invoker click with the window dismiss listener installed.
+    // Browsers can install it during the opening click, before it reaches
+    // window; fireEvent's act batching postpones that until after dispatch.
+    fireEvent.click(within(trigger).getByText("···"));
+    expect(screen.getByRole("menuitem", { name: "Remove pwrsnap" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "More actions for context7" }));
+    expect(screen.queryByRole("menuitem", { name: "Remove pwrsnap" })).not.toBeInTheDocument();
+    expect(screen.getByRole("menuitem", { name: "Remove context7" })).toBeInTheDocument();
+  });
+
   it("filters by server name and by tool name", async () => {
     render(
       <PluginsSettings

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/PluginsSettings.test.tsx
@@ -234,6 +234,18 @@ describe("PluginsSettings", () => {
     expect(
       screen.getByRole("button", { name: "More actions for datadog" }),
     ).toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: "More actions for datadog" });
+    fireEvent.click(trigger);
+    expect(screen.getByRole("menu")).toHaveClass("settings-mcp-context-menu");
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("menuitem", { name: "Remove datadog" })).toBeInTheDocument();
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(trigger);
+    fireEvent.click(document.body);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
   });
 
   it("filters by server name and by tool name", async () => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -660,6 +660,12 @@ describe("Tangerine Terminal theme contract", () => {
     );
   });
 
+  it("layers MCP action menus above full-window settings", () => {
+    const menuRule = extractRuleBody(css, ".settings-mcp-context-menu");
+    const settingsRule = extractRuleBody(css, ".app-shell__settings-layer");
+    expect(readZIndex(menuRule)).toBeGreaterThan(readZIndex(settingsRule));
+  });
+
   it("layers Messaging popovers and tooltips above full-window settings", () => {
     const appTitlebarRule = extractRuleBody(css, ".app-titlebar");
     const settingsLayerRule = extractRuleBody(css, ".app-shell__settings-layer");

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6665,6 +6665,11 @@ a.button {
   min-width: 220px;
 }
 
+.settings-mcp-context-menu {
+  /* This menu portals to body, outside the Settings layer at 120. */
+  z-index: 140;
+}
+
 .thread-context-menu button {
   display: flex;
   width: 100%;


### PR DESCRIPTION
## Summary

- I fixed the MCP server kebab menu appearing to do nothing. Its body portal rendered behind Settings, and the opening click could reach the newly mounted window dismiss listener and immediately close it.
- I raised the MCP menu above Settings and made the shared menu dismiss handler ignore clicks on its own invoker, including child elements. Clicking another menu's invoker still dismisses the previous menu.
- I exposed the trigger's expanded state for accessibility.

## Verification

- I reproduced immediate dismissal in headless Chromium using the real PluginsSettings component and stylesheet with contrived server data: a pointer click left no menu and aria-expanded=false. With the fix, the menu stays visible.
- I verified pointer and keyboard opening, Remove opening its confirmation dialog, Escape dismissal, and focus restoration in Chromium.
- I confirmed both regression tests fail before their respective fixes: the layer test rejects 50 below 120, and the invoker-click test loses the menu before the dismiss guard is added.
- I ran all 106 tests across PluginsSettings, the theme contract, and PrChip successfully. Coverage also checks outside-click dismissal and switching between server menus.
- I ran pnpm lint:eslint successfully.

## Notes

- I verified the renderer in headless Chromium with contrived data; I have not restarted the operator's desktop app.
