### PR TITLE
fix(desktop): report all federation endpoint failures

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
@@ -118,14 +118,47 @@ describe("federation endpoint fallback", () => {
     expect(attempts).toEqual([LAN, TAILSCALE]);
   });
 
-  it("throws the final endpoint error after a fully failed cycle", async () => {
+  it("reports every endpoint failure instead of hiding LAN behind Tailscale DNS", async () => {
     const runtime = createHarness([LAN, TAILSCALE]);
     runtime.connectClient = async (gatewayUrl) => {
-      throw new Error(`connect ECONNREFUSED ${gatewayUrl}`);
+      throw new Error(gatewayUrl === LAN
+        ? "connect ECONNREFUSED 192.168.1.20:47830"
+        : "getaddrinfo ENOTFOUND studio.example.ts.net");
     };
 
     await expect(runtime.connectToGateway()).rejects.toThrow(
-      `connect ECONNREFUSED ${TAILSCALE}`,
+      "Federation gateway is unreachable on every configured endpoint. "
+      + "ws://192.168.1.20:47830: connect ECONNREFUSED 192.168.1.20:47830; "
+      + "wss://studio.example.ts.net: getaddrinfo ENOTFOUND studio.example.ts.net",
+    );
+  });
+
+  it("falls back to LAN when the last-good Tailscale endpoint cannot resolve", async () => {
+    metaStore.set(LAST_ENDPOINT_KEY, TAILSCALE);
+    const runtime = createHarness([LAN, TAILSCALE]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+      if (gatewayUrl === TAILSCALE) {
+        throw new Error("getaddrinfo ENOTFOUND studio.example.ts.net");
+      }
+    };
+
+    await runtime.connectToGateway();
+
+    expect(attempts).toEqual([TAILSCALE, LAN]);
+  });
+
+  it("omits credentials, paths, and query tokens from endpoint labels", async () => {
+    const runtime = createHarness([
+      "wss://user:password@gateway.example.com/private?token=secret",
+    ]);
+    runtime.connectClient = async () => {
+      throw new Error("connect ECONNREFUSED");
+    };
+
+    await expect(runtime.connectToGateway()).rejects.toThrow(
+      /^Federation gateway is unreachable on every configured endpoint\. wss:\/\/gateway\.example\.com: connect ECONNREFUSED$/,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
@@ -149,6 +149,40 @@ describe("federation endpoint fallback", () => {
     expect(attempts).toEqual([TAILSCALE, LAN]);
   });
 
+  it("continues to a healthy fallback after a malformed endpoint", async () => {
+    const malformed = "ws://gateway.example.com:bad";
+    const runtime = createHarness([malformed, LAN]);
+    const attempts: string[] = [];
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+      if (gatewayUrl === malformed) throw new Error("Invalid URL");
+    };
+
+    await runtime.connectToGateway();
+
+    expect(attempts).toEqual([malformed, LAN]);
+    expect(runtime.endpointStatuses.get(malformed)).toMatchObject({
+      state: "failed",
+      lastError: "Invalid URL",
+    });
+  });
+
+  it("safely labels malformed endpoints when every attempt fails", async () => {
+    const runtime = createHarness([
+      "ws://user:password@gateway.example.com:bad/private?token=secret",
+      LAN,
+    ]);
+    runtime.connectClient = async (gatewayUrl) => {
+      throw new Error(gatewayUrl === LAN ? "connect ECONNREFUSED" : "Invalid URL");
+    };
+
+    await expect(runtime.connectToGateway()).rejects.toThrow(
+      "Federation gateway is unreachable on every configured endpoint. "
+      + "Invalid endpoint (attempt 1): Invalid URL; "
+      + "ws://192.168.1.20:47830: connect ECONNREFUSED",
+    );
+  });
+
   it("omits credentials, paths, and query tokens from endpoint labels", async () => {
     const runtime = createHarness([
       "wss://user:password@gateway.example.com/private?token=secret",

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2777,9 +2777,15 @@ export class DesktopFederationRuntime {
         const rawMessage =
           error instanceof Error ? error.message : String(error);
         // Identify the path without exposing URL credentials or query tokens.
-        const endpointUrl = new URL(endpoint);
+        let endpointLabel = `Invalid endpoint (attempt ${failures.length + 1})`;
+        try {
+          const endpointUrl = new URL(endpoint);
+          endpointLabel = `${endpointUrl.protocol}//${endpointUrl.host}`;
+        } catch {
+          // Diagnostic formatting must not interrupt fallback for a bad URL.
+        }
         failures.push(
-          `${endpointUrl.protocol}//${endpointUrl.host}: ${redactFederationDiagnostic(rawMessage)}`,
+          `${endpointLabel}: ${redactFederationDiagnostic(rawMessage)}`,
         );
         this.endpointStatuses.set(endpoint, {
           ...this.endpointStatuses.get(endpoint),

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -2767,16 +2767,20 @@ export class DesktopFederationRuntime {
     // here because connectClient bumps it per attempt; this epoch changes only
     // when the runtime is torn down.
     const walkEpoch = this.walkEpoch;
-    let lastError: unknown;
+    const failures: string[] = [];
     for (const endpoint of attempts) {
       if (this.stopping || this.walkEpoch !== walkEpoch) return;
       try {
         await this.connectClient(endpoint);
         return;
       } catch (error) {
-        lastError = error;
         const rawMessage =
           error instanceof Error ? error.message : String(error);
+        // Identify the path without exposing URL credentials or query tokens.
+        const endpointUrl = new URL(endpoint);
+        failures.push(
+          `${endpointUrl.protocol}//${endpointUrl.host}: ${redactFederationDiagnostic(rawMessage)}`,
+        );
         this.endpointStatuses.set(endpoint, {
           ...this.endpointStatuses.get(endpoint),
           state: "failed",
@@ -2792,11 +2796,10 @@ export class DesktopFederationRuntime {
         }
       }
     }
-    throw lastError instanceof Error
-      ? lastError
-      : new Error(
-          "Federation gateway is unreachable on every configured endpoint.",
-        );
+    throw new Error(
+      "Federation gateway is unreachable on every configured endpoint. "
+      + failures.join("; "),
+    );
   }
 
   private async connectClient(gatewayUrl: string): Promise<void> {


### PR DESCRIPTION
## Summary

When every federation endpoint fails, the logs and status popup currently show only the final error. A Tailscale DNS failure can therefore hide an earlier LAN connection refusal. Report each attempted endpoint and its error in one failure summary.

## Verification

- All 9 federation endpoint fallback tests passed, including combined LAN/DNS errors, fallback from unavailable Tailscale to LAN, and omission of credentials from endpoint labels.
- `pnpm lint:eslint` passed.
- `git diff --check` passed.

## Notes

Endpoint ordering, retry behavior, and early rejection of authentication failures remain unchanged. Endpoint labels omit URL credentials, paths, and query parameters; errors retain existing diagnostic redaction.
