### PR TITLE
feat(desktop): capture directory enrichment probe diagnostics

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -14394,6 +14394,7 @@ script = "echo setup"
     });
 
     expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
+    expect(enrichThreadDirectories).toHaveBeenCalledWith(expect.any(Array), "missing-worktree-backfill");
     expect(
       overlaysByThreadId["project-a-worktree-2"]?.extraLinkedDirectories[0],
     ).toMatchObject({
@@ -15142,7 +15143,7 @@ script = "echo setup"
     });
 
     expect(enrichThreadDirectories).toHaveBeenCalledTimes(1);
-    expect(enrichThreadDirectories).toHaveBeenCalledWith([cheapThread]);
+    expect(enrichThreadDirectories).toHaveBeenCalledWith([cheapThread], "selected-thread");
     await expect(
       overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }),
     ).resolves.toMatchObject({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2026,6 +2026,7 @@ describe("CodexAppServerClient", () => {
     expect(threadDirectoryEnricher).toHaveBeenCalledTimes(1);
     expect(threadDirectoryEnricher).toHaveBeenCalledWith(
       "/Users/fixture-user/.pwragent/profiles/default/projects/2026-05-30-ab12cd",
+      "thread-list",
     );
 
     await client.close();
@@ -2133,8 +2134,8 @@ describe("CodexAppServerClient", () => {
       "thread-pwragent",
     ]);
     expect(threadDirectoryEnricher).toHaveBeenCalledTimes(2);
-    expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/fixture-user/github/PwrSnap");
-    expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/fixture-user/github/PwrAgnt");
+    expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/fixture-user/github/PwrSnap", "thread-list");
+    expect(threadDirectoryEnricher).toHaveBeenCalledWith("/Users/fixture-user/github/PwrAgnt", "thread-list");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -388,11 +388,16 @@ describe("codex environment runtime", () => {
   it("strips parent Electron runtime variables from detached actions", async () => {
     const root = await mkdtemp(path.join(os.tmpdir(), "pwragent-env-electron-"));
     const outputPath = path.join(root, "env.txt");
+    let resolveDetachedExit!: (event: { exitCode: number | null }) => void;
+    const detachedExit = new Promise<{ exitCode: number | null }>((resolve) => {
+      resolveDetachedExit = resolve;
+    });
 
     try {
       const result = await startLocalCodexEnvironmentAction({
         actionId: "start-dev",
         runId: "test-run-3",
+        onDetachedExit: resolveDetachedExit,
         env: {
           ...process.env,
           ELECTRON_RENDERER_URL: "http://127.0.0.1:5173",
@@ -438,15 +443,11 @@ describe("codex environment runtime", () => {
         "hydrated=hydrated-override",
         "",
       ].join("\n");
-      await expect(
-        expectEventually(async () => {
-          const output = await readFile(outputPath, "utf8");
-          if (output !== expectedOutput) {
-            throw new Error(`Output is not complete yet: ${JSON.stringify(output)}`);
-          }
-          return output;
-        }),
-      ).resolves.toBe(expectedOutput);
+      // Complete output does not mean the detached shell and its Windows Job
+      // launcher have released the cwd. Observe the owner's close callback
+      // before reading the result and removing that directory.
+      await expect(detachedExit).resolves.toMatchObject({ exitCode: 0 });
+      await expect(readFile(outputPath, "utf8")).resolves.toBe(expectedOutput);
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/directory-enrichment-diagnostics.test.ts
+++ b/apps/desktop/src/main/__tests__/directory-enrichment-diagnostics.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  DirectoryEnrichmentDiagnostics,
+  type DirectoryEnrichmentContext,
+} from "../diagnostics/directory-enrichment-diagnostics";
+
+const context: DirectoryEnrichmentContext = {
+  directory: "/fixture/repo", enricherId: 1, caller: "thread-list", reason: "cold",
+};
+
+describe("directory enrichment diagnostics", () => {
+  it("attributes starts and completions to their time buckets without mutating prior snapshots", () => {
+    let now = 0;
+    const diagnostics = new DirectoryEnrichmentDiagnostics(() => now, () => now);
+    expect(diagnostics.createEnricherId()).toBe(1);
+    expect(diagnostics.createEnricherId()).toBe(2);
+    diagnostics.record(context, { requests: 1 });
+    const finish = diagnostics.startGit(context, ["rev-parse", "--show-toplevel"]);
+    const before = diagnostics.snapshot();
+    now = 2_010;
+    finish(true);
+    const after = diagnostics.snapshot();
+    expect(before.buckets[0].totals).toMatchObject({ requests: 1, gitStarted: 1, gitFailed: 0 });
+    expect(after.enricherInstancesCreated).toBe(2);
+    expect(after.buckets[0].rows[0]).toMatchObject({ ...context, topLevelCommands: 1 });
+    expect(after.buckets[1].rows[0]).toMatchObject({ gitFailed: 1, gitDurationMs: 2_010 });
+    expect(before.buckets).toHaveLength(1);
+  });
+
+  it("bounds rows, includes overflow in totals, and expires idle history without a timer", () => {
+    let now = 0;
+    const diagnostics = new DirectoryEnrichmentDiagnostics(() => now, () => now);
+    for (let i = 0; i < 40; i += 1) {
+      diagnostics.record({ ...context, directory: `/fixture/${i}` }, { requests: 1 });
+    }
+    let snapshot = diagnostics.snapshot();
+    expect(snapshot.buckets[0].rows).toHaveLength(snapshot.rowsPerBucket);
+    expect(snapshot.buckets[0].totals.requests).toBe(40);
+    expect(snapshot.buckets[0].overflow.requests).toBe(8);
+    for (let i = 1; i <= 80; i += 1) {
+      now = i * 2_000;
+      diagnostics.record(context, { requests: 1 });
+    }
+    snapshot = diagnostics.snapshot();
+    expect(snapshot.buckets).toHaveLength(60);
+    now += snapshot.retentionMs;
+    expect(diagnostics.snapshot().buckets).toEqual([]);
+  });
+
+  it("separates callers, reasons and cache owners and bounds path text", () => {
+    const diagnostics = new DirectoryEnrichmentDiagnostics(() => 0, () => 0);
+    diagnostics.record(context, { requests: 1 });
+    diagnostics.record({ ...context, caller: "selected-thread" }, { requests: 1 });
+    diagnostics.record({ ...context, reason: "cache-hit" }, { requests: 1 });
+    diagnostics.record({ ...context, enricherId: 2 }, { requests: 1 });
+    diagnostics.record({ ...context, directory: "x".repeat(2_000) }, { requests: 1 });
+    const snapshot = diagnostics.snapshot();
+    expect(snapshot.buckets[0].rows).toHaveLength(5);
+    expect(snapshot.buckets[0].rows[4].directory).toHaveLength(snapshot.maxPathLength);
+  });
+
+  it("accounts successful worktree and branch commands without timing assertions", () => {
+    const diagnostics = new DirectoryEnrichmentDiagnostics(() => 0, () => 0);
+    diagnostics.startGit(context, ["worktree", "list", "--porcelain"])(false);
+    diagnostics.startGit(context, ["rev-parse", "--abbrev-ref", "HEAD"])(false);
+    expect(diagnostics.snapshot().buckets[0].totals).toMatchObject({
+      gitStarted: 2, gitSucceeded: 2, gitFailed: 0,
+      worktreeListCommands: 1, branchCommands: 1,
+    });
+  });
+});

--- a/apps/desktop/src/main/__tests__/main-process-hot-cpu-target.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-hot-cpu-target.test.ts
@@ -7,6 +7,7 @@ import { createMainProcessHotCpuTarget } from "../diagnostics/main-process-hot-c
 import { HotCpuProfiler } from "../diagnostics/hot-cpu-profiler";
 import { createHotCpuProfileSession } from "../diagnostics/hot-cpu-profile-session";
 import { resolveHotCpuProfileConfig } from "../diagnostics/hot-cpu-profile-config";
+import { directoryEnrichmentDiagnostics } from "../diagnostics/directory-enrichment-diagnostics";
 import type { HotCpuProfileCapturedEvent } from "../../shared/hot-cpu-profile";
 
 function metric(pid: number, cpuPercent: number, cumulativeCpu: number): ProcessMetric {
@@ -23,9 +24,11 @@ function metric(pid: number, cpuPercent: number, cumulativeCpu: number): Process
   };
 }
 
-it("captures main CPU and heap usage when only the main process is hot", async () => {
+it.each([false, true])("captures main CPU and heap usage (auxiliary failure: %s)", async (diagnosticsFail) => {
   const workspace = await createTemporaryTestDirectory();
   const target = createMainProcessHotCpuTarget();
+  if (diagnosticsFail) target.readDiagnostics = () => { throw new Error("fixture diagnostics failure"); };
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
   let profiler: HotCpuProfiler | undefined;
   try {
     const resolved = resolveHotCpuProfileConfig({ enabled: true, repoRoot: workspace.path, env: {} });
@@ -46,7 +49,7 @@ it("captures main CPU and heap usage when only the main process is hot", async (
     let nowMs = 0;
     profiler = new HotCpuProfiler({
       config, session: created.session, target,
-      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      logger,
       now: () => new Date(nowMs += 1000),
       getAppMetrics: () => [
         metric(1234, 0, 0),
@@ -54,12 +57,29 @@ it("captures main CPU and heap usage when only the main process is hot", async (
       ],
       onProfileWritten: resolveCapture,
     });
+    directoryEnrichmentDiagnostics.record({
+      directory: "/fixture/cpu-capture", enricherId: 0, caller: "thread-list", reason: "cold",
+    }, { requests: 1, gitStarted: 3 });
     await profiler.start();
     const event = await capture;
     await profiler.stop("test-complete");
     expect(event).toMatchObject({ target: "main", profileFilename: "main-hot-0001.cpuprofile", heapSnapshotArtifacts: [] });
     const profile = JSON.parse(await fs.readFile(event.profilePath, "utf8"));
     expect(profile.nodes.length).toBeGreaterThan(0);
+    const diagnosticsFilename = "main-hot-0001.diagnostics.json";
+    const manifest = JSON.parse(await fs.readFile(path.join(created.session.directoryPath, "session.json"), "utf8"));
+    if (diagnosticsFail) {
+      expect(manifest.artifacts).not.toContain(diagnosticsFilename);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "[pwragent:hot-cpu] auxiliary diagnostics failed", expect.any(Error),
+      );
+    } else {
+      const diagnostics = JSON.parse(await fs.readFile(path.join(created.session.directoryPath, diagnosticsFilename), "utf8"));
+      expect(diagnostics.directoryEnrichment.schemaVersion).toBe(1);
+      expect(diagnostics.directoryEnrichment.buckets.flatMap((bucket: { rows: unknown[] }) => bucket.rows))
+        .toContainEqual(expect.objectContaining({ directory: "/fixture/cpu-capture", requests: 1, gitStarted: 3 }));
+      expect(manifest.artifacts).toContain(diagnosticsFilename);
+    }
     const samples = (await fs.readFile(created.session.samplesPath, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
     expect(samples.length).toBeGreaterThanOrEqual(2);
     expect(samples[0]).toMatchObject({ pid: process.pid, heapUsed: expect.any(Number), heapTotal: expect.any(Number) });

--- a/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
@@ -3,14 +3,17 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createThreadDirectoryEnricher } from "../app-server/thread-directory-enricher";
+import { directoryEnrichmentDiagnostics } from "../diagnostics/directory-enrichment-diagnostics";
 import budgets from "./fixtures/git-subprocess-budgets.json";
 
 const git = vi.hoisted(() => vi.fn());
 const readPointer = vi.hoisted(() => vi.fn());
+const observeStat = vi.hoisted(() => vi.fn());
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
   readPointer.mockImplementation(actual.readFile);
-  return { ...actual, readFile: readPointer };
+  observeStat.mockImplementation(actual.stat);
+  return { ...actual, readFile: readPointer, stat: observeStat };
 });
 vi.mock("node:child_process", () => ({ execFile: git }));
 vi.mock("../git-command", () => ({ getGitCommand: () => "git" }));
@@ -74,6 +77,79 @@ async function initializeRealGit(initOptions: string[] = []) {
 }
 
 describe("directory enrichment invalidation", () => {
+  it("records the cache decision and Git budget for each caller", async () => {
+    const record = vi.spyOn(directoryEnrichmentDiagnostics, "record");
+    const enrich = createThreadDirectoryEnricher();
+    await enrich(repo, "thread-list");
+    await enrich(repo, "selected-thread");
+    branch = "feature/diagnostics";
+    await fs.writeFile(path.join(repo, ".git", "HEAD"), `ref: refs/heads/${branch}\n`);
+    await enrich(repo, "selected-thread");
+    await fs.writeFile(path.join(repo, ".git", "config"), "[core]\n bare = false\n");
+    await enrich(repo, "missing-worktree-backfill");
+    const decisions = record.mock.calls.filter(([, delta]) => delta.requests);
+    expect(decisions.map(([context]) => [context.caller, context.reason])).toEqual([
+      ["thread-list", "cold"], ["selected-thread", "cache-hit"],
+      ["selected-thread", "head-changed"], ["missing-worktree-backfill", "relationship-changed"],
+    ]);
+    const commands = record.mock.calls.filter(([, delta]) => delta.gitStarted);
+    expect(commands.map(([context]) => context.reason)).toEqual([
+      "cold", "cold", "cold", "head-changed",
+      "relationship-changed", "relationship-changed", "relationship-changed",
+    ]);
+    expect(new Set(record.mock.calls.map(([context]) => context.enricherId)).size).toBe(1);
+    expect(git).toHaveBeenCalledTimes(7);
+  });
+
+  it("counts pending reuse separately from the caller that owns Git", async () => {
+    const record = vi.spyOn(directoryEnrichmentDiagnostics, "record");
+    const enrich = createThreadDirectoryEnricher();
+    await Promise.all([enrich(repo, "thread-list"), enrich(repo, "selected-thread")]);
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ caller: "selected-thread", reason: "pending-reuse" }),
+      { requests: 1 },
+    );
+    expect(record.mock.calls.filter(([, delta]) => delta.gitStarted)
+      .every(([context]) => context.caller === "thread-list")).toBe(true);
+    expect(git).toHaveBeenCalledTimes(3);
+  });
+
+  it("records failed probes and missing paths without retaining a fallback", async () => {
+    const record = vi.spyOn(directoryEnrichmentDiagnostics, "record");
+    const enrich = createThreadDirectoryEnricher();
+    fail = true;
+    await enrich(repo);
+    expect(record.mock.calls.filter(([, delta]) => delta.gitFailed)).toHaveLength(3);
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({ reason: "cold" }), { resultNotCached: 1 });
+    record.mockClear();
+    await enrich(path.join(root, "missing"));
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "observation-unavailable" }),
+      { requests: 1, observationErrors: 0 },
+    );
+    expect(record.mock.calls.some(([, delta]) => delta.gitStarted)).toBe(false);
+  });
+
+  it("distinguishes observation errors from a cold cache and records rejected publication", async () => {
+    const record = vi.spyOn(directoryEnrichmentDiagnostics, "record");
+    const enrich = createThreadDirectoryEnricher();
+    observeStat.mockRejectedValueOnce(new Error("fixture observation error"));
+    expect((await enrich(repo)).observedGitBranch).toBe("main");
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "observation-unavailable" }),
+      { requests: 1, observationErrors: 1 },
+    );
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "observation-unavailable" }), { resultNotCached: 1 },
+    );
+    record.mockClear();
+    await enrich(repo);
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "cold" }), { requests: 1, observationErrors: 0 },
+    );
+    expect(git).toHaveBeenCalledTimes(6);
+  });
+
   it("keeps a confirmed mapping across a day of repeated reads without Git", async () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
     const enrich = createThreadDirectoryEnricher();
@@ -234,6 +310,7 @@ describe("directory enrichment invalidation", () => {
   });
 
   it("does not publish a cache entry if HEAD changes while Git is running", async () => {
+    const record = vi.spyOn(directoryEnrichmentDiagnostics, "record");
     const enrich = createThreadDirectoryEnricher();
     const invoke = git.getMockImplementation()!;
     let release: () => void = () => {};
@@ -248,6 +325,9 @@ describe("directory enrichment invalidation", () => {
     await fs.writeFile(path.join(repo, ".git", "HEAD"), "ref: refs/heads/new-head\n");
     release();
     await pending;
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "cold" }), { observationChangedDuringProbe: 1 },
+    );
     branch = "new-head";
     git.mockClear();
     expect((await enrich(repo)).observedGitBranch).toBe(branch);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -515,7 +515,10 @@ import {
   ProviderThreadSnapshotStore,
   type ProviderThreadSnapshotStoreLike,
 } from "./provider-thread-snapshot-store";
-import { resolveWorktreeRepositoryDirectory } from "./thread-directory-enricher";
+import {
+  resolveWorktreeRepositoryDirectory,
+  type DirectoryEnrichmentCaller,
+} from "./thread-directory-enricher";
 import {
   BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
   selectStaleWorktreeWorkingStatePaths,
@@ -760,6 +763,7 @@ type BackendClient = {
   ): Promise<AppServerThreadSummary[]>;
   enrichThreadDirectories?(
     threads: AppServerThreadSummary[],
+    caller?: DirectoryEnrichmentCaller,
   ): Promise<AppServerThreadSummary[]>;
   archiveThread?(params: { threadId: string }): Promise<{ threadId: string }>;
   restoreThread?(params: { threadId: string }): Promise<{ threadId: string }>;
@@ -23485,7 +23489,7 @@ export class DesktopBackendRegistry {
 
       const [enrichedThread] = await this.codexClient.enrichThreadDirectories([
         cheapThread,
-      ]);
+      ], "selected-thread");
       if (!enrichedThread) {
         return;
       }
@@ -24512,7 +24516,9 @@ export class DesktopBackendRegistry {
     }
 
     try {
-      const enrichedThreads = await this.codexClient.enrichThreadDirectories(candidates);
+      const enrichedThreads = await this.codexClient.enrichThreadDirectories(
+        candidates, "missing-worktree-backfill",
+      );
       const updatedOverlaysByThreadId: Record<
         string,
         ThreadOverlayState | undefined

--- a/apps/desktop/src/main/app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/app-server/thread-directory-enricher.ts
@@ -3,3 +3,4 @@ export {
   resolveWorktreeRepositoryDirectory,
   type ThreadDirectoryEnrichment,
 } from "../codex-app-server/thread-directory-enricher";
+export type { DirectoryEnrichmentCaller } from "../diagnostics/directory-enrichment-diagnostics";

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -107,6 +107,7 @@ import {
 import {
   createThreadDirectoryEnricher,
   type ThreadDirectoryEnrichment,
+  type DirectoryEnrichmentCaller,
 } from "../app-server/thread-directory-enricher";
 import {
   normalizeReviewDisplayText,
@@ -264,7 +265,8 @@ type CodexClientOptions = {
     projectKey?: string
   ) => Promise<LinkedDirectorySummary[]>;
   threadDirectoryEnricher?: (
-    projectKey?: string
+    projectKey?: string,
+    caller?: DirectoryEnrichmentCaller,
   ) => Promise<ThreadDirectoryEnrichment>;
   connectionObserver?: JsonRpcObserver;
   requestTimeoutMs?: number;
@@ -7366,7 +7368,8 @@ async function ensureCodexThreadTitleWorkspace(): Promise<string> {
 export class CodexAppServerClient {
   private readonly connection: JsonRpcConnection;
   private readonly threadDirectoryEnricher: (
-    projectKey?: string
+    projectKey?: string,
+    caller?: DirectoryEnrichmentCaller,
   ) => Promise<ThreadDirectoryEnrichment>;
   private readonly archivedThreadMetadataByFilter = new Map<
     string,
@@ -8290,22 +8293,25 @@ export class CodexAppServerClient {
       });
     }
 
-    const enrichedThreads = await this.enrichRawThreadDirectories(threads);
+    const enrichedThreads = await this.enrichRawThreadDirectories(threads, "thread-list");
 
     return hydrateMissingLinkedDirectoriesFromSiblingRepos(enrichedThreads);
   }
 
   async enrichThreadDirectories(
     threads: AppServerThreadSummary[],
+    caller: DirectoryEnrichmentCaller = "explicit-enrichment",
   ): Promise<AppServerThreadSummary[]> {
     const enrichedThreads = await this.enrichRawThreadDirectories(
       threads as RawCodexThreadSummary[],
+      caller,
     );
     return hydrateMissingLinkedDirectoriesFromSiblingRepos(enrichedThreads);
   }
 
   private async enrichRawThreadDirectories(
     threads: RawCodexThreadSummary[],
+    caller: DirectoryEnrichmentCaller,
   ): Promise<EnrichedCodexThread[]> {
     const enrichedThreads: Array<EnrichedCodexThread | undefined> = [];
     // A listing can span many mapper batches and contain hundreds of threads
@@ -8326,7 +8332,7 @@ export class CodexAppServerClient {
           const directoryKey = projectKey ? path.resolve(projectKey) : "";
           let pending = directories.get(directoryKey);
           if (!pending) {
-            pending = this.threadDirectoryEnricher(projectKey);
+            pending = this.threadDirectoryEnricher(projectKey, caller);
             directories.set(directoryKey, pending);
           }
           enrichment = await pending;

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -9,6 +9,12 @@ import { getMainLogger } from "../log";
 import { getGitCommand } from "../git-command";
 import { createGitDirectoryObserver, type GitDirectoryObservation } from "./git-directory-observation";
 
+import {
+  directoryEnrichmentDiagnostics,
+  type DirectoryEnrichmentCaller,
+  type DirectoryEnrichmentContext,
+} from "../diagnostics/directory-enrichment-diagnostics";
+
 const execFile = promisify(execFileCallback);
 const threadDirectoryLog = getMainLogger("pwragent:thread-directory-enricher");
 const GIT_DIRECTORY_PROBE_TIMEOUT_MS = 2_000;
@@ -44,13 +50,24 @@ type GitMetadataEvidence = {
   error?: string;
 };
 
-async function runGit(projectKey: string, args: string[]): Promise<string> {
-  const result = await execFile(getGitCommand(), ["-C", projectKey, ...args], {
-    env: buildPwrAgentChildProcessEnv(process.env),
-    maxBuffer: GIT_DIRECTORY_PROBE_MAX_BUFFER_BYTES,
-    timeout: GIT_DIRECTORY_PROBE_TIMEOUT_MS,
-  });
-  return result.stdout.trim();
+async function runGit(
+  projectKey: string,
+  args: string[],
+  context: DirectoryEnrichmentContext,
+): Promise<string> {
+  const finish = directoryEnrichmentDiagnostics.startGit(context, args);
+  try {
+    const result = await execFile(getGitCommand(), ["-C", projectKey, ...args], {
+      env: buildPwrAgentChildProcessEnv(process.env),
+      maxBuffer: GIT_DIRECTORY_PROBE_MAX_BUFFER_BYTES,
+      timeout: GIT_DIRECTORY_PROBE_TIMEOUT_MS,
+    });
+    finish(false);
+    return result.stdout.trim();
+  } catch (error) {
+    finish(true);
+    throw error;
+  }
 }
 
 function buildFallbackLinkedDirectory(currentPath: string): LinkedDirectorySummary {
@@ -212,7 +229,8 @@ function findContainingWorktree(
 }
 
 async function loadThreadDirectoryEnrichment(
-  projectKey?: string,
+  projectKey: string,
+  context: DirectoryEnrichmentContext,
 ): Promise<ThreadDirectoryEnrichment> {
   if (!projectKey?.trim()) {
     return { linkedDirectories: [] };
@@ -226,9 +244,9 @@ async function loadThreadDirectoryEnrichment(
   try {
     const [repoRoot, worktreeList, observedGitBranch, gitMetadata] =
       await Promise.all([
-        runGit(currentPath, ["rev-parse", "--show-toplevel"]),
-        runGit(currentPath, ["worktree", "list", "--porcelain"]),
-        runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"]).catch(() => undefined),
+        runGit(currentPath, ["rev-parse", "--show-toplevel"], context),
+        runGit(currentPath, ["worktree", "list", "--porcelain"], context),
+        runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"], context).catch(() => undefined),
         readGitMetadataEvidence(currentPath),
       ]);
     const worktreePaths = parseGitWorktrees(worktreeList);
@@ -307,16 +325,33 @@ async function loadThreadDirectoryEnrichment(
  */
 export function createThreadDirectoryEnricher(): (
   projectKey?: string,
+  caller?: DirectoryEnrichmentCaller,
 ) => Promise<ThreadDirectoryEnrichment> {
+  const enricherId = directoryEnrichmentDiagnostics.createEnricherId();
   const cache = new Map<string, CachedEnrichment>();
   const pending = new Map<string, Promise<ThreadDirectoryEnrichment>>();
   const observe = createGitDirectoryObserver();
 
-  async function refresh(key: string): Promise<ThreadDirectoryEnrichment> {
-    const before = await observe(key).catch(() => undefined);
+  async function refresh(key: string, caller: DirectoryEnrichmentCaller): Promise<ThreadDirectoryEnrichment> {
+    let observationErrors = 0;
+    const before = await observe(key).catch(() => {
+      observationErrors += 1;
+      return undefined;
+    });
     const cached = cache.get(key);
     const sameRelationship = before
       && cached?.observation.relationship === before.relationship;
+    const context: DirectoryEnrichmentContext = {
+      directory: key,
+      enricherId,
+      caller,
+      reason: !before ? "observation-unavailable"
+        : sameRelationship && cached.observation.head === before.head ? "cache-hit"
+        : !before.repository ? "unversioned"
+        : !cached ? "cold"
+        : sameRelationship ? "head-changed" : "relationship-changed",
+    };
+    directoryEnrichmentDiagnostics.record(context, { requests: 1, observationErrors });
     if (sameRelationship && cached.observation.head === before.head) {
       return cached.value;
     }
@@ -325,30 +360,47 @@ export function createThreadDirectoryEnricher(): (
     if (before && !before.repository) {
       value = { linkedDirectories: [buildFallbackLinkedDirectory(key)] };
     } else if (sameRelationship) {
-      const branch = await runGit(key, ["rev-parse", "--abbrev-ref", "HEAD"])
+      const branch = await runGit(key, ["rev-parse", "--abbrev-ref", "HEAD"], context)
         .catch(() => undefined);
       value = { ...cached.value, observedGitBranch: branch || undefined };
     } else {
-      value = await loadThreadDirectoryEnrichment(key);
+      value = await loadThreadDirectoryEnrichment(key, context);
     }
     // The branch is present only when the complete probe succeeded. Retaining
     // a fallback would hide recovery after a failed executable/filesystem read.
     if (before && (!before.repository || value.observedGitBranch)) {
-      const after = await observe(key).catch(() => undefined);
+      const after = await observe(key).catch(() => {
+        directoryEnrichmentDiagnostics.record(context, { observationErrors: 1 });
+        return undefined;
+      });
       if (after?.relationship === before.relationship && after.head === before.head) {
         cache.set(key, { observation: after, value });
+        directoryEnrichmentDiagnostics.record(context, { cacheStored: 1 });
+      } else {
+        directoryEnrichmentDiagnostics.record(context, { observationChangedDuringProbe: 1 });
       }
+    } else {
+      directoryEnrichmentDiagnostics.record(context, { resultNotCached: 1 });
     }
     return value;
   }
 
-  return async (projectKey) => {
-    if (!projectKey?.trim()) return { linkedDirectories: [] };
+  return async (projectKey, caller = "direct") => {
+    if (!projectKey?.trim()) {
+      directoryEnrichmentDiagnostics.record(
+        { directory: "", enricherId, caller, reason: "empty-path" }, { requests: 1 },
+      );
+      return { linkedDirectories: [] };
+    }
     const key = path.resolve(projectKey.trim());
     let inFlight = pending.get(key);
     if (!inFlight) {
-      inFlight = refresh(key).finally(() => pending.delete(key));
+      inFlight = refresh(key, caller).finally(() => pending.delete(key));
       pending.set(key, inFlight);
+    } else {
+      directoryEnrichmentDiagnostics.record(
+        { directory: key, enricherId, caller, reason: "pending-reuse" }, { requests: 1 },
+      );
     }
     return await inFlight;
   };

--- a/apps/desktop/src/main/diagnostics/directory-enrichment-diagnostics.ts
+++ b/apps/desktop/src/main/diagnostics/directory-enrichment-diagnostics.ts
@@ -1,0 +1,149 @@
+/** In-memory only. No timers, filesystem reads, or per-request log writes. */
+export type DirectoryEnrichmentCaller =
+  | "thread-list"
+  | "selected-thread"
+  | "missing-worktree-backfill"
+  | "explicit-enrichment"
+  | "direct";
+
+export type DirectoryEnrichmentReason =
+  | "empty-path"
+  | "pending-reuse"
+  | "cache-hit"
+  | "observation-unavailable"
+  | "unversioned"
+  | "cold"
+  | "relationship-changed"
+  | "head-changed";
+
+export type DirectoryEnrichmentContext = {
+  directory: string;
+  enricherId: number;
+  caller: DirectoryEnrichmentCaller;
+  reason: DirectoryEnrichmentReason;
+};
+
+type Counters = {
+  requests: number;
+  observationErrors: number;
+  gitStarted: number;
+  gitSucceeded: number;
+  gitFailed: number;
+  gitDurationMs: number;
+  topLevelCommands: number;
+  worktreeListCommands: number;
+  branchCommands: number;
+  cacheStored: number;
+  observationChangedDuringProbe: number;
+  resultNotCached: number;
+};
+
+function counters(): Counters {
+  return {
+    requests: 0, observationErrors: 0, gitStarted: 0, gitSucceeded: 0, gitFailed: 0, gitDurationMs: 0,
+    topLevelCommands: 0, worktreeListCommands: 0, branchCommands: 0,
+    cacheStored: 0, observationChangedDuringProbe: 0, resultNotCached: 0,
+  };
+}
+
+const BUCKET_MS = 2_000;
+const BUCKET_COUNT = 60;
+const ROWS_PER_BUCKET = 32;
+const MAX_PATH_LENGTH = 1_024;
+
+type Row = DirectoryEnrichmentContext & Counters;
+type Bucket = {
+  startMs: number;
+  totals: Counters;
+  overflow: Counters;
+  rows: Map<string, Row>;
+};
+
+/**
+ * Each bucket retains the first 32 directory/caller/reason combinations.
+ * Overflow still contributes to exact totals; it is never presented as a
+ * complete directory ranking. Command starts and completions are counted in
+ * their respective buckets; elapsed time is wall duration, not CPU time.
+ */
+export class DirectoryEnrichmentDiagnostics {
+  private enricherInstancesCreated = 0;
+  private readonly buckets = new Map<number, Bucket>();
+
+  constructor(
+    private readonly now: () => number = Date.now,
+    private readonly monotonicNow: () => number = () => performance.now(),
+  ) {}
+
+  createEnricherId(): number {
+    return ++this.enricherInstancesCreated;
+  }
+
+  private prune(now: number): void {
+    const start = Math.floor(now / BUCKET_MS) * BUCKET_MS;
+    for (const key of this.buckets.keys()) {
+      if (key <= start - BUCKET_COUNT * BUCKET_MS || key > start) {
+        this.buckets.delete(key);
+      }
+    }
+  }
+
+  record(context: DirectoryEnrichmentContext, delta: Partial<Counters>): void {
+    const now = this.now();
+    const startMs = Math.floor(now / BUCKET_MS) * BUCKET_MS;
+    let bucket = this.buckets.get(startMs);
+    if (!bucket) {
+      this.prune(now);
+      bucket = { startMs, totals: counters(), overflow: counters(), rows: new Map() };
+      this.buckets.set(startMs, bucket);
+    }
+    const directory = context.directory.slice(0, MAX_PATH_LENGTH);
+    const key = JSON.stringify([directory, context.enricherId, context.caller, context.reason]);
+    let row = bucket.rows.get(key);
+    if (!row && bucket.rows.size < ROWS_PER_BUCKET) {
+      row = { ...context, directory, ...counters() };
+      bucket.rows.set(key, row);
+    }
+    for (const name of Object.keys(delta) as Array<keyof Counters>) {
+      const amount = delta[name] ?? 0;
+      bucket.totals[name] += amount;
+      (row ?? bucket.overflow)[name] += amount;
+    }
+  }
+
+  startGit(context: DirectoryEnrichmentContext, args: string[]): (failed: boolean) => void {
+    const started = this.monotonicNow();
+    this.record(context, {
+      gitStarted: 1,
+      ...(args.includes("--show-toplevel") ? { topLevelCommands: 1 }
+        : args.includes("--porcelain") ? { worktreeListCommands: 1 }
+        : { branchCommands: 1 }),
+    });
+    return (failed) => this.record(context, {
+      gitSucceeded: failed ? 0 : 1,
+      gitFailed: failed ? 1 : 0,
+      gitDurationMs: Math.max(0, this.monotonicNow() - started),
+    });
+  }
+
+  snapshot() {
+    const capturedAtMs = this.now();
+    this.prune(capturedAtMs);
+    return {
+      schemaVersion: 1,
+      enricherInstancesCreated: this.enricherInstancesCreated,
+      capturedAtMs,
+      bucketMs: BUCKET_MS,
+      retentionMs: BUCKET_COUNT * BUCKET_MS,
+      rowsPerBucket: ROWS_PER_BUCKET,
+      maxPathLength: MAX_PATH_LENGTH,
+      buckets: [...this.buckets.values()].map((bucket) => ({
+        startMs: bucket.startMs,
+        totals: { ...bucket.totals },
+        overflow: { ...bucket.overflow },
+        rows: [...bucket.rows.values()].map((row) => ({ ...row })),
+      })),
+    };
+  }
+}
+
+export const directoryEnrichmentDiagnostics = new DirectoryEnrichmentDiagnostics();

--- a/apps/desktop/src/main/diagnostics/hot-cpu-profiler.ts
+++ b/apps/desktop/src/main/diagnostics/hot-cpu-profiler.ts
@@ -30,6 +30,7 @@ type HotCpuDebugger = {
 export type HotCpuTarget = {
   debugger: HotCpuDebugger;
   getOSProcessId: () => number;
+  readDiagnostics?: () => Record<string, unknown>;
   isDestroyed?: () => boolean;
   takeHeapSnapshot?: (filePath: string) => Promise<void>;
   readHeapUsage?: () => {
@@ -618,6 +619,22 @@ export class HotCpuProfiler {
     }
   }
 
+  private async writeDiagnostics(profilePath: string): Promise<void> {
+    if (!this.target.readDiagnostics) return;
+    const diagnosticsPath = profilePath.replace(/\.cpuprofile$/, ".diagnostics.json");
+    try {
+      await fs.writeFile(
+        diagnosticsPath,
+        `${JSON.stringify(this.target.readDiagnostics())}\n`,
+        "utf8",
+      );
+      await this.session.registerArtifact(artifactFilename(diagnosticsPath));
+    } catch (error) {
+      // Auxiliary accounting must never prevent delivery of the CPU profile.
+      this.logger.warn("[pwragent:hot-cpu] auxiliary diagnostics failed", error);
+    }
+  }
+
   private async stopProfileInner(reason: string): Promise<void> {
     this.profiling = false;
     this.clearProfileDurationTimer();
@@ -644,6 +661,7 @@ export class HotCpuProfiler {
         "utf8",
       );
       await this.session.registerArtifact(profileFilename);
+      await this.writeDiagnostics(profilePath);
       await this.session.appendEvent({
         capturedAt: this.now().toISOString(),
         type: "profile-written",

--- a/apps/desktop/src/main/diagnostics/main-process-hot-cpu-target.ts
+++ b/apps/desktop/src/main/diagnostics/main-process-hot-cpu-target.ts
@@ -8,6 +8,7 @@
 // .cpuprofile-shaped object for the main thread.
 
 import { Session } from "node:inspector";
+import { directoryEnrichmentDiagnostics } from "./directory-enrichment-diagnostics";
 import type { HotCpuTarget } from "./hot-cpu-profiler";
 
 export function createMainProcessHotCpuTarget(): HotCpuTarget {
@@ -47,6 +48,7 @@ export function createMainProcessHotCpuTarget(): HotCpuTarget {
       off: () => {},
     },
     getOSProcessId: () => process.pid,
+    readDiagnostics: () => ({ directoryEnrichment: directoryEnrichmentDiagnostics.snapshot() }),
     readHeapUsage: () => {
       const { heapUsed, heapTotal, external, arrayBuffers } = process.memoryUsage();
       return { heapUsed, heapTotal, external, arrayBuffers };

--- a/docs/design/directory-enrichment-diagnostics.md
+++ b/docs/design/directory-enrichment-diagnostics.md
@@ -1,0 +1,73 @@
+# Directory enrichment diagnostics
+
+Main-process hot CPU captures write a sibling `main-hot-NNNN.diagnostics.json`
+and register it in the session manifest. Its `directoryEnrichment` section
+explains which enrichment requests launched Git. The existing `.cpuprofile`
+format is unchanged. Auxiliary diagnostics failure does not discard the CPU
+capture. Renderer and startup profiles do not collect this summary.
+
+The collector runs in memory before profiling starts, with no timer, filesystem
+probe, per-call log entry, or SQLite write. It retains at most 60 two-second
+buckets. Each bucket keeps the first 32 distinct directory / enricher instance /
+caller / reason combinations. Directory text is clipped to 1,024 characters.
+Older buckets expire on the next observation or snapshot, so idle operation
+needs no cleanup timer. SQLite write projection: **0 MB/day**.
+
+## Reading a capture
+
+Each bucket has its epoch `startMs`, exact `totals`, attributed `rows`, and
+`overflow` counters for combinations beyond its row limit. Use bucket times
+alongside the profile's trigger and pre-trigger duration. Buckets overlap
+capture boundaries by up to two seconds, and the final bucket can be partial.
+The snapshot covers recent history, not exactly the profile interval; long
+captures can extend beyond the two-minute retention. Do not label these counts
+as exact counts within an arbitrary five-second CPU slice.
+
+Sum `gitStarted` by directory, caller and reason to find the retained rows
+responsible for probes. Inspect `overflow.gitStarted` before treating this as a
+complete ranking. Overflow contributes to `totals` even when its paths cannot
+be retained. These are bounded samples of directory attribution, not an
+approximate heavy-hitter algorithm. Clipped directory names can share a row.
+
+Caller labels distinguish `thread-list`, `selected-thread`,
+`missing-worktree-backfill`, `explicit-enrichment` and standalone `direct`
+requests. A client listing already coalesces duplicate directory rows before
+calling the enricher, so these counters measure enricher requests, not threads.
+Injected replacement enrichers/resolvers are outside this collector.
+
+Each enricher receives a process-local increasing `enricherId`; repeated cold
+probes for one path under different IDs point to cache-owner recreation rather
+than invalidation in one cache. `enricherInstancesCreated` is a process-lifetime
+counter, while the bucket counters cover only retained history.
+
+| Reason | Meaning |
+|---|---|
+| `empty-path` | No requested directory |
+| `pending-reuse` | Another request already owns validation/probes for this path |
+| `cache-hit` | Filesystem relationship and HEAD evidence still match |
+| `observation-unavailable` | Missing path, incomplete metadata, or failed observation |
+| `unversioned` | Observation found no repository |
+| `cold` | Valid repository observation with no retained result |
+| `relationship-changed` | Existing mapping invalidated by filesystem relationship evidence |
+| `head-changed` | Stable relationship with changed HEAD evidence |
+
+`requests` counts one decision per call. Pending reuse belongs to the joining
+caller; actual commands belong to the caller that initiated the work.
+`observationErrors` distinguishes thrown filesystem observations from missing
+or incomplete evidence. `cacheStored`, `resultNotCached` and
+`observationChangedDuringProbe` explain publication or rejection of new results.
+A failed probe is intentionally not cached; its next request can be `cold`.
+
+Command counters distinguish top-level, worktree-list and branch probes.
+`gitSucceeded` and `gitFailed` count command completions, including the failures
+that enrichment catches to return a fallback. Starts and completions belong to
+the buckets in which they occur; commands crossing a boundary need not balance
+inside one bucket or capture. `gitDurationMs` is summed monotonic elapsed time
+at completion, **not CPU time**. Concurrent commands overlap, so summed duration
+can exceed the bucket width. No command output, error text, branch names or
+thread text is collected.
+
+This instrumentation does not change probing, cache retention, invalidation,
+process ownership, retry behavior or timeouts. Its purpose is to distinguish
+cold discovery, owner churn, failed probes and actual invalidations before
+changing any of those contracts.


### PR DESCRIPTION
Directory-enrichment Git spawns dominate the reported CPU slice, but the profile cannot distinguish cold paths, cache invalidations, failed observations, or recreated cache owners. The existing pending map already coalesces in-flight requests.

Add bounded in-memory accounting for enrichment callers, cache decisions, cache-owner IDs, publication outcomes, and Git command starts, successes, failures, and elapsed time. Main-process hot CPU captures write and register a sibling `main-hot-NNNN.diagnostics.json`; failure to collect auxiliary diagnostics does not discard the CPU profile.

Retain 60 two-second buckets, with 32 directory/caller/reason/owner rows per bucket and explicit overflow totals. The documentation explains retention, attribution limits, bucket boundaries, and elapsed-time interpretation. Collection adds no timers, per-call logging, Git commands, or SQLite writes (0 MB/day). Probe behavior and cache invalidation remain unchanged.

Validation: 885 tests passed across seven directory, client, registry, and CPU-capture suites. Full `pnpm lint` passed, including typechecks and dependency boundaries; ESLint reported 0 errors and 47 existing warnings. `git diff --check` passed. The running application was not restarted.


Windows CI exposed an existing cleanup race in the Electron-environment detached-action test: complete output appeared before the command owner released its cwd. The test now waits for `onDetachedExit` before checking output and deleting the fixture directory. Both affected suites pass locally (66 tests), along with ESLint and typechecks. This scoped repair does not change process launch behavior or increase retries/timeouts; the separate Git-for-Windows startup failures remain subject to Windows CI verification.
