### PR TITLE
fix(desktop): coalesce concurrent Git remote lookups

### DIFF
--- a/apps/desktop/src/main/__tests__/git-remote.test.ts
+++ b/apps/desktop/src/main/__tests__/git-remote.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  type GitRemote,
   clearGitHubRemoteCache,
   hasGitHubRemoteForDirectory,
   parseGitHubRemote,
@@ -66,6 +67,165 @@ describe("parseGitHubRemote", () => {
 describe("resolveGitHubRepoForDirectory", () => {
   beforeEach(() => {
     clearGitHubRemoteCache();
+  });
+
+  function deferred<T>() {
+    let resolve!: (value: T) => void;
+    let reject!: (reason: Error) => void;
+    const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    return { promise, resolve, reject };
+  }
+
+  const githubRemote = (repo: string): GitRemote[] => [
+    { name: "origin", url: `https://github.com/owner/${repo}.git` },
+  ];
+
+  it("shares a pending cache miss across all directory lookup APIs", async () => {
+    const pending = deferred<GitRemote[]>();
+    const readRemotes = vi.fn(() => pending.promise);
+    const options = { readRemotes };
+    const origin = resolveGitHubRepoForDirectory("/repo", options);
+    const eligible = hasGitHubRemoteForDirectory("/repo", options);
+    const repos = resolveGitHubReposForDirectory("/repo", options);
+    pending.resolve(githubRemote("project"));
+    await expect(origin).resolves.toEqual({ host: "github.com", owner: "owner", repo: "project" });
+    await expect(eligible).resolves.toBe(true);
+    await expect(repos).resolves.toHaveLength(1);
+    expect(readRemotes).toHaveBeenCalledTimes(1);
+  });
+
+  it("resolves each exact SSH host once while preserving distinct aliases and remotes", async () => {
+    const pending = deferred<string | undefined>();
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "git@work:fork/project.git" },
+      { name: "upstream", url: "ssh://git@work/team/project.git" },
+      { name: "backup", url: "other:team/project.git" },
+    ]);
+    const resolveSshHostname = vi.fn((host: string) =>
+      host === "work" ? pending.promise : Promise.resolve("gitlab.com"),
+    );
+    const options = { readRemotes, resolveSshHostname };
+    const repos = resolveGitHubReposForDirectory("/repo", options);
+    await Promise.resolve();
+    const origin = resolveGitHubRepoForDirectory("/repo", options);
+    pending.resolve("github.com");
+    await expect(repos).resolves.toEqual([
+      { host: "github.com", owner: "fork", repo: "project" },
+      { host: "github.com", owner: "team", repo: "project" },
+    ]);
+    await expect(origin).resolves.toMatchObject({ owner: "fork" });
+    expect(readRemotes).toHaveBeenCalledTimes(1);
+    expect(resolveSshHostname.mock.calls).toEqual([["work"], ["other"]]);
+  });
+
+  it.each(["old-first", "new-first"])("isolates invalidated pending work (%s)", async (order) => {
+    const old = deferred<GitRemote[]>();
+    const fresh = deferred<GitRemote[]>();
+    const readRemotes = vi.fn().mockReturnValueOnce(old.promise).mockReturnValue(fresh.promise);
+    const options = { readRemotes };
+    const first = resolveGitHubRepoForDirectory("/repo", options);
+    clearGitHubRemoteCache();
+    const second = resolveGitHubRepoForDirectory("/repo", options);
+    if (order === "old-first") {
+      old.resolve(githubRemote("old"));
+      await first;
+    } else {
+      fresh.resolve(githubRemote("fresh"));
+      await second;
+    }
+    const third = resolveGitHubRepoForDirectory("/repo", options);
+    old.resolve(githubRemote("old"));
+    fresh.resolve(githubRemote("fresh"));
+    await expect(first).resolves.toMatchObject({ repo: "old" });
+    await expect(second).resolves.toMatchObject({ repo: "fresh" });
+    await expect(third).resolves.toMatchObject({ repo: "fresh" });
+    await expect(resolveGitHubRepoForDirectory("/repo", options)).resolves.toMatchObject({ repo: "fresh" });
+    expect(readRemotes).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares failed work, preserves negative TTL, and retries at expiry", async () => {
+    const pending = deferred<GitRemote[]>();
+    let clock = 0;
+    const readRemotes = vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValue(githubRemote("recovered"));
+    const options = { readRemotes, now: () => clock };
+    const first = hasGitHubRemoteForDirectory("/repo", options);
+    const second = hasGitHubRemoteForDirectory("/repo", options);
+    pending.reject(new Error("git failed"));
+    await expect(first).resolves.toBe(false);
+    await expect(second).resolves.toBe(false);
+    clock = 5 * 60_000 - 1;
+    await expect(hasGitHubRemoteForDirectory("/repo", options)).resolves.toBe(false);
+    expect(readRemotes).toHaveBeenCalledTimes(1);
+    clock++;
+    await expect(Promise.all([
+      hasGitHubRemoteForDirectory("/repo", options),
+      hasGitHubRemoteForDirectory("/repo", options),
+    ])).resolves.toEqual([true, true]);
+    expect(readRemotes).toHaveBeenCalledTimes(2);
+  });
+
+  it.each(["undefined", "reject"])("retries SSH %s results after cache expiry and invalidation", async (failure) => {
+    let clock = 0;
+    const readRemotes = vi.fn(async () => [
+      { name: "origin", url: "work:fork/project.git" },
+      { name: "upstream", url: "work:team/project.git" },
+    ]);
+    const resolveSshHostname = vi.fn(async (): Promise<string | undefined> => {
+      if (failure === "reject") {
+        throw new Error("ssh failed");
+      }
+      return undefined;
+    });
+    const options = { readRemotes, resolveSshHostname, now: () => clock };
+    await expect(hasGitHubRemoteForDirectory("/repo", options)).resolves.toBe(false);
+    await expect(hasGitHubRemoteForDirectory("/repo", options)).resolves.toBe(false);
+    expect(resolveSshHostname).toHaveBeenCalledTimes(1);
+    resolveSshHostname.mockResolvedValue("github.com");
+    clock = 5 * 60_000;
+    await expect(resolveGitHubReposForDirectory("/repo", options)).resolves.toHaveLength(2);
+    expect(resolveSshHostname).toHaveBeenCalledTimes(2);
+    clearGitHubRemoteCache();
+    resolveSshHostname.mockResolvedValue("gitlab.com");
+    await expect(hasGitHubRemoteForDirectory("/repo", options)).resolves.toBe(false);
+    expect(resolveSshHostname).toHaveBeenCalledTimes(3);
+  });
+
+  it("starts the TTL at completion and invalidates during SSH expansion", async () => {
+    let clock = 0;
+    const hostname = deferred<string | undefined>();
+    const started = deferred<void>();
+    const readRemotes = vi.fn(async () => [{ name: "origin", url: "work:owner/project.git" }]);
+    const resolveSshHostname = vi.fn(() => {
+      started.resolve();
+      return hostname.promise;
+    });
+    const options = { readRemotes, resolveSshHostname, now: () => clock };
+    const old = hasGitHubRemoteForDirectory("/repo", options);
+    await started.promise;
+    clearGitHubRemoteCache();
+    resolveSshHostname.mockResolvedValue("gitlab.com");
+    const fresh = hasGitHubRemoteForDirectory("/repo", options);
+    clock = 10 * 60_000;
+    await expect(fresh).resolves.toBe(false);
+    hostname.resolve("github.com");
+    await expect(old).resolves.toBe(true);
+    clock += 5 * 60_000 - 1;
+    await expect(hasGitHubRemoteForDirectory("/repo", options)).resolves.toBe(false);
+    expect(readRemotes).toHaveBeenCalledTimes(2);
+    expect(resolveSshHostname).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps different directories independent", async () => {
+    const pending = deferred<GitRemote[]>();
+    const readRemotes = vi.fn((cwd: string) => cwd === "/slow" ? pending.promise : Promise.resolve(githubRemote("fast")));
+    const slow = resolveGitHubRepoForDirectory("/slow", { readRemotes });
+    await expect(resolveGitHubRepoForDirectory("/fast", { readRemotes })).resolves.toMatchObject({ repo: "fast" });
+    pending.resolve([]);
+    await expect(slow).resolves.toBeUndefined();
+    expect(readRemotes).toHaveBeenCalledTimes(2);
   });
 
   it("resolves a directory through its origin remote", async () => {

--- a/apps/desktop/src/main/pr-status/git-remote.ts
+++ b/apps/desktop/src/main/pr-status/git-remote.ts
@@ -98,9 +98,12 @@ type RemoteCacheEntry = {
 };
 
 const remoteCache = new Map<string, RemoteCacheEntry>();
+const remoteLookups = new Map<string, Promise<ParsedGitRemote[]>>();
 
 export function clearGitHubRemoteCache(): void {
   remoteCache.clear();
+  // Existing callers may finish, but cannot publish into the new cache.
+  remoteLookups.clear();
 }
 
 export type ResolveGitHubRepoOptions = {
@@ -178,18 +181,50 @@ async function readParsedGitRemotes(
     return cached.value;
   }
 
+  const existing = remoteLookups.get(cwd);
+  if (existing) {
+    return existing;
+  }
+
+  const pending = loadParsedGitRemotes(cwd, options).then((value) => {
+    if (remoteLookups.get(cwd) === pending) {
+      remoteCache.set(cwd, { value, fetchedAt: now() });
+    }
+    return value;
+  }).finally(() => {
+    // An invalidation may have already installed a replacement lookup.
+    if (remoteLookups.get(cwd) === pending) {
+      remoteLookups.delete(cwd);
+    }
+  });
+  remoteLookups.set(cwd, pending);
+  return pending;
+}
+
+async function loadParsedGitRemotes(
+  cwd: string,
+  options: ResolveGitHubRepoOptions,
+): Promise<ParsedGitRemote[]> {
   const readRemotes = options.readRemotes ?? defaultReadRemotes;
   const resolveSshHostname =
     options.resolveSshHostname ?? defaultResolveSshHostname;
-  let value: ParsedGitRemote[];
+  // Share exact host inputs across this probe's remotes. Keeping this local
+  // preserves SSH config freshness on expiry/invalidation and alias identity.
+  const sshLookups = new Map<string, Promise<string | undefined>>();
   try {
-    value = await Promise.all(
+    return await Promise.all(
       (await readRemotes(cwd)).map(async (remote) => {
         const repo = parseGitHubRemote(remote.url);
         const sshHost = readSshHost(remote.url);
-        const resolvedHost = sshHost
-          ? await resolveSshHostname(sshHost)
-          : undefined;
+        let hostname: Promise<string | undefined> | undefined;
+        if (sshHost) {
+          hostname = sshLookups.get(sshHost);
+          if (!hostname) {
+            hostname = Promise.resolve().then(() => resolveSshHostname(sshHost));
+            sshLookups.set(sshHost, hostname);
+          }
+        }
+        const resolvedHost = await hostname;
         return {
           ...remote,
           repo: repo && resolvedHost
@@ -199,11 +234,9 @@ async function readParsedGitRemotes(
       }),
     );
   } catch {
-    value = [];
+    // Preserve the bounded negative cache, including non-git directories.
+    return [];
   }
-
-  remoteCache.set(cwd, { value, fetchedAt: now() });
-  return value;
 }
 
 async function defaultReadRemotes(cwd: string): Promise<GitRemote[]> {


### PR DESCRIPTION
Concurrent cache misses for the same directory could each start `git remote` and `git remote get-url --all` probes. Multiple SSH remotes using the same host also each ran hostname expansion. Directory lookups now share pending work, and each exact SSH host is resolved once per directory probe.

## Reproduction and behavior

- Deterministic deferred-promise tests overlap origin, eligibility, and all-repository lookups before remote reading completes. Before the fix, the single-probe assertion fails. A second test overlaps callers during SSH expansion and checks repeated hosts versus distinct aliases.
- Five new regression cases failed against the original implementation: duplicate remote work, repeated SSH resolution, both invalidation completion orders, and shared failure handling. They pass with this change.
- Cache clearing detaches pending work. Existing callers can finish, but old results cannot overwrite the new cache or remove a replacement lookup.
- Preserve five-minute positive and negative caching, measured from completion. Pending entries are removed on settlement; failed Git/SSH lookups recover after expiry or explicit invalidation. HTTPS remotes, distinct aliases, multiple repositories, and independent directories retain their behavior.

## Validation

- `pnpm test apps/desktop/src/main/__tests__/git-remote.test.ts apps/desktop/src/main/__tests__/app-server-ipc.test.ts` — 165 tests passed.
- `pnpm lint` — passed SQL, Codex storage, colors, Electron version, licenses, ESLint, workspace type checks, and dependency boundaries. ESLint: 47 warnings, zero errors.
- `git diff --check` — passed.

## Limitations

SSH deduplication is local to a directory probe; different directories do not share SSH results. Invalidation does not cancel existing subprocesses. The existing process launch, environment, timeout, and ownership behavior is unchanged. Negative failures retain the existing bounded TTL rather than retrying immediately.

The CPU profile motivated investigation of spawning cost; it does not establish duplicate request counts or quantify this fix's performance benefit. The duplication evidence here comes from deterministic tests. No profiler or Markdown rendering changes are included.
