### PR TITLE
perf(desktop): avoid Markdown reparsing on thread membership updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadMarkdown.tsx
@@ -36,7 +36,6 @@ import {
   resolveThreadHref,
   resolveThreadIdText,
   useThreadLinks,
-  type ThreadLinkContextValue,
   type ThreadLinkSource,
 } from "../../lib/thread-links";
 import {
@@ -147,8 +146,8 @@ function TranscriptCode(props: {
   onOpenSkillInEditor?: (skill: SkillActionTarget) => void;
   onViewSkillMarkdown?: (skill: SkillActionTarget) => void;
   skill?: AppServerSkillSummary;
-  threadLinks: ThreadLinkContextValue | undefined;
 }) {
+  const threadLinks = useThreadLinks();
   const insideCodeBlock = useContext(CodeBlockContext);
   const insideLink = useContext(MarkdownLinkContext);
   const isBlockCode = insideCodeBlock || (props.className?.includes("language-") ?? false);
@@ -156,7 +155,7 @@ function TranscriptCode(props: {
   // Only inline code on a navigation-capable surface can become a chip; skip
   // the text extraction entirely on block code and on the Activity/Changelog/
   // file-viewer surfaces (no `threadLinks` context there).
-  if (!isBlockCode && !insideLink && props.threadLinks) {
+  if (!isBlockCode && !insideLink && threadLinks) {
     // Transcripts written before the link protocol existed — and any model
     // that ignores the `threadLink` convention — put the bare thread id in a
     // code span. Recognizing it makes those threads reachable without asking
@@ -164,10 +163,10 @@ function TranscriptCode(props: {
     // so an unrelated uuid stays plain code.
     const threadLink = resolveThreadIdText(
       extractTextContent(props.children),
-      props.threadLinks,
+      threadLinks,
     );
     if (threadLink) {
-      return <ThreadChip link={threadLink} onOpen={props.threadLinks.show} />;
+      return <ThreadChip link={threadLink} onOpen={threadLinks.show} />;
     }
   }
 
@@ -235,8 +234,6 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
   );
   const [markdownViewerTarget, setMarkdownViewerTarget] =
     useState<MarkdownViewerTarget>();
-  const threadLinks = useThreadLinks();
-  const pullRequestLinks = usePullRequestLinks();
   const editorApplication = useMemo(
     () =>
       props.applications?.editors.find(
@@ -343,7 +340,11 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
 
   const components = useMemo<Components>(
     () => ({
-      a(anchorProps) {
+      a: function MarkdownAnchor(anchorProps) {
+        // Navigation membership affects these links, not the parsed document.
+        // Subscribe in the leaf so unchanged Markdown is not parsed again.
+        const threadLinks = useThreadLinks();
+        const pullRequestLinks = usePullRequestLinks();
         const href = typeof anchorProps.href === "string" ? anchorProps.href : "";
         const localTarget = localFileTargetFromHref(href);
         const isLocalMarkdownFile = Boolean(
@@ -556,7 +557,6 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
               ? viewSkillMarkdown
               : undefined}
             skill={skill}
-            threadLinks={threadLinks}
           >
             {codeProps.children}
           </TranscriptCode>
@@ -684,11 +684,9 @@ export const ThreadMarkdown = memo(function ThreadMarkdown(props: ThreadMarkdown
       props.imageParts,
       props.onOpenImage,
       props.threadLinkSource,
-      pullRequestLinks,
       sourceMarkdownText,
       skillsByPath,
       skillsByToken,
-      threadLinks,
       viewSkillMarkdown,
     ]
   );

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-context-parsing.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/markdown-context-parsing.test.tsx
@@ -1,0 +1,53 @@
+import "@testing-library/jest-dom/vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import { ThreadLinkProvider } from "../../../lib/thread-links";
+import { ThreadMarkdown } from "../ThreadMarkdown";
+import { remarkTableProfile } from "../remark-table-profile";
+
+vi.mock("../remark-table-profile", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../remark-table-profile")>();
+  return { ...actual, remarkTableProfile: vi.fn(actual.remarkTableProfile) };
+});
+
+afterEach(() => vi.clearAllMocks());
+
+it("updates thread links when membership changes without reparsing unchanged Markdown", () => {
+  const id = "019f5d79-a595-73f2-84d9-a0976762c303";
+  const thread: NavigationThreadSummary = {
+    id,
+    title: "Newly available thread",
+    titleSource: "explicit",
+    source: "codex",
+    linkedDirectories: [],
+    inbox: { inInbox: false },
+  };
+  const onShowThread = vi.fn();
+  const onOpenRemoteViewer = vi.fn();
+  const text = `See [related work](pwragent://thread/${id}?backend=codex) and \`${id}\`.`;
+  const view = (threads: NavigationThreadSummary[], markdown = text) => (
+    <ThreadLinkProvider threads={threads} onShowThread={onShowThread} onOpenRemoteViewer={onOpenRemoteViewer}>
+      <ThreadMarkdown text={markdown} />
+    </ThreadLinkProvider>
+  );
+  const { rerender } = render(view([]));
+  const parses = vi.mocked(remarkTableProfile).mock.calls.length;
+  expect(parses).toBeGreaterThan(0);
+  expect(screen.queryByRole("button", { name: "Open thread Newly available thread" })).not.toBeInTheDocument();
+
+  rerender(view([thread]));
+  const links = screen.getAllByRole("button", { name: "Open thread Newly available thread" });
+  expect(links).toHaveLength(2);
+  fireEvent.click(links[0]);
+  expect(onShowThread).toHaveBeenCalledWith(expect.objectContaining({ threadId: id }));
+  expect(remarkTableProfile).toHaveBeenCalledTimes(parses);
+
+  rerender(view([]));
+  expect(screen.queryByRole("button", { name: "Open thread Newly available thread" })).not.toBeInTheDocument();
+  expect(remarkTableProfile).toHaveBeenCalledTimes(parses);
+
+  rerender(view([], `${text}\n\nNew content.`));
+  expect(screen.getByText("New content.")).toBeInTheDocument();
+  expect(vi.mocked(remarkTableProfile).mock.calls.length).toBeGreaterThan(parses);
+});


### PR DESCRIPTION
## Summary

Adding or removing a thread changes the thread-link context and previously made every mounted ThreadMarkdown consumer parse unchanged text again. Move thread-link and PR-link context consumption into the rendered anchors and inline-code components, so link availability updates without rerunning the Markdown pipeline.

The regression test demonstrates the original redundant parse, then checks that newly available links appear and open correctly, removed links disappear, and actual text edits still parse. Existing title and PR-status updates already use stable provider contexts; this change targets thread membership changes.

## Verification

- 99 focused Markdown, thread-link, PR-link, and file-viewer tests passed.
- The new regression failed before the fix: the Markdown plugin ran twice instead of once on a membership update.
- pnpm lint:eslint passed with existing warnings and no errors.
- Desktop typecheck and git diff --check passed.

## Notes

A CPU capture identified Markdown parsing as a hotspot. This change removes a proven source of redundant parsing, but a new dev-build profile is still needed to measure its contribution to the observed spike. The running app has not been restarted.
