### PR TITLE
fix(desktop): prevent later usage from overwriting earlier turns

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -27245,6 +27245,60 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it.each(["explicit", "turnless"])(
+    "preserves an earlier turn when a %s snapshot includes a newer turn's usage",
+    async (attribution) => {
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/read"] },
+      });
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex", threadId: "thread-1", executionMode: "default",
+            extraLinkedDirectories: [], model: "gpt-6-astra", serviceTier: "standard",
+          },
+        },
+      });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const emitUsage = async (turnId: string | undefined, total: number, last: number) => {
+        const tokens = (inputTokens: number) => ({
+          inputTokens, cachedInputTokens: 0, outputTokens: 0,
+          reasoningOutputTokens: 0, totalTokens: inputTokens,
+        });
+        await codexClient.emit({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1", ...(turnId ? { turnId } : {}),
+            tokenUsage: { total: tokens(total), last: tokens(last) },
+          },
+        });
+      };
+      const readLines = async () => (await overlayStore.readThreadPricing({
+        backend: "codex", threadId: "thread-1",
+      })).lines;
+
+      await emitUsage("turn-1", 1_000, 1_000);
+      await codexClient.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1", turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      });
+      // A resumed stream can expose turn 2 usage without its start event.
+      await emitUsage("turn-2", 101_000, 10_000);
+      const earlier = (await readLines()).find((line) => line.turnId === "turn-1");
+      await emitUsage(attribution === "explicit" ? "turn-1" : undefined, 102_000, 1_000);
+      expect((await readLines()).find((line) => line.turnId === "turn-1")).toEqual(earlier);
+      await emitUsage("turn-2", 103_000, 1_000);
+      const lines = await readLines();
+      expect(lines).toHaveLength(2);
+      expect(lines.find((line) => line.turnId === "turn-2")?.inputTokens).toBe(102_000);
+      expect(lines.reduce((sum, line) => sum + line.inputTokens, 0)).toBe(103_000);
+      await registry.close();
+    },
+  );
+
   it("does not regress Codex cumulative usage on a late older-turn snapshot", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -27299,6 +27299,66 @@ command = "pnpm dev"
     },
   );
 
+  it.each(["explicit", "turnless"])(
+    "keeps current usage advancing after an equal-total %s older-turn replay",
+    async (attribution) => {
+      const codexClient = new MockBackendClient({
+        initializeResult: { methods: ["thread/read"] },
+      });
+      const overlayStore = createOverlayStoreMock({
+        overlays: {
+          "codex:thread-1": {
+            backend: "codex", threadId: "thread-1", executionMode: "default",
+            extraLinkedDirectories: [], model: "gpt-6-astra", serviceTier: "standard",
+          },
+        },
+      });
+      const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+      const emitUsage = async (turnId: string | undefined, total: number, last: number) => {
+        const tokens = (inputTokens: number) => ({
+          inputTokens, cachedInputTokens: 0, outputTokens: 0,
+          reasoningOutputTokens: 0, totalTokens: inputTokens,
+        });
+        await codexClient.emit({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1", ...(turnId ? { turnId } : {}),
+            tokenUsage: { total: tokens(total), last: tokens(last) },
+          },
+        });
+      };
+      await emitUsage("turn-1", 1_000, 1_000);
+      await codexClient.emit({
+        method: "turn/completed",
+        params: {
+          threadId: "thread-1", turnId: "turn-1",
+          turn: { id: "turn-1", status: "completed", output: [] },
+        },
+      });
+      // Turn 2 has an identity before it consumes any additional tokens.
+      await emitUsage("turn-2", 1_000, 1_000);
+      const replayTurnId = attribution === "explicit" ? "turn-1" : undefined;
+      await emitUsage(replayTurnId, 1_000, 1_000);
+      await emitUsage(replayTurnId, 1_000, 1_000);
+      await emitUsage("turn-2", 2_000, 1_000);
+      await emitUsage("turn-2", 3_000, 1_000);
+      // Ownership must also remain correct when the next turn starts.
+      await emitUsage("turn-3", 4_000, 1_000);
+      await emitUsage("turn-2", 3_000, 1_000);
+      await emitUsage("turn-3", 5_000, 1_000);
+      const pricing = await overlayStore.readThreadPricing({
+        backend: "codex", threadId: "thread-1",
+      });
+      expect(pricing.lines).toHaveLength(3);
+      for (const [turnId, inputTokens] of [
+        ["turn-1", 1_000], ["turn-2", 2_000], ["turn-3", 2_000],
+      ] as const) {
+        expect(pricing.lines.find((line) => line.turnId === turnId)?.inputTokens).toBe(inputTokens);
+      }
+      await registry.close();
+    },
+  );
+
   it("does not regress Codex cumulative usage on a late older-turn snapshot", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -258,6 +258,20 @@
     "rowsChanged": 2,
     "statements": 2
   },
+  "thread-usage-finalization": {
+    "commits": 1,
+    "note": "one successor pricing flush finalizes its predecessor in the same transaction",
+    "observedWalBytes": 74160,
+    "rowsChanged": 4,
+    "statements": 4
+  },
+  "thread-usage-finalized-replays": {
+    "commits": 0,
+    "note": "100 stale finalized-turn updates return durable rows without any SQLite commit",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "token-miser-retrieval-ledger": {
     "commits": 1,
     "note": "one previously gated output retrieved in a later parent turn, updating its savings equation at the turn boundary",

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -272,6 +272,20 @@
     "rowsChanged": 0,
     "statements": 0
   },
+  "thread-usage-protected-enrichment": {
+    "commits": 1,
+    "note": "one hydration fills missing protected-turn metadata while retaining its usage and price",
+    "observedWalBytes": 53560,
+    "rowsChanged": 3,
+    "statements": 3
+  },
+  "thread-usage-protected-enrichment-replays": {
+    "commits": 0,
+    "note": "100 repeated hydrations of already-filled metadata make no SQLite commit",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "token-miser-retrieval-ledger": {
     "commits": 1,
     "note": "one previously gated output retrieved in a later parent turn, updating its savings equation at the turn boundary",

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -158,6 +158,81 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     expect(pricing.summaries[0]?.totalTokens).toBe(3_300);
   });
 
+  it.each([false, true])("enriches protected metadata without accepting stale usage (priced=%s)", async (priced) => {
+    const first = buildUsageLine({
+      source: "live", model: priced ? "gpt-5.5" : undefined,
+      serviceTier: undefined, reasoningEffort: undefined,
+      cumulativeTotalTokens: 1_300,
+    });
+    await store.upsertThreadUsageLine({ line: first });
+    await store.upsertThreadUsageLine({ line: buildUsageLine({
+      source: "live", usageLineId: "line-2", turnId: "turn-2", cumulativeTotalTokens: 2_600,
+    }) });
+    const before = (await store.readThreadPricing({ backend: "codex", threadId: "thread-1" }))
+      .lines.find((line) => line.turnId === "turn-1")!;
+    // Simulate v60's restriction on filling a missing pricing field. Reopening
+    // must replace that trigger while retaining the separate token guards.
+    stateDb.raw.exec(`
+      DROP TRIGGER protect_finalized_thread_usage_update;
+      CREATE TRIGGER protect_finalized_thread_usage_update
+      BEFORE UPDATE ON thread_usage_lines
+      WHEN OLD.service_tier IS NOT NEW.service_tier
+      BEGIN SELECT RAISE(IGNORE); END;
+      PRAGMA user_version = 60;
+    `);
+    stateDb.close();
+    stateDb = StateDb.open(path.join(tempDir, "state.db"));
+    store = new SqliteOverlayStore(stateDb);
+    const hydration = buildUsageLine({
+      source: "hydration", usageLineId: "hydrated-replacement", model: "gpt-5.5",
+      startedAt: first.createdAt - 100, completedAt: first.createdAt + 1_000,
+      finalContextTokens: 600, peakContextTokens: 900, modelContextWindow: 258_400,
+      inputTokens: 100_000, uncachedInputTokens: 99_800,
+      totalTokens: 100_300, cumulativeTotalTokens: 100_300,
+      totalCostMicros: 900_000_000,
+    });
+    await store.upsertThreadUsageLine({ line: hydration });
+    const pricing = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(pricing.lines).toHaveLength(2);
+    const enriched = pricing.lines.find((line) => line.turnId === "turn-1")!;
+    expect(enriched).toMatchObject({
+      usageLineId: "line-1", source: "live", model: "gpt-5.5", serviceTier: "standard",
+      startedAt: first.createdAt - 100, completedAt: first.createdAt + 1_000,
+      finalContextTokens: 600, peakContextTokens: 900, modelContextWindow: 258_400,
+      inputTokens: before.inputTokens, totalTokens: before.totalTokens,
+      cumulativeTotalTokens: before.cumulativeTotalTokens, priceStatus: "priced",
+    });
+    expect(enriched.totalCostMicros).toBe(priced ? before.totalCostMicros : 16_100);
+    await store.upsertThreadUsageLine({ line: {
+      ...hydration, model: "gpt-6-astra", completedAt: first.createdAt + 9_000,
+      modelContextWindow: 999_999,
+    } });
+    expect(await store.readThreadPricing({ backend: "codex", threadId: "thread-1" })).toEqual(pricing);
+  });
+
+  it("prices a protected Astra aggregate when hydration supplies its missing context ceiling", async () => {
+    const first = buildUsageLine(buildAstraAggregateOverrides({
+      source: "live", cumulativeTotalTokens: 1_658_805,
+    }));
+    await store.upsertThreadUsageLine({ line: first });
+    await store.upsertThreadUsageLine({ line: {
+      ...first, usageLineId: "line-2", turnId: "turn-2", cumulativeTotalTokens: 3_317_610,
+    } });
+    const before = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(before.lines.find((line) => line.turnId === "turn-1")?.priceStatus).toBe("unpriced");
+    await store.upsertThreadUsageLine({ line: {
+      ...first, source: "hydration", usageLineId: "hydrated-astra",
+      modelContextWindow: 258_400, totalTokens: 9_999_999, cumulativeTotalTokens: 9_999_999,
+    } });
+    const after = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(after.lines).toHaveLength(2);
+    expect(after.lines.find((line) => line.turnId === "turn-1")).toMatchObject({
+      priceStatus: "priced", modelContextWindow: 258_400,
+      totalTokens: 1_658_805, cumulativeTotalTokens: 1_658_805,
+      totalCostMicros: 3_269_538,
+    });
+  });
+
   it("upserts a priced usage line and cached summary idempotently", async () => {
     const line = buildUsageLine();
 

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -23,6 +23,127 @@ afterEach(() => {
 });
 
 describe("SqliteOverlayStore thread usage pricing ledger", () => {
+  it.each(["live", "hydration", "backfill"] as const)(
+    "preserves finalized turn accounting across restart and %s replacement",
+    async (source) => {
+      const first = buildUsageLine({
+        source: "live", status: "pending", turnUsageAttributed: true,
+        cumulativeTotalTokens: 1_300,
+      });
+      await store.upsertThreadUsageLine({ line: first });
+      // Completion alone must still allow a legitimate final usage update.
+      const final = buildUsageLine({
+        ...first, inputTokens: 1_100, uncachedInputTokens: 900,
+        totalTokens: 1_400, cumulativeTotalTokens: 1_400,
+      });
+      await store.upsertThreadUsageLine({ line: final });
+      const second = buildUsageLine({
+        source: "live", status: "pending", turnUsageAttributed: true,
+        usageLineId: "line-2", turnId: "turn-2", sourceItemId: "item-2",
+        createdAt: first.createdAt + 1,
+        cumulativeTotalTokens: 2_700,
+      });
+      await store.upsertThreadUsageLine({ line: second });
+      const before = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+      // Exercise the upgrade too: existing non-overlapping rows must acquire
+      // durable boundaries without needing another live notification.
+      stateDb.raw.exec(`
+        DROP TRIGGER protect_finalized_thread_usage_insert;
+        DROP TRIGGER protect_finalized_thread_usage_update;
+        DROP TRIGGER protect_thread_usage_boundary_update;
+        DROP TABLE thread_usage_boundaries;
+        PRAGMA user_version = 59;
+      `);
+      stateDb.close();
+      stateDb = StateDb.open(path.join(tempDir, "state.db"));
+      store = new SqliteOverlayStore(stateDb);
+      await store.upsertThreadUsageLine({
+        line: buildUsageLine({
+          ...first, source, usageLineId: source === "live" ? "line-1" : "replacement",
+          inputTokens: 100_000, uncachedInputTokens: 99_800,
+          totalTokens: 100_300, cumulativeTotalTokens: 100_300,
+        }),
+      });
+      expect(stateDb.raw.prepare(
+        "UPDATE thread_usage_lines SET total_tokens = 999999 WHERE usage_line_id = ?",
+      ).run("line-1").changes).toBe(0);
+      expect(stateDb.raw.prepare(
+        "UPDATE thread_usage_lines SET total_cost_micros = 999999 WHERE usage_line_id = ?",
+      ).run("line-1").changes).toBe(0);
+      // An older writer that does not know about finalization cannot insert a
+      // second billable row for the same finalized turn either.
+      stateDb.raw.exec("CREATE TEMP TABLE usage_copy AS SELECT * FROM thread_usage_lines WHERE usage_line_id = 'line-1'");
+      stateDb.raw.exec("UPDATE usage_copy SET usage_line_id = 'raw-replacement'");
+      stateDb.raw.exec("INSERT INTO thread_usage_lines SELECT * FROM usage_copy");
+      const after = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+      expect(after).toEqual(before);
+      // The new turn remains writable after reopening the database.
+      await store.upsertThreadUsageLine({
+        line: { ...second, inputTokens: 1_100, uncachedInputTokens: 900,
+          totalTokens: 1_400, cumulativeTotalTokens: 2_800 },
+      });
+      const advanced = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+      expect(advanced.lines.find((line) => line.turnId === "turn-2")?.totalTokens).toBe(1_400);
+      expect(advanced.lines.find((line) => line.turnId === "turn-1")).toEqual(
+        before.lines.find((line) => line.turnId === "turn-1"),
+      );
+    },
+  );
+
+  it.each([false, true])("finalizes before a coalesced stale write (reversed=%s)", async (reversed) => {
+    const first = buildUsageLine({ source: "live", cumulativeTotalTokens: 1_300 });
+    await store.upsertThreadUsageLine({ line: first });
+    const successor = buildUsageLine({
+      source: "live", usageLineId: "line-2", turnId: "turn-2", cumulativeTotalTokens: 2_600,
+    });
+    const stale = { ...first, inputTokens: 100_000, uncachedInputTokens: 99_800,
+      totalTokens: 100_300, cumulativeTotalTokens: 100_300 };
+    await store.upsertThreadUsageLines({ lines: reversed ? [successor, stale] : [stale, successor] });
+    const pricing = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(pricing.lines.find((line) => line.turnId === "turn-1")?.totalTokens).toBe(1_300);
+    expect(pricing.summaries[0]?.totalTokens).toBe(2_600);
+  });
+
+  it.each([0, 1_300])("keeps equal-total replays from finalizing the active turn (prefix=%s)", async (prefix) => {
+    const empty = buildUsageLine({
+      source: "live", inputTokens: 0, cachedInputTokens: 0, uncachedInputTokens: 0,
+      outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0, cumulativeTotalTokens: 0,
+    });
+    const first = prefix === 0 ? empty : buildUsageLine({ source: "live", cumulativeTotalTokens: prefix });
+    await store.upsertThreadUsageLine({ line: first });
+    const second = { ...empty, usageLineId: "line-2", turnId: "turn-2", cumulativeTotalTokens: prefix };
+    await store.upsertThreadUsageLine({ line: second });
+    await store.upsertThreadUsageLine({ line: first });
+    const advanced = buildUsageLine({
+      source: "live", usageLineId: "line-2", turnId: "turn-2", cumulativeTotalTokens: prefix + 1_300,
+    });
+    await store.upsertThreadUsageLine({ line: advanced });
+    await store.upsertThreadUsageLine({ line: { ...first, totalTokens: 999_999, cumulativeTotalTokens: 999_999 } });
+    const pricing = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(pricing.lines.find((line) => line.turnId === "turn-1")?.totalTokens).toBe(prefix);
+    expect(pricing.lines.find((line) => line.turnId === "turn-2")?.totalTokens).toBe(1_300);
+  });
+
+  it("accepts a missing final request within a durable successor boundary", async () => {
+    const first = buildUsageLine({ source: "live", cumulativeTotalTokens: 1_300 });
+    await store.upsertThreadUsageLine({ line: first });
+    await store.upsertThreadUsageLine({ line: buildUsageLine({
+      source: "live", usageLineId: "line-2", turnId: "turn-2", cumulativeTotalTokens: 3_300,
+    }) });
+    stateDb.close();
+    stateDb = StateDb.open(path.join(tempDir, "state.db"));
+    store = new SqliteOverlayStore(stateDb);
+    const final = { ...first, inputTokens: 1_700, uncachedInputTokens: 1_500,
+      totalTokens: 2_000, cumulativeTotalTokens: 2_000 };
+    await store.upsertThreadUsageLine({ line: final });
+    let pricing = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(pricing.lines.find((line) => line.turnId === "turn-1")?.totalTokens).toBe(2_000);
+    expect(pricing.summaries[0]?.totalTokens).toBe(3_300);
+    await store.upsertThreadUsageLine({ line: { ...final, totalTokens: 3_300, cumulativeTotalTokens: 3_300 } });
+    pricing = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(pricing.summaries[0]?.totalTokens).toBe(3_300);
+  });
+
   it("upserts a priced usage line and cached summary idempotently", async () => {
     const line = buildUsageLine();
 

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -133,6 +133,20 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     stateDb.close();
     stateDb = StateDb.open(path.join(tempDir, "state.db"));
     store = new SqliteOverlayStore(stateDb);
+    // Even while the final request is missing, the persisted ceiling and
+    // baseline reject a later turn's total or a freshly reset accumulator.
+    await store.upsertThreadUsageLine({ line: {
+      ...first, inputTokens: 3_000, uncachedInputTokens: 2_800,
+      totalTokens: 3_300, cumulativeTotalTokens: 3_300,
+    } });
+    await store.upsertThreadUsageLine({ line: {
+      ...first, totalTokens: 100, cumulativeTotalTokens: 1_900,
+    } });
+    expect(stateDb.raw.prepare(
+      "UPDATE thread_usage_lines SET total_tokens = 3300, cumulative_total_tokens = 3300 WHERE usage_line_id = ?",
+    ).run("line-1").changes).toBe(0);
+    const bounded = await store.readThreadPricing({ backend: "codex", threadId: "thread-1" });
+    expect(bounded.lines.find((line) => line.turnId === "turn-1")?.totalTokens).toBe(1_300);
     const final = { ...first, inputTokens: 1_700, uncachedInputTokens: 1_500,
       totalTokens: 2_000, cumulativeTotalTokens: 2_000 };
     await store.upsertThreadUsageLine({ line: final });

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -100,6 +100,30 @@ describe("sqlite write metrics", () => {
       note: "100 stale finalized-turn updates return durable rows without any SQLite commit",
       writes: rejectedWrites,
     });
+    const enrichment = {
+      ...first, source: "hydration" as const, usageLineId: "hydrated-replacement",
+      completedAt: first.createdAt + 1_000, modelContextWindow: 258_400,
+      inputTokens: 100_000, uncachedInputTokens: 100_000,
+      totalTokens: 100_000, cumulativeTotalTokens: 100_000,
+    };
+    const { writes: enrichmentWrites } = await measureSqliteWrites(async () => {
+      await store.upsertThreadUsageLine({ line: enrichment });
+    });
+    expectSqliteWriteBudget({
+      scenario: "thread-usage-protected-enrichment",
+      note: "one hydration fills missing protected-turn metadata while retaining its usage and price",
+      writes: enrichmentWrites,
+    });
+    const { writes: repeatedEnrichmentWrites } = await measureSqliteWrites(async () => {
+      for (let index = 0; index < 100; index += 1) {
+        await store.upsertThreadUsageLine({ line: enrichment });
+      }
+    });
+    expectSqliteWriteBudget({
+      scenario: "thread-usage-protected-enrichment-replays",
+      note: "100 repeated hydrations of already-filled metadata make no SQLite commit",
+      writes: repeatedEnrichmentWrites,
+    });
   });
 
   it("keeps partial navigation search reconciliation read-only", async () => {

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -63,6 +63,45 @@ afterEach(() => {
 });
 
 describe("sqlite write metrics", () => {
+  it("finalizes usage in the successor transaction and ignores stale writes", async () => {
+    const first: ThreadUsageLineRecord = {
+      backend: "codex", provider: "openai", threadId: "sealed-thread",
+      turnId: "turn-1", usageLineId: "sealed-line-1", source: "live",
+      scope: "turn", status: "pending", turnUsageAttributed: true,
+      createdAt: 1_800_000_000_000, currency: "USD", model: "gpt-5.5",
+      inputTokens: 1_000, uncachedInputTokens: 1_000, cachedInputTokens: 0,
+      outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 1_000,
+      cumulativeTotalTokens: 1_000, priceStatus: "priced",
+      totalCostMicros: 5_000, uncachedInputCostMicros: 5_000,
+      cachedInputCostMicros: 0, outputCostMicros: 0,
+    };
+    await store.upsertThreadUsageLine({ line: first });
+    const { writes } = await measureSqliteWrites(async () => {
+      await store.upsertThreadUsageLine({ line: {
+        ...first, turnId: "turn-2", usageLineId: "sealed-line-2",
+        cumulativeTotalTokens: 2_000,
+      } });
+    });
+    expectSqliteWriteBudget({
+      scenario: "thread-usage-finalization",
+      note: "one successor pricing flush finalizes its predecessor in the same transaction",
+      writes,
+    });
+    const { writes: rejectedWrites } = await measureSqliteWrites(async () => {
+      for (let index = 0; index < 100; index += 1) {
+        await store.upsertThreadUsageLine({ line: {
+          ...first, inputTokens: 100_000, uncachedInputTokens: 100_000,
+          totalTokens: 100_000, cumulativeTotalTokens: 100_000,
+        } });
+      }
+    });
+    expectSqliteWriteBudget({
+      scenario: "thread-usage-finalized-replays",
+      note: "100 stale finalized-turn updates return durable rows without any SQLite commit",
+      writes: rejectedWrites,
+    });
+  });
+
   it("keeps partial navigation search reconciliation read-only", async () => {
     const thread: AppServerThreadSummary = {
       id: "thread-search",

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8307,6 +8307,13 @@ export class DesktopBackendRegistry {
       usage: TaskMonitorTokenUsageBreakdown;
     }
   >();
+  // Once another turn consumes usage, the preceding cumulative snapshot is
+  // the upper bound for the older turn. Keep it across start/completion events
+  // so a replay cannot charge a later turn's tokens to an earlier ledger row.
+  private readonly liveCodexThreadUsageCeilings = new Map<
+    string,
+    TaskMonitorTokenUsageBreakdown
+  >();
   private readonly liveThreadUsageAggregates = new Map<
     string,
     LiveThreadUsageAggregate
@@ -25331,6 +25338,17 @@ export class DesktopBackendRegistry {
         )
       )
     ) {
+      if (priorCumulative && priorCumulative.turnId !== params.turnId) {
+        const priorTurnKey = [
+          params.backend,
+          params.threadId,
+          priorCumulative.turnId,
+          "live-token-usage",
+        ].join(":");
+        if (!this.liveCodexThreadUsageCeilings.has(priorTurnKey)) {
+          this.liveCodexThreadUsageCeilings.set(priorTurnKey, priorCumulative.usage);
+        }
+      }
       this.liveCodexThreadCumulativeUsage.set(cumulativeKey, {
         observationSequence,
         turnId: params.turnId,
@@ -25740,6 +25758,22 @@ export class DesktopBackendRegistry {
       }
 
       const tokenUsage = notification.params.tokenUsage;
+      const usageCeiling = event.backend === "codex" && turnId
+        ? this.liveCodexThreadUsageCeilings.get(
+            [event.backend, threadId, turnId, "live-token-usage"].join(":"),
+          )
+        : undefined;
+      const cumulativeUsage = readTaskMonitorTokenUsageRecords(tokenUsage)?.totalUsage;
+      if (
+        usageCeiling
+        && cumulativeUsage
+        && cumulativeUsage.totalTokens > usageCeiling.totalTokens
+      ) {
+        // A stale turn id (including the turnless completion fallback) cannot
+        // own a thread snapshot that already includes a subsequent turn.
+        // Reject before advancing pricing, request, and replay cursors.
+        return;
+      }
       derivedUsage = this.deriveLiveThreadTokenUsage({
         appendLatestUsage: Boolean(recentlyCompletedTurn),
         backend: event.backend,

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -25767,7 +25767,7 @@ export class DesktopBackendRegistry {
       if (
         usageCeiling
         && cumulativeUsage
-        && cumulativeUsage.totalTokens > usageCeiling.totalTokens
+        && (cumulativeUsage.totalTokens ?? 0) > (usageCeiling.totalTokens ?? 0)
       ) {
         // A stale turn id (including the turnless completion fallback) cannot
         // own a thread snapshot that already includes a subsequent turn.

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -25327,6 +25327,9 @@ export class DesktopBackendRegistry {
       params.backend === "codex"
       && params.turnId
       && observationSequence !== undefined
+      // A superseded turn may refresh its own bounded usage, but it can never
+      // own the thread cursor again, even when cumulative totals are equal.
+      && !this.liveCodexThreadUsageCeilings.has(key)
       && (
         !priorCumulative
         || (

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1299,7 +1299,12 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     // Finalized rows and summaries are immutable to this path. A fully stale
     // batch is read-only and must not open even an empty SQLite transaction.
     const finalizedBatch = lines.map((line) => this.readProtectedThreadUsageSync(line));
-    if (finalizedBatch.every((entry) => entry !== undefined)) {
+    if (
+      finalizedBatch.every((entry) => entry !== undefined)
+      && finalizedBatch.every((entry, index) =>
+        !enrichProtectedThreadUsage(entry.line, lines[index]!),
+      )
+    ) {
       const summaries = new Map<string, ThreadPricingSummary>();
       for (const entry of finalizedBatch) {
         const summary = entry.summary;
@@ -1346,15 +1351,21 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       let line = inputLine;
       const finalized = this.readProtectedThreadUsageSync(line);
       if (finalized) {
-        const summary = finalized.summary;
-        unchangedSummaries.set(JSON.stringify([
-          summary.provider, summary.backend, summary.threadId, summary.currency,
-        ]), summary);
-        return finalized.line;
+        const enriched = enrichProtectedThreadUsage(finalized.line, inputLine);
+        if (!enriched) {
+          const summary = finalized.summary;
+          unchangedSummaries.set(JSON.stringify([
+            summary.provider, summary.backend, summary.threadId, summary.currency,
+          ]), summary);
+          return finalized.line;
+        }
+        // Only allowlisted metadata was copied. All identity, token, replay,
+        // and finalized price fields still come from the authoritative row.
+        line = enriched;
       }
       this.boundPrecedingThreadUsageSync(line);
       const existing = this.readThreadUsageLineSync(line.usageLineId);
-      if (existing) {
+      if (existing && !finalized) {
         line = mergeThreadUsageLineForUpsert(line, existing);
       }
       // Codex hydration records expose either the last request or the
@@ -6821,6 +6832,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       return undefined;
     }
     const preserved = threadUsageLineFromRow(row);
+    this.attachUsageTurnMetadataSync(preserved.backend, preserved.threadId, [preserved]);
     const summaryRow = this.stateDb.raw.prepare(
       `SELECT * FROM thread_pricing_summaries
        WHERE provider = ? AND backend = ? AND thread_id = ? AND currency = ?`,
@@ -7505,6 +7517,38 @@ function mergeUsageSettingValue<T extends string>(
     return existing;
   }
   return next;
+}
+
+function enrichProtectedThreadUsage(
+  preserved: ThreadUsageLineRecord,
+  incoming: ThreadUsageLineRecord,
+): ThreadUsageLineRecord | undefined {
+  let enriched = { ...preserved };
+  let changed = false;
+  for (const key of [
+    "model", "reasoningEffort", "serviceTier", "fastMode", "completedAt",
+    "finalContextTokens", "peakContextTokens", "modelContextWindow",
+  ] as const) {
+    if (preserved[key] === undefined && incoming[key] !== undefined) {
+      enriched = { ...enriched, [key]: incoming[key] };
+      changed = true;
+    }
+  }
+  // Live usage can precede hydration of the actual start time; the turn table
+  // initially uses the observation time. Replace that fallback once, without
+  // overwriting an already-enriched start time on subsequent replays.
+  if (incoming.startedAt !== undefined
+    && (preserved.startedAt === undefined
+      || (preserved.startedAt === preserved.createdAt && incoming.startedAt < preserved.startedAt))) {
+    enriched.startedAt = incoming.startedAt;
+    changed = true;
+  }
+  if (!changed) {
+    return undefined;
+  }
+  // Never copy the incoming cost or reprice a finalized priced row. A missing
+  // model/context ceiling can price an unpriced row using its frozen tokens.
+  return preserved.priceStatus === "priced" ? enriched : repriceTokenUsageLine(enriched);
 }
 
 function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineRecord {

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -1296,6 +1296,22 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     const lines = [...latestLinesById.values()].map((line) =>
       repriceTokenUsageLine(normalizeThreadUsageLine(line, now)),
     );
+    // Finalized rows and summaries are immutable to this path. A fully stale
+    // batch is read-only and must not open even an empty SQLite transaction.
+    const finalizedBatch = lines.map((line) => this.readProtectedThreadUsageSync(line));
+    if (finalizedBatch.every((entry) => entry !== undefined)) {
+      const summaries = new Map<string, ThreadPricingSummary>();
+      for (const entry of finalizedBatch) {
+        const summary = entry.summary;
+        summaries.set(JSON.stringify([
+          summary.provider, summary.backend, summary.threadId, summary.currency,
+        ]), summary);
+      }
+      return {
+        lines: finalizedBatch.map((entry) => entry.line),
+        summaries: [...summaries.values()],
+      };
+    }
     const summaryTargets = new Map<
       string,
       {
@@ -1323,10 +1339,20 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         target,
       );
     };
+    const unchangedSummaries = new Map<string, ThreadPricingSummary>();
     const upsertLine = (
       inputLine: ThreadUsageLineRecord,
     ): ThreadUsageLineRecord => {
       let line = inputLine;
+      const finalized = this.readProtectedThreadUsageSync(line);
+      if (finalized) {
+        const summary = finalized.summary;
+        unchangedSummaries.set(JSON.stringify([
+          summary.provider, summary.backend, summary.threadId, summary.currency,
+        ]), summary);
+        return finalized.line;
+      }
+      this.boundPrecedingThreadUsageSync(line);
       const existing = this.readThreadUsageLineSync(line.usageLineId);
       if (existing) {
         line = mergeThreadUsageLineForUpsert(line, existing);
@@ -1679,6 +1705,9 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         )
         .run(toThreadUsageLineRowParams(line));
 
+      if (existing?.totalTokens === 0 && line.totalTokens > 0) {
+        this.boundPrecedingThreadUsageSync(line);
+      }
       if (existing) {
         const existingRollupThreadId = existing.parentThreadId ?? existing.threadId;
         const nextRollupThreadId = line.parentThreadId ?? line.threadId;
@@ -1748,13 +1777,25 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     };
 
     const upsert = this.stateDb.raw.transaction(() => {
+      // Establish boundaries against the durable snapshots before a coalesced
+      // stale update can overwrite its predecessor earlier in the same batch.
+      if (lines.length > 1) {
+        for (const line of lines) {
+          this.boundPrecedingThreadUsageSync(line);
+        }
+      }
       for (let index = 0; index < lines.length; index += 1) {
         lines[index] = upsertLine(lines[index]!);
       }
 
-      return [...summaryTargets.values()].map((target) =>
-        this.recomputeThreadPricingSummarySync(target),
-      );
+      return [
+        ...[...unchangedSummaries.entries()]
+          .filter(([key]) => !summaryTargets.has(key))
+          .map(([, summary]) => summary),
+        ...[...summaryTargets.values()].map((target) =>
+          this.recomputeThreadPricingSummarySync(target),
+        ),
+      ];
     });
 
     return { lines, summaries: upsert() };
@@ -6695,6 +6736,98 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     return Object.fromEntries(
       rows.map((r) => [r.directory_key, JSON.parse(r.payload) as DirectoryOverlayState]),
     );
+  }
+
+  private boundPrecedingThreadUsageSync(input: ThreadUsageLineRecord): void {
+    if (this.readProtectedThreadUsageSync(input)) {
+      return;
+    }
+    const line = this.readThreadUsageLineSync(input.usageLineId) ?? input;
+    if (
+      line.backend === "codex" && line.scope === "turn" && line.turnId
+      && line.status !== "superseded" && line.turnUsageAttributed !== false
+      && line.cumulativeTotalTokens !== undefined
+      && line.cumulativeTotalTokens >= line.totalTokens
+    ) {
+      // The successor's per-turn delta excludes this durable cumulative
+      // prefix. Finalize only non-overlapping, attributed turn aggregates;
+      // elapsed time, turn ids, and replay order are not ordering evidence.
+      const predecessor = this.stateDb.raw.prepare(
+        `SELECT 1 FROM thread_usage_lines l
+         WHERE provider = ? AND backend = ? AND thread_id = ? AND turn_id != ?
+           AND scope = 'turn' AND status != 'superseded'
+           AND COALESCE(turn_usage_attributed, 1) = 1 AND total_tokens >= 0
+           AND (total_tokens > 0 OR cumulative_total_tokens < ?)
+           AND cumulative_total_tokens >= total_tokens
+           AND cumulative_total_tokens <= ?
+           AND NOT EXISTS (
+             SELECT 1 FROM thread_usage_boundaries f
+             WHERE f.provider = l.provider AND f.backend = l.backend
+               AND f.thread_id = l.thread_id AND f.turn_id = l.turn_id
+           )
+         LIMIT 1`,
+      ).get(
+        line.provider, line.backend, line.threadId, line.turnId,
+        line.cumulativeTotalTokens, line.cumulativeTotalTokens - line.totalTokens,
+      );
+      if (!predecessor) {
+        return;
+      }
+      this.stateDb.raw.prepare(
+        `INSERT OR IGNORE INTO thread_usage_boundaries
+           (provider, backend, thread_id, turn_id, usage_line_id, successor_usage_line_id, cumulative_total_tokens)
+         SELECT provider, backend, thread_id, turn_id, usage_line_id, ?, ?
+         FROM thread_usage_lines
+         WHERE provider = ? AND backend = ? AND thread_id = ? AND turn_id != ?
+           AND scope = 'turn' AND status != 'superseded'
+           AND COALESCE(turn_usage_attributed, 1) = 1 AND total_tokens >= 0
+           AND (total_tokens > 0 OR cumulative_total_tokens < ?)
+           AND cumulative_total_tokens >= total_tokens
+           AND cumulative_total_tokens <= ?`,
+      ).run(
+        line.usageLineId, line.cumulativeTotalTokens - line.totalTokens,
+        line.provider, line.backend, line.threadId, line.turnId,
+        line.cumulativeTotalTokens, line.cumulativeTotalTokens - line.totalTokens,
+      );
+    }
+  }
+
+  private readProtectedThreadUsageSync(
+    line: ThreadUsageLineRecord,
+  ): { line: ThreadUsageLineRecord; summary: ThreadPricingSummary } | undefined {
+    if (line.backend !== "codex" || !line.turnId) {
+      return undefined;
+    }
+    const row = this.stateDb.raw.prepare(
+      `SELECT l.*, f.cumulative_total_tokens AS usage_ceiling FROM thread_usage_boundaries f
+       JOIN thread_usage_lines l ON l.usage_line_id = f.usage_line_id
+       WHERE f.provider = ? AND f.backend = ? AND f.thread_id = ? AND f.turn_id = ?`,
+    ).get(line.provider, line.backend, line.threadId, line.turnId) as (ThreadUsageLineRow & { usage_ceiling: number }) | undefined;
+    if (!row) {
+      return undefined;
+    }
+    // A successor can expose a still-missing final request. Accept that tail
+    // only within the durable boundary and with the same per-turn baseline.
+    // Once the cumulative endpoint reaches the boundary, usage is finalized.
+    if (
+      row.cumulative_total_tokens !== row.usage_ceiling
+      && line.usageLineId === row.usage_line_id
+      && line.cumulativeTotalTokens !== undefined
+      && line.cumulativeTotalTokens <= row.usage_ceiling
+      && line.cumulativeTotalTokens >= (row.cumulative_total_tokens ?? 0)
+      && line.cumulativeTotalTokens - line.totalTokens
+        === (row.cumulative_total_tokens ?? 0) - row.total_tokens
+    ) {
+      return undefined;
+    }
+    const preserved = threadUsageLineFromRow(row);
+    const summaryRow = this.stateDb.raw.prepare(
+      `SELECT * FROM thread_pricing_summaries
+       WHERE provider = ? AND backend = ? AND thread_id = ? AND currency = ?`,
+    ).get(
+      preserved.provider, preserved.backend, preserved.parentThreadId ?? preserved.threadId, preserved.currency,
+    ) as ThreadPricingSummaryRow | undefined;
+    return summaryRow ? { line: preserved, summary: threadPricingSummaryFromRow(summaryRow) } : undefined;
   }
 
   private readThreadUsageLineSync(

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 60;
+export const CURRENT_STATE_DB_USER_VERSION = 61;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -840,8 +840,9 @@ WHEN EXISTS (
     OR OLD.output_cost_micros IS NOT NEW.output_cost_micros
     OR OLD.price_status IS NOT NEW.price_status
     OR OLD.currency IS NOT NEW.currency
-    OR OLD.model IS NOT NEW.model OR OLD.service_tier IS NOT NEW.service_tier
-    OR OLD.fast_mode IS NOT NEW.fast_mode
+    OR (OLD.model IS NOT NULL AND OLD.model IS NOT NEW.model)
+    OR (OLD.service_tier IS NOT NULL AND OLD.service_tier IS NOT NEW.service_tier)
+    OR (OLD.fast_mode IS NOT NULL AND OLD.fast_mode IS NOT NEW.fast_mode)
   ))
 )
 BEGIN
@@ -1770,6 +1771,15 @@ export class StateDb {
       }
       if ((db.pragma("user_version", { simple: true }) as number) < 60) {
         db.transaction(() => {
+          db.exec(THREAD_USAGE_FINALIZATION_SCHEMA);
+          db.pragma("user_version = 60");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 61) {
+        db.transaction(() => {
+          // Missing pricing metadata may be filled without changing a priced
+          // row's existing cost. Token and boundary guards remain unchanged.
+          db.exec("DROP TRIGGER IF EXISTS protect_finalized_thread_usage_update");
           db.exec(THREAD_USAGE_FINALIZATION_SCHEMA);
           db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
         })();

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -14,7 +14,7 @@ import {
   isSqliteWriteMetricsEnabled,
 } from "./sqlite-write-metrics.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 59;
+export const CURRENT_STATE_DB_USER_VERSION = 60;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -742,6 +742,111 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_pr_status_watches_active_target
   WHERE status IN ('watching', 'dispatching');
 CREATE INDEX IF NOT EXISTS idx_pr_status_watches_active_pr
   ON pr_status_watches(pr_key, status, lease_expires_at);
+`;
+
+// Finalization is keyed by turn identity, so a replacement usage-line id cannot
+// bypass it. Token intervals establish ordering; wall clocks and replay arrival
+// order do not. The original row owns the marker's lifetime.
+const THREAD_USAGE_FINALIZATION_SCHEMA = `
+CREATE TABLE IF NOT EXISTS thread_usage_boundaries (
+  provider TEXT NOT NULL,
+  backend TEXT NOT NULL,
+  thread_id TEXT NOT NULL,
+  turn_id TEXT NOT NULL,
+  usage_line_id TEXT NOT NULL UNIQUE REFERENCES thread_usage_lines(usage_line_id) ON DELETE CASCADE,
+  successor_usage_line_id TEXT NOT NULL,
+  cumulative_total_tokens INTEGER NOT NULL,
+  PRIMARY KEY (provider, backend, thread_id, turn_id)
+);
+INSERT OR IGNORE INTO thread_usage_boundaries
+  (provider, backend, thread_id, turn_id, usage_line_id, successor_usage_line_id, cumulative_total_tokens)
+SELECT older.provider, older.backend, older.thread_id, older.turn_id,
+       older.usage_line_id, newer.usage_line_id, MIN(newer.cumulative_total_tokens - newer.total_tokens)
+FROM thread_usage_lines older
+JOIN thread_usage_lines newer
+  ON newer.provider = older.provider AND newer.backend = older.backend
+ AND newer.thread_id = older.thread_id AND newer.turn_id != older.turn_id
+WHERE older.backend = 'codex'
+  AND older.scope = 'turn' AND newer.scope = 'turn'
+  AND older.status != 'superseded' AND newer.status != 'superseded'
+  AND older.total_tokens >= 0 AND newer.total_tokens >= 0
+  AND (older.total_tokens > 0 OR newer.cumulative_total_tokens > older.cumulative_total_tokens)
+  AND COALESCE(older.turn_usage_attributed, 1) = 1
+  AND COALESCE(newer.turn_usage_attributed, 1) = 1
+  AND older.cumulative_total_tokens >= older.total_tokens
+  AND older.cumulative_total_tokens <= newer.cumulative_total_tokens - newer.total_tokens
+GROUP BY older.provider, older.backend, older.thread_id, older.turn_id;
+
+CREATE TRIGGER IF NOT EXISTS protect_finalized_thread_usage_insert
+BEFORE INSERT ON thread_usage_lines
+WHEN EXISTS (
+  SELECT 1 FROM thread_usage_boundaries f
+  WHERE f.provider = NEW.provider AND f.backend = NEW.backend
+    AND f.thread_id = NEW.thread_id AND f.turn_id = NEW.turn_id
+    AND f.usage_line_id != NEW.usage_line_id
+)
+BEGIN
+  SELECT RAISE(IGNORE);
+END;
+
+CREATE TRIGGER IF NOT EXISTS protect_thread_usage_boundary_update
+BEFORE UPDATE ON thread_usage_lines
+WHEN EXISTS (
+  SELECT 1 FROM thread_usage_boundaries f WHERE f.usage_line_id = OLD.usage_line_id
+    AND (
+      NEW.cumulative_total_tokens IS NULL
+      OR NEW.cumulative_total_tokens > f.cumulative_total_tokens
+      OR NEW.cumulative_total_tokens < OLD.cumulative_total_tokens
+      OR (NEW.cumulative_total_tokens - NEW.total_tokens)
+         IS NOT (OLD.cumulative_total_tokens - OLD.total_tokens)
+      OR OLD.usage_line_id IS NOT NEW.usage_line_id OR OLD.turn_id IS NOT NEW.turn_id
+      OR OLD.provider IS NOT NEW.provider OR OLD.backend IS NOT NEW.backend
+      OR OLD.thread_id IS NOT NEW.thread_id OR OLD.parent_thread_id IS NOT NEW.parent_thread_id
+    )
+)
+BEGIN
+  SELECT RAISE(IGNORE);
+END;
+
+CREATE TRIGGER IF NOT EXISTS protect_finalized_thread_usage_update
+BEFORE UPDATE ON thread_usage_lines
+WHEN EXISTS (
+  SELECT 1 FROM thread_usage_boundaries f WHERE f.usage_line_id = OLD.usage_line_id
+    AND OLD.cumulative_total_tokens = f.cumulative_total_tokens
+) AND (
+  OLD.usage_line_id IS NOT NEW.usage_line_id OR OLD.turn_id IS NOT NEW.turn_id
+  OR OLD.provider IS NOT NEW.provider OR OLD.backend IS NOT NEW.backend
+  OR OLD.thread_id IS NOT NEW.thread_id OR OLD.parent_thread_id IS NOT NEW.parent_thread_id
+  OR OLD.status IS NOT NEW.status OR OLD.scope IS NOT NEW.scope
+  OR OLD.input_tokens IS NOT NEW.input_tokens
+  OR OLD.cached_input_tokens IS NOT NEW.cached_input_tokens
+  OR OLD.cache_write_input_tokens IS NOT NEW.cache_write_input_tokens
+  OR OLD.uncached_input_tokens IS NOT NEW.uncached_input_tokens
+  OR OLD.output_tokens IS NOT NEW.output_tokens
+  OR OLD.reasoning_output_tokens IS NOT NEW.reasoning_output_tokens
+  OR OLD.total_tokens IS NOT NEW.total_tokens
+  OR OLD.cumulative_input_tokens IS NOT NEW.cumulative_input_tokens
+  OR OLD.cumulative_cached_input_tokens IS NOT NEW.cumulative_cached_input_tokens
+  OR OLD.cumulative_cache_write_input_tokens IS NOT NEW.cumulative_cache_write_input_tokens
+  OR OLD.cumulative_uncached_input_tokens IS NOT NEW.cumulative_uncached_input_tokens
+  OR OLD.cumulative_output_tokens IS NOT NEW.cumulative_output_tokens
+  OR OLD.cumulative_reasoning_output_tokens IS NOT NEW.cumulative_reasoning_output_tokens
+  OR OLD.cumulative_total_tokens IS NOT NEW.cumulative_total_tokens
+  OR (OLD.price_status = 'priced' AND (
+    OLD.total_cost_micros IS NOT NEW.total_cost_micros
+    OR OLD.uncached_input_cost_micros IS NOT NEW.uncached_input_cost_micros
+    OR OLD.cached_input_cost_micros IS NOT NEW.cached_input_cost_micros
+    OR OLD.cache_write_input_cost_micros IS NOT NEW.cache_write_input_cost_micros
+    OR OLD.output_cost_micros IS NOT NEW.output_cost_micros
+    OR OLD.price_status IS NOT NEW.price_status
+    OR OLD.currency IS NOT NEW.currency
+    OR OLD.model IS NOT NEW.model OR OLD.service_tier IS NOT NEW.service_tier
+    OR OLD.fast_mode IS NOT NEW.fast_mode
+  ))
+)
+BEGIN
+  SELECT RAISE(IGNORE);
+END;
 `;
 
 const THREAD_USAGE_PRICING_SCHEMA = `
@@ -1660,6 +1765,12 @@ export class StateDb {
           // price from the turn's context-window ceiling. Reprice rows that
           // were persisted as "insufficient-token-breakdown" before that rule.
           repairTokenUsagePricing(db);
+          db.pragma("user_version = 59");
+        })();
+      }
+      if ((db.pragma("user_version", { simple: true }) as number) < 60) {
+        db.transaction(() => {
+          db.exec(THREAD_USAGE_FINALIZATION_SCHEMA);
           db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
         })();
       }


### PR DESCRIPTION
## Summary

- I prevent an older Codex turn from absorbing later cumulative usage and doubling the thread total. Superseded turns cannot reclaim the in-memory accounting cursor, including equal-total replays.
- I persist cumulative turn boundaries in SQLite. A missing final request can fill its known gap with the original baseline; usage and already-priced costs become immutable when the turn reaches its boundary. The store returns the authoritative row for stale live, hydration, and backfill updates, including replacement row IDs.
- I enforce the boundary with database triggers as well, so writers that bypass the current store cannot change finalized usage or insert another billable row for that turn. Schema migration 60 derives boundaries only where existing attributed turn aggregates establish non-overlapping token intervals. Migration 61 permits filling null pricing metadata while retaining the token guards and existing priced costs.

- I allow missing timing, model, and context metadata to be filled on protected rows. I price previously unpriced rows from their frozen tokens, preserve already-priced costs, and reject conflicting metadata and stale usage. Repeated enrichment is read-only.

## Verification

- I reproduced both original overwrite paths and the equal-total review finding with failing tests before fixing them.
- I reproduced three SQLite restart/replacement failures before adding durable protection.
- I ran the registry, context replay, SQLite ledger, schema migration, and write-budget suites: all 804 tests passed. The final ledger suite passed all 50 tests, including an additional protected-Astra context-ceiling repair. Missing-metadata regressions failed before the fix and passed afterward.
- Coverage includes restart and upgrade, raw SQL attempts, alternate row IDs, either batch order, zero/equal totals, continued current-turn usage, and legitimate late final requests within a persisted boundary.
- SQL template lint, ESLint, and workspace type checking passed. The full `pnpm test:sqlite-writes` survey for commit `eeca18a69` passed (exit 0): 702 files, 10,423 tests passed and 7 skipped. The test workload recorded 4,418 commits, 16,353 write statements, 20,211 rows, and 59.84 MB WAL across 64 sources.

## Notes

- Finalization rides the existing successor pricing transaction: one commit and 74,160 measured WAL bytes for the entire flush, including existing pricing work. At one successor per hour, that is 1/3600 × 74,160 × 86,400 = 1.78 MB/day. Existing stream/timer budgets are unchanged. One hundred rejected finalized-turn replays make zero commits and generate zero WAL bytes; there is no idle write.
- A one-time metadata enrichment measured one commit and 53,560 WAL bytes (1.29 MB/day at one enriched turn per hour). One hundred repeated enrichments produced zero commits and zero WAL.
- A boundary requires attributed cumulative usage. I do not infer missing history or turn order from wall clocks. Pricing enrichment of a previously unpriced row can still use the exact preserved tokens.
- I repaired the reported operator ledger separately after a full database backup. The original completion snapshot and successor baseline independently establish 35,156 input tokens and 15 output tokens: $0.35231, rather than the overwritten $268.137216. The repair reduced the thread total by $267.784906. Private evidence and the backup are kept locally.
- The available logs do not establish whether steering caused the original notification. Durable guards activate when an updated build applies the migration; this PR does not deploy a release.
