### PR TITLE
perf(desktop): preserve remote pricing card renders

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/PricingPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/PricingPanel.test.tsx
@@ -116,3 +116,176 @@ it("keeps pricing cards cached across rail updates even with an Explorer callbac
   view.rerender(<ThreadContextPanel {...props} width={420} />);
   expect(formatTokens).not.toHaveBeenCalled();
 });
+
+// Recreate the IPC/federation boundary: every poll/notification has new
+// objects, including unchanged finalized rows and nested accounting.
+function wireCopy<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+it("preserves historical DOM and formatting across remote snapshots, active updates and insertion", () => {
+  const formatTokens = vi.spyOn(formatting, "formatTokenCount");
+  const calculate = vi.spyOn(spend, "buildPricingSpendByModel");
+  const historical = buildMonitorLine({
+    usageLineId: "historical", scope: "turn", source: "live", turnId: "old-turn",
+    uncachedInputTokens: 123456, createdAt: 1_800_000_000_000,
+    startedAt: 1_800_000_000_000, completedAt: 1_800_000_001_000,
+  });
+  const active = buildMonitorLine({
+    usageLineId: "active", scope: "turn", source: "live", turnId: "active-turn",
+    uncachedInputTokens: 234567, createdAt: 1_800_000_010_000, status: "pending",
+  });
+  const props = {
+    activeTurnId: "active-turn",
+    pricing: { lines: [active, historical], summaries: [] },
+    displayOptions: { codexCredits: false, usd: true },
+  };
+  const view = render(<PricingPanel {...wireCopy(props)} />);
+  const cards = () => Array.from(view.container.querySelectorAll("li.pricing-usage-row"));
+  const [activeCard, historicalCard] = cards();
+  for (let update = 0; update < 5; update += 1) {
+    formatTokens.mockClear();
+    calculate.mockClear();
+    view.rerender(<PricingPanel {...wireCopy(props)} />);
+    expect(calculate).not.toHaveBeenCalled();
+    expect(formatTokens).not.toHaveBeenCalled();
+    expect(cards()[0]).toBe(activeCard);
+    expect(cards()[1]).toBe(historicalCard);
+  }
+  for (let update = 1; update <= 3; update += 1) {
+    formatTokens.mockClear();
+    view.rerender(<PricingPanel {...wireCopy({
+      ...props,
+      pricing: { ...props.pricing, lines: [{ ...active, uncachedInputTokens: 234567 + update }, historical] },
+    })} />);
+    expect(formatTokens).toHaveBeenCalledWith(234567 + update);
+    expect(formatTokens).not.toHaveBeenCalledWith(123456);
+    expect(cards()[0]).toBe(activeCard);
+    expect(cards()[1]).toBe(historicalCard);
+  }
+  formatTokens.mockClear();
+  const inserted = buildMonitorLine({
+    usageLineId: "inserted", uncachedInputTokens: 345678, createdAt: 1_800_000_020_000,
+  });
+  view.rerender(<PricingPanel {...wireCopy({
+    ...props, pricing: { ...props.pricing, lines: [inserted, active, historical] },
+  })} />);
+  expect(cards()).toHaveLength(3);
+  expect(cards()[1]).toBe(activeCard);
+  expect(cards()[2]).toBe(historicalCard);
+  expect(formatTokens).toHaveBeenCalledWith(345678);
+  expect(formatTokens).not.toHaveBeenCalledWith(123456);
+
+  // A late historical correction also changes subsequent running totals.
+  const previousActiveText = activeCard?.textContent;
+  view.rerender(<PricingPanel {...wireCopy({
+    ...props, pricing: { ...props.pricing, lines: [active, { ...historical, totalCostMicros: 9_000_000 }] },
+  })} />);
+  expect(cards()[0]).toBe(activeCard);
+  expect(activeCard?.textContent).not.toBe(previousActiveText);
+  expect(historicalCard).toHaveTextContent("$9");
+
+  // IDs can be reused by another thread. Its cards must get fresh instances.
+  view.rerender(<PricingPanel {...wireCopy({
+    ...props, pricing: { ...props.pricing, lines: [active, historical].map((line) => ({ ...line, threadId: "other-thread" })) },
+  })} />);
+  expect(cards()[0]).not.toBe(activeCard);
+  expect(cards()[1]).not.toBe(historicalCard);
+});
+
+it("retains expanded Token Miser cards and only reformats the changed gate", () => {
+  const formatTokens = vi.spyOn(formatting, "formatTokenCount");
+  const parent = buildMonitorLine({
+    usageLineId: "parent", scope: "turn", source: "live", turnId: "parent-turn",
+    uncachedInputTokens: 111111,
+  });
+  const gate = buildMonitorLine({
+    usageLineId: "gate", sourceItemId: "system:token-miser:gate",
+    createdAt: parent.createdAt + 1000, uncachedInputTokens: 222222,
+  });
+  const props: ComponentProps<typeof PricingPanel> = {
+    pricing: { lines: [parent, gate], summaries: [] },
+    subAgents: [{
+      monitorId: gate.sourceItemId!, parentTurnId: "parent-turn", agentName: "Token Miser",
+      status: "success", task: "Fixture gate", createdAt: gate.createdAt, updatedAt: gate.createdAt,
+      tokenMiserAccounting: {
+        baselineParentCostMicros: 500_000, baselineParentTokens: 10000,
+        currency: "USD", gateCostMicros: 2000, gateModel: "gpt-5.6-luna",
+        gateTotalTokens: 2100, originalModel: "gpt-5.6-sol",
+        revealedParentCostMicros: 1500, revealedParentTokens: 300, savingsMicros: 496500,
+      },
+    }],
+  };
+  const sibling = { ...gate, usageLineId: "sibling-gate", sourceItemId: "system:token-miser:sibling", uncachedInputTokens: 333333 };
+  props.pricing!.lines.push(sibling);
+  props.subAgents!.push({ ...wireCopy(props.subAgents![0]!), monitorId: sibling.sourceItemId });
+  const view = render(<PricingPanel {...wireCopy(props)} />);
+  const fold = view.getByRole("button", { name: /Token Miser.*saved/ });
+  act(() => { fold.click(); });
+  const gateCard = view.container.querySelector(".pricing-token-miser li.pricing-usage-row");
+  expect(gateCard).not.toBeNull();
+  formatTokens.mockClear();
+  view.rerender(<PricingPanel {...wireCopy(props)} />);
+  expect(fold).toHaveAttribute("aria-expanded", "true");
+  expect(view.container.querySelector(".pricing-token-miser li.pricing-usage-row")).toBe(gateCard);
+  expect(formatTokens).not.toHaveBeenCalled();
+
+  const changed = wireCopy(props);
+  changed.subAgents![0]!.tokenMiserAccounting!.savingsMicros = 396500;
+  view.rerender(<PricingPanel {...changed} />);
+  expect(fold).toHaveAttribute("aria-expanded", "true");
+  expect(fold).toHaveTextContent("$0.90 saved");
+  expect(view.container.querySelector(".pricing-token-miser li.pricing-usage-row")).toBe(gateCard);
+  expect(formatTokens).toHaveBeenCalledWith(222222);
+  expect(formatTokens).not.toHaveBeenCalledWith(333333);
+
+  const switched = wireCopy(changed);
+  switched.pricing!.lines = switched.pricing!.lines.map((line) => ({ ...line, threadId: "other-thread" }));
+  view.rerender(<PricingPanel {...switched} />);
+  const newFold = view.getByRole("button", { name: /Token Miser.*saved/ });
+  expect(newFold).not.toBe(fold);
+  expect(newFold).toHaveAttribute("aria-expanded", "false");
+});
+
+it("keeps card formatting static when the transcript scroll callback changes, but invokes its latest handler", () => {
+  const formatTokens = vi.spyOn(formatting, "formatTokenCount");
+  const line = buildMonitorLine({ scope: "turn", source: "live", turnId: "turn-1" });
+  const pricing = { lines: [line], summaries: [] };
+  const first = vi.fn();
+  const latest = vi.fn();
+  const view = render(<PricingPanel pricing={pricing} onScrollToTurn={first} />);
+  const button = view.getByRole("button", { name: /Scroll the transcript to this turn/ });
+  formatTokens.mockClear();
+  view.rerender(<PricingPanel pricing={wireCopy(pricing)} onScrollToTurn={latest} />);
+  expect(formatTokens).not.toHaveBeenCalled();
+  expect(view.getByRole("button", { name: /Scroll the transcript to this turn/ })).toBe(button);
+  act(() => { button.click(); });
+  expect(first).not.toHaveBeenCalled();
+  expect(latest).toHaveBeenCalledWith("turn-1", line.createdAt);
+  view.rerender(<PricingPanel pricing={wireCopy(pricing)} />);
+  expect(view.queryByRole("button", { name: /Scroll the transcript to this turn/ })).toBeNull();
+});
+
+it("formats one changed card out of a full page of twenty remote usage rows", () => {
+  const formatTokens = vi.spyOn(formatting, "formatTokenCount");
+  const lines = Array.from({ length: 20 }, (_, index) => buildMonitorLine({
+    usageLineId: `row-${index}`, createdAt: 1_800_000_000_000 + index * 1000,
+    scope: "turn", source: "live", turnId: `turn-${index}`,
+    uncachedInputTokens: 1000 + index,
+  }));
+  const view = render(<PricingPanel activeTurnId="turn-19" pricing={{ lines, summaries: [] }} />);
+  const before = Array.from(view.container.querySelectorAll("li.pricing-usage-row"));
+  expect(before).toHaveLength(20);
+  for (let update = 1; update <= 5; update += 1) {
+    formatTokens.mockClear();
+    const next = wireCopy(lines);
+    next[19]!.uncachedInputTokens += update;
+    next[19]!.totalCostMicros += update * 1000;
+    view.rerender(<PricingPanel activeTurnId="turn-19" pricing={{ lines: next, summaries: [] }} />);
+    // Three token fields in the changed card; none of the 19 historical cards.
+    expect(formatTokens).toHaveBeenCalledTimes(3);
+    expect(formatTokens).toHaveBeenCalledWith(1019 + update);
+    const after = Array.from(view.container.querySelectorAll("li.pricing-usage-row"));
+    after.forEach((card, index) => { expect(card).toBe(before[index]); });
+  }
+});

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/PricingPanel.tsx
@@ -13,7 +13,7 @@ import {
   estimateHistoricalThreadUsageGapLines,
   formatTokenUsageMicrosAsUsd,
 } from "@pwragent/shared";
-import { memo, useMemo, useRef, useState, type ReactNode } from "react";
+import { memo, useCallback, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   ChipContextMenu,
   type ChipContextMenuItem,
@@ -92,6 +92,16 @@ const DEFAULT_PRICING_DISPLAY_OPTIONS: PricingDisplayOptions = {
 const PRICING_USAGE_PAGE_SIZE = 20;
 
 export const PricingPanel = memo(function PricingPanel(props: PricingPanelProps) {
+  // ThreadView's scroll handler follows transcript updates. Keep card actions
+  // stable while dispatching to the latest committed handler, including after
+  // a thread switch. Absence still disables the action in the card.
+  const scrollToTurnRef = useRef(props.onScrollToTurn);
+  useLayoutEffect(() => {
+    scrollToTurnRef.current = props.onScrollToTurn;
+  }, [props.onScrollToTurn]);
+  const scrollToTurn = useCallback((turnId: string, turnTimeMs?: number) => {
+    scrollToTurnRef.current?.(turnId, turnTimeMs);
+  }, []);
   // These derivations cover the entire history, including folded gate rows.
   // Reuse them for presentation updates when their source data is unchanged.
   const summaries = useMemo(
@@ -235,198 +245,39 @@ export const PricingPanel = memo(function PricingPanel(props: PricingPanelProps)
     () => groupCompactionsByRow(props.pricing?.compactions ?? []),
     [props.pricing?.compactions],
   );
-  // Rebuilt per render alongside the row map: rows are laid out newest-first in
-  // one pass, so the first row of a turn claims that turn's pending markers.
+  // Compaction ownership must be assigned in list order, before memoized
+  // cards decide whether to render. A skipped card still claims its markers.
   const claimedCompactionTurns = new Set<string>();
-
-  // One usage row, whether it sits in the flat list or nested under a turn.
-  // Nested gates render the same full card as before — title, model, helper
-  // usage, timing, list price, the savings equation, running total — the
-  // heading above them is a fold, not a replacement.
-  const renderUsageRow = (
-    line: PricingUsageLine,
-    options: { nested?: boolean } = {},
-  ) => {
-    const orphanGroup = options.nested
-      ? undefined
-      : orphanGroupsByAnchor.get(line.usageLineId);
-    if (orphanGroup) {
-      // A gate with no turn to nest under is either the compact group
-      // or nothing. Full cards for gates that cannot be priced were
-      // pure noise — the summarizer's cost is still in the totals, and
-      // the Explorer still lists every gate.
-      const anyPriced = orphanGroup.some((gate) =>
-        gate.sourceItemId
-        && subAgentsById.get(gate.sourceItemId)?.tokenMiserAccounting,
-      );
-      return anyPriced ? (
-        <li
-          key={line.usageLineId}
-          className="rail-card pricing-usage-row pricing-usage-row--orphan-gates"
-        >
-          <TokenMiserTurnGroup
-            decisions={tokenMiserDecisionsForGateLines({
-              accounting: props.tokenMiserAccounting,
-              gates: orphanGroup,
-              subAgentsById,
-            })}
-            gates={orphanGroup}
-            renderGate={(gate) => renderUsageRow(gate, { nested: true })}
-            subAgentsById={subAgentsById}
-          />
-        </li>
-      ) : null;
-    }
-    const lineTotals = pricingTotals.byLineId.get(line.usageLineId);
-    const usageLineEstimate = formatUsageLineEstimates({
-      displayOptions,
-      line,
-      lineTotals,
-    });
-    const runningTotal = formatUsageLineRunningTotal({
-      displayOptions,
-      line,
-      lineTotals,
-    });
-    const contextReplayLines = formatContextReplayEstimate({
-      displayOptions,
-      line,
-    });
-    const rowCompactions = selectRowCompactions(
-      compactionsByRow,
-      line,
-      claimedCompactionTurns,
-    );
-    const runningTokens = formatUsageLineRunningTokens(line);
-    const subAgent =
-      line.scope === "monitor" && line.sourceItemId
-        ? subAgentsById.get(line.sourceItemId)
-        : undefined;
-    const nestedGates = line.scope !== "monitor" && line.turnId
-      ? (gateLinesByTurn.get(line.turnId) ?? [])
-      : [];
+  const buildUsageRow = (line: PricingUsageLine, nested = false): PricingUsageRowData => {
+    const orphanGroup = nested ? undefined : orphanGroupsByAnchor.get(line.usageLineId);
+    const gates = orphanGroup ?? (line.scope !== "monitor" && line.turnId
+      ? gateLinesByTurn.get(line.turnId) ?? []
+      : []);
     const isActive = isActiveUsageLine({ activeTurnId, line, subAgentsById });
-    const turnFailure = !isActive && line.scope === "turn"
-      ? props.turnFailures?.find((failure) => failure.turnId === line.turnId)
-      : undefined;
-    const usageTitle = formatUsageLineTitle(line, subAgent);
-    const showUsageTitle = usageTitle !== "Turn usage";
-    const reasoningEffort =
-      line.reasoningEffort
-      ?? subAgent?.preferredReasoningEffort
-      ?? (isActive && line.scope !== "monitor"
+    return {
+      line,
+      nested,
+      orphan: Boolean(orphanGroup),
+      isActive,
+      lineTotals: pricingTotals.byLineId.get(line.usageLineId),
+      rowCompactions: selectRowCompactions(compactionsByRow, line, claimedCompactionTurns),
+      subAgent: line.scope === "monitor" && line.sourceItemId
+        ? subAgentsById.get(line.sourceItemId)
+        : undefined,
+      turnFailure: !isActive && line.scope === "turn"
+        ? props.turnFailures?.find((failure) => failure.turnId === line.turnId)
+        : undefined,
+      threadReasoningEffort: isActive && line.scope !== "monitor"
         ? props.threadReasoningEffort
-        : undefined);
-    const runtimeLabel = formatUsageLineRuntimeLabel(line, subAgent);
-    const runtimeModel = resolveUsageLineModel(line, subAgent);
-
-    return (
-      <li
-        key={line.usageLineId}
-        className={`rail-card pricing-usage-row${
-          isActive ? " pricing-usage-row--active" : ""
-        }`}
-      >
-        <div className="pricing-usage-row__header">
-          <div className="pricing-usage-row__identity">
-            {showUsageTitle ? (
-              <p className="rail-card__title">{usageTitle}</p>
-            ) : null}
-            <p className="rail-card__runtime">
-              <span className="rail-card__provider-chip">
-                {runtimeLabel}
-              </span>
-              <span className="rail-card__model">
-                {runtimeModel ?? "Unknown model"}
-                {reasoningEffort ? ` · ${reasoningEffort}` : ""}
-                {formatServiceTierLabel(line)}
-              </span>
-            </p>
-          </div>
-          <div className="pricing-usage-row__controls">
-            {isActive ? (
-              <RailStatusChip tone="active">Running</RailStatusChip>
-            ) : turnFailure ? (
-              <RailStatusChip tone="error" alert>Failed</RailStatusChip>
-            ) : null}
-            <PricingUsageActions
-              line={line}
-              onScrollToTurn={props.onScrollToTurn}
-              startedAt={
-                subAgent?.createdAt ?? line.startedAt ?? line.createdAt
-              }
-              subAgent={subAgent}
-            />
-          </div>
-        </div>
-        {/* Under the Token Miser fold the heading already names the agent,
-            and the card keeps its own title — a second "Token Miser" line on
-            every nested card was one title too many. */}
-        {subAgent?.agentName && !options.nested ? (
-          <p className="rail-card__agent-name" title={subAgent.agentName}>
-            {subAgent.agentName}
-          </p>
-        ) : null}
-        {/* Cost first: it is the answer the card exists to give. Tokens,
-            timing and replay estimates are the working shown under it. */}
-        {usageLineEstimate ? (
-          <p className="pricing-usage-row__cost">{usageLineEstimate}</p>
-        ) : null}
-        {turnFailure ? <p className="rail-card__error">{turnFailure.error}</p> : null}
-        <p className="rail-card__usage">
-          {formatTokenCount(line.uncachedInputTokens)} uncached in ·{" "}
-          {formatTokenCount(line.cachedInputTokens)} cached ·{" "}
-          {formatTokenCount(line.outputTokens)} out
-          {line.reasoningOutputTokens > 0
-            ? ` (${formatTokenCount(line.reasoningOutputTokens)} reasoning)`
-            : ""}
-        </p>
-        <PricingUsageTimestamp
-          isActive={isActive}
-          line={line}
-          onScrollToTurn={props.onScrollToTurn}
-          subAgent={subAgent}
-        />
-        {contextReplayLines.map((replayLine) => (
-          <p key={replayLine} className="rail-card__usage">
-            {replayLine}
-          </p>
-        ))}
-        {subAgent?.tokenMiserAccounting ? (
-          <TokenMiserSavingsBreakdown
-            accounting={subAgent.tokenMiserAccounting}
-          />
-        ) : null}
-        {nestedGates.length > 0 ? (
-          <TokenMiserTurnGroup
-            decisions={tokenMiserDecisionsForTurn(
-              props.tokenMiserAccounting,
-              line.turnId,
-            )}
-            gates={nestedGates}
-            renderGate={(gate) => renderUsageRow(gate, { nested: true })}
-            subAgentsById={subAgentsById}
-          />
-        ) : null}
-        {rowCompactions.length > 0 ? (
-          <CompactionBreakdown compactions={rowCompactions} />
-        ) : null}
-        {runningTokens ? (
-          <details className="pricing-running-total">
-            <summary className="pricing-running-total__summary">
-              {runningTotal ?? "Running total"}
-            </summary>
-            <p className="rail-card__usage pricing-running-total__tokens">
-              {runningTokens}
-            </p>
-          </details>
-        ) : runningTotal ? (
-          <p className="rail-card__usage">{runningTotal}</p>
-        ) : null}
-      </li>
-    );
+        : undefined,
+      decisions: orphanGroup
+        ? tokenMiserDecisionsForGateLines({
+            accounting: props.tokenMiserAccounting, gates, subAgentsById,
+          })
+        : tokenMiserDecisionsForTurn(props.tokenMiserAccounting, line.turnId),
+      gates: gates.map((gate) => buildUsageRow(gate, true)),
     };
-
+  };
 
   return (
     <section className="context-panel__section">
@@ -531,7 +382,14 @@ export const PricingPanel = memo(function PricingPanel(props: PricingPanelProps)
 
       {displayLines.length > 0 ? (
         <ul className="context-list context-list--cards pricing-usage-list">
-          {visibleDisplayLines.map((line) => renderUsageRow(line))}
+          {visibleDisplayLines.map((line) => (
+            <PricingUsageRow
+              key={`${line.backend}:${line.threadId}:${line.usageLineId}`}
+              row={buildUsageRow(line)}
+              displayOptions={displayOptions}
+              onScrollToTurn={props.onScrollToTurn ? scrollToTurn : undefined}
+            />
+          ))}
         </ul>
       ) : null}
       {hiddenUsageRowCount > 0 ? (
@@ -564,7 +422,187 @@ export const PricingPanel = memo(function PricingPanel(props: PricingPanelProps)
       ) : null}
     </section>
   );
-});
+}, equalPricingData);
+
+type PricingUsageRowData = {
+  line: PricingUsageLine;
+  nested: boolean;
+  orphan: boolean;
+  isActive: boolean;
+  lineTotals: PricingRunningLineTotals | undefined;
+  rowCompactions: ThreadCompactionRecord[];
+  subAgent: ThreadSubAgentSummary | undefined;
+  turnFailure: ThreadTurnFailure | undefined;
+  threadReasoningEffort: string | undefined;
+  decisions: ThreadTokenMiserInterceptionAccounting[] | undefined;
+  gates: PricingUsageRowData[];
+};
+
+// Federation/IPC delivers fresh JSON objects, even for finalized history.
+// The panel skips identical snapshots; each card compares only its own data
+// when a snapshot changes. Include every field (including nested replay
+// evidence) so late corrections cannot leave stale cards. These props contain
+// JSON data and callbacks only; callbacks must retain identity to compare equal.
+function equalPricingData(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (!left || !right || typeof left !== "object" || typeof right !== "object") return false;
+  if (Array.isArray(left) !== Array.isArray(right)) return false;
+  const a = left as Record<string, unknown>;
+  const b = right as Record<string, unknown>;
+  const keys = Object.keys(a);
+  return keys.length === Object.keys(b).length
+    && keys.every((key) => Object.prototype.hasOwnProperty.call(b, key)
+      && equalPricingData(a[key], b[key]));
+}
+
+const PricingUsageRow = memo(function PricingUsageRowCard(props: {
+  row: PricingUsageRowData;
+  displayOptions: PricingDisplayOptions;
+  onScrollToTurn: PricingPanelProps["onScrollToTurn"];
+}) {
+  const { line, lineTotals, rowCompactions, subAgent, isActive, turnFailure } = props.row;
+  const { displayOptions } = props;
+  const renderGroup = () => {
+    const rowsById = new Map(props.row.gates.map((row) => [row.line.usageLineId, row]));
+    const subAgentsById = new Map<string, ThreadSubAgentSummary>();
+    for (const row of props.row.gates) {
+      if (row.subAgent) subAgentsById.set(row.subAgent.monitorId, row.subAgent);
+    }
+    return (
+      <TokenMiserTurnGroup
+        decisions={props.row.decisions}
+        gates={props.row.gates.map((row) => row.line)}
+        subAgentsById={subAgentsById}
+        renderGate={(gate) => (
+          <PricingUsageRow
+            key={`${gate.backend}:${gate.threadId}:${gate.usageLineId}`}
+            row={rowsById.get(gate.usageLineId)!}
+            displayOptions={displayOptions}
+            onScrollToTurn={props.onScrollToTurn}
+          />
+        )}
+      />
+    );
+  };
+  if (props.row.orphan) {
+    return props.row.gates.some((gate) => gate.subAgent?.tokenMiserAccounting) ? (
+      <li className="rail-card pricing-usage-row pricing-usage-row--orphan-gates">
+        {renderGroup()}
+      </li>
+    ) : null;
+  }
+  const usageLineEstimate = formatUsageLineEstimates({ displayOptions, line, lineTotals });
+  const runningTotal = formatUsageLineRunningTotal({ displayOptions, line, lineTotals });
+  const contextReplayLines = formatContextReplayEstimate({ displayOptions, line });
+  const runningTokens = formatUsageLineRunningTokens(line);
+  const usageTitle = formatUsageLineTitle(line, subAgent);
+  const showUsageTitle = usageTitle !== "Turn usage";
+  const reasoningEffort = line.reasoningEffort
+    ?? subAgent?.preferredReasoningEffort
+    ?? props.row.threadReasoningEffort;
+  const runtimeLabel = formatUsageLineRuntimeLabel(line, subAgent);
+  const runtimeModel = resolveUsageLineModel(line, subAgent);
+
+  return (
+    <li
+      key={line.usageLineId}
+      className={`rail-card pricing-usage-row${
+        isActive ? " pricing-usage-row--active" : ""
+      }`}
+    >
+      <div className="pricing-usage-row__header">
+        <div className="pricing-usage-row__identity">
+          {showUsageTitle ? (
+            <p className="rail-card__title">{usageTitle}</p>
+          ) : null}
+          <p className="rail-card__runtime">
+            <span className="rail-card__provider-chip">
+              {runtimeLabel}
+            </span>
+            <span className="rail-card__model">
+              {runtimeModel ?? "Unknown model"}
+              {reasoningEffort ? ` · ${reasoningEffort}` : ""}
+              {formatServiceTierLabel(line)}
+            </span>
+          </p>
+        </div>
+        <div className="pricing-usage-row__controls">
+          {isActive ? (
+            <RailStatusChip tone="active">Running</RailStatusChip>
+          ) : turnFailure ? (
+            <RailStatusChip tone="error" alert>Failed</RailStatusChip>
+          ) : null}
+          <PricingUsageActions
+            line={line}
+            onScrollToTurn={props.onScrollToTurn}
+            startedAt={
+              subAgent?.createdAt ?? line.startedAt ?? line.createdAt
+            }
+            subAgent={subAgent}
+          />
+        </div>
+      </div>
+      {/* Under the Token Miser fold the heading already names the agent,
+          and the card keeps its own title — a second "Token Miser" line on
+          every nested card was one title too many. */}
+      {subAgent?.agentName && !props.row.nested ? (
+        <p className="rail-card__agent-name" title={subAgent.agentName}>
+          {subAgent.agentName}
+        </p>
+      ) : null}
+      {/* Cost first: it is the answer the card exists to give. Tokens,
+          timing and replay estimates are the working shown under it. */}
+      {usageLineEstimate ? (
+        <p className="pricing-usage-row__cost">{usageLineEstimate}</p>
+      ) : null}
+      {turnFailure ? <p className="rail-card__error">{turnFailure.error}</p> : null}
+      <p className="rail-card__usage">
+        {formatTokenCount(line.uncachedInputTokens)} uncached in ·{" "}
+        {formatTokenCount(line.cachedInputTokens)} cached ·{" "}
+        {formatTokenCount(line.outputTokens)} out
+        {line.reasoningOutputTokens > 0
+          ? ` (${formatTokenCount(line.reasoningOutputTokens)} reasoning)`
+          : ""}
+      </p>
+      <PricingUsageTimestamp
+        isActive={isActive}
+        line={line}
+        onScrollToTurn={props.onScrollToTurn}
+        subAgent={subAgent}
+      />
+      {contextReplayLines.map((replayLine) => (
+        <p key={replayLine} className="rail-card__usage">
+          {replayLine}
+        </p>
+      ))}
+      {subAgent?.tokenMiserAccounting ? (
+        <TokenMiserSavingsBreakdown
+          accounting={subAgent.tokenMiserAccounting}
+        />
+      ) : null}
+      {props.row.gates.length > 0 ? renderGroup() : null}
+      {rowCompactions.length > 0 ? (
+        <CompactionBreakdown compactions={rowCompactions} />
+      ) : null}
+      {runningTokens ? (
+        <details className="pricing-running-total">
+          <summary className="pricing-running-total__summary">
+            {runningTotal ?? "Running total"}
+          </summary>
+          <p className="rail-card__usage pricing-running-total__tokens">
+            {runningTokens}
+          </p>
+        </details>
+      ) : runningTotal ? (
+        <p className="rail-card__usage">{runningTotal}</p>
+      ) : null}
+    </li>
+  );
+
+}, (previous, next) =>
+  previous.onScrollToTurn === next.onScrollToTurn
+  && equalPricingData(previous.displayOptions, next.displayOptions)
+  && equalPricingData(previous.row, next.row));
 
 /**
  * One model's share of the bill, closed by default, opening onto the token


### PR DESCRIPTION
Remote pricing notifications replace the complete pricing snapshot, including fresh objects for finalized history. `App` also recreates display options, and transcript updates replace the scroll-to-turn callback. `PricingPanel` previously shallow-memoized its inputs but built every visible card and nested Token Miser card inline, repeating timestamp/token/currency formatting on each update. Existing usage-line keys preserved DOM nodes and expanded gate state: the reproduced problem was rerendering, not wholesale remounting. The cards have no thread-context subscription; only active timestamps subscribe to the clock.

Add memoized pricing-card boundaries with comparisons scoped to each row's data, including nested gate accounting, compactions, failure state, and running totals. Skip identical JSON snapshots at the panel boundary and keep card actions stable while dispatching to the latest committed scroll handler. Keys include backend and thread identity so switching threads resets card instances. Compaction ownership is still assigned in list order before any card can skip rendering. The change is confined to PricingPanel and its regression tests; federation/session reconciliation and the running app are unchanged.

Validation:
- 99 focused tests pass across PricingPanel and ThreadContextPanel.
- Repeated fresh remote snapshots, active changes, insertion, late historical corrections and their downstream totals, nested Token Miser accounting updates, sibling-card preservation, expanded state, thread switches, and callback replacement are covered.
- The 20-card regression fails on origin/main with 60 token-format calls for one changed card; this change makes 3 calls and preserves all 20 DOM nodes across five updates. Identical snapshots do no card token formatting or spend derivation. This is an operation-count result, not a claimed wall-clock or live CPU-profile improvement.
- Baseline nested-gate regression preserves DOM and expansion before failing on repeated formatting, distinguishing rerenders from remounts.
- Full `pnpm lint` passes (SQL, Codex storage, colors, Electron version, licenses, ESLint, workspace typechecks, and dependency boundaries; 47 existing ESLint warnings, no errors). Final changed-file ESLint and desktop typecheck also pass.
