### PR TITLE
fix(desktop): restore Star Map transcript image interactions

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapChatCard.tsx
@@ -14,6 +14,7 @@ import {
   buildThreadIdentityKey,
   isCelestialIconId,
   isRemoteFederationTarget,
+  type AppServerThreadImagePart,
   type CelestialIconId,
   type NavigationLaunchpadFileAttachment,
   type NavigationLaunchpadImageAttachment,
@@ -34,6 +35,11 @@ import {
 } from "../composer/CompactComposer";
 import { useComposerMentionSources } from "../composer/useComposerMentionSources";
 import type { ComposerMentionSources } from "../composer/useComposerMentions";
+import { ImageLightbox } from "../thread-detail/ImageLightbox";
+import {
+  collectThreadImageGallery,
+  threadGalleryImageMatches,
+} from "../thread-detail/thread-image-gallery";
 import { TranscriptList } from "../thread-detail/TranscriptList";
 import { ActiveSubAgentsStrip } from "../thread-detail/ActiveSubAgentsStrip";
 import { useTranscriptWindow } from "../thread-detail/useTranscriptWindow";
@@ -265,6 +271,20 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
     // bare id is worse. Same key ThreadView keys its window by.
     threadKey: buildThreadIdentityKey(thread.source, thread.id),
   });
+
+  const [expandedImage, setExpandedImage] = useState<AppServerThreadImagePart>();
+  const threadImageGallery = useMemo(
+    () => collectThreadImageGallery([
+      ...session.entries,
+      session.pendingAssistantMessage,
+    ]),
+    [session.entries, session.pendingAssistantMessage],
+  );
+  const expandedImageIndex = expandedImage
+    ? threadImageGallery.findIndex((image) =>
+        threadGalleryImageMatches(image, expandedImage)
+      )
+    : -1;
 
   // Backend capability belongs to the instance the thread lives on. Reduce
   // the target to its stable identity before rebuilding the object: every
@@ -1324,6 +1344,25 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
       onPointerDown={() => onRaise(cardKey)}
       style={style}
     >
+      {expandedImage ? (
+        <ImageLightbox
+          src={expandedImage.url}
+          alt={expandedImage.alt ?? "Expanded image"}
+          position={expandedImageIndex >= 0 ? expandedImageIndex + 1 : undefined}
+          total={expandedImageIndex >= 0 ? threadImageGallery.length : undefined}
+          onClose={() => setExpandedImage(undefined)}
+          onNext={
+            expandedImageIndex >= 0 && expandedImageIndex < threadImageGallery.length - 1
+              ? () => setExpandedImage(threadImageGallery[expandedImageIndex + 1])
+              : undefined
+          }
+          onPrevious={
+            expandedImageIndex > 0
+              ? () => setExpandedImage(threadImageGallery[expandedImageIndex - 1])
+              : undefined
+          }
+        />
+      ) : null}
       <header
         className="star-map-chat-card__bar"
         onPointerDown={(event) => beginDrag(event, "move")}
@@ -1489,6 +1528,7 @@ export function StarMapChatCard(props: StarMapChatCardProps) {
             loading={session.loading}
             loadingMore={session.loadingMore}
             onLoadOlder={transcriptWindow.loadOlder}
+            onOpenImage={setExpandedImage}
             pagination={transcriptWindow.visiblePagination}
             parentThreadId={thread.id}
             pendingAssistantMessage={session.pendingAssistantMessage}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -322,6 +322,52 @@ describe("StarMapChatCard transcript loading", () => {
     });
   });
 
+  it("opens a window-level image gallery and preserves the native image menu", async () => {
+    const desktopApi = buildApi({
+      readThread: vi.fn(async () => ({
+        backend: "codex",
+        threadId: "t",
+        replay: {
+          messages: [],
+          pagination: { supportsPagination: false, hasPreviousPage: false },
+          entries: [{
+            type: "message",
+            id: "images",
+            role: "assistant",
+            text: "Two images",
+            parts: [
+              { type: "image", url: "https://example.com/one.png", alt: "First image" },
+              { type: "image", url: "https://example.com/two.png", alt: "Second image" },
+            ],
+          }],
+        },
+      })),
+    } as unknown as Partial<DesktopApi>);
+    renderCard({ desktopApi, thread: remoteThread() });
+    const first = await screen.findByRole("button", { name: "Expand transcript image 1" });
+    const preview = within(first).getByRole("img");
+    expect(fireEvent.mouseDown(preview, { button: 2 })).toBe(false);
+    expect(fireEvent.contextMenu(preview)).toBe(true);
+    expect(screen.queryByRole("dialog", { name: "Expanded image" })).toBeNull();
+
+    first.focus();
+    fireEvent.click(first);
+    const dialog = screen.getByRole("dialog", { name: "Expanded image" });
+    expect(dialog.parentElement).toBe(document.body);
+    expect(document.activeElement).toBe(dialog);
+    expect(isStarMapTypingTarget(dialog)).toBe(true);
+    expect(within(dialog).getByRole("img").getAttribute("src")).toContain("one.png");
+    expect(within(dialog).getByRole("button", { name: "Previous image" })).toHaveProperty("disabled", true);
+    fireEvent.click(within(dialog).getByRole("button", { name: "Next image" }));
+    expect(within(dialog).getByRole("img").getAttribute("src")).toContain("two.png");
+    expect(within(dialog).getByRole("button", { name: "Next image" })).toHaveProperty("disabled", true);
+    fireEvent.keyDown(dialog, { key: "ArrowLeft" });
+    expect(within(dialog).getByRole("img").getAttribute("src")).toContain("one.png");
+    fireEvent.keyDown(dialog, { key: "Escape" });
+    expect(screen.queryByRole("dialog", { name: "Expanded image" })).toBeNull();
+    expect(document.activeElement).toBe(first);
+  });
+
   it("mounts only the newest entries of a long transcript", async () => {
     const entries = Array.from({ length: 200 }, (_, index) => ({
       type: "message" as const,

--- a/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ImageLightbox.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useEffect } from "react";
+import { type ReactNode, useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { ChevronLeftIcon, ChevronRightIcon, CloseIcon } from "../../icons";
 import { TranscriptImage } from "./TranscriptImage";
@@ -39,26 +39,40 @@ export function ImageLightbox({
   onNext,
   onPrevious,
 }: ImageLightboxProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const previousFocus = document.activeElement;
+    dialogRef.current?.focus();
+    return () => {
+      if (previousFocus instanceof HTMLElement && previousFocus.isConnected) {
+        previousFocus.focus();
+      }
+    };
+  }, []);
+
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        event.stopPropagation();
         onClose();
         return;
       }
       if (event.key === "ArrowLeft" && onPrevious) {
+        event.stopPropagation();
         event.preventDefault();
         onPrevious();
         return;
       }
       if (event.key === "ArrowRight" && onNext) {
+        event.stopPropagation();
         event.preventDefault();
         onNext();
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
     return () => {
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
     };
   }, [onClose, onNext, onPrevious]);
 
@@ -68,7 +82,11 @@ export function ImageLightbox({
 
   return createPortal(
     <div
+      ref={dialogRef}
+      tabIndex={-1}
       className="image-lightbox"
+      onPointerDown={(event) => event.stopPropagation()}
+      onWheel={(event) => event.stopPropagation()}
       role="dialog"
       aria-modal="true"
       aria-label={dialogLabel}

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -125,63 +125,10 @@ import {
 } from "./live-transcript-activity";
 import { findTranscriptCommandDetailEntryIndex } from "./tool-call-details";
 
-function collectThreadImageGallery(
-  entries: Array<AppServerThreadEntry | undefined>,
-): AppServerThreadImagePart[] {
-  const images: AppServerThreadImagePart[] = [];
-  const seenSourceUrls = new Set<string>();
-  const seenUrls = new Set<string>();
-
-  const appendImage = (image: AppServerThreadImagePart): void => {
-    if (
-      seenUrls.has(image.url)
-      || (image.sourceUrl ? seenSourceUrls.has(image.sourceUrl) : false)
-    ) {
-      return;
-    }
-    seenUrls.add(image.url);
-    if (image.sourceUrl) {
-      seenSourceUrls.add(image.sourceUrl);
-    }
-    images.push(image);
-  };
-
-  for (const entry of entries) {
-    if (entry?.type === "message") {
-      for (const part of entry.parts ?? []) {
-        if (part.type === "image") {
-          appendImage(part);
-        }
-      }
-      continue;
-    }
-
-    if (entry?.type === "activity") {
-      for (const detail of entry.details) {
-        for (const image of detail.images ?? []) {
-          appendImage(image);
-        }
-      }
-    }
-  }
-
-  return images;
-}
-
-function threadGalleryImageMatches(
-  candidate: AppServerThreadImagePart,
-  selected: AppServerThreadImagePart,
-): boolean {
-  return (
-    candidate === selected
-    || candidate.url === selected.url
-    || Boolean(
-      candidate.sourceUrl
-      && selected.sourceUrl
-      && candidate.sourceUrl === selected.sourceUrl,
-    )
-  );
-}
+import {
+  collectThreadImageGallery,
+  threadGalleryImageMatches,
+} from "./thread-image-gallery";
 
 const LazyIntegratedTerminal = lazy(async () => {
   const module = await import("./IntegratedTerminal");

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptMessage.tsx
@@ -725,6 +725,10 @@ export function TranscriptImageTile(props: {
       type="button"
       className="transcript-message__image-button"
       aria-label={`Expand transcript image ${props.imageNumber}`}
+      onMouseDown={(event) => {
+        // Preserve the native image menu without selecting the message.
+        if (event.button === 2) event.preventDefault();
+      }}
       onClick={() => {
         props.onOpenImage?.(props.imagePart);
       }}

--- a/apps/desktop/src/renderer/src/features/thread-detail/thread-image-gallery.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/thread-image-gallery.ts
@@ -1,0 +1,60 @@
+import type { AppServerThreadEntry, AppServerThreadImagePart } from "@pwragent/shared";
+
+export function collectThreadImageGallery(
+  entries: Array<AppServerThreadEntry | undefined>,
+): AppServerThreadImagePart[] {
+  const images: AppServerThreadImagePart[] = [];
+  const seenSourceUrls = new Set<string>();
+  const seenUrls = new Set<string>();
+
+  const appendImage = (image: AppServerThreadImagePart): void => {
+    if (
+      seenUrls.has(image.url)
+      || (image.sourceUrl ? seenSourceUrls.has(image.sourceUrl) : false)
+    ) {
+      return;
+    }
+    seenUrls.add(image.url);
+    if (image.sourceUrl) {
+      seenSourceUrls.add(image.sourceUrl);
+    }
+    images.push(image);
+  };
+
+  for (const entry of entries) {
+    if (entry?.type === "message") {
+      for (const part of entry.parts ?? []) {
+        if (part.type === "image") {
+          appendImage(part);
+        }
+      }
+      continue;
+    }
+
+    if (entry?.type === "activity") {
+      for (const detail of entry.details) {
+        for (const image of detail.images ?? []) {
+          appendImage(image);
+        }
+      }
+    }
+  }
+
+  return images;
+}
+
+export function threadGalleryImageMatches(
+  candidate: AppServerThreadImagePart,
+  selected: AppServerThreadImagePart,
+): boolean {
+  return (
+    candidate === selected
+    || candidate.url === selected.url
+    || Boolean(
+      candidate.sourceUrl
+      && selected.sourceUrl
+      && candidate.sourceUrl === selected.sourceUrl,
+    )
+  );
+}
+


### PR DESCRIPTION
Star Map transcript images now open the shared, window-level lightbox with previous/next buttons and arrow-key navigation. The card uses the same gallery collection and image matching as the regular thread view, including images from message and activity entries.

Right-clicking an image prevents the mouse-down text selection while preserving Electron’s native Copy Image context menu. The lightbox takes and restores focus, stops pointer/wheel propagation, and consumes gallery/Escape keys before they reach the map.

Validation:
- 163 tests passed across StarMapChatCard, ImageLightbox, and ThreadView, including a new multi-image regression test.
- `pnpm typecheck`, `pnpm lint:eslint`, and `pnpm lint:boundaries` passed.
- `git diff --check` passed.
- Native macOS context-menu and visual verification were not performed; the regression test checks that right mouse-down is prevented and the context-menu event remains uncancelled.
