### PR TITLE
fix(desktop): scope federation toggles to the app instance

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-activity-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-activity-ipc.test.ts
@@ -6,7 +6,7 @@ import {
 
 const mocks = vi.hoisted(() => ({
   handlers: new Map<string, (...args: unknown[]) => unknown>(),
-  runtime: { activity: vi.fn(), resetActivity: vi.fn(), restart: vi.fn() },
+  runtime: { activity: vi.fn(), resetActivity: vi.fn(), restart: vi.fn(), setEnabledForSession: vi.fn() },
   service: { readFederationConfig: vi.fn(), writeConfigPatchTargeted: vi.fn() },
   show: vi.fn(), topmost: vi.fn(), fromWebContents: vi.fn(),
 }));
@@ -53,26 +53,22 @@ describe("Federation Activity IPC", () => {
     expect(mocks.runtime.restart).not.toHaveBeenCalled();
   });
 
-  it("disables then restores the previous mode and reports actual lease-denied runtime state", async () => {
+  it("toggles only the local runtime and reports a lease-denied enable attempt", async () => {
     await invoke(FEDERATION_SET_ENABLED_CHANNEL, false);
-    expect(mocks.service.writeConfigPatchTargeted).toHaveBeenLastCalledWith({ federation: { mode: "disabled" } });
-    mocks.service.readFederationConfig.mockReturnValue({ mode: "disabled" });
+    expect(mocks.runtime.setEnabledForSession).toHaveBeenLastCalledWith(false);
     const result = await invoke(FEDERATION_SET_ENABLED_CHANNEL, true);
-    expect(mocks.service.writeConfigPatchTargeted).toHaveBeenLastCalledWith({ federation: { mode: "dual" } });
-    expect(mocks.runtime.restart).toHaveBeenCalledTimes(2);
+    expect(mocks.runtime.setEnabledForSession).toHaveBeenLastCalledWith(true);
+    expect(mocks.service.writeConfigPatchTargeted).not.toHaveBeenCalled();
+    expect(mocks.service.readFederationConfig).not.toHaveBeenCalled();
     expect(result).toMatchObject({ configuredMode: "dual", running: false, health: { leaseHolder: { instanceId: "holder" } } });
   });
 
-  it("uses enrollment endpoints to restore a client after a process starts disabled", async () => {
-    mocks.service.readFederationConfig.mockReturnValue({ mode: "disabled", gatewayEndpoints: ["wss://fixture.invalid"] });
-    await invoke(FEDERATION_SET_ENABLED_CHANNEL, true);
-    expect(mocks.service.writeConfigPatchTargeted).toHaveBeenCalledWith({ federation: { mode: "client" } });
-  });
-
-  it("does not restart on failed writes and rejects malformed toggle/topmost requests", async () => {
-    mocks.service.writeConfigPatchTargeted.mockRejectedValue(new Error("Read-only settings"));
-    await expect(invoke(FEDERATION_SET_ENABLED_CHANNEL, false)).rejects.toThrow("Read-only settings");
-    expect(mocks.runtime.restart).not.toHaveBeenCalled();
+  it("reports runtime failures, permits a subsequent toggle, and rejects malformed requests", async () => {
+    mocks.runtime.setEnabledForSession.mockRejectedValueOnce(new Error("Startup failed"));
+    await expect(invoke(FEDERATION_SET_ENABLED_CHANNEL, true)).rejects.toThrow("Startup failed");
+    await invoke(FEDERATION_SET_ENABLED_CHANNEL, false);
+    expect(mocks.runtime.setEnabledForSession).toHaveBeenLastCalledWith(false);
+    expect(mocks.service.writeConfigPatchTargeted).not.toHaveBeenCalled();
     expect(() => invoke(FEDERATION_SET_ENABLED_CHANNEL, "false")).toThrow("boolean");
     expect(() => invoke(FEDERATION_ACTIVITY_TOPMOST_CHANNEL, {})).toThrow("boolean");
   });

--- a/apps/desktop/src/main/__tests__/federation-runtime-startup.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime-startup.test.ts
@@ -241,3 +241,73 @@ describe("DesktopFederationRuntime session toggle", () => {
     expect(start).toHaveBeenCalledTimes(1);
   });
 });
+
+
+describe("Federation activity during connection attempts", () => {
+  type DialHarness = StartupHarness & {
+    stopping: boolean;
+    configuredEndpoints: string[];
+    connectClient(endpoint: string): Promise<void>;
+    connectToGateway(): Promise<void>;
+    scheduleReconnect(): void;
+  };
+
+  function dialingRuntime() {
+    const runtime = new DesktopFederationRuntime();
+    const dial = runtime as unknown as DialHarness;
+    dial.stopping = false;
+    dial.configuredEndpoints = ["wss://fixture.invalid"];
+    vi.spyOn(runtime, "health").mockResolvedValue({ enabled: true, role: "client", status: "connecting", peers: [] });
+    return { runtime, dial };
+  }
+
+  it("stays running after the reconnect timer fires and can stop before the handshake finishes", async () => {
+    vi.useFakeTimers();
+    const { runtime, dial } = dialingRuntime();
+    const handshake = deferred<void>();
+    const connect = vi.spyOn(dial, "connectClient").mockReturnValue(handshake.promise);
+    try {
+      dial.scheduleReconnect();
+      expect((await runtime.activity({ includeHistory: false })).running).toBe(true);
+      await vi.advanceTimersToNextTimerAsync();
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect((await runtime.activity({ includeHistory: false })).running).toBe(true);
+      await runtime.setEnabledForSession(false);
+      expect((await runtime.activity({ includeHistory: false })).running).toBe(false);
+      handshake.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(connect).toHaveBeenCalledTimes(1);
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      handshake.resolve();
+      await runtime.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not let an old handshake clear a newer attempt's running state", async () => {
+    const { runtime, dial } = dialingRuntime();
+    const oldHandshake = deferred<void>();
+    const newHandshake = deferred<void>();
+    vi.spyOn(dial, "connectClient")
+      .mockReturnValueOnce(oldHandshake.promise).mockReturnValueOnce(newHandshake.promise);
+    const oldAttempt = dial.connectToGateway();
+    await runtime.stop();
+    dial.stopping = false;
+    dial.configuredEndpoints = ["wss://fixture.invalid"];
+    const newAttempt = dial.connectToGateway();
+    oldHandshake.resolve();
+    await oldAttempt;
+    expect((await runtime.activity({ includeHistory: false })).running).toBe(true);
+    newHandshake.resolve();
+    await newAttempt;
+    expect((await runtime.activity({ includeHistory: false })).running).toBe(false);
+  });
+
+  it("clears running state when the endpoint walk rejects", async () => {
+    const { runtime, dial } = dialingRuntime();
+    vi.spyOn(dial, "connectClient").mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(dial.connectToGateway()).rejects.toThrow("ECONNREFUSED");
+    expect((await runtime.activity({ includeHistory: false })).running).toBe(false);
+  });
+});

--- a/apps/desktop/src/main/__tests__/federation-runtime-startup.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-runtime-startup.test.ts
@@ -8,6 +8,7 @@ import type { FederationRuntimeConfig } from "../federation/federation-runtime-c
 // vi.hoisted so the mock factories (which run when the statically imported
 // federation-runtime module first resolves them) can reach these fns.
 const mocks = vi.hoisted(() => ({
+  readFederationConfig: vi.fn(),
   getNoiseKeyPair: vi.fn(),
   getIdentityKeyPair: vi.fn(),
   gatewayServerStart: vi.fn(),
@@ -30,9 +31,14 @@ const GatewayServerCtorMock = vi.hoisted(() =>
 
 vi.mock("../settings/desktop-settings-singleton", () => ({
   getDesktopSettingsService: vi.fn(() => ({
+    readFederationConfig: mocks.readFederationConfig,
     getOrCreateFederationNoiseStaticKeyPair: mocks.getNoiseKeyPair,
     getOrCreateFederationIdentityKeyPair: mocks.getIdentityKeyPair,
   })),
+}));
+
+vi.mock("../federation/federation-host-info", () => ({
+  collectFederationHostInfo: vi.fn(async () => undefined),
 }));
 
 vi.mock("../state/app-state", () => ({
@@ -105,6 +111,7 @@ function deferred<T>(): {
 }
 
 beforeEach(() => {
+  mocks.readFederationConfig.mockReturnValue(fakeSettings);
   mocks.getNoiseKeyPair.mockReset();
   mocks.getIdentityKeyPair.mockReset();
   mocks.gatewayServerStart.mockReset();
@@ -175,5 +182,62 @@ describe("DesktopFederationRuntime startup lease fence", () => {
     expect(runtime.listenUrl).toBeUndefined();
     expect(runtime.server).toBeUndefined();
     expect(mocks.gatewayServerStop).toHaveBeenCalled();
+  });
+});
+
+
+describe("DesktopFederationRuntime session toggle", () => {
+  it("keeps a stopped instance off across restarts without changing a sibling or the saved mode", async () => {
+    const runtime = new DesktopFederationRuntime();
+    const sibling = new DesktopFederationRuntime();
+    const start = vi.spyOn(runtime as unknown as StartupHarness, "startAfterLeaseAcquired").mockResolvedValue(undefined);
+    const siblingStart = vi.spyOn(sibling as unknown as StartupHarness, "startAfterLeaseAcquired").mockResolvedValue(undefined);
+    await runtime.setEnabledForSession(false);
+    await runtime.restart();
+    await sibling.restart();
+    expect(start).not.toHaveBeenCalled();
+    expect(siblingStart).toHaveBeenCalledWith("gateway", expect.objectContaining({ mode: "gateway" }));
+    expect(fakeSettings.mode).toBe("gateway");
+    mocks.readFederationConfig.mockReturnValue({ ...fakeSettings, mode: "dual" });
+    await runtime.restart();
+    expect(start).not.toHaveBeenCalled();
+    await runtime.setEnabledForSession(true);
+    expect(start).toHaveBeenCalledWith("dual", expect.objectContaining({ mode: "dual" }));
+    expect(siblingStart).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { gatewayEndpoints: [], mode: "gateway" },
+    { gatewayEndpoints: ["wss://fixture.invalid"], mode: "client" },
+  ])("enables a saved-disabled profile as $mode only for this instance", async ({ gatewayEndpoints, mode }) => {
+    const saved = { ...fakeSettings, mode: "disabled", gatewayEndpoints };
+    mocks.readFederationConfig.mockReturnValue(saved);
+    const runtime = new DesktopFederationRuntime();
+    const start = vi.spyOn(runtime as unknown as StartupHarness, "startAfterLeaseAcquired").mockResolvedValue(undefined);
+    await runtime.setEnabledForSession(true);
+    await runtime.restart();
+    expect(start).toHaveBeenCalledTimes(2);
+    expect(start).toHaveBeenLastCalledWith(mode, expect.objectContaining({ mode }));
+    expect(saved.mode).toBe("disabled");
+    vi.spyOn(runtime, "health").mockResolvedValue({ enabled: true, role: "gateway", status: "connected", peers: [] });
+    expect((await runtime.activity({ includeHistory: false })).configuredMode).toBe("disabled");
+    const fresh = new DesktopFederationRuntime();
+    const freshStart = vi.spyOn(fresh as unknown as StartupHarness, "startAfterLeaseAcquired").mockResolvedValue(undefined);
+    await fresh.restart();
+    expect(freshStart).not.toHaveBeenCalled();
+  });
+
+  it("applies a toggle after an in-flight restart finishes", async () => {
+    const runtime = new DesktopFederationRuntime();
+    const pendingStart = deferred<void>();
+    const start = vi.spyOn(runtime as unknown as StartupHarness, "startAfterLeaseAcquired")
+      .mockImplementation(() => pendingStart.promise);
+    const restarting = runtime.restart();
+    await vi.waitFor(() => expect(start).toHaveBeenCalledTimes(1));
+    const stopping = runtime.setEnabledForSession(false);
+    pendingStart.resolve();
+    await Promise.all([restarting, stopping]);
+    await runtime.restart();
+    expect(start).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
@@ -87,6 +87,22 @@ afterEach(() => {
 });
 
 describe("RuntimeFederationLeaseCoordinator", () => {
+  it("a local stop preserves a sibling's lease and an enable attempt cannot evict it", async () => {
+    const runtime = createRuntime();
+    const owner = createCoordinator({ instanceId: "instance-a", now: () => 1_000, store });
+    const sibling = createCoordinator({ instanceId: "instance-b", now: () => 1_000, store });
+    await owner.applyMode(runtime, "client");
+    await expect(sibling.applyMode(runtime, "disabled", true)).resolves.toMatchObject({
+      enabled: false, disabledReasonKind: "runtime_stopped",
+    });
+    expect(owner.snapshot().leaseHeld).toBe(true);
+    await expect(sibling.applyMode(runtime, "client")).resolves.toMatchObject({
+      enabled: false, disabledReasonKind: "lease_held",
+    });
+    await owner.applyMode(runtime, "disabled", true);
+    await expect(sibling.applyMode(runtime, "client")).resolves.toMatchObject({ enabled: true });
+  });
+
   it("acquires the profile lease when federation is enabled", async () => {
     const runtime = createRuntime();
     recordInstance("instance-a", {

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -797,6 +797,7 @@ function eventClassAllowedByCapabilities(
 }
 
 export class DesktopFederationRuntime {
+  private sessionEnabledOverride?: boolean;
   private router?: FederationRouter;
   private server?: FederationGatewayWebSocketServer;
   private client?: FederationClientWebSocketClient;
@@ -1076,6 +1077,15 @@ export class DesktopFederationRuntime {
     ).includes(capability);
   }
 
+  /** A toolbar toggle belongs to this process, never the shared profile settings. */
+  async setEnabledForSession(enabled: boolean): Promise<void> {
+    // A settings-driven restart may already be running. Apply this choice after
+    // it finishes so restart() cannot coalesce away the operator's toggle.
+    await this.restartPromise?.catch(() => undefined);
+    this.sessionEnabledOverride = enabled;
+    await this.restart();
+  }
+
   async restart(): Promise<void> {
     this.restartPromise ??= this.restartNow().finally(() => {
       this.restartPromise = undefined;
@@ -1143,7 +1153,9 @@ export class DesktopFederationRuntime {
     return {
       activity: this.activityLedger.snapshot(Date.now(), request),
       health: await this.health(),
-      configuredMode: this.readRuntimeConfig().mode,
+      configuredMode: resolveFederationRuntimeConfig(
+        getDesktopSettingsService().readFederationConfig(),
+      ).mode,
       running: Boolean(this.listenUrl || this.client || this.reconnectTimer),
     };
   }
@@ -1222,6 +1234,9 @@ export class DesktopFederationRuntime {
       ? getExistingRuntimeFederationLeaseCoordinator()?.snapshot()
       : undefined;
     applyFederationLeaseSnapshot(health, federationLeaseSnapshot);
+    if (this.sessionEnabledOverride === false) {
+      health.unavailableReason = "Federation is stopped for this app instance.";
+    }
     return health;
   }
 
@@ -2537,7 +2552,7 @@ export class DesktopFederationRuntime {
     // each other from the gateway in a connect/replace loop.
     if (isAppStateInitialized()) {
       const leaseCoordinator = getRuntimeFederationLeaseCoordinator();
-      const leaseGate = await leaseCoordinator.applyMode(this, mode);
+      const leaseGate = await leaseCoordinator.applyMode(this, mode, this.sessionEnabledOverride === false);
       if (!leaseGate.enabled) {
         if (leaseGate.disabledReasonKind === "lease_held") {
           this.lastConnectionError = leaseGate.disabledReason;
@@ -2563,9 +2578,14 @@ export class DesktopFederationRuntime {
   }
 
   private readRuntimeConfig(): FederationRuntimeConfig {
-    return resolveFederationRuntimeConfig(
+    const config = resolveFederationRuntimeConfig(
       getDesktopSettingsService().readFederationConfig(),
     );
+    if (this.sessionEnabledOverride === false) return { ...config, mode: "disabled" };
+    if (this.sessionEnabledOverride && config.mode === "disabled") {
+      return { ...config, mode: config.gatewayEndpoints.length ? "client" : "gateway" };
+    }
+    return config;
   }
 
   private async startAfterLeaseAcquired(

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -865,6 +865,7 @@ export class DesktopFederationRuntime {
   private restartPromise: Promise<void> | undefined;
   private remoteThreadSummaryCache: RemoteThreadSummaryCache | undefined;
   private reconnectTimer?: ReturnType<typeof setTimeout>;
+  private connectionAttempt?: symbol;
   private reconnectAttempt = 0;
   private connectionGeneration = 0;
   /** Bumped only by stop(), so an in-flight endpoint walk can detect teardown. */
@@ -1095,6 +1096,7 @@ export class DesktopFederationRuntime {
 
   async stop(): Promise<void> {
     this.stopping = true;
+    this.connectionAttempt = undefined;
     this.connectionGeneration += 1;
     this.walkEpoch += 1;
     if (isAppStateInitialized()) {
@@ -1156,7 +1158,7 @@ export class DesktopFederationRuntime {
       configuredMode: resolveFederationRuntimeConfig(
         getDesktopSettingsService().readFederationConfig(),
       ).mode,
-      running: Boolean(this.listenUrl || this.client || this.reconnectTimer),
+      running: Boolean(this.listenUrl || this.client || this.reconnectTimer || this.connectionAttempt),
     };
   }
 
@@ -1191,7 +1193,7 @@ export class DesktopFederationRuntime {
           // the panel surfaces the duplicate-identity explanation.
           : this.lastConnectionFailureKind === "replaced"
             ? "degraded"
-            : this.reconnectTimer
+            : this.reconnectTimer || this.connectionAttempt
               ? "connecting"
               : "disconnected";
       health.unavailableReason = this.lastConnectionError;
@@ -2773,6 +2775,18 @@ export class DesktopFederationRuntime {
   // identical pinned-identity + Noise handshake, so fallback can only change
   // reachability, never which gateway the client will trust.
   private async connectToGateway(): Promise<void> {
+    if (this.stopping || this.configuredEndpoints.length === 0) return;
+    const attempt = Symbol("federation connection attempt");
+    this.connectionAttempt = attempt;
+    try {
+      await this.walkGatewayEndpoints();
+    } finally {
+      // A stopped or superseded attempt must not clear a newer dial's state.
+      if (this.connectionAttempt === attempt) this.connectionAttempt = undefined;
+    }
+  }
+
+  private async walkGatewayEndpoints(): Promise<void> {
     const endpoints = this.configuredEndpoints;
     if (endpoints.length === 0) return;
     const lastGoodEndpoint =

--- a/apps/desktop/src/main/ipc/federation.ts
+++ b/apps/desktop/src/main/ipc/federation.ts
@@ -59,7 +59,6 @@ import {
   showFederationActivityWindow,
   setFederationActivityTopmost,
 } from "../federation-activity-window";
-import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import {
   federationTailscaleAdvertisementFromStatus,
@@ -89,7 +88,6 @@ function peerAllowsEventClass(
   }
 }
 
-let previousEnabledMode: "client" | "gateway" | "dual" | undefined;
 let activityToggle: Promise<unknown> = Promise.resolve();
 
 export function registerFederationIpcHandlers(): void {
@@ -123,14 +121,7 @@ export function registerFederationIpcHandlers(): void {
   ipcMain.handle(FEDERATION_SET_ENABLED_CHANNEL, (_event, enabled: unknown) => {
     if (typeof enabled !== "boolean") throw new Error("Expected a boolean.");
     const change = activityToggle.catch(() => undefined).then(async () => {
-      const service = getDesktopSettingsService();
-      const current = service.readFederationConfig();
-      if (current.mode !== "disabled") previousEnabledMode = current.mode;
-      const resumeMode = previousEnabledMode
-        ?? (current.gatewayUrl || current.gatewayEndpoints?.length ? "client" : "gateway");
-      const mode = enabled ? resumeMode : "disabled";
-      await service.writeConfigPatchTargeted({ federation: { mode } });
-      await getDesktopFederationRuntime().restart();
+      await getDesktopFederationRuntime().setEnabledForSession(enabled);
       return getDesktopFederationRuntime().activity();
     });
     activityToggle = change;

--- a/apps/desktop/src/main/runtime-federation-lease.ts
+++ b/apps/desktop/src/main/runtime-federation-lease.ts
@@ -77,20 +77,21 @@ export class RuntimeFederationLeaseCoordinator {
    * DesktopFederationRuntime.restartNow after the previous runtime has been
    * torn down. An enabled mode must hold the profile federation lease before
    * any socket is opened; a live holder elsewhere keeps this instance
-   * stopped. Unlike messaging there is no session override or runnable-
-   * adapter gate: the federation mode is the whole ladder.
+   * stopped. The runtime supplies its effective mode, including any local
+   * session override, without changing the saved profile configuration.
    */
   async applyMode(
     _runtime: FederationLeaseRuntime,
     mode: DesktopFederationMode,
+    disabledForSession = false,
   ): Promise<RuntimeFederationLeaseApplyResult> {
     if (mode === "disabled") {
       this.leaseManager.release("federation");
-      this.disabledReasonKind = "saved_disabled";
+      this.disabledReasonKind = disabledForSession ? "runtime_stopped" : "saved_disabled";
       return {
         enabled: false,
-        disabledReasonKind: "saved_disabled",
-        disabledReason: "Federation is disabled in saved settings.",
+        disabledReasonKind: this.disabledReasonKind,
+        disabledReason: federationDisabledReasonMessage(this.disabledReasonKind),
       };
     }
 

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -72,19 +72,34 @@ describe("Federation activity surfaces", () => {
     denied.health.enabled = false;
     denied.health.leaseHolder = { instanceId: "other-app", processId: 123, cwdHint: "/fixture/other" };
     denied.health.unavailableReason = "This profile is already served by another app.";
-    const off = { ...fixture(), configuredMode: "disabled" as const, running: false };
-    const setFederationEnabled = vi.fn(async () => off);
+    const setFederationEnabled = vi.fn(async () => denied);
     render(<FederationStatusControl desktopApi={{ readFederationActivity: async () => denied, setFederationEnabled }} onOpen={vi.fn()} />);
     fireEvent.focus(screen.getByRole("button", { name: "Open Star Map" }));
     await screen.findByText("Not running · lease held by another instance");
     expect(screen.getByText("Configured on · gateway")).toBeInTheDocument();
     expect(screen.getByText(/Holder: other-app · PID 123/)).toBeInTheDocument();
     const toggle = screen.getByRole("switch", { name: "Federation enabled" });
-    expect(toggle).toHaveAttribute("aria-checked", "true");
-    fireEvent.click(toggle);
-    await screen.findByText("Configured off");
-    expect(setFederationEnabled).toHaveBeenCalledWith(false);
     expect(toggle).toHaveAttribute("aria-checked", "false");
+    fireEvent.click(toggle);
+    await waitFor(() => expect(setFederationEnabled).toHaveBeenCalledWith(true));
+    expect(screen.getByText("Configured on · gateway")).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it.each(["popup", "activity"])("turns off only the runtime in the %s while preserving configured-on", async (surface) => {
+    const off = { ...fixture(), running: false, health: { ...fixture().health, enabled: false } };
+    const setFederationEnabled = vi.fn(async () => off);
+    const desktopApi = { readFederationActivity: async () => fixture(), setFederationEnabled };
+    render(surface === "popup"
+      ? <FederationStatusControl desktopApi={desktopApi} onOpen={vi.fn()} />
+      : <FederationActivityScreen desktopApi={desktopApi} />);
+    if (surface === "popup") fireEvent.focus(screen.getByRole("button", { name: "Open Star Map" }));
+    await screen.findByText("Running · connected");
+    fireEvent.click(screen.getByRole("switch", { name: "Federation enabled" }));
+    await screen.findByText("Stopped");
+    expect(setFederationEnabled).toHaveBeenCalledWith(false);
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByText("Configured on · gateway")).toBeInTheDocument();
   });
 
   it("labels chart axes with amounts and units, exposes periods and per-peer attribution, and confirms topmost", async () => {
@@ -146,15 +161,15 @@ describe("Federation activity surfaces", () => {
     expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
   });
 
-  it("keeps the switch state and reports errors if a configuration change fails", async () => {
+  it("keeps the switch state and reports errors if a runtime toggle fails", async () => {
     render(<FederationStatusControl desktopApi={{
       readFederationActivity: async () => fixture(),
-      setFederationEnabled: async () => { throw new Error("Config is read-only"); },
+      setFederationEnabled: async () => { throw new Error("Startup failed"); },
     }} onOpen={vi.fn()} />);
     fireEvent.focus(screen.getByRole("button", { name: "Open Star Map" }));
     await screen.findByText("Running · connected");
     fireEvent.click(screen.getByRole("switch"));
-    expect(await screen.findByRole("alert")).toHaveTextContent("Config is read-only");
+    expect(await screen.findByRole("alert")).toHaveTextContent("Startup failed");
     expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
   });
   it("shows recent bursts beside lifetime totals regardless of chart range", async () => {

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -102,6 +102,17 @@ describe("Federation activity surfaces", () => {
     expect(screen.getByText("Configured on · gateway")).toBeInTheDocument();
   });
 
+  it("sends a stop while a client connection attempt is running", async () => {
+    const connecting = fixture();
+    connecting.health.status = "connecting";
+    const setFederationEnabled = vi.fn(async () => ({ ...connecting, running: false }));
+    render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => connecting, setFederationEnabled }} />);
+    await screen.findByText("Running · connecting");
+    expect(screen.getByRole("switch")).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() => expect(setFederationEnabled).toHaveBeenCalledWith(false));
+  });
+
   it("labels chart axes with amounts and units, exposes periods and per-peer attribution, and confirms topmost", async () => {
     const readFederationActivity = vi.fn(async () => fixture());
     const setFederationActivityTopmost = vi.fn(async (enabled: boolean) => enabled);

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -188,13 +188,14 @@ export function FederationActivityScreen({ desktopApi }: { desktopApi?: DesktopA
   });
   const peers = snapshot ? view === "physical" ? snapshot.activity.peers : snapshot.activity.logical : [];
   const series = peerId ? peers.find((peer) => peer.peerId === peerId)?.series : snapshot?.activity.physical;
-  const enabled = Boolean(snapshot && snapshot.configuredMode !== "disabled");
+  const enabled = Boolean(snapshot?.running);
   const labelFor = (id: string) => snapshot?.health.peers.find((peer) => peer.id === id)?.label || id;
   return <div className="federation-activity">
     <div className="federation-activity__toolbar">
       <div><strong>{snapshot ? federationRuntimeLabel(snapshot) : "Loading Federation activity…"}</strong>
         {snapshot ? <p>Configured {snapshot.configuredMode === "disabled" ? "off" : `on · ${snapshot.configuredMode}`}</p> : null}</div>
       <button type="button" role="switch" aria-label="Federation enabled"
+        title="Turn Federation on or off for this app instance only"
         aria-checked={enabled}
         className={`settings-switch messaging-status-popover__switch${enabled ? " is-on" : ""}`}
         disabled={!snapshot || pending || !desktopApi?.setFederationEnabled} onClick={() => void toggle()}>

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationStatusControl.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationStatusControl.tsx
@@ -22,7 +22,7 @@ export function FederationStatusControl(props: { desktopApi?: DesktopApi; onOpen
     document.addEventListener("pointerdown", dismiss);
     return () => document.removeEventListener("pointerdown", dismiss);
   }, [open]);
-  const enabled = Boolean(snapshot && snapshot.configuredMode !== "disabled");
+  const enabled = Boolean(snapshot?.running);
   return (
     <div ref={root} className="messaging-status-bar federation-status-control"
       onPointerEnter={() => { cancelDismiss(); setOpen(true); }}
@@ -56,10 +56,11 @@ export function FederationStatusControl(props: { desktopApi?: DesktopApi; onOpen
               <div>
                 <div className="messaging-status-popover__title">Federation</div>
                 <div className="messaging-status-popover__summary">
-                  {snapshot ? `Configured ${enabled ? `on · ${snapshot.configuredMode}` : "off"}` : "Loading…"}
+                  {snapshot ? `Configured ${snapshot.configuredMode !== "disabled" ? `on · ${snapshot.configuredMode}` : "off"}` : "Loading…"}
                 </div>
               </div>
               <button type="button" role="switch" aria-label="Federation enabled"
+                title="Turn Federation on or off for this app instance only"
                 aria-checked={Boolean(snapshot && enabled)} disabled={!snapshot || pending || !props.desktopApi?.setFederationEnabled}
                 className={`settings-switch messaging-status-popover__switch${enabled ? " is-on" : ""}`}
                 onClick={() => void toggle()}>

--- a/apps/desktop/src/renderer/src/features/federation-activity/useFederationActivity.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/useFederationActivity.ts
@@ -36,7 +36,7 @@ export function useFederationActivity(
     setPending(true);
     toggleGeneration.current += 1;
     try {
-      const next = await desktopApi.setFederationEnabled(snapshot.configuredMode === "disabled");
+      const next = await desktopApi.setFederationEnabled(!snapshot.running);
       // Preserve the selected chart until the next poll refreshes its history.
       setSnapshot((previous) => ({ ...next, activity: previous?.activity ?? next.activity }));
       setError(undefined);
@@ -61,5 +61,5 @@ export function useFederationActivity(
 export function federationRuntimeLabel(snapshot: ReadFederationActivityResponse): string {
   if (snapshot.health.leaseHolder) return "Not running · lease held by another instance";
   if (snapshot.running) return `Running · ${snapshot.health.status}`;
-  return snapshot.configuredMode === "disabled" ? "Stopped" : "Not running";
+  return !snapshot.health.enabled ? "Stopped" : "Not running";
 }


### PR DESCRIPTION
## Summary

The Federation popup and Activity switches wrote `federation.mode` to shared profile settings, so toggling one running app changed the configuration used by sibling instances. Make both switches control only the local process through an in-memory session override.

The switch reflects the actual local runtime, while the Configured label continues to show saved profile configuration. A lease-denied instance shows Off, and enabling it cannot evict the current holder. A local stop survives runtime/configuration restarts in that process; a new process starts from saved settings. If saved mode is disabled, a local enable chooses client when enrollment endpoints exist, otherwise gateway.

## Verification

- 130 tests pass across the activity IPC, runtime startup, federation lease, renderer activity, federation runtime, federation health, and runtime lease-manager suites.
- Regression coverage verifies no settings writes, isolation between runtime objects sharing configuration, lease ownership preservation and handoff, session override retention, startup/toggle ordering, and both UI switches.
- `pnpm typecheck`
- `pnpm lint:eslint`
- `pnpm lint:boundaries`
- `git diff --check`

## Notes

Branched from `origin/main` after the prior chart PR was squash merged. The override adds no persisted state or SQLite writes; existing lease acquisition/release remains in use.

Live verification with two app processes has not been performed; tests use isolated runtimes and a shared temporary lease database. No screenshots are attached.
