### PR TITLE
fix(desktop): reduce managed subagent navigation scan CPU

### DIFF
--- a/apps/desktop/scripts/benchmark-managed-subagent-scan.ts
+++ b/apps/desktop/scripts/benchmark-managed-subagent-scan.ts
@@ -30,7 +30,10 @@ raw.transaction(() => {
   for (let index = 0; index < 629; index += 1) {
     insert.run(`codex:parent-${index}`, JSON.stringify({
       backend: "codex", threadId: `parent-${index}`, immutableUsageActivities: history,
-      subAgents: [{ monitorThreadId: `child-${index}`, backend: "codex", task: "Synthetic worker" }],
+      subAgents: [{
+        monitorThreadId: `child-${index}`, backend: "codex", task: "Synthetic worker",
+        ...(index === 0 ? { title: "x".repeat(2 * 1024 * 1024) } : {}),
+      }],
     }));
     insert.run(`codex:child-${index}`, JSON.stringify({
       backend: "codex", threadId: `child-${index}`, immutableUsageActivities: history,
@@ -96,6 +99,7 @@ function transferredRows(read: () => unknown): object[] {
 }
 
 try {
+  invalidate();
   const baselineTransferredRows = transferredRows(oldScan);
   invalidate();
   const currentTransferredRows = transferredRows(newScan);
@@ -108,10 +112,13 @@ try {
       arch: process.arch,
       cpu: os.cpus()[0]?.model,
     },
-    fixture: { parents: 629, children: 629, unrelated: 3_000, knownThreadKeys: 10_000 },
+    fixture: {
+      parents: 629, children: 629, unrelated: 3_000, knownThreadKeys: 10_000,
+      subagentTitleBytes: 2 * 1024 * 1024,
+    },
     baselineTransferredRows,
     currentTransferredRows,
-    baselineFullHelper: measure(oldScan),
+    baselineFullHelper: measure(oldScan, invalidate),
     currentInvalidatedFullHelper: measure(newScan, invalidate),
     currentUnchangedFullHelper: measure(newScan),
     baselineBackend: measure(() => baseline["getBackend"]("all")),

--- a/apps/desktop/scripts/benchmark-managed-subagent-scan.ts
+++ b/apps/desktop/scripts/benchmark-managed-subagent-scan.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import Database from "better-sqlite3";
+import { SqliteOverlayStore } from "../src/main/state/overlay-store-sqlite";
+import type { StateDb } from "../src/main/state/state-db";
+
+// Supply a git-exported baseline module under apps/desktop/.local so it uses
+// this checkout's dependencies. Only synthetic data is opened by this probe.
+const baselinePath = process.argv[2];
+if (!baselinePath) throw new Error("Pass the baseline overlay-store TypeScript module path");
+const { SqliteOverlayStore: BaselineStore } = await import(
+  pathToFileURL(path.resolve(baselinePath)).href
+) as { SqliteOverlayStore: typeof SqliteOverlayStore };
+const tempDir = mkdtempSync(path.join(os.tmpdir(), "managed-subagent-bench-"));
+const raw = new Database(path.join(tempDir, "state.db"));
+raw.pragma("journal_mode = WAL");
+raw.exec(`
+  CREATE TABLE threads(thread_id TEXT PRIMARY KEY, payload TEXT NOT NULL);
+  CREATE TABLE backends(scope TEXT PRIMARY KEY, payload TEXT NOT NULL);
+`);
+const insert = raw.prepare("INSERT INTO threads VALUES (?, ?)");
+const history = Array.from({ length: 100 }, (_, index) => ({
+  id: `activity-${index}`, createdAt: index, kind: "fixture",
+  detail: "Synthetic activity metadata. ".repeat(6),
+}));
+raw.transaction(() => {
+  for (let index = 0; index < 629; index += 1) {
+    insert.run(`codex:parent-${index}`, JSON.stringify({
+      backend: "codex", threadId: `parent-${index}`, immutableUsageActivities: history,
+      subAgents: [{ monitorThreadId: `child-${index}`, backend: "codex", task: "Synthetic worker" }],
+    }));
+    insert.run(`codex:child-${index}`, JSON.stringify({
+      backend: "codex", threadId: `child-${index}`, immutableUsageActivities: history,
+      handoffOrigin: { groupingMode: index % 4 === 0 ? "subthread" : "none" },
+    }));
+  }
+  for (let index = 0; index < 3_000; index += 1) {
+    insert.run(`codex:ordinary-${index}`, JSON.stringify({
+      backend: "codex", threadId: `ordinary-${index}`, immutableUsageActivities: history.slice(0, 10),
+    }));
+  }
+  raw.prepare("INSERT INTO backends VALUES (?, ?)").run("all", JSON.stringify({
+    knownThreadKeys: Array.from({ length: 10_000 }, (_, index) => `acp%3Agrok:thread-${index}`),
+    lastSnapshotHash: "baseline",
+  }));
+})();
+const stateDb = { raw } as StateDb;
+const baseline = new BaselineStore(stateDb);
+const current = new SqliteOverlayStore(stateDb);
+const oldScan = () => baseline["listManagedSubAgentThreadKeys"]();
+const newScan = () => current["listManagedSubAgentThreadKeys"]();
+assert.deepEqual(newScan(), oldScan());
+assert.deepEqual(current["getBackend"]("all"), baseline["getBackend"]("all"));
+
+function measure(run: () => unknown, before: () => void = () => {}): object {
+  const samples: number[] = [];
+  for (let index = 0; index < 25; index += 1) {
+    before();
+    const start = performance.now();
+    run();
+    const elapsed = performance.now() - start;
+    if (index >= 5) samples.push(elapsed);
+  }
+  samples.sort((left, right) => left - right);
+  return { medianMs: samples[10], p95Ms: samples[18] };
+}
+const invalidate = () => raw.prepare("UPDATE backends SET payload = payload WHERE scope = ?").run("all");
+
+function transferredRows(read: () => unknown): object[] {
+  const prepare = raw.prepare;
+  const queries: object[] = [];
+  raw.prepare = ((sql: string) => {
+    const statement = prepare.call(raw, sql) as Database.Statement;
+    const all = statement.all.bind(statement);
+    statement.all = (...params: unknown[]) => {
+      const rows = all(...params) as Record<string, unknown>[];
+      queries.push({
+        rows: rows.length,
+        textBytes: rows.reduce((total, row) => total + Object.values(row).reduce<number>(
+          (bytes, value) => bytes + (typeof value === "string" ? Buffer.byteLength(value) : 0), 0,
+        ), 0),
+      });
+      return rows;
+    };
+    return statement;
+  }) as typeof raw.prepare;
+  try {
+    read();
+    return queries;
+  } finally {
+    raw.prepare = prepare;
+  }
+}
+
+try {
+  const baselineTransferredRows = transferredRows(oldScan);
+  invalidate();
+  const currentTransferredRows = transferredRows(newScan);
+  console.log(JSON.stringify({
+    runtime: {
+      node: process.versions.node,
+      v8: process.versions.v8,
+      sqlite: raw.prepare("SELECT sqlite_version()").pluck().get(),
+      platform: process.platform,
+      arch: process.arch,
+      cpu: os.cpus()[0]?.model,
+    },
+    fixture: { parents: 629, children: 629, unrelated: 3_000, knownThreadKeys: 10_000 },
+    baselineTransferredRows,
+    currentTransferredRows,
+    baselineFullHelper: measure(oldScan),
+    currentInvalidatedFullHelper: measure(newScan, invalidate),
+    currentUnchangedFullHelper: measure(newScan),
+    baselineBackend: measure(() => baseline["getBackend"]("all")),
+    currentUnchangedBackend: measure(() => current["getBackend"]("all")),
+  }, null, 2));
+} finally {
+  raw.close();
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -139,6 +139,13 @@
     "rowsChanged": 30,
     "statements": 30
   },
+  "managed-subagent-navigation-reads": {
+    "commits": 0,
+    "note": "10 cold and 10 warm managed-child/backend reads, with large parent and child overlays",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "messaging-agent-conversation-rename": {
     "commits": 5,
     "note": "one agent-driven conversation rename persists the binding title and re-renders the status card inline (no bus event exists for binding-local mutations); bounded by explicit tool calls, not per turn or per item",

--- a/apps/desktop/src/main/__tests__/overlay-store-managed-subagent-scan.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-managed-subagent-scan.test.ts
@@ -1,0 +1,220 @@
+import { execFileSync } from "node:child_process";
+import { createRequire } from "node:module";
+import Database from "better-sqlite3";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
+import { StateDb } from "../state/state-db";
+import { measureSqliteWrites, SQLITE_WRITE_METRICS_ENV } from "../state/sqlite-write-metrics";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
+import { createTempStateDb, removeTempStateDbDir } from "./sqlite-test-utils";
+
+let dbPath: string;
+let tempDir: string;
+let stateDb: StateDb;
+let store: SqliteOverlayStore;
+
+function seed(threadId: string, fields: Record<string, unknown>, db = stateDb.raw): void {
+  db.prepare("INSERT OR REPLACE INTO threads(thread_id, payload) VALUES (?, ?)")
+    .run(`codex:${threadId}`, JSON.stringify({ backend: "codex", threadId, ...fields }));
+}
+
+function keys(target = store): string[] {
+  return [...target["listManagedSubAgentThreadKeys"]()].sort();
+}
+
+beforeEach(() => {
+  vi.stubEnv(SQLITE_WRITE_METRICS_ENV, "1");
+  ({ dbPath, tempDir } = createTempStateDb("pwragent-managed-scan-"));
+  stateDb = StateDb.open(dbPath);
+  store = new SqliteOverlayStore(stateDb);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  stateDb.close();
+  removeTempStateDbDir(tempDir);
+});
+
+describe("managed subagent navigation reads", () => {
+  it("preserves identities, malformed-row isolation, and the grouped handoff exception", async () => {
+    seed("parent", {
+      subAgents: [
+        { monitorThreadId: " child " },
+        { monitorThreadId: "parent" },
+        { monitorThreadId: "parent", backend: "acp:grok" },
+        { monitorThreadId: "child" },
+        { monitorThreadId: " " },
+        { monitorThreadId: "grouped" },
+        { monitorThreadId: "malformed-child" },
+      ],
+    });
+    seed("grouped", { handoffOrigin: { groupingMode: "subthread" } });
+    seed("bad-subagents", { subAgents: { monitorThreadId: "not-an-array" } });
+    stateDb.raw.prepare("INSERT INTO threads(thread_id, payload) VALUES (?, ?)")
+      .run("codex:malformed-parent", '{"monitorThreadId":');
+    stateDb.raw.prepare("INSERT INTO threads(thread_id, payload) VALUES (?, ?)")
+      .run("codex:malformed-child", "not json");
+    expect(keys()).toEqual([
+      buildThreadIdentityKey("acp:grok", "parent"), "codex:child", "codex:malformed-child",
+    ]);
+    const snapshot = await store.reconcileNavigationSnapshot({
+      backend: "all", fetchedAt: 1, partial: true,
+      threads: ["child", "grouped"].map((id) => ({
+        id, title: id, titleSource: "explicit", source: "codex", linkedDirectories: [],
+      })),
+    });
+    expect(snapshot.threads.map((thread) => thread.id)).toEqual(["grouped"]);
+  });
+
+  it("reuses only unchanged reads and detects local inserts, updates and deletes", () => {
+    expect(keys()).toEqual([]);
+    seed("parent", { subAgents: [{ monitorThreadId: "first" }] });
+    expect(keys()).toEqual(["codex:first"]);
+    const prepare = vi.spyOn(stateDb.raw, "prepare");
+    expect(keys()).toEqual(["codex:first"]);
+    expect(prepare.mock.calls.map(([sql]) => sql).some((sql) => sql.includes("FROM threads"))).toBe(false);
+    seed("parent", { subAgents: [{ monitorThreadId: "second" }] });
+    expect(keys()).toEqual(["codex:second"]);
+    stateDb.raw.prepare("DELETE FROM threads WHERE thread_id = ?").run("codex:parent");
+    expect(keys()).toEqual([]);
+  });
+
+  it("sees shared-profile parent and child changes from another connection", () => {
+    const other = new Database(dbPath);
+    try {
+      expect(keys()).toEqual([]);
+      seed("parent", { subAgents: [{ monitorThreadId: "child" }] }, other);
+      expect(keys()).toEqual(["codex:child"]);
+      seed("child", { handoffOrigin: { groupingMode: "subthread" } }, other);
+      expect(keys()).toEqual([]);
+      seed("child", { handoffOrigin: { groupingMode: "none" } }, other);
+      expect(keys()).toEqual(["codex:child"]);
+      other.prepare("DELETE FROM threads WHERE thread_id = ?").run("codex:parent");
+      expect(keys()).toEqual([]);
+    } finally {
+      other.close();
+    }
+  });
+
+  it("sees a commit from an independent profile process on the very next read", () => {
+    expect(keys()).toEqual([]);
+    const require = createRequire(import.meta.url);
+    execFileSync(process.execPath, ["-e", `
+      const Database = require(process.argv[1]);
+      const db = new Database(process.argv[2]);
+      db.prepare("INSERT INTO threads(thread_id, payload) VALUES (?, ?)").run(
+        "codex:parent", JSON.stringify({ backend: "codex", threadId: "parent",
+          subAgents: [{ monitorThreadId: "other-process-child" }] }));
+      db.close();
+    `, require.resolve("better-sqlite3"), dbPath]);
+    expect(keys()).toEqual(["codex:other-process-child"]);
+  });
+
+  it("does not publish transaction or savepoint results after rollback", () => {
+    seed("parent", { subAgents: [{ monitorThreadId: "committed" }] });
+    expect(keys()).toEqual(["codex:committed"]);
+    stateDb.raw.exec("BEGIN");
+    try {
+      seed("parent", { subAgents: [{ monitorThreadId: "uncommitted" }] });
+      expect(keys()).toEqual(["codex:uncommitted"]);
+      stateDb.raw.exec("SAVEPOINT nested");
+      seed("parent", { subAgents: [{ monitorThreadId: "savepoint" }] });
+      expect(keys()).toEqual(["codex:savepoint"]);
+      stateDb.raw.exec("ROLLBACK TO nested");
+      expect(keys()).toEqual(["codex:uncommitted"]);
+    } finally {
+      stateDb.raw.exec("ROLLBACK");
+    }
+    expect(keys()).toEqual(["codex:committed"]);
+  });
+
+  it("does not certify a scan with a concurrent commit's newer generation", () => {
+    seed("parent", { subAgents: [{ monitorThreadId: "first" }] });
+    const other = new Database(dbPath);
+    const prepare = stateDb.raw.prepare.bind(stateDb.raw);
+    let committed = false;
+    vi.spyOn(stateDb.raw, "prepare").mockImplementation((sql) => {
+      // Commit after the parent query but before the child query. That first
+      // result may reflect the prior snapshot, but it must not remain cached.
+      if (!committed && sql.includes("WHERE thread_id IN")) {
+        committed = true;
+        seed("parent", { subAgents: [{ monitorThreadId: "second" }] }, other);
+      }
+      return prepare(sql);
+    });
+    try {
+      expect(keys()).toEqual(["codex:first"]);
+      expect(keys()).toEqual(["codex:second"]);
+    } finally {
+      other.close();
+    }
+  });
+
+  it("bounds materialization for both parent and candidate queries and adds no writes", async () => {
+    const largeHistory = Array.from({ length: 2_000 }, (_, id) => ({ id, text: "fixture".repeat(40) }));
+    seed("parent", {
+      immutableUsageActivities: largeHistory,
+      subAgents: [{ monitorThreadId: "child" }, { monitorThreadId: "grouped" }],
+    });
+    seed("child", { immutableUsageActivities: largeHistory });
+    seed("grouped", { immutableUsageActivities: largeHistory, handoffOrigin: { groupingMode: "subthread" } });
+    stateDb.raw.prepare("INSERT INTO backends(scope, payload) VALUES (?, ?)").run("all", JSON.stringify({
+      knownThreadKeys: ["acp%3Agrok:child"], lastSnapshotHash: "hash",
+    }));
+    const prepare = stateDb.raw.prepare.bind(stateDb.raw);
+    let largestResultBytes = 0;
+    vi.spyOn(stateDb.raw, "prepare").mockImplementation((sql) => {
+      const statement = prepare(sql);
+      const all = statement.all.bind(statement);
+      vi.spyOn(statement, "all").mockImplementation((...params: unknown[]) => {
+        const rows = all(...params);
+        largestResultBytes = Math.max(largestResultBytes, Buffer.byteLength(JSON.stringify(rows)));
+        return rows;
+      });
+      return statement;
+    });
+    const parse = vi.spyOn(JSON, "parse");
+    const { writes } = await measureSqliteWrites(async () => {
+      for (let index = 0; index < 10; index += 1) {
+        const fresh = new SqliteOverlayStore(stateDb);
+        expect(keys(fresh)).toEqual(["codex:child"]);
+        expect(keys(fresh)).toEqual(["codex:child"]);
+        expect(fresh["getBackend"]("all")?.knownThreadKeys).toEqual(["acp:grok:child"]);
+        fresh["getBackend"]("all");
+      }
+    });
+    // Neither child payload may cross into JSON.parse, and the parent only
+    // supplies its relationship projection. This is deterministic, not a clock.
+    expect(Math.max(...parse.mock.calls.map(([text]) => text.length))).toBeLessThan(1_024);
+    expect(largestResultBytes).toBeLessThan(1_024);
+    expectSqliteWriteBudget({
+      scenario: "managed-subagent-navigation-reads",
+      note: "10 cold and 10 warm managed-child/backend reads, with large parent and child overlays",
+      writes,
+    });
+  });
+
+  it("normalizes backend keys once per identical payload while observing replacements and deletion", () => {
+    const other = new Database(dbPath);
+    const write = (scope: string, key: string) => other.prepare(
+      "INSERT OR REPLACE INTO backends(scope, payload) VALUES (?, ?)",
+    ).run(scope, JSON.stringify({ knownThreadKeys: [key], lastSnapshotHash: scope }));
+    try {
+      write("all", "acp%3Agrok:first");
+      expect(store["getBackend"]("all")?.knownThreadKeys).toEqual(["acp:grok:first"]);
+      const parse = vi.spyOn(JSON, "parse");
+      expect(store["getBackend"]("all")?.knownThreadKeys).toEqual(["acp:grok:first"]);
+      expect(parse).not.toHaveBeenCalled();
+      write("all", "acp%3Agrok:second");
+      expect(store["getBackend"]("all")?.knownThreadKeys).toEqual(["acp:grok:second"]);
+      write("codex", "codex:third");
+      expect(store["getBackend"]("codex")?.knownThreadKeys).toEqual(["codex:third"]);
+      other.prepare("DELETE FROM backends WHERE scope = ?").run("all");
+      expect(store["getBackend"]("all")).toBeUndefined();
+    } finally {
+      other.close();
+    }
+  });
+});

--- a/apps/desktop/src/main/__tests__/overlay-store-managed-subagent-scan.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-managed-subagent-scan.test.ts
@@ -38,6 +38,20 @@ afterEach(() => {
 });
 
 describe("managed subagent navigation reads", () => {
+  it("preserves malformed subagent entry isolation during nested projection", () => {
+    seed("primitive-entries", {
+      subAgents: ["not-json", 42, false, [], { monitorThreadId: "valid" }],
+    });
+    seed("null-entry", {
+      subAgents: [{ monitorThreadId: "before-null" }, null, { monitorThreadId: "after-null" }],
+    });
+    seed("invalid-id", {
+      subAgents: [{ monitorThreadId: 42 }, { monitorThreadId: "after-invalid-id" }],
+    });
+    seed("non-array", { subAgents: { monitorThreadId: "not-a-child" } });
+    expect(keys()).toEqual(["codex:before-null", "codex:valid"]);
+  });
+
   it("preserves identities, malformed-row isolation, and the grouped handoff exception", async () => {
     seed("parent", {
       subAgents: [
@@ -156,7 +170,10 @@ describe("managed subagent navigation reads", () => {
     const largeHistory = Array.from({ length: 2_000 }, (_, id) => ({ id, text: "fixture".repeat(40) }));
     seed("parent", {
       immutableUsageActivities: largeHistory,
-      subAgents: [{ monitorThreadId: "child" }, { monitorThreadId: "grouped" }],
+      subAgents: [
+        { monitorThreadId: "child", title: "x".repeat(2 * 1024 * 1024) },
+        { monitorThreadId: "grouped" },
+      ],
     });
     seed("child", { immutableUsageActivities: largeHistory });
     seed("grouped", { immutableUsageActivities: largeHistory, handoffOrigin: { groupingMode: "subthread" } });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -618,6 +618,16 @@ function stripFederationStamp(
 }
 
 export class SqliteOverlayStore implements RemoteThreadTargetStore {
+  private managedSubAgentCache?: {
+    dataVersion: number;
+    totalChanges: number;
+    threadKeys: Set<string>;
+  };
+  private backendReadCache?: {
+    payload: string;
+    state: { knownThreadKeys: string[]; lastSnapshotHash?: string };
+  };
+
   constructor(private readonly stateDb: StateDb) {}
 
   /**
@@ -6452,24 +6462,53 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
   }
 
   private listManagedSubAgentThreadKeys(): Set<string> {
+    // data_version detects commits from other connections (including older
+    // shared-profile processes); total_changes detects this connection's writes.
+    // Capture BEFORE the queries: a concurrent commit must invalidate the next
+    // read, never certify an older result with a newer generation. Do not cache
+    // inside transactions, where a later rollback could otherwise leak a result.
+    const generation = this.stateDb.raw.inTransaction
+      ? undefined
+      : this.stateDb.raw.prepare(
+        `SELECT data_version AS dataVersion, total_changes() AS totalChanges
+         FROM pragma_data_version`,
+      ).get() as { dataVersion: number; totalChanges: number } | undefined;
+    if (
+      generation
+      && this.managedSubAgentCache?.dataVersion === generation.dataVersion
+      && this.managedSubAgentCache.totalChanges === generation.totalChanges
+    ) {
+      return this.managedSubAgentCache.threadKeys;
+    }
+
     const rows = this.stateDb.raw
       .prepare(
-        `SELECT payload FROM threads
+        `SELECT CASE WHEN json_valid(payload) THEN
+           json_extract(payload, '$.backend', '$.threadId', '$.subAgents')
+         END AS projection FROM threads
          WHERE payload LIKE '%"monitorThreadId"%'`,
       )
-      .all() as Array<{ payload: string }>;
+      .all() as Array<{ projection: string | null }>;
     const threadKeys = new Set<string>();
     for (const row of rows) {
       try {
-        const overlay = normalizeThreadOverlayState(
-          JSON.parse(row.payload) as ThreadOverlayState,
-        );
-        for (const subAgent of overlay.subAgents ?? []) {
+        if (!row.projection) continue;
+        // Overlay normalization only removes a legacy agent persona; it does
+        // not change these relationship fields. Avoid materializing histories,
+        // usage, PRs, and agent instructions just to discover child identities.
+        const [parentBackend, parentThreadId, subAgents] = JSON.parse(
+          row.projection,
+        ) as [
+          ThreadOverlayState["backend"],
+          string,
+          ThreadOverlayState["subAgents"],
+        ];
+        for (const subAgent of subAgents ?? []) {
           const threadId = subAgent.monitorThreadId?.trim();
-          const backend = subAgent.backend ?? overlay.backend;
+          const backend = subAgent.backend ?? parentBackend;
           if (
             !threadId
-            || (backend === overlay.backend && threadId === overlay.threadId)
+            || (backend === parentBackend && threadId === parentThreadId)
           ) {
             continue;
           }
@@ -6495,30 +6534,28 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
     if (storageKeys.length > 0) {
       const candidateRows = this.stateDb.raw
         .prepare(
-          `SELECT thread_id, payload FROM threads
+          `SELECT thread_id, CASE WHEN json_valid(payload) THEN
+             json_extract(payload, '$.handoffOrigin.groupingMode')
+           END AS grouping_mode FROM threads
            WHERE thread_id IN (SELECT value FROM json_each(?))`,
         )
         .all(JSON.stringify(storageKeys)) as Array<{
-          payload: string;
+          grouping_mode: unknown;
           thread_id: string;
         }>;
       for (const candidate of candidateRows) {
-        try {
-          const overlay = normalizeThreadOverlayState(
-            JSON.parse(candidate.payload) as ThreadOverlayState,
+        if (candidate.grouping_mode === "subthread") {
+          const canonicalKey = canonicalKeyByStorageKey.get(
+            candidate.thread_id,
           );
-          if (overlay.handoffOrigin?.groupingMode === "subthread") {
-            const canonicalKey = canonicalKeyByStorageKey.get(
-              candidate.thread_id,
-            );
-            if (canonicalKey) {
-              threadKeys.delete(canonicalKey);
-            }
+          if (canonicalKey) {
+            threadKeys.delete(canonicalKey);
           }
-        } catch {
-          // A malformed unrelated child overlay must not block navigation.
         }
       }
+    }
+    if (generation) {
+      this.managedSubAgentCache = { ...generation, threadKeys };
     }
     return threadKeys;
   }
@@ -6584,16 +6621,24 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       .prepare("SELECT payload FROM backends WHERE scope = ?")
       .get(scope) as { payload: string } | undefined;
     if (!row) return undefined;
+    // Still read the authoritative row on every call. Equality avoids parsing
+    // and normalizing thousands of identities again, without hiding a write
+    // from another process or retaining an unbounded cache of scopes.
+    if (this.backendReadCache?.payload === row.payload) {
+      return this.backendReadCache.state;
+    }
     const state = JSON.parse(row.payload) as {
       knownThreadKeys: string[];
       lastSnapshotHash?: string;
     };
-    return {
+    const normalized = {
       ...state,
       knownThreadKeys: state.knownThreadKeys.map((threadKey) =>
         normalizeThreadIdentityKey(threadKey) ?? threadKey
       ),
     };
+    this.backendReadCache = { payload: row.payload, state: normalized };
+    return normalized;
   }
 
   private putBackend(

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -6483,9 +6483,15 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
 
     const rows = this.stateDb.raw
       .prepare(
-        `SELECT CASE WHEN json_valid(payload) THEN
-           json_extract(payload, '$.backend', '$.threadId', '$.subAgents')
-         END AS projection FROM threads
+        `SELECT CASE WHEN json_valid(payload) THEN json_array(
+           json_extract(payload, '$.backend'), json_extract(payload, '$.threadId'),
+           json(CASE WHEN json_type(payload, '$.subAgents') = 'array' THEN
+             (SELECT json_group_array(CASE WHEN type = 'object' THEN json_object(
+               'backend', json_extract(value, '$.backend'),
+               'monitorThreadId', json_extract(value, '$.monitorThreadId')
+             ) ELSE value END) FROM json_each(payload, '$.subAgents'))
+           ELSE 'null' END)
+         ) END AS projection FROM threads
          WHERE payload LIKE '%"monitorThreadId"%'`,
       )
       .all() as Array<{ projection: string | null }>;
@@ -6495,7 +6501,8 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
         if (!row.projection) continue;
         // Overlay normalization only removes a legacy agent persona; it does
         // not change these relationship fields. Avoid materializing histories,
-        // usage, PRs, and agent instructions just to discover child identities.
+        // usage, PRs, agent instructions, and nested subagent task/title metadata
+        // just to discover child identities.
         const [parentBackend, parentThreadId, subAgents] = JSON.parse(
           row.projection,
         ) as [

--- a/docs/design/managed-subagent-navigation-reads.md
+++ b/docs/design/managed-subagent-navigation-reads.md
@@ -13,7 +13,10 @@ SQLite/V8 boundary even though this path only needs relationship fields.
 ## Read behavior
 
 - The first query keeps the existing `monitorThreadId` substring predicate and
-  projects `[backend, threadId, subAgents]` with one `json_extract` call.
+  projects parent identity plus only `backend` and `monitorThreadId` from each
+  object in `subAgents`. `json_each` and `json_group_array` omit nested task/title
+  metadata. Non-object entries retain the existing iteration behavior; a
+  non-array `subAgents` value projects as null.
 - The second query retains its primary-key candidate lookup and projects only
   `handoffOrigin.groupingMode`. Neither query returns full overlay payloads.
 - `json_valid` guards extraction so malformed unrelated rows cannot abort the
@@ -63,7 +66,8 @@ JSON parsing, normalization, and key construction. Five warmup samples precede
 20 measured samples. Invalidated samples force a local write outside timing;
 byte accounting runs separately from timed samples.
 
-Recorded on Apple M4 arm64, Node 24.18.0, V8 13.6, better-sqlite3's SQLite 3.53.2:
+Initial measurements before the nested subagent projection, on Apple M4 arm64,
+Node 24.18.0, V8 13.6, better-sqlite3's SQLite 3.53.2:
 
 | Read | Baseline median / p95 | Changed median / p95 |
 | --- | --- | --- |
@@ -83,6 +87,38 @@ so absolute timings should not be interpreted independently of machine load.
 This is a synthetic same-runtime comparison, not an Electron recapture or proof
 of a PR #2001 regression. The original M5 capture motivated the investigation;
 no running default app was restarted and no operator database was read.
+
+## Nested subagent projection follow-up
+
+The initial projection still returned complete subagent objects. A task/title
+can itself carry arbitrarily large metadata. The current fixture therefore adds
+a 2 MiB title to one subagent, and the regression still requires both native
+results and parser inputs to remain below 1 KiB for its small relationship set.
+The production query adopts the narrower projection integrated into #2001.
+
+Using the same runtime above and the updated synthetic fixture:
+
+| Comparison | Baseline median / p95 | Narrow projection median / p95 |
+| --- | --- | --- |
+| Original main `314f16851`, invalidated helper | 67.952 / 74.900 ms | 58.314 / 62.311 ms |
+| Previous PR head `aa69e75e0`, invalidated helper | 47.998 / 51.065 ms | 60.076 / 65.787 ms |
+
+The two comparisons are separate same-process runs. Unchanged reads measured
+0.0037–0.0038 ms. The narrower query is about 14% faster than original main on
+this fixture but about 25% slower than the prior projection: reducing transferred
+bytes does not eliminate the SQL cost of extracting fields from every subagent.
+This is an explicit materialization bound, not a claim of another cold CPU win.
+
+Parent/child native text bytes were 17,219,361 / 15,100,344 for original main,
+2,159,843 / 12,631 for the previous PR head, and **46,326 / 12,631** for the new
+projection. Backend handling is unchanged; versus original main its median was
+1.634 → 0.072 ms in the updated run.
+
+The reproduction command above now includes the large title. To compare against
+the prior PR version, export `aa69e75e0` instead of `314f16851`. Both baseline and
+changed cold samples now force invalidation outside timing, so a baseline that
+already has caching cannot accidentally measure warm reads or return no byte
+accounting rows.
 
 ## Regression and write budgets
 

--- a/docs/design/managed-subagent-navigation-reads.md
+++ b/docs/design/managed-subagent-navigation-reads.md
@@ -1,0 +1,100 @@
+# Managed subagent navigation reads
+
+`SqliteOverlayStore.reconcileNavigationSnapshot` discovers managed workers from
+parent overlays, then excludes ordinary grouped handoffs by reading each
+candidate child's `handoffOrigin.groupingMode`. The relationship can be written
+by another PwrAgent process sharing the profile, including a supported older
+build that recreates a stale native-worker card.
+
+The inherited implementation selected and parsed complete overlays twice. Large
+activity histories, agent instructions, and other unrelated metadata crossed the
+SQLite/V8 boundary even though this path only needs relationship fields.
+
+## Read behavior
+
+- The first query keeps the existing `monitorThreadId` substring predicate and
+  projects `[backend, threadId, subAgents]` with one `json_extract` call.
+- The second query retains its primary-key candidate lookup and projects only
+  `handoffOrigin.groupingMode`. Neither query returns full overlay payloads.
+- `json_valid` guards extraction so malformed unrelated rows cannot abort the
+  query. Overlay normalization only removes a legacy agent persona; it does not
+  change the projected relationship fields.
+- The child set is reused only when both SQLite `data_version` and
+  `total_changes()` match the values captured **before** the last scan.
+  `data_version` catches other connections' commits; `total_changes()` catches
+  local writes, including direct SQL outside the overlay store. A concurrent
+  commit during a scan therefore invalidates the next read.
+- Calls inside a transaction neither consume nor publish the cached set. This
+  prevents transaction snapshots and rolled-back savepoints from escaping.
+- Backend reads still select the current row every time. One bounded cache
+  retains the last payload and normalized state, avoiding repeated identity
+  normalization when the row's bytes are equal. Scope changes, replacements,
+  deletes, and writes from another process remain visible.
+
+The invalidation semantics follow SQLite's
+[`data_version`](https://www.sqlite.org/pragma.html#pragma_data_version) and
+[`total_changes`](https://www.sqlite.org/c3ref/total_changes.html) contracts.
+There is no timer, persistent index, trigger, schema migration, or new write.
+
+A database change still causes a full parent payload scan. Invalidation is
+conservative: unrelated writes also invalidate it, and complete navigation
+reconciliation already writes the backend baseline. Thus the warm result below
+applies to repeated reads without intervening writes, including partial
+projections; it is not a claim that every complete reconciliation avoids scans.
+Caller frequency/admission remains separate work in PR #2001.
+
+## Reproducible measurement
+
+From the repository root, export the baseline implementation and run both
+versions in the same Node process with the same native SQLite library:
+
+```sh
+mkdir -p apps/desktop/.local
+git show 314f16851:apps/desktop/src/main/state/overlay-store-sqlite.ts > apps/desktop/.local/overlay-store-baseline.ts
+pnpm --filter @pwragent/desktop exec tsx scripts/benchmark-managed-subagent-scan.ts .local/overlay-store-baseline.ts
+```
+
+The probe creates and deletes its own temporary WAL database. It uses 629
+parents, 629 children, 3,000 unrelated threads, and 10,000 legacy encoded backend
+identities. Parent and child overlays carry synthetic activity metadata; every
+fourth child is an ordinary grouped handoff. It asserts equal results before
+measuring the actual complete helper methods, including both queries,
+JSON parsing, normalization, and key construction. Five warmup samples precede
+20 measured samples. Invalidated samples force a local write outside timing;
+byte accounting runs separately from timed samples.
+
+Recorded on Apple M4 arm64, Node 24.18.0, V8 13.6, better-sqlite3's SQLite 3.53.2:
+
+| Read | Baseline median / p95 | Changed median / p95 |
+| --- | --- | --- |
+| Complete managed-child helper, invalidated | 66.765 / 79.209 ms | 50.673 / 53.211 ms |
+| Complete managed-child helper, unchanged database | 66.765 / 79.209 ms | 0.0044 / 0.0057 ms |
+| Backend read, identical payload | 1.821 / 2.169 ms | 0.077 / 0.112 ms |
+
+| Native result text | Baseline | Changed |
+| --- | ---: | ---: |
+| Parent query, 629 rows | 15,122,198 bytes | 62,680 bytes |
+| Child query, 629 rows | 15,100,344 bytes | 12,631 bytes |
+
+The invalidated helper median improved about 24%; total returned text fell about
+99.75%. Timing is observational, not a CI threshold. A repeat under concurrent
+lint/typechecking was noisier (101.4 to 88.4 ms medians, with a worse changed p95),
+so absolute timings should not be interpreted independently of machine load.
+This is a synthetic same-runtime comparison, not an Electron recapture or proof
+of a PR #2001 regression. The original M5 capture motivated the investigation;
+no running default app was restarted and no operator database was read.
+
+## Regression and write budgets
+
+`overlay-store-managed-subagent-scan.test.ts` covers identity fallback, trimming,
+self-reference and duplicate exclusion, malformed rows, grouped handoffs,
+local mutations, a second connection, an independent writer process, a commit
+between the queries, transactions/savepoints, and backend replacement/deletion.
+The materialization test bounds both native result bytes and JSON parser input,
+so a full-payload regression fails without a fragile wall-clock assertion.
+
+The checked-in `managed-subagent-navigation-reads` budget measures ten cold and
+ten warm helper/backend reads after real database setup: **0 commits, 0 write
+statements, 0 changed rows, 0 observed WAL bytes**. Added write cost is therefore
+0 writes/second × commit cost × 86,400 seconds = **0 MB/day**. Existing full
+reconciliation writes are unchanged.


### PR DESCRIPTION
## Summary

- I reduced managed-subagent navigation materialization by projecting parent identity and only backend/monitorThreadId from nested subagent objects and only the grouping flag from candidate child rows. I preserved the grouped-handoff exception, backend identity handling, and malformed-row isolation.
- I reuse the managed-child set only while SQLite `data_version` and `total_changes()` both match, with transaction reads bypassing reuse. Backend reads still fetch the authoritative row and reuse normalization only for identical payload bytes.
- I measured the complete old/new helper methods in one Node/native-SQLite runtime: with a 2 MiB nested title, invalidated median versus original main **68.0 → 58.3 ms**, unchanged **0.0037 ms**; native result text **32.32 MB → 59.0 KB** across both queries. Identical backend payload reads improved **1.63 → 0.072 ms**. Against the prior PR projection, cold reads were slower (**48.0 → 60.1 ms**); I retained the narrower projection to bound nested metadata materialization and documented that tradeoff. The reproducible probe and limits are in [the measurement note](docs/design/managed-subagent-navigation-reads.md).

## Verification

- I passed 63 tests across the managed-scan, handoff-repair, partial-navigation, agent-overlay, and SQLite write-budget suites. The new coverage includes another connection, an independent writer process, a commit between queries, rollback/savepoints, malformed subagent entries, and deterministic 1 KiB native-result/JSON-input limits despite a 2 MiB nested title.
- I recorded **0 commits, 0 statements, 0 changed rows, 0 WAL bytes** for ten cold plus ten warm helper/backend reads: **0 MB/day added writes**.
- I passed `pnpm lint:eslint`, `pnpm typecheck`, `pnpm lint:sql`, `pnpm lint:codex-storage`, `pnpm lint:boundaries`, and `git diff --check`. I also typechecked the completed benchmark script.

## Notes

- I based this work on `origin/main` (`314f16851`) and kept it separate from #2001's caller frequency/admission work. #2027's Git remote coalescing is merged; #2030's directory-enrichment diagnostics are orthogonal.
- I added no schema/index, timer, or event write. Unrelated database writes conservatively invalidate the managed-child set; cold reads still scan parent payloads, and existing complete reconciliation writes are unchanged.
- I used only synthetic temporary data for measurement. These numbers are a same-runtime Node comparison, not an Electron recapture or evidence that #2001 introduced the inherited cost. I did not restart a default Electron instance or read Codex storage.
