### PR TITLE
fix(desktop): refresh idle Codex usage from the sidebar

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6278,6 +6278,40 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("refreshes idle Codex quotas without rediscovery and coalesces repeated reads", async () => {
+    const codexClient = new MockBackendClient({
+      rateLimits: [{ name: "Weekly limit", remaining: 91 }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    // A hover before startup discovery must not start the provider.
+    await registry.listBackends({ refreshRateLimits: true });
+    expect(codexClient.readRateLimitsCallCount).toBe(0);
+    await registry.refreshProvidersAtStartup(issueProviderDiscoveryPermit("startup"));
+    const initialReads = codexClient.readRateLimitsCallCount;
+    const initialModelReads = codexClient.listModelsCallCount;
+    const read = vi.spyOn(codexClient, "readRateLimits").mockResolvedValue([
+      { name: "Weekly limit", remaining: 42 },
+    ]);
+    const response = await registry.listBackends({ refreshRateLimits: true });
+    expect(response.backends.find((backend) => backend.kind === "codex")?.rateLimits)
+      .toEqual([{ name: "Weekly limit", remaining: 42 }]);
+    await registry.listBackends({ refreshRateLimits: true });
+    expect(read).toHaveBeenCalledTimes(1);
+    expect(initialReads).toBe(1);
+    expect(codexClient.listModelsCallCount).toBe(initialModelReads);
+    const now = Date.now();
+    const clock = vi.spyOn(Date, "now").mockReturnValue(now + 6_000);
+    read.mockRejectedValueOnce(new Error("temporarily unavailable"));
+    const retained = await registry.listBackends({ refreshRateLimits: true });
+    expect(retained.backends.find((backend) => backend.kind === "codex")?.rateLimits)
+      .toEqual([{ name: "Weekly limit", remaining: 42 }]);
+    clock.mockRestore();
+    await registry.close();
+  });
+
   it("updates cached Codex rate limits from notifications without rewriting unchanged state", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8080,6 +8080,8 @@ export class DesktopBackendRegistry {
     rateLimits: BackendRateLimitSummary[];
   };
   private codexRateLimitsNotificationVersion = 0;
+  private codexQuotaRefresh?: Promise<void>;
+  private codexQuotaRefreshAt?: number;
   private providerRuntimeFingerprints?: Readonly<Record<ProviderId, string>>;
   private providerRuntimeInvalidationPromise?: Promise<void>;
   private readonly correspondenceStore: ThreadCorrespondenceStore;
@@ -10257,6 +10259,9 @@ export class DesktopBackendRegistry {
     } else if (request.refreshModels === "codex") {
       this.modelCatalog.invalidate("codex");
     }
+    if (request.refreshRateLimits) {
+      await this.refreshCodexQuotas();
+    }
     const codexSummary =
       request.refreshModels === true || request.refreshModels === "codex"
         ? await this.discoverCodexBackend(discoveryPermit!)
@@ -10291,6 +10296,8 @@ export class DesktopBackendRegistry {
     this.codexBackendGeneration += 1;
     this.codexBackendSummary = undefined;
     this.pendingCodexRateLimits = undefined;
+    this.codexQuotaRefresh = undefined;
+    this.codexQuotaRefreshAt = undefined;
     this.pendingCodexRateLimitBroadcast = undefined;
     this.codexRateLimitLastBroadcastAt = undefined;
     if (this.codexRateLimitBroadcastTimer) {
@@ -24737,7 +24744,7 @@ export class DesktopBackendRegistry {
           || !currentKeys.has(rateLimitSummaryKey(limit)),
       )
     ) {
-      return await this.refetchCodexRateLimitsForNotification({
+      return await this.refetchCodexRateLimits({
         backendGeneration,
         notificationVersion,
       });
@@ -24770,7 +24777,28 @@ export class DesktopBackendRegistry {
     return true;
   }
 
-  private async refetchCodexRateLimitsForNotification(params: {
+  private async refreshCodexQuotas(): Promise<void> {
+    // Quota reads must not launch discovery or persist provider observations.
+    if (this.closed || !this.codexBackendSummary?.available) return;
+    if (this.codexQuotaRefresh) return await this.codexQuotaRefresh;
+    if (
+      this.codexQuotaRefreshAt !== undefined
+      && Date.now() - this.codexQuotaRefreshAt < 5_000
+    ) return;
+    this.codexQuotaRefreshAt = Date.now();
+    const work = this.refetchCodexRateLimits({
+      backendGeneration: this.codexBackendGeneration,
+      notificationVersion: this.codexRateLimitsNotificationVersion,
+    }).then(() => undefined);
+    this.codexQuotaRefresh = work;
+    try {
+      await work;
+    } finally {
+      if (this.codexQuotaRefresh === work) this.codexQuotaRefresh = undefined;
+    }
+  }
+
+  private async refetchCodexRateLimits(params: {
     backendGeneration: number;
     notificationVersion: number;
   }): Promise<boolean> {
@@ -24779,7 +24807,7 @@ export class DesktopBackendRegistry {
       refetchedRateLimits = await readClientRateLimits(this.codexClient);
     } catch (error) {
       backendRegistryLog.warn(
-        "Codex rate-limit refetch after sparse notification failed",
+        "Codex rate-limit refresh failed",
         { error: error instanceof Error ? error.message : String(error) },
       );
       return false;

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1492,6 +1492,7 @@ function DesktopAppShell(props: {
     enabled: normalAppEnabled,
     federationTarget: activeFederationTarget,
     suspended: remoteReadsSuspended,
+    pollRateLimits: !sidebarHidden,
   });
   const startupBackend = useMemo(
     () => resolveNewThreadBackend(backendSummaries.backends),
@@ -2641,6 +2642,7 @@ function DesktopAppShell(props: {
           }}
           addingProjectDirectory={navigation.pickingDirectory}
           backends={backendSummaries.backends}
+          onRefreshRateLimits={backendSummaries.refreshRateLimits}
           browseMode={navigation.browseMode}
           creatingThread={navigation.creatingThread}
           directories={navigation.directories}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -227,6 +227,7 @@ type SidebarProps = {
   };
   runtimeIdentity?: RuntimeIdentity;
   activeProfile?: string;
+  onRefreshRateLimits?: () => void;
   automationsActive?: boolean;
   profiles?: DesktopPwrAgentProfileSummary[];
   threadSearchActive?: boolean;
@@ -1971,6 +1972,7 @@ export function Sidebar(props: SidebarProps) {
           <ProfileIdentityButton
             label={profileLabel ?? `profile:${props.activeProfile}`}
             tooltipText={profileTooltip}
+            onRefresh={props.onRefreshRateLimits}
             onToggle={(event) => {
               event.stopPropagation();
               setProfileMenuOpen((open) => !open);
@@ -3016,11 +3018,17 @@ function placeThreadContextMenu(
 
 function ProfileIdentityButton(props: {
   label: string;
+  onRefresh?: () => void;
   tooltipText?: string;
   onToggle: (event: ReactMouseEvent<HTMLButtonElement>) => void;
 }) {
   const tooltip = useViewportTooltip({ className: "viewport-tooltip" });
+  const updateTooltip = tooltip.update;
+  useEffect(() => {
+    updateTooltip(props.tooltipText);
+  }, [props.tooltipText, updateTooltip]);
   const showTooltip = (target: HTMLButtonElement): void => {
+    props.onRefresh?.();
     if (props.tooltipText) {
       tooltip.show(target, props.tooltipText);
     }
@@ -3030,6 +3038,7 @@ function ProfileIdentityButton(props: {
     <>
       <button
         aria-label="Open PwrAgent profile menu"
+        aria-describedby={tooltip.visible ? tooltip.tooltipId : undefined}
         className="runtime-identity__button"
         type="button"
         onBlur={tooltip.hide}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -2058,6 +2058,38 @@ describe("Sidebar", () => {
     expect(onForkThread).toHaveBeenCalledWith(childThread, "same-worktree");
   });
 
+  it("refreshes profile quotas on hover and focus and updates the open tooltip", async () => {
+    const onRefreshRateLimits = vi.fn();
+    const props = {
+      activeProfile: "work",
+      backends,
+      browseMode: "recents" as const,
+      directories,
+      inboxThreads: [],
+      loading: false,
+      threads: [],
+      onBrowseModeChange: () => undefined,
+      onCreateThread: async () => undefined,
+      onOpenLaunchpad: async () => undefined,
+      onSelectThread: () => undefined,
+      onRefreshRateLimits,
+    };
+    const { rerender } = render(<Sidebar {...props} />);
+    const button = screen.getByRole("button", { name: "Open PwrAgent profile menu" });
+    fireEvent.mouseEnter(button);
+    expect(onRefreshRateLimits).toHaveBeenCalledTimes(1);
+    await screen.findByRole("tooltip");
+    rerender(<Sidebar {...props} backends={[{
+      ...backends[0]!,
+      rateLimits: [{ name: "Weekly limit", usedPercent: 58 }],
+    }]} />);
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Weekly limit: 42% left");
+    expect(button).toHaveAttribute("aria-describedby", screen.getByRole("tooltip").id);
+    fireEvent.mouseLeave(button);
+    fireEvent.focus(button);
+    expect(onRefreshRateLimits).toHaveBeenCalledTimes(2);
+  });
+
   it("shows the active PwrAgent and Codex profiles with account tooltip details", async () => {
     render(
       <Sidebar

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBackendSummaries.test.tsx
@@ -8,6 +8,47 @@ import {
 } from "../useBackendSummaries";
 
 describe("useBackendSummaries", () => {
+  it("refreshes quotas while visible and stops when the sidebar closes", async () => {
+    vi.useFakeTimers();
+    const listBackends = vi.fn().mockResolvedValue({ fetchedAt: 1, backends: [] });
+    const desktopApi = { listBackends };
+    const { result, rerender, unmount } = renderHook(
+      ({ open }) => useBackendSummaries(desktopApi, { pollRateLimits: open }),
+      { initialProps: { open: true } },
+    );
+    try {
+      await act(async () => {});
+      expect(listBackends).toHaveBeenCalledWith({
+        includeUnavailable: true,
+        refreshRateLimits: true,
+      });
+      listBackends.mockClear();
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+      expect(listBackends).toHaveBeenCalledTimes(1);
+      vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+      listBackends.mockClear();
+      await act(async () => { await vi.advanceTimersByTimeAsync(30_000); });
+      expect(listBackends).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+      act(() => document.dispatchEvent(new Event("visibilitychange")));
+      await act(async () => {});
+      expect(listBackends).toHaveBeenCalledTimes(1);
+      rerender({ open: false });
+      listBackends.mockClear();
+      await act(async () => { await vi.advanceTimersByTimeAsync(60_000); });
+      expect(listBackends).not.toHaveBeenCalled();
+      await act(async () => { await result.current.refreshRateLimits(); });
+      expect(listBackends).toHaveBeenCalledWith({
+        includeUnavailable: true,
+        refreshRateLimits: true,
+      });
+    } finally {
+      unmount();
+      vi.restoreAllMocks();
+      vi.useRealTimers();
+    }
+  });
+
   it("distinguishes pending discovery from a completed empty result", async () => {
     let resolveBackends!: (value: {
       fetchedAt: number;

--- a/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
+++ b/apps/desktop/src/renderer/src/lib/useBackendSummaries.ts
@@ -10,6 +10,7 @@ type BackendSummaryData = {
 };
 
 type BackendSummaryState = BackendSummaryData & {
+  refreshRateLimits: () => Promise<BackendSummary[]>;
   refreshAcpAgents: () => Promise<BackendSummary[]>;
 };
 
@@ -20,6 +21,7 @@ export function useBackendSummaries(
   desktopApi?: DesktopApi,
   options: {
     enabled?: boolean;
+    pollRateLimits?: boolean;
     federationTarget?: FederationTarget;
     suspended?: boolean;
   } = {},
@@ -38,7 +40,7 @@ export function useBackendSummaries(
   const acpRefreshPromiseRef =
     useRef<Promise<BackendSummary[]> | undefined>(undefined);
 
-  const refresh = useCallback(async (): Promise<BackendSummary[]> => {
+  const readSummaries = useCallback(async (refreshRateLimits = false): Promise<BackendSummary[]> => {
     if (!enabled) {
       setState({
         backends: [],
@@ -64,6 +66,7 @@ export function useBackendSummaries(
     try {
       const response = await desktopApi.listBackends({
         includeUnavailable: true,
+        ...(refreshRateLimits ? { refreshRateLimits: true } : {}),
         ...(federationTarget ? { federationTarget } : {}),
       });
       setState({
@@ -80,13 +83,33 @@ export function useBackendSummaries(
         return stateRef.current.backends;
       }
       setState({
-        backends: [],
+        backends: refreshRateLimits ? stateRef.current.backends : [],
         error: error instanceof Error ? error.message : String(error),
         loaded: true,
       });
       return [];
     }
   }, [desktopApi, enabled, federationTarget, suspended]);
+
+  const refresh = useCallback(() => readSummaries(), [readSummaries]);
+  const refreshRateLimits = useCallback(
+    () => readSummaries(true),
+    [readSummaries],
+  );
+
+  useEffect(() => {
+    if (!enabled || suspended || !options.pollRateLimits) return;
+    const refreshVisible = (): void => {
+      if (document.visibilityState !== "hidden") void refreshRateLimits();
+    };
+    refreshVisible();
+    const timer = window.setInterval(refreshVisible, 30_000);
+    document.addEventListener("visibilitychange", refreshVisible);
+    return () => {
+      window.clearInterval(timer);
+      document.removeEventListener("visibilitychange", refreshVisible);
+    };
+  }, [enabled, suspended, options.pollRateLimits, refreshRateLimits]);
 
   const refreshAcpAgents = useCallback(async (): Promise<BackendSummary[]> => {
     if (federationTarget?.scope === "remote") {
@@ -156,6 +179,7 @@ export function useBackendSummaries(
 
   return {
     ...state,
+    refreshRateLimits,
     refreshAcpAgents,
   };
 }

--- a/packages/shared/src/contracts/backend.ts
+++ b/packages/shared/src/contracts/backend.ts
@@ -284,6 +284,8 @@ export type BackendSummary = {
 };
 
 export type ListBackendsRequest = {
+  /** Refresh account quotas for the already discovered Codex provider. */
+  refreshRateLimits?: boolean;
   includeUnavailable?: boolean;
   /**
    * Re-read model capabilities before describing providers. A backend id


### PR DESCRIPTION
Codex usage in the sidebar stayed stale while no thread was active because backend summaries only served cached rate limits. Refresh quotas through `account/rateLimits/read` when the profile button is hovered or focused, when the sidebar becomes visible, and every 30 seconds while the sidebar and document are visible. Update an already open tooltip as results arrive.

The request refreshes only an already discovered Codex provider. It shares in-flight reads, applies a five-second cooldown across windows, preserves cached quotas on failure, and rejects results superseded by a provider change or quota notification. Quota refresh adds no SQLite writes or model discovery.

Validation: 807 tests pass across backend registry, backend summary hook, and sidebar suites. Workspace typecheck, ESLint (zero errors), dependency boundaries, and Codex storage boundary checks pass. No visual layout changes.
