### PR TITLE
fix(desktop): support copying images from the context menu

### DIFF
--- a/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
+++ b/apps/desktop/src/main/__tests__/app-bootstrap.test.ts
@@ -31,6 +31,7 @@ const shellOpenExternalMock = vi.fn();
 const clipboardWriteTextMock = vi.fn();
 const addWordToSpellCheckerDictionaryMock = vi.fn();
 const replaceMisspellingMock = vi.fn();
+const copyImageAtMock = vi.fn();
 const menuPopupMock = vi.fn();
 const buildFromTemplateMock = vi.fn((template: MenuItemConstructorOptions[]) => ({
   popup: menuPopupMock,
@@ -139,6 +140,7 @@ const BrowserWindowMock = vi.fn(function BrowserWindow(
         })
       ),
       replaceMisspelling: replaceMisspellingMock,
+      copyImageAt: copyImageAtMock,
       session: {
         addWordToSpellCheckerDictionary: addWordToSpellCheckerDictionaryMock,
       },
@@ -238,6 +240,7 @@ describe("createMainWindow", () => {
     clipboardWriteTextMock.mockReset();
     addWordToSpellCheckerDictionaryMock.mockReset();
     replaceMisspellingMock.mockReset();
+    copyImageAtMock.mockReset();
     menuPopupMock.mockReset();
     buildFromTemplateMock.mockClear();
     RendererHeapMonitorMock.mockClear();
@@ -445,6 +448,49 @@ describe("createMainWindow", () => {
     expect(clipboardWriteTextMock).toHaveBeenCalledWith(
       "file:///Users/fixture-user/project/AGENTS.md:12"
     );
+  });
+
+  it("copies loaded images through the native context menu, including linked images", async () => {
+    const { createMainWindow } = await import("../window");
+    createMainWindow();
+
+    emitWebContentsEvent("context-menu", {}, {
+      mediaType: "image",
+      hasImageContents: true,
+      srcURL: "blob:http://localhost/fixture-image",
+      linkURL: "https://example.com/image",
+      x: 123,
+      y: 456,
+    });
+
+    const template = buildFromTemplateMock.mock.calls[0]?.[0];
+    expect(template).toEqual([
+      expect.objectContaining({ label: "Copy Image", click: expect.any(Function) }),
+      { type: "separator" },
+      expect.objectContaining({ label: "Copy Link", click: expect.any(Function) }),
+    ]);
+    expect(menuPopupMock).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 123, y: 456 }),
+    );
+    expect(copyImageAtMock).not.toHaveBeenCalled();
+    const click = template?.[0]?.click as () => void;
+    click();
+    expect(copyImageAtMock).toHaveBeenCalledExactlyOnceWith(123, 456);
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { mediaType: "image", hasImageContents: false },
+    { mediaType: "none", hasImageContents: false },
+    { mediaType: "video", hasImageContents: true },
+  ])("omits image copying for unavailable or non-image content: %j", async (params) => {
+    const { createMainWindow } = await import("../window");
+    createMainWindow();
+
+    emitWebContentsEvent("context-menu", {}, { ...params, x: 12, y: 34 });
+
+    expect(buildFromTemplateMock).not.toHaveBeenCalled();
+    expect(copyImageAtMock).not.toHaveBeenCalled();
   });
 
   it("shows native spelling suggestions when editable text is right-clicked", async () => {

--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -238,6 +238,16 @@ function buildNativeContextMenuTemplate(
     });
   }
 
+  if (params.mediaType === "image" && params.hasImageContents) {
+    appendSeparator(template);
+    template.push({
+      label: "Copy Image",
+      click: () => {
+        window.webContents.copyImageAt(params.x, params.y);
+      },
+    });
+  }
+
   if (params.linkURL) {
     appendSeparator(template);
     template.push({


### PR DESCRIPTION
## Summary

- I added **Copy Image** to the native right-click menu for loaded images, including transcript thumbnails and expanded lightbox images.
- I use Electron’s `webContents.copyImageAt` to copy the image itself, including renderer-owned blob images. Linked images keep **Copy Link**; unavailable images do not offer image copying.

## Verification

- I ran the app bootstrap tests: all 17 passed, including image menu availability, copying at the clicked coordinates, linked images, and unavailable/non-image content.
- I ran `pnpm lint:eslint` and `pnpm typecheck`: both passed.

## Notes

- I have not manually verified the native menu and clipboard in a running app. This change uses the shared window context-menu handler and requires no renderer or IPC changes.
