### PR TITLE
fix(desktop): reconnect PwrSnap after a revoked session

### DIFF
--- a/apps/desktop/src/main/__tests__/pwrsnap-connection-service.test.ts
+++ b/apps/desktop/src/main/__tests__/pwrsnap-connection-service.test.ts
@@ -1,6 +1,8 @@
 import { fileURLToPath } from "node:url";
+import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  PWRSNAP_SESSION_REVOKED_DETAIL,
   PwrSnapConnectionService,
 } from "../mcp-connections/pwrsnap-connection-service";
 
@@ -16,6 +18,40 @@ function createSettings(initial?: string) {
     }),
   };
 }
+
+// A credential as PwrAgent stores it after a completed OAuth approval. The
+// cached discovery state lets the SDK skip metadata fetches, so a 401 on the
+// MCP endpoint goes straight to the token check and then to a new
+// authorization, exactly as it does against a real PwrSnap.
+function createAuthorizedCredential(): string {
+  return JSON.stringify({
+    clientInformation: { client_id: "pwragent-client" },
+    discoveryState: {
+      authorizationServerUrl: "http://127.0.0.1:51729",
+      resourceMetadata: {
+        resource: "http://127.0.0.1:51729/mcp",
+        authorization_servers: ["http://127.0.0.1:51729"],
+      },
+      authorizationServerMetadata: {
+        issuer: "http://127.0.0.1:51729",
+        authorization_endpoint: "http://127.0.0.1:51729/oauth/authorize",
+        token_endpoint: "http://127.0.0.1:51729/oauth/token",
+        response_types_supported: ["code"],
+        code_challenge_methods_supported: ["S256"],
+      },
+    },
+    tokens: { access_token: "revoked-by-pwrsnap", token_type: "bearer" },
+  });
+}
+
+type BridgeInternals = {
+  dispatchBridgeOperation: (
+    operation: unknown,
+    params: unknown,
+  ) => Promise<unknown>;
+  grants: Map<string, { connectionId: "pwrsnap" }>;
+  handleBridgeLine: (socket: unknown, line: string) => Promise<void>;
+};
 
 const services: PwrSnapConnectionService[] = [];
 
@@ -130,5 +166,82 @@ describe("PwrSnapConnectionService", () => {
       undefined,
       { timeout: 720_000 },
     );
+  });
+
+  it("clears the stored credential when PwrSnap rejects the session token", async () => {
+    const settings = createSettings(createAuthorizedCredential());
+    const openExternal = vi.fn(async () => undefined);
+    const service = new PwrSnapConnectionService({
+      fetchFn: vi.fn(async () => new Response("unauthorized", { status: 401 })),
+      openExternal,
+      resolveInstallPaths: () => [],
+      settings,
+    });
+    services.push(service);
+
+    await expect(service.readStatus()).resolves.toMatchObject({
+      availability: "running",
+      configured: true,
+    });
+
+    const bridge = service as unknown as BridgeInternals;
+    await expect(bridge.dispatchBridgeOperation("tools/list", {}))
+      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_DETAIL);
+
+    // The proxy must never try to open a consent window of its own.
+    expect(openExternal).not.toHaveBeenCalled();
+    expect(settings.clearPwrSnapMcpCredential).toHaveBeenCalledOnce();
+    await expect(service.readStatus()).resolves.toMatchObject({
+      availability: "running",
+      configured: false,
+      detail: PWRSNAP_SESSION_REVOKED_DETAIL,
+    });
+    await expect(service.registerBridge("pwrsnap", "thread-1"))
+      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_DETAIL);
+
+    // A fresh approval stored by the connect flow hides the revoke notice.
+    await settings.savePwrSnapMcpCredential(createAuthorizedCredential());
+    await expect(service.readStatus()).resolves.toMatchObject({
+      configured: true,
+    });
+    await expect(service.readStatus()).resolves.not.toHaveProperty("detail");
+  });
+
+  it("clears the stored credential when a proxied call gets 401 after connecting", async () => {
+    const settings = createSettings(createAuthorizedCredential());
+    const service = new PwrSnapConnectionService({
+      fetchFn: vi.fn(async () => new Response("ok", { status: 200 })),
+      resolveInstallPaths: () => [],
+      settings,
+    });
+    services.push(service);
+    Object.assign(service, {
+      upstreamClient: {
+        listTools: vi.fn(async () => {
+          throw new StreamableHTTPError(
+            401,
+            "Server returned 401 after successful authentication",
+          );
+        }),
+        close: vi.fn(async () => undefined),
+      },
+    });
+    const bridge = service as unknown as BridgeInternals;
+    bridge.grants.set("grant-token", { connectionId: "pwrsnap" });
+    const socket = { destroyed: false, end: vi.fn() };
+
+    await bridge.handleBridgeLine(
+      socket,
+      JSON.stringify({ token: "grant-token", op: "tools/list" }),
+    );
+
+    expect(socket.end).toHaveBeenCalledWith(
+      expect.stringContaining("Server returned 401 after successful authentication"),
+    );
+    expect(settings.clearPwrSnapMcpCredential).toHaveBeenCalledOnce();
+    await expect(service.readStatus()).resolves.toMatchObject({
+      configured: false,
+      detail: PWRSNAP_SESSION_REVOKED_DETAIL,
+    });
   });
 });

--- a/apps/desktop/src/main/__tests__/pwrsnap-connection-service.test.ts
+++ b/apps/desktop/src/main/__tests__/pwrsnap-connection-service.test.ts
@@ -1,8 +1,8 @@
 import { fileURLToPath } from "node:url";
-import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { PWRSNAP_SESSION_REVOKED_DETAIL } from "@pwragent/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  PWRSNAP_SESSION_REVOKED_DETAIL,
+  PWRSNAP_SESSION_REVOKED_ERROR,
   PwrSnapConnectionService,
 } from "../mcp-connections/pwrsnap-connection-service";
 
@@ -23,7 +23,7 @@ function createSettings(initial?: string) {
 // cached discovery state lets the SDK skip metadata fetches, so a 401 on the
 // MCP endpoint goes straight to the token check and then to a new
 // authorization, exactly as it does against a real PwrSnap.
-function createAuthorizedCredential(): string {
+function createAuthorizedCredential(accessToken = "revoked-by-pwrsnap"): string {
   return JSON.stringify({
     clientInformation: { client_id: "pwragent-client" },
     discoveryState: {
@@ -40,7 +40,7 @@ function createAuthorizedCredential(): string {
         code_challenge_methods_supported: ["S256"],
       },
     },
-    tokens: { access_token: "revoked-by-pwrsnap", token_type: "bearer" },
+    tokens: { access_token: accessToken, token_type: "bearer" },
   });
 }
 
@@ -49,8 +49,6 @@ type BridgeInternals = {
     operation: unknown,
     params: unknown,
   ) => Promise<unknown>;
-  grants: Map<string, { connectionId: "pwrsnap" }>;
-  handleBridgeLine: (socket: unknown, line: string) => Promise<void>;
 };
 
 const services: PwrSnapConnectionService[] = [];
@@ -147,12 +145,7 @@ describe("PwrSnapConnectionService", () => {
       upstreamClient: { callTool, close: vi.fn(async () => undefined) },
     });
 
-    const bridge = service as unknown as {
-      dispatchBridgeOperation: (
-        operation: unknown,
-        params: unknown,
-      ) => Promise<unknown>;
-    };
+    const bridge = service as unknown as BridgeInternals;
     await bridge.dispatchBridgeOperation("tools/call", {
       name: "pwrsnap_image_edit_send",
       arguments: { captureId: "cap-1", instruction: "Add an arrow" },
@@ -186,62 +179,73 @@ describe("PwrSnapConnectionService", () => {
 
     const bridge = service as unknown as BridgeInternals;
     await expect(bridge.dispatchBridgeOperation("tools/list", {}))
-      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_DETAIL);
+      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_ERROR);
 
-    // The proxy must never try to open a consent window of its own.
+    // The proxy must never try to open a consent window of its own, and the
+    // code verifier the SDK saves for that window must not be written back.
     expect(openExternal).not.toHaveBeenCalled();
+    expect(settings.savePwrSnapMcpCredential).not.toHaveBeenCalled();
     expect(settings.clearPwrSnapMcpCredential).toHaveBeenCalledOnce();
     await expect(service.readStatus()).resolves.toMatchObject({
       availability: "running",
       configured: false,
       detail: PWRSNAP_SESSION_REVOKED_DETAIL,
     });
-    await expect(service.registerBridge("pwrsnap", "thread-1"))
-      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_DETAIL);
+
+    // A thread that enabled PwrSnap keeps starting turns; only its PwrSnap
+    // calls report the revoke, and a repeat does not clear the store again.
+    await expect(service.registerBridge("pwrsnap", "thread-1")).resolves.toBeTruthy();
+    await expect(bridge.dispatchBridgeOperation("tools/list", {}))
+      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_ERROR);
+    expect(settings.clearPwrSnapMcpCredential).toHaveBeenCalledOnce();
 
     // A fresh approval stored by the connect flow hides the revoke notice.
-    await settings.savePwrSnapMcpCredential(createAuthorizedCredential());
-    await expect(service.readStatus()).resolves.toMatchObject({
-      configured: true,
-    });
-    await expect(service.readStatus()).resolves.not.toHaveProperty("detail");
+    await settings.savePwrSnapMcpCredential(createAuthorizedCredential("fresh"));
+    await expect(service.readStatus()).resolves.toEqual(
+      expect.not.objectContaining({ detail: expect.anything() }),
+    );
   });
 
-  it("clears the stored credential when a proxied call gets 401 after connecting", async () => {
-    const settings = createSettings(createAuthorizedCredential());
+  it("keeps a credential that a concurrent Connect stored while the 401 was in flight", async () => {
+    const settings = createSettings(createAuthorizedCredential("stale"));
     const service = new PwrSnapConnectionService({
-      fetchFn: vi.fn(async () => new Response("ok", { status: 200 })),
+      fetchFn: vi.fn(async () => {
+        // PwrSnap rejects the stale token; meanwhile the operator's Connect
+        // flow lands a fresh approval before the SDK reaches the redirect.
+        await settings.savePwrSnapMcpCredential(createAuthorizedCredential("fresh"));
+        return new Response("unauthorized", { status: 401 });
+      }),
       resolveInstallPaths: () => [],
       settings,
     });
     services.push(service);
-    Object.assign(service, {
-      upstreamClient: {
-        listTools: vi.fn(async () => {
-          throw new StreamableHTTPError(
-            401,
-            "Server returned 401 after successful authentication",
-          );
-        }),
-        close: vi.fn(async () => undefined),
-      },
-    });
+
     const bridge = service as unknown as BridgeInternals;
-    bridge.grants.set("grant-token", { connectionId: "pwrsnap" });
-    const socket = { destroyed: false, end: vi.fn() };
+    await expect(bridge.dispatchBridgeOperation("tools/list", {}))
+      .rejects.toThrow(PWRSNAP_SESSION_REVOKED_ERROR);
 
-    await bridge.handleBridgeLine(
-      socket,
-      JSON.stringify({ token: "grant-token", op: "tools/list" }),
-    );
-
-    expect(socket.end).toHaveBeenCalledWith(
-      expect.stringContaining("Server returned 401 after successful authentication"),
-    );
-    expect(settings.clearPwrSnapMcpCredential).toHaveBeenCalledOnce();
+    expect(settings.clearPwrSnapMcpCredential).not.toHaveBeenCalled();
     await expect(service.readStatus()).resolves.toMatchObject({
-      configured: false,
-      detail: PWRSNAP_SESSION_REVOKED_DETAIL,
+      configured: true,
+    });
+  });
+
+  it("keeps the stored credential when PwrSnap fails for a reason other than the token", async () => {
+    const settings = createSettings(createAuthorizedCredential());
+    const service = new PwrSnapConnectionService({
+      fetchFn: vi.fn(async () => new Response("busy", { status: 503 })),
+      resolveInstallPaths: () => [],
+      settings,
+    });
+    services.push(service);
+
+    const bridge = service as unknown as BridgeInternals;
+    await expect(bridge.dispatchBridgeOperation("tools/list", {})).rejects.toThrow();
+
+    expect(settings.clearPwrSnapMcpCredential).not.toHaveBeenCalled();
+    await expect(service.readStatus()).resolves.toMatchObject({
+      availability: "running",
+      configured: true,
     });
   });
 });

--- a/apps/desktop/src/main/mcp-connections/pwrsnap-connection-service.ts
+++ b/apps/desktop/src/main/mcp-connections/pwrsnap-connection-service.ts
@@ -9,10 +9,14 @@ import { shell } from "electron";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   auth,
+  UnauthorizedError,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
 } from "@modelcontextprotocol/sdk/client/auth.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type {
   OAuthClientInformationMixed,
   OAuthClientMetadata,
@@ -44,6 +48,8 @@ const PWRSNAP_SCOPES = [
   "sizzle.full.read",
 ].join(" ");
 const OAUTH_CALLBACK_TIMEOUT_MS = 5 * 60_000;
+export const PWRSNAP_SESSION_REVOKED_DETAIL =
+  "PwrSnap revoked this connection. Choose Connect to PwrSnap on the New thread card to connect again.";
 const MAX_RPC_LINE_BYTES = 1024 * 1024;
 const MAX_RPC_CONNECTIONS = 32;
 
@@ -93,6 +99,29 @@ type FetchLike = (
   input: string | URL,
   init?: RequestInit,
 ) => Promise<Response>;
+
+/**
+ * PwrSnap rejected the stored access token. PwrSnap issues no refresh token,
+ * so the only recovery is a fresh OAuth approval from the New thread card.
+ */
+export class PwrSnapSessionRevokedError extends Error {
+  constructor() {
+    super(PWRSNAP_SESSION_REVOKED_DETAIL);
+    this.name = "PwrSnapSessionRevokedError";
+  }
+}
+
+/**
+ * True for the SDK failures that only occur after PwrSnap answered 401 with
+ * the stored token. The redirect handler raises PwrSnapSessionRevokedError
+ * itself after revoking, so that error is deliberately not matched here.
+ */
+function isRejectedTokenError(error: unknown): boolean {
+  return (
+    error instanceof UnauthorizedError
+    || (error instanceof StreamableHTTPError && error.code === 401)
+  );
+}
 
 export type PwrSnapConnectionServiceOptions = {
   bridgeEntryPath?: string;
@@ -399,6 +428,7 @@ export class PwrSnapConnectionService {
   private upstreamClient?: Client;
   private upstreamTransport?: StreamableHTTPClientTransport;
   private connectPromise?: Promise<ConnectPwrSnapResponse>;
+  private revokedDetail?: string;
 
   constructor(options: PwrSnapConnectionServiceOptions = {}) {
     this.bridgeEntryPath =
@@ -419,6 +449,13 @@ export class PwrSnapConnectionService {
       this.isEndpointAvailable(),
     ]);
     const installed = endpointAvailable || Boolean(this.findInstalledPath());
+    const configured = Boolean(credential.tokens?.access_token);
+    const detail = [
+      !configured ? this.revokedDetail : undefined,
+      !endpointAvailable && installed
+        ? "Open PwrSnap and enable Local Agent Access to connect agents."
+        : undefined,
+    ].filter(Boolean).join(" ");
     return {
       connectionId: PWRSNAP_MCP_CONNECTION_ID,
       displayName: "PwrSnap",
@@ -427,13 +464,8 @@ export class PwrSnapConnectionService {
         : installed
           ? "installed"
           : "not_installed",
-      configured: Boolean(credential.tokens?.access_token),
-      ...(!endpointAvailable && installed
-        ? {
-            detail:
-              "Open PwrSnap and enable Local Agent Access to connect agents.",
-          }
-        : {}),
+      configured,
+      ...(detail ? { detail } : {}),
     };
   }
 
@@ -476,7 +508,7 @@ export class PwrSnapConnectionService {
     }
     const credential = await this.readCredential();
     if (!credential.tokens?.access_token) {
-      throw new Error("PwrSnap is not connected to PwrAgent.");
+      throw new Error(this.revokedDetail ?? "PwrSnap is not connected to PwrAgent.");
     }
     const registrationKey = threadId
       ? `${connectionId}:${threadId}`
@@ -770,21 +802,40 @@ export class PwrSnapConnectionService {
       await this.settings.clearPwrSnapMcpCredential();
       return;
     }
+    this.revokedDetail = undefined;
     await this.settings.savePwrSnapMcpCredential(JSON.stringify(credential));
+  }
+
+  /**
+   * PwrSnap rejected the stored token, so drop it: readStatus() then reports
+   * configured: false and the New thread card offers Connect to PwrSnap again.
+   */
+  private async revokeStoredSession(): Promise<void> {
+    this.revokedDetail = PWRSNAP_SESSION_REVOKED_DETAIL;
+    connectionLog.warn("PwrSnap rejected the stored session; clearing credential");
+    await this.settings.clearPwrSnapMcpCredential();
+  }
+
+  private async revokeIfTokenRejected(error: unknown): Promise<void> {
+    if (isRejectedTokenError(error)) await this.revokeStoredSession();
   }
 
   private async ensureUpstreamClient(): Promise<Client> {
     if (this.upstreamClient) return this.upstreamClient;
     const credential = await this.readCredential();
     if (!credential.tokens?.access_token) {
-      throw new Error("PwrSnap is not connected to PwrAgent.");
+      throw new Error(this.revokedDetail ?? "PwrSnap is not connected to PwrAgent.");
     }
     const provider = new StoredOAuthProvider(
       new URL("http://127.0.0.1/oauth/callback"),
       credential,
       randomBytes(24).toString("base64url"),
       async () => {
-        throw new Error("PwrSnap needs to be reconnected from New Thread.");
+        // The SDK only starts a new authorization after PwrSnap answered 401
+        // and no refresh token could rescue the session. The proxy cannot
+        // open a consent window, so treat this as a revoked session.
+        await this.revokeStoredSession();
+        throw new PwrSnapSessionRevokedError();
       },
       async (next) => await this.persistCredential(next),
     );
@@ -800,6 +851,7 @@ export class PwrSnapConnectionService {
       await client.connect(transport);
     } catch (error) {
       await transport.close().catch(() => undefined);
+      await this.revokeIfTokenRejected(error);
       throw error;
     }
     this.upstreamClient = client;
@@ -891,6 +943,7 @@ export class PwrSnapConnectionService {
       this.respond(socket, { ok: true, result });
     } catch (error) {
       await this.closeUpstream();
+      await this.revokeIfTokenRejected(error);
       const message = error instanceof Error ? error.message : String(error);
       connectionLog.warn("proxied MCP operation failed", {
         message,

--- a/apps/desktop/src/main/mcp-connections/pwrsnap-connection-service.ts
+++ b/apps/desktop/src/main/mcp-connections/pwrsnap-connection-service.ts
@@ -9,14 +9,10 @@ import { shell } from "electron";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
   auth,
-  UnauthorizedError,
   type OAuthClientProvider,
   type OAuthDiscoveryState,
 } from "@modelcontextprotocol/sdk/client/auth.js";
-import {
-  StreamableHTTPClientTransport,
-  StreamableHTTPError,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type {
   OAuthClientInformationMixed,
   OAuthClientMetadata,
@@ -24,6 +20,7 @@ import type {
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import {
   PWRSNAP_MCP_CONNECTION_ID,
+  PWRSNAP_SESSION_REVOKED_DETAIL,
   type ConnectPwrSnapResponse,
   type OpenPwrSnapResponse,
   type PwrSnapConnectionStatus,
@@ -48,8 +45,9 @@ const PWRSNAP_SCOPES = [
   "sizzle.full.read",
 ].join(" ");
 const OAUTH_CALLBACK_TIMEOUT_MS = 5 * 60_000;
-export const PWRSNAP_SESSION_REVOKED_DETAIL =
-  "PwrSnap revoked this connection. Choose Connect to PwrSnap on the New thread card to connect again.";
+/** Returned to agents through the bridge, where no Connect button is visible. */
+export const PWRSNAP_SESSION_REVOKED_ERROR =
+  "PwrSnap revoked this connection. PwrSnap tools stay unavailable until the operator chooses Connect to PwrSnap on New thread in PwrAgent.";
 const MAX_RPC_LINE_BYTES = 1024 * 1024;
 const MAX_RPC_CONNECTIONS = 32;
 
@@ -99,29 +97,6 @@ type FetchLike = (
   input: string | URL,
   init?: RequestInit,
 ) => Promise<Response>;
-
-/**
- * PwrSnap rejected the stored access token. PwrSnap issues no refresh token,
- * so the only recovery is a fresh OAuth approval from the New thread card.
- */
-export class PwrSnapSessionRevokedError extends Error {
-  constructor() {
-    super(PWRSNAP_SESSION_REVOKED_DETAIL);
-    this.name = "PwrSnapSessionRevokedError";
-  }
-}
-
-/**
- * True for the SDK failures that only occur after PwrSnap answered 401 with
- * the stored token. The redirect handler raises PwrSnapSessionRevokedError
- * itself after revoking, so that error is deliberately not matched here.
- */
-function isRejectedTokenError(error: unknown): boolean {
-  return (
-    error instanceof UnauthorizedError
-    || (error instanceof StreamableHTTPError && error.code === 401)
-  );
-}
 
 export type PwrSnapConnectionServiceOptions = {
   bridgeEntryPath?: string;
@@ -428,7 +403,7 @@ export class PwrSnapConnectionService {
   private upstreamClient?: Client;
   private upstreamTransport?: StreamableHTTPClientTransport;
   private connectPromise?: Promise<ConnectPwrSnapResponse>;
-  private revokedDetail?: string;
+  private sessionRevoked = false;
 
   constructor(options: PwrSnapConnectionServiceOptions = {}) {
     this.bridgeEntryPath =
@@ -450,12 +425,14 @@ export class PwrSnapConnectionService {
     ]);
     const installed = endpointAvailable || Boolean(this.findInstalledPath());
     const configured = Boolean(credential.tokens?.access_token);
-    const detail = [
-      !configured ? this.revokedDetail : undefined,
-      !endpointAvailable && installed
-        ? "Open PwrSnap and enable Local Agent Access to connect agents."
-        : undefined,
-    ].filter(Boolean).join(" ");
+    const details: string[] = [];
+    if (!configured && this.sessionRevoked) {
+      details.push(PWRSNAP_SESSION_REVOKED_DETAIL);
+    }
+    if (!endpointAvailable && installed) {
+      details.push("Open PwrSnap and enable Local Agent Access to connect agents.");
+    }
+    const detail = details.join(" ");
     return {
       connectionId: PWRSNAP_MCP_CONNECTION_ID,
       displayName: "PwrSnap",
@@ -506,10 +483,9 @@ export class PwrSnapConnectionService {
     if (connectionId !== PWRSNAP_MCP_CONNECTION_ID) {
       throw new Error(`Unknown MCP connection: ${connectionId}`);
     }
-    const credential = await this.readCredential();
-    if (!credential.tokens?.access_token) {
-      throw new Error(this.revokedDetail ?? "PwrSnap is not connected to PwrAgent.");
-    }
+    // No credential check here: a thread that enabled PwrSnap must keep
+    // starting turns after PwrSnap revokes the session. Each proxied call
+    // reports the revoke to the agent instead, through ensureUpstreamClient.
     const registrationKey = threadId
       ? `${connectionId}:${threadId}`
       : undefined;
@@ -802,29 +778,36 @@ export class PwrSnapConnectionService {
       await this.settings.clearPwrSnapMcpCredential();
       return;
     }
-    this.revokedDetail = undefined;
+    this.sessionRevoked = false;
     await this.settings.savePwrSnapMcpCredential(JSON.stringify(credential));
   }
 
   /**
-   * PwrSnap rejected the stored token, so drop it: readStatus() then reports
-   * configured: false and the New thread card offers Connect to PwrSnap again.
+   * PwrSnap rejected `rejectedAccessToken`, so drop it: readStatus() then
+   * reports configured: false and New thread offers Connect to PwrSnap again.
+   * A concurrent Connect may already have stored a fresh token, and a
+   * concurrent proxied call may already have cleared this one; neither
+   * case writes.
    */
-  private async revokeStoredSession(): Promise<void> {
-    this.revokedDetail = PWRSNAP_SESSION_REVOKED_DETAIL;
+  private async revokeStoredSession(rejectedAccessToken: string): Promise<void> {
+    const storedAccessToken = (await this.readCredential()).tokens?.access_token;
+    if (storedAccessToken && storedAccessToken !== rejectedAccessToken) return;
+    this.sessionRevoked = true;
+    if (!storedAccessToken) return;
     connectionLog.warn("PwrSnap rejected the stored session; clearing credential");
     await this.settings.clearPwrSnapMcpCredential();
-  }
-
-  private async revokeIfTokenRejected(error: unknown): Promise<void> {
-    if (isRejectedTokenError(error)) await this.revokeStoredSession();
   }
 
   private async ensureUpstreamClient(): Promise<Client> {
     if (this.upstreamClient) return this.upstreamClient;
     const credential = await this.readCredential();
-    if (!credential.tokens?.access_token) {
-      throw new Error(this.revokedDetail ?? "PwrSnap is not connected to PwrAgent.");
+    const accessToken = credential.tokens?.access_token;
+    if (!accessToken) {
+      throw new Error(
+        this.sessionRevoked
+          ? PWRSNAP_SESSION_REVOKED_ERROR
+          : "PwrSnap is not connected to PwrAgent.",
+      );
     }
     const provider = new StoredOAuthProvider(
       new URL("http://127.0.0.1/oauth/callback"),
@@ -834,10 +817,16 @@ export class PwrSnapConnectionService {
         // The SDK only starts a new authorization after PwrSnap answered 401
         // and no refresh token could rescue the session. The proxy cannot
         // open a consent window, so treat this as a revoked session.
-        await this.revokeStoredSession();
-        throw new PwrSnapSessionRevokedError();
+        await this.revokeStoredSession(accessToken);
+        throw new Error(PWRSNAP_SESSION_REVOKED_ERROR);
       },
-      async (next) => await this.persistCredential(next),
+      async (next) => {
+        // The SDK saves a code verifier for the authorization it is about to
+        // start, while the snapshot still carries the rejected token. Do not
+        // write that back: only a token change is worth persisting here.
+        if (next.tokens?.access_token === accessToken) return;
+        await this.persistCredential(next);
+      },
     );
     const transport = new StreamableHTTPClientTransport(PWRSNAP_MCP_URL, {
       authProvider: provider,
@@ -851,7 +840,6 @@ export class PwrSnapConnectionService {
       await client.connect(transport);
     } catch (error) {
       await transport.close().catch(() => undefined);
-      await this.revokeIfTokenRejected(error);
       throw error;
     }
     this.upstreamClient = client;
@@ -943,7 +931,6 @@ export class PwrSnapConnectionService {
       this.respond(socket, { ok: true, result });
     } catch (error) {
       await this.closeUpstream();
-      await this.revokeIfTokenRejected(error);
       const message = error instanceof Error ? error.message : String(error);
       connectionLog.warn("proxied MCP operation failed", {
         message,

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
@@ -119,4 +119,31 @@ describe("PwrSnapConnectionPrompt", () => {
     });
     fireEvent.click(toggle);
     await waitFor(() => expect(onEnabledChange).toHaveBeenCalledWith(true));
-  });});
+  });
+
+  it("offers to reconnect and explains why after PwrSnap revoked the session", async () => {
+    const detail =
+      "PwrSnap revoked this connection. Choose Connect to PwrSnap on the New thread card to connect again.";
+    render(
+      <PwrSnapConnectionPrompt
+        backend="codex"
+        desktopApi={{
+          readPwrSnapConnectionStatus: async () => ({
+            connectionId: "pwrsnap",
+            displayName: "PwrSnap",
+            availability: "running",
+            configured: false,
+            detail,
+          }),
+        }}
+        enabled={false}
+        onEnabledChange={vi.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("button", { name: "Connect to PwrSnap" }))
+      .toBeTruthy();
+    expect(screen.getByText(detail)).toBeTruthy();
+    expect(screen.queryByRole("switch")).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { PWRSNAP_SESSION_REVOKED_DETAIL } from "@pwragent/shared";
 import { describe, expect, it, vi } from "vitest";
 import { PwrSnapConnectionPrompt } from "./PwrSnapConnectionPrompt";
 
@@ -122,8 +123,7 @@ describe("PwrSnapConnectionPrompt", () => {
   });
 
   it("offers to reconnect and explains why after PwrSnap revoked the session", async () => {
-    const detail =
-      "PwrSnap revoked this connection. Choose Connect to PwrSnap on the New thread card to connect again.";
+    const detail = PWRSNAP_SESSION_REVOKED_DETAIL;
     render(
       <PwrSnapConnectionPrompt
         backend="codex"

--- a/packages/shared/src/contracts/mcp-connections.ts
+++ b/packages/shared/src/contracts/mcp-connections.ts
@@ -2,6 +2,13 @@ import type { FederationRemoteTarget } from "./federation";
 
 export const PWRSNAP_MCP_CONNECTION_ID = "pwrsnap" as const;
 
+/**
+ * Shown on the New thread PwrSnap band next to the Connect to PwrSnap button
+ * after PwrSnap rejected the stored session.
+ */
+export const PWRSNAP_SESSION_REVOKED_DETAIL =
+  "PwrSnap revoked this connection. Choose Connect to PwrSnap to connect again.";
+
 export type McpConnectionId = typeof PWRSNAP_MCP_CONNECTION_ID;
 
 export type PwrSnapConnectionAvailability =


### PR DESCRIPTION
## Problem

When PwrSnap revokes PwrAgent's session, the stored OAuth credential was never cleared. PwrSnap issues no refresh token, so on a 401 the MCP SDK's `auth()` falls through to `startAuthorization` and calls the proxy provider's `redirectToAuthorization`, which threw "PwrSnap needs to be reconnected from New Thread." The access token stayed in the secret store, `readStatus()` kept reporting `configured: true`, and the New thread card kept rendering the **Use in this thread** switch instead of **Connect to PwrSnap**. The operator had no way to reconnect from the UI.

## Fix

- The proxy provider's redirect handler is the single revoke seam. The SDK only reaches it after PwrSnap answered 401 with the stored token and no refresh token could rescue the session. The handler clears the credential (via `settings.clearPwrSnapMcpCredential()`), remembers that the session was revoked, and throws an agent-facing error.
- The revoke compares the rejected token against what is currently stored, so a 401 chain that overlaps a fresh Connect keeps the new token, and a repeat revoke from a concurrent call does not write again. The provider also skips persisting the code-verifier snapshot the SDK saves right before the redirect, which still carried the rejected token.
- `readStatus()` then reports `configured: false` and a detail: *PwrSnap revoked this connection. Choose Connect to PwrSnap to connect again.* The card already renders `status.detail`, so the reason appears next to the **Connect to PwrSnap** button. A fresh approval clears the notice. The detail string lives in `@pwragent/shared` beside the connection id.
- `registerBridge` no longer requires a stored credential. A thread that enabled PwrSnap keeps starting turns after the revoke; each proxied PwrSnap call reports the revoke to the agent instead, naming New thread in PwrAgent as the place to reconnect.

## Tests

- `pwrsnap-connection-service.test.ts`: drives the real SDK 401 path with a stored credential carrying cached discovery state, and asserts the proxy never opens a consent window, never writes the rejected snapshot back, clears the credential exactly once, flips `readStatus()` to `configured: false` with the revoke detail, still registers a bridge for an enabled thread, and hides the notice once a fresh credential is stored. Two more tests cover a Connect that lands while the 401 is in flight (the fresh token survives) and a non-token failure (the credential survives).
- `PwrSnapConnectionPrompt.test.tsx`: a revoked status renders the Connect button and the shared detail, with no switch.

## Docs follow-up

pwrdrvr/docs.pwragent.ai#12 adds a "Reconnecting to PwrSnap after a revoke" bullet under **Not yet** in `desktop.md`, plus a "One caveat in current builds" paragraph in the Connect to PwrSnap section. Both should be dropped once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
