### PR TITLE
fix(desktop): show federation traffic in one-second bars

### DIFF
--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -70,7 +70,7 @@ for (const theme of ["dark", "light"] as const) {
       await activity.emulateMedia({ reducedMotion: "reduce" });
       await expect(activity.getByText("Running · connected")).toBeVisible();
       await expect(activity.getByRole("switch", { name: "Federation enabled" })).toHaveClass(/settings-switch/);
-      await expect(activity.getByRole("img", { name: /Data and wire rates/ })).toBeVisible();
+      await expect(activity.getByRole("img", { name: /Data and wire amounts/ })).toBeVisible();
       const topmost = activity.getByRole("checkbox", { name: "Always on top", exact: true });
       await topmost.click();
       await expect(topmost).toBeChecked();

--- a/apps/desktop/e2e/federation-activity.spec.ts
+++ b/apps/desktop/e2e/federation-activity.spec.ts
@@ -71,6 +71,23 @@ for (const theme of ["dark", "light"] as const) {
       await expect(activity.getByText("Running · connected")).toBeVisible();
       await expect(activity.getByRole("switch", { name: "Federation enabled" })).toHaveClass(/settings-switch/);
       await expect(activity.getByRole("img", { name: /Data and wire amounts/ })).toBeVisible();
+      for (const period of ["10m", "1h"]) {
+        await activity.getByLabel("Chart window").selectOption(period);
+        for (const chart of await activity.locator(".federation-activity__chart").all()) {
+          const axis = chart.locator(".federation-activity__chart-axis");
+          const scroller = chart.locator(".federation-activity__chart-scroll");
+          await expect.poll(() => scroller.evaluate((element) => element.scrollLeft)).toBeGreaterThan(0);
+          const recentAxis = await axis.boundingBox();
+          const viewport = await chart.boundingBox();
+          expect(recentAxis).not.toBeNull();
+          expect(viewport).not.toBeNull();
+          expect(recentAxis!.x).toBeGreaterThanOrEqual(viewport!.x);
+          expect(recentAxis!.x + recentAxis!.width).toBeLessThanOrEqual(viewport!.x + viewport!.width);
+          await scroller.evaluate((element) => { element.scrollLeft = 0; });
+          expect(await axis.boundingBox()).toEqual(recentAxis);
+        }
+      }
+      await activity.getByLabel("Chart window").selectOption("1m");
       const topmost = activity.getByRole("checkbox", { name: "Always on top", exact: true });
       await topmost.click();
       await expect(topmost).toBeChecked();

--- a/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ledger.test.ts
@@ -86,6 +86,16 @@ describe("Federation activity ledger", () => {
     expect(snapshot.physical.lifetime.sent.requests).toBe(3);
   });
 
+  it("keeps a short burst in its exact second without scaling its bytes", () => {
+    const ledger = new FederationActivityLedger(0);
+    ledger.record({ ...base, at: 1_998, byteCount: 50_000, dataByteCount: 50_000 });
+    ledger.record({ ...base, at: 1_999, byteCount: 50_000, dataByteCount: 50_000 });
+    ledger.record({ ...base, at: 2_000, byteCount: 7, dataByteCount: 7 });
+    const history = ledger.snapshot(3_000).physical.history;
+    expect(history.slice(-3).map((bucket) => [bucket.at, bucket.totals.sent.wireBytes]))
+      .toEqual([[1_000, 100_000], [2_000, 7], [3_000, 0]]);
+  });
+
   it("bounds history and peer cardinality while overflow and lifetime counters retain every event", () => {
     const ledger = new FederationActivityLedger(0);
     for (let index = 1; index <= 8_000; index += 1) {
@@ -95,7 +105,7 @@ describe("Federation activity ledger", () => {
     const snapshot = ledger.snapshot(8_000_000);
     expect(snapshot.physical.lifetime.sent.requests).toBe(8_000);
     expect(snapshot.physical.windows["1h"].sent.requests).toBe(3_600);
-    expect(snapshot.physical.history).toHaveLength(360);
+    expect(snapshot.physical.history).toHaveLength(3600);
     expect(snapshot.peers).toHaveLength(33);
     expect(snapshot.logical).toHaveLength(33);
     expect(snapshot.peers.reduce((sum, peer) => sum + peer.series.lifetime.sent.requests, 0)).toBe(8_000);
@@ -109,7 +119,7 @@ describe("Federation activity ledger", () => {
       expect(series.values).toHaveLength(3_600 * 12);
       expect(series.times.byteLength + series.values.byteLength).toBe(374_400);
     }
-    expect(JSON.stringify(snapshot).length).toBeLessThan(180_000);
+    expect(JSON.stringify(snapshot).length).toBeLessThan(900_000);
   });
 
   it("returns independent copies, retains no payloads, and only returns requested peer history", () => {
@@ -119,7 +129,7 @@ describe("Federation activity ledger", () => {
     const snapshot = ledger.snapshot(1_000, { historyView: "logical", historyPeerId: "remote" });
     expect(snapshot.physical.history).toHaveLength(0);
     expect(snapshot.peers[0].series.history).toHaveLength(0);
-    expect(snapshot.logical[0].series.history).toHaveLength(360);
+    expect(snapshot.logical[0].series.history).toHaveLength(3600);
     expect(inspect(ledger, { depth: 12 })).not.toContain("private payload");
     snapshot.physical.lifetime.sent.requests = 9_999;
     expect(ledger.snapshot(1_000, { includeHistory: false }).physical.lifetime.sent.requests).toBe(1);
@@ -203,7 +213,7 @@ it("caps all numeric storage at 28.73 MB even when every peer and size histogram
   const snapshot = ledger.snapshot(7_199_000);
   expect(snapshot.physical.lifetime.sent.requests).toBe(7_200 * 40);
   expect(snapshot.physical.windows["1h"].sent.requests).toBe(3_600 * 40);
-  expect(snapshot.physical.history.every((bucket) => bucket.totals.sent.requests === 400)).toBe(true);
+  expect(snapshot.physical.history.every((bucket) => bucket.totals.sent.requests === 40)).toBe(true);
   ledger.reset();
   expect(retainedBytes(ledger)).toBe(0);
 });

--- a/apps/desktop/src/main/federation/federation-activity-ledger.ts
+++ b/apps/desktop/src/main/federation/federation-activity-ledger.ts
@@ -75,9 +75,9 @@ class Series {
     const windows = { "1m": totals(), "5m": totals(), "10m": totals(), "1h": totals() };
     const history: FederationActivitySeries["history"] = [];
     const first = at - HOUR + 1;
-    // Ten-second chart bins, with rolling totals evaluated at second boundaries.
+    // One-second chart bins use the same counts as the rolling totals.
     if (includeHistory) {
-      for (let start = first; start <= at; start += 10) {
+      for (let start = first; start <= at; start += 1) {
         history.push({ at: start * SECOND, totals: totals() });
       }
     }
@@ -90,7 +90,7 @@ class Series {
         if (time > at - 600) addBucket(windows["10m"], this.values, offset);
         if (time > at - 300) addBucket(windows["5m"], this.values, offset);
         if (time > at - 60) addBucket(windows["1m"], this.values, offset);
-        if (includeHistory) addBucket(history[Math.floor((time - first) / 10)].totals, this.values, offset);
+        if (includeHistory) addBucket(history[time - first].totals, this.values, offset);
       }
     }
     return {

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -17,7 +17,7 @@ function fixture(): ReadFederationActivityResponse {
       received: { requests: { count: 0 }, responses: { count: 0 } },
     },
     lifetime: totals(), windows: { "1m": totals(), "5m": totals(), "10m": totals(), "1h": totals() },
-    history: Array.from({ length: 360 }, (_, index) => ({ at: index * 10_000, totals: totals() })),
+    history: Array.from({ length: 3600 }, (_, index) => ({ at: index * 1_000, totals: totals() })),
   };
   return {
     activity: { since: 0, at: 3_600_000, bucketMs: 1_000, physical: series,
@@ -87,14 +87,14 @@ describe("Federation activity surfaces", () => {
     expect(toggle).toHaveAttribute("aria-checked", "false");
   });
 
-  it("labels chart axes with numeric rates and units, exposes periods and per-peer attribution, and confirms topmost", async () => {
+  it("labels chart axes with amounts and units, exposes periods and per-peer attribution, and confirms topmost", async () => {
     const readFederationActivity = vi.fn(async () => fixture());
     const setFederationActivityTopmost = vi.fn(async (enabled: boolean) => enabled);
     const api: DesktopApi = { readFederationActivity, setFederationActivityTopmost };
     render(<FederationActivityScreen desktopApi={api} />);
     await screen.findByText("Running · connected");
-    expect(screen.getByText("0.2")).toBeInTheDocument();
-    expect(screen.getByText("2.4")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("24")).toBeInTheDocument();
     for (const name of ["Sent traffic", "Received traffic"]) {
       const table = within(screen.getByRole("table", { name }));
       for (const column of ["Last 1m", "Last 10m", "Last 1h", "Total"]) {
@@ -112,6 +112,23 @@ describe("Federation activity surfaces", () => {
     fireEvent.click(screen.getByRole("checkbox", { name: "Always on top" }));
     await waitFor(() => expect(screen.getByRole("checkbox")).toBeChecked());
     expect(setFederationActivityTopmost).toHaveBeenCalledWith(true);
+  });
+
+  it("shows exact one-second amounts on hover and keyboard focus", async () => {
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => fixture() }} />);
+    const chart = await screen.findByRole("img", { name: /Data and wire amounts/ });
+    fireEvent.focus(chart);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Sent wire: 800 bytes");
+    expect(screen.getByRole("tooltip")).toHaveTextContent("In progress");
+    fireEvent.keyDown(chart, { key: "ArrowLeft" });
+    expect(screen.getByRole("tooltip")).not.toHaveTextContent("In progress");
+    fireEvent.keyDown(chart, { key: "Escape" });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    vi.spyOn(chart, "getBoundingClientRect").mockReturnValue({ left: 0, width: 640 } as DOMRect);
+    fireEvent.pointerMove(chart, { clientX: 100 });
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Received data: 4,000 bytes");
+    fireEvent.pointerLeave(chart);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
   it("keeps the switch state and reports errors if a configuration change fails", async () => {

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -114,6 +114,21 @@ describe("Federation activity surfaces", () => {
     expect(setFederationActivityTopmost).toHaveBeenCalledWith(true);
   });
 
+  it("keeps numeric axes outside scrolling history in longer windows", async () => {
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => fixture() }} />);
+    await screen.findByRole("img", { name: /Data and wire amounts/ });
+    for (const period of ["10m", "1h"]) {
+      fireEvent.change(screen.getByLabelText("Chart window"), { target: { value: period } });
+      for (const plot of screen.getAllByRole("img")) {
+        const scroller = plot.parentElement!;
+        const axis = scroller.parentElement!.querySelector(".federation-activity__chart-axis")!;
+        expect(axis).toHaveTextContent("0");
+        expect(axis.querySelectorAll("text")).toHaveLength(4);
+        expect(scroller).not.toContainElement(axis as HTMLElement);
+      }
+    }
+  });
+
   it("shows exact one-second amounts on hover and keyboard focus", async () => {
     render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => fixture() }} />);
     const chart = await screen.findByRole("img", { name: /Data and wire amounts/ });

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -99,19 +99,25 @@ export function FederationAmountChart({ history, period, bytes }: {
   const scale = bytes ? byteUnit.scale : 1;
   const unit = bytes ? byteUnit.unit : "envelopes";
   const axisNumber = (value: number) => value.toLocaleString(undefined, { maximumSignificantDigits: 3 });
-  const width = Math.max(640, 95 + length * 8 + 10);
-  const step = (width - 105) / length;
+  const width = Math.max(545, length * 8 + 10);
+  const step = (width - 10) / length;
   const selectedIndex = points.findIndex((point) => point.at === selectedAt);
   const selected = points[selectedIndex];
   const time = (at: number) => new Date(at).toLocaleTimeString();
   return <figure className="federation-activity__chart">
     <figcaption>{bytes ? "Data and wire" : "Envelopes"} · {unit} per one-second bar</figcaption>
+    <div className="federation-activity__chart-frame">
+    <svg className="federation-activity__chart-axis" viewBox="0 0 95 165" aria-hidden="true">
+      <text x="87" y="12" textAnchor="end">{unit}</text>
+      {[0, 0.5, 1].map((fraction) => <text key={fraction} x="87"
+        y={134 - fraction * 110} textAnchor="end">{axisNumber(max * fraction / scale)}</text>)}
+    </svg>
     <div className="federation-activity__chart-scroll" ref={scrollRef}>
-    <svg viewBox={`0 0 ${width} 165`} style={{ minWidth: width }} role="img" tabIndex={0}
+    <svg viewBox={`0 0 ${width} 165`} style={{ minWidth: width }} preserveAspectRatio="none" role="img" tabIndex={0}
       aria-labelledby={`${id}-title ${id}-description`} aria-describedby={selected ? `${id}-tooltip` : undefined}
       onPointerMove={(event) => {
         const bounds = event.currentTarget.getBoundingClientRect();
-        const index = Math.floor(((event.clientX - bounds.left) * width / bounds.width - 95) / step);
+        const index = Math.floor(((event.clientX - bounds.left) * width / bounds.width) / step);
         setSelectedAt(points[index]?.at);
       }}
       onPointerLeave={() => setSelectedAt(undefined)} onBlur={() => setSelectedAt(undefined)}
@@ -123,31 +129,30 @@ export function FederationAmountChart({ history, period, bytes }: {
         const index = Math.max(0, Math.min(points.length - 1,
           (selectedIndex < 0 ? points.length - 1 : selectedIndex) + (event.key === "ArrowLeft" ? -1 : 1)));
         setSelectedAt(points[index]?.at);
-        if (scrollRef.current) scrollRef.current.scrollLeft = 95 + index * step - 150;
+        if (scrollRef.current) scrollRef.current.scrollLeft = index * step - 150;
       }}>
       <title id={`${id}-title`}>{bytes ? "Data and wire" : "Envelope"} amounts, {unit}</title>
       <desc id={`${id}-description`}>One-second totals. Peak {axisNumber(max / scale)} {unit}.
         Sent uses accent bars; received uses neutral bars. Faded bars show uncompressed data.
         Hover or use left and right arrow keys for exact amounts. The latest second may be incomplete.</desc>
-      <text x="87" y="12" textAnchor="end">{unit}</text>
-      {[0, 0.5, 1].map((fraction) => <g key={fraction}>
-        <line x1="95" x2={width - 10} y1={130 - fraction * 110} y2={130 - fraction * 110} className="federation-activity__grid" />
-        <text x="87" y={134 - fraction * 110} textAnchor="end">{axisNumber(max * fraction / scale)}</text>
-      </g>)}
+      {[0, 0.5, 1].map((fraction) => <line key={fraction}
+        x1="0" x2={width - 10} y1={130 - fraction * 110} y2={130 - fraction * 110}
+        className="federation-activity__grid" />)}
       {lines.map((line, index) => <path key={line.label}
         className={`federation-activity__bar federation-activity__bar--${line.direction}`}
         opacity={line.dashed ? 0.4 : 1}
         d={values[index].map((value, point) => {
           if (value <= 0) return "";
-          const x = 95 + point * step + index * step / lines.length;
+          const x = point * step + index * step / lines.length;
           const height = value / max * 110;
           return `M${x},130v${-height}h${step / lines.length - 0.5}v${height}Z`;
         }).join(" ")} />)}
-      {selected ? <rect x={95 + selectedIndex * step} y="20" width={step} height="110"
+      {selected ? <rect x={selectedIndex * step} y="20" width={step} height="110"
         className="federation-activity__selection" /> : null}
-      <text x="95" y="155">{period} ago</text>
+      <text x="0" y="155">{period} ago</text>
       <text x={width - 10} y="155" textAnchor="end">Now</text>
     </svg>
+    </div>
     </div>
     <div className="federation-activity__legend">{lines.map((line) => <span key={line.label}
       className={`federation-activity__legend--${line.direction}`}>

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { CheckIcon, CopyIcon } from "../../icons";
 import { copyText } from "../../lib/copy-text";
 import { formatActivityReport } from "./format-activity-report";
@@ -67,11 +67,18 @@ function PayloadSizes({ series }: { series: FederationActivitySeries }) {
   </div>;
 }
 
-export function FederationRateChart({ history, period, bytes }: {
+export function FederationAmountChart({ history, period, bytes }: {
   history: FederationActivitySeries["history"]; period: Period; bytes: boolean;
 }) {
   const id = useId();
-  const length = period === "1m" ? 6 : period === "10m" ? 60 : 360;
+  const length = period === "1m" ? 60 : period === "10m" ? 600 : 3600;
+  const [selectedAt, setSelectedAt] = useState<number>();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const element = scrollRef.current;
+    if (element) element.scrollLeft = element.scrollWidth;
+    setSelectedAt(undefined);
+  }, [period]);
   const points = history.slice(-length);
   const lines = bytes ? [
     { direction: "sent", field: "wireBytes", label: "Sent wire", dashed: false },
@@ -85,34 +92,75 @@ export function FederationRateChart({ history, period, bytes }: {
   const values = lines.map((line) => points.map(({ totals }) => {
     const value = totals[line.direction];
     return (line.field === "events" ? value.requests + value.responses + value.notifications + value.other
-      : value[line.field]) / 10;
+      : value[line.field]);
   }));
   const max = Math.max(0, ...values.flat()) || 1;
   const byteUnit = trafficByteUnit(max);
   const scale = bytes ? byteUnit.scale : 1;
-  const unit = bytes ? `${byteUnit.unit}/s` : "envelopes/s";
+  const unit = bytes ? byteUnit.unit : "envelopes";
   const axisNumber = (value: number) => value.toLocaleString(undefined, { maximumSignificantDigits: 3 });
+  const width = Math.max(640, 95 + length * 8 + 10);
+  const step = (width - 105) / length;
+  const selectedIndex = points.findIndex((point) => point.at === selectedAt);
+  const selected = points[selectedIndex];
+  const time = (at: number) => new Date(at).toLocaleTimeString();
   return <figure className="federation-activity__chart">
-    <figcaption>{bytes ? "Data and wire rate" : "Envelope rate"} · {unit}</figcaption>
-    <svg viewBox="0 0 640 165" role="img" aria-labelledby={`${id}-title ${id}-description`}>
-      <title id={`${id}-title`}>{bytes ? "Data and wire" : "Envelope"} rates, {unit}</title>
-      <desc id={`${id}-description`}>Ten-second averages. Peak {axisNumber(max / scale)} {unit}. Sent uses the accent line,
-        received uses the neutral line. Dashed lines show uncompressed data.</desc>
+    <figcaption>{bytes ? "Data and wire" : "Envelopes"} · {unit} per one-second bar</figcaption>
+    <div className="federation-activity__chart-scroll" ref={scrollRef}>
+    <svg viewBox={`0 0 ${width} 165`} style={{ minWidth: width }} role="img" tabIndex={0}
+      aria-labelledby={`${id}-title ${id}-description`} aria-describedby={selected ? `${id}-tooltip` : undefined}
+      onPointerMove={(event) => {
+        const bounds = event.currentTarget.getBoundingClientRect();
+        const index = Math.floor(((event.clientX - bounds.left) * width / bounds.width - 95) / step);
+        setSelectedAt(points[index]?.at);
+      }}
+      onPointerLeave={() => setSelectedAt(undefined)} onBlur={() => setSelectedAt(undefined)}
+      onFocus={() => setSelectedAt(points.at(-1)?.at)}
+      onKeyDown={(event) => {
+        if (event.key === "Escape") { setSelectedAt(undefined); return; }
+        if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
+        event.preventDefault();
+        const index = Math.max(0, Math.min(points.length - 1,
+          (selectedIndex < 0 ? points.length - 1 : selectedIndex) + (event.key === "ArrowLeft" ? -1 : 1)));
+        setSelectedAt(points[index]?.at);
+        if (scrollRef.current) scrollRef.current.scrollLeft = 95 + index * step - 150;
+      }}>
+      <title id={`${id}-title`}>{bytes ? "Data and wire" : "Envelope"} amounts, {unit}</title>
+      <desc id={`${id}-description`}>One-second totals. Peak {axisNumber(max / scale)} {unit}.
+        Sent uses accent bars; received uses neutral bars. Faded bars show uncompressed data.
+        Hover or use left and right arrow keys for exact amounts. The latest second may be incomplete.</desc>
       <text x="87" y="12" textAnchor="end">{unit}</text>
       {[0, 0.5, 1].map((fraction) => <g key={fraction}>
-        <line x1="95" x2="630" y1={130 - fraction * 110} y2={130 - fraction * 110} className="federation-activity__grid" />
+        <line x1="95" x2={width - 10} y1={130 - fraction * 110} y2={130 - fraction * 110} className="federation-activity__grid" />
         <text x="87" y={134 - fraction * 110} textAnchor="end">{axisNumber(max * fraction / scale)}</text>
       </g>)}
-      {lines.map((line, index) => <polyline key={line.label}
-        className={`federation-activity__line federation-activity__line--${line.direction}`}
-        strokeDasharray={line.dashed ? "5 4" : undefined}
-        points={values[index].map((value, point) => `${95 + point * 535 / Math.max(1, points.length - 1)},${130 - value / max * 110}`).join(" ")} />)}
+      {lines.map((line, index) => <path key={line.label}
+        className={`federation-activity__bar federation-activity__bar--${line.direction}`}
+        opacity={line.dashed ? 0.4 : 1}
+        d={values[index].map((value, point) => {
+          if (value <= 0) return "";
+          const x = 95 + point * step + index * step / lines.length;
+          const height = value / max * 110;
+          return `M${x},130v${-height}h${step / lines.length - 0.5}v${height}Z`;
+        }).join(" ")} />)}
+      {selected ? <rect x={95 + selectedIndex * step} y="20" width={step} height="110"
+        className="federation-activity__selection" /> : null}
       <text x="95" y="155">{period} ago</text>
-      <text x="630" y="155" textAnchor="end">Now</text>
+      <text x={width - 10} y="155" textAnchor="end">Now</text>
     </svg>
+    </div>
     <div className="federation-activity__legend">{lines.map((line) => <span key={line.label}
       className={`federation-activity__legend--${line.direction}`}>
-      {line.dashed ? "┄" : "━"} {line.label}</span>)}</div>
+      <span style={{ opacity: line.dashed ? 0.4 : 1 }}>■</span> {line.label}</span>)}</div>
+    <div className="federation-activity__chart-detail">
+      {selected ? <div role="tooltip" id={`${id}-tooltip`}>
+        <strong>{time(selected.at)} – {time(selected.at + 1000)}</strong>
+        {selectedIndex === points.length - 1 ? " · In progress" : ""}
+        <div>{lines.map((line, index) => <span key={line.label}>
+          {line.label}: {bytes ? `${number(values[index][selectedIndex])} bytes` : number(values[index][selectedIndex])}
+        </span>)}</div>
+      </div> : <span>Hover a bar or focus the chart and use ← → for amounts. Scroll to see earlier seconds.</span>}
+    </div>
   </figure>;
 }
 
@@ -197,14 +245,15 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
     <p className="federation-activity__muted">{view === "physical"
       ? "Each direct or gateway connection counts its own transfers. A relayed envelope crosses two connections at a gateway."
       : "Only traffic sent or received by this instance as an endpoint; transit forwarding is excluded. This is an alternate view, not extra traffic."}</p>
+    <p className="federation-activity__muted">Sent counts bytes accepted by the local socket; it does not confirm delivery.</p>
     {series && (view === "physical" || peerId) ? <>
-      <FederationRateChart history={series.history} period={period} bytes />
-      <FederationRateChart history={series.history} period={period} bytes={false} />
+      <FederationAmountChart history={series.history} period={period} bytes />
+      <FederationAmountChart history={series.history} period={period} bytes={false} />
       <Totals series={series} />
       <PayloadSizes series={series} />
     </> : <p>No endpoint traffic recorded.</p>}
     {snapshot ? <p className="federation-activity__muted">Totals since {new Date(snapshot.activity.since).toLocaleString()}.
-      Rolling totals have one-second resolution; charts show ten-second averages for up to one hour.</p> : null}
+      Charts show amounts recorded in each second for up to one hour. The latest second is still in progress.</p> : null}
     <details className="federation-activity__boundaries"><summary>What is measured</summary>
       <p>Data is the serialized envelope before compression and encryption, including its protocol metadata and binary blob data.
         Wire is the encoded WebSocket application-message payload, including Noise authentication tags when present.

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33892,10 +33892,12 @@ button.pricing-token-miser__folded:focus-visible {
 .federation-activity__muted { color: var(--text-secondary); }
 .federation-activity__chart { margin: 16px 0; }
 .federation-activity__chart figcaption { font-weight: 600; }
-.federation-activity__chart svg { display: block; width: 100%; }
+.federation-activity__chart svg { display: block; width: 100%; height: 165px; }
 .federation-activity__chart text { fill: var(--text-secondary); font-size: 11px; font-variant-numeric: tabular-nums; }
 .federation-activity__grid { stroke: var(--border-subtle); }
-.federation-activity__chart-scroll { overflow-x: auto; }
+.federation-activity__chart-frame { display: flex; }
+.federation-activity__chart svg.federation-activity__chart-axis { flex: 0 0 95px; width: 95px; }
+.federation-activity__chart-scroll { flex: 1; min-width: 0; overflow-x: auto; }
 .federation-activity__chart svg:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: -2px; }
 .federation-activity__bar--sent { fill: var(--accent); }
 .federation-activity__bar--received { fill: var(--text-secondary); }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -33895,9 +33895,13 @@ button.pricing-token-miser__folded:focus-visible {
 .federation-activity__chart svg { display: block; width: 100%; }
 .federation-activity__chart text { fill: var(--text-secondary); font-size: 11px; font-variant-numeric: tabular-nums; }
 .federation-activity__grid { stroke: var(--border-subtle); }
-.federation-activity__line { fill: none; stroke-width: 1.8; }
-.federation-activity__line--sent { stroke: var(--accent); }
-.federation-activity__line--received { stroke: var(--text-secondary); }
+.federation-activity__chart-scroll { overflow-x: auto; }
+.federation-activity__chart svg:focus-visible { outline: 2px solid var(--focus-ring); outline-offset: -2px; }
+.federation-activity__bar--sent { fill: var(--accent); }
+.federation-activity__bar--received { fill: var(--text-secondary); }
+.federation-activity__selection { fill: var(--text-secondary); opacity: 0.15; pointer-events: none; }
+.federation-activity__chart-detail { min-height: 54px; margin-top: 8px; font-size: 12px; color: var(--text-secondary); }
+.federation-activity__chart-detail span { display: inline-block; margin-right: 12px; }
 .federation-activity__legend { display: flex; flex-wrap: wrap; gap: 14px; font-size: 12px; }
 .federation-activity__legend--sent { color: var(--accent); }
 .federation-activity__legend--received { color: var(--text-secondary); }

--- a/packages/shared/src/contracts/federation.ts
+++ b/packages/shared/src/contracts/federation.ts
@@ -874,6 +874,7 @@ export type FederationActivitySeries = {
   sizes: FederationActivitySizes;
   lifetime: FederationActivityTotals;
   windows: Record<"1m" | "5m" | "10m" | "1h", FederationActivityTotals>;
+  /** One-second amounts; at is the inclusive start of each bucket. */
   history: Array<{ at: number; totals: FederationActivityTotals }>;
 };
 export type FederationActivitySnapshot = {


### PR DESCRIPTION
## Summary

Replace Federation Activity's connected ten-second average rate charts with one-second amount bars. A 100 KB burst now appears as 100 KB in its second, making bursty traffic easier to interpret.

Add hover and keyboard tooltips with exact amounts and time intervals, mark the current second as in progress, and explain that sent bytes are accepted by the local socket without confirmed delivery. Longer chart windows scroll horizontally, and bars share SVG paths to keep rendering lightweight.

## Verification

- 24 focused renderer and ledger tests pass, including a 100 KB millisecond burst, adjacent second boundaries, hover tooltips, and keyboard navigation.
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:colors`
- `git diff --check`

## Notes

Retained ledger storage stays unchanged. Requested history grows from 360 ten-second buckets to 3,600 one-second buckets; the serialized snapshot regression ceiling increases from 180 KB to 900 KB. Only the selected series includes history.

Visual review in the running desktop app remains unverified; no screenshots are attached.
