### PR TITLE
fix(desktop): use stable Mac names for federation labels

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-instance-label.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-instance-label.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execFileSync: vi.fn(),
+  hostname: vi.fn(),
+  platform: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execFileSync: mocks.execFileSync }));
+vi.mock("node:os", () => ({ hostname: mocks.hostname, platform: mocks.platform }));
+
+describe("automatic federation instance label", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    mocks.platform.mockReturnValue("darwin");
+    mocks.hostname.mockReturnValue("ip-192-168-10-2.ec2.internal");
+    mocks.execFileSync.mockReturnValue("Harold-MBP-M5-Max\n");
+  });
+
+  it("advertises the stable Mac name instead of a network-assigned hostname", async () => {
+    const { defaultInstanceLabel } = await import("../federation/federation-instance-label");
+
+    expect(defaultInstanceLabel()).toBe("Harold-MBP-M5-Max");
+    expect(mocks.hostname).not.toHaveBeenCalled();
+    expect(mocks.execFileSync).toHaveBeenCalledWith(
+      "/usr/sbin/scutil",
+      ["--get", "LocalHostName"],
+      expect.objectContaining({ timeout: 1_000 }),
+    );
+    // Health reads must not spawn another process each time they poll.
+    expect(defaultInstanceLabel()).toBe("Harold-MBP-M5-Max");
+    expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["linux", "win32"])("keeps the hostname fallback on %s", async (platform) => {
+    mocks.platform.mockReturnValue(platform);
+    mocks.hostname.mockReturnValue("workstation.local");
+    const { defaultInstanceLabel } = await import("../federation/federation-instance-label");
+
+    expect(defaultInstanceLabel()).toBe("workstation");
+    expect(mocks.execFileSync).not.toHaveBeenCalled();
+  });
+
+  it("falls back when the system-name lookup fails", async () => {
+    mocks.execFileSync.mockImplementation(() => { throw new Error("unavailable"); });
+    mocks.hostname.mockReturnValue("fallback.local");
+    const { defaultInstanceLabel } = await import("../federation/federation-instance-label");
+
+    expect(defaultInstanceLabel()).toBe("fallback");
+    expect(defaultInstanceLabel()).toBe("fallback");
+    expect(mocks.execFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses the application name when both system names are empty", async () => {
+    mocks.execFileSync.mockReturnValue(" \n");
+    mocks.hostname.mockReturnValue(" ");
+    const { defaultInstanceLabel } = await import("../federation/federation-instance-label");
+
+    expect(defaultInstanceLabel()).toBe("PwrAgent");
+  });
+});

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -46,8 +46,8 @@ import {
   collectFederationHostInfo,
   collectFederationLoadStatus,
 } from "./federation-host-info";
+import { defaultInstanceLabel } from "./federation-instance-label";
 import {
-  defaultInstanceLabel,
   getDesktopFederationRuntime,
   type DesktopFederationRuntime,
 } from "./federation-runtime";

--- a/apps/desktop/src/main/federation/federation-instance-label.ts
+++ b/apps/desktop/src/main/federation/federation-instance-label.ts
@@ -1,0 +1,30 @@
+import { execFileSync } from "node:child_process";
+import { hostname, platform } from "node:os";
+
+let cachedLabel: string | undefined;
+
+/** Automatic label only; an operator-configured instance label takes priority. */
+export function defaultInstanceLabel(): string {
+  if (cachedLabel !== undefined) return cachedLabel;
+
+  if (platform() === "darwin") {
+    try {
+      // macOS's network hostname can change with DHCP/reverse DNS. The
+      // configured LocalHostName is stable across networks and profiles.
+      const localName = execFileSync("/usr/sbin/scutil", ["--get", "LocalHostName"], {
+        encoding: "utf8",
+        timeout: 1_000,
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+      if (localName) {
+        cachedLabel = localName;
+        return cachedLabel;
+      }
+    } catch {
+      // A missing/unavailable system name must not prevent federation startup.
+    }
+  }
+
+  cachedLabel = hostname().trim().replace(/\.local$/i, "") || "PwrAgent";
+  return cachedLabel;
+}

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -249,6 +249,7 @@ import {
   collectFederationHostInfo,
   collectFederationLoadStatus,
 } from "./federation-host-info";
+import { defaultInstanceLabel } from "./federation-instance-label";
 import { FederationActivityLedger } from "./federation-activity-ledger";
 import { FederationTransferLedger } from "./federation-transfer-ledger";
 import { lookupFederationArchivedThreads, readFederationPinnedSnapshot } from "./federation-collection-client";
@@ -5026,16 +5027,6 @@ export class DesktopFederationRuntime {
     }
     return true;
   }
-}
-
-/**
- * Fallback display name when the operator has not set one: the machine
- * hostname (minus the mDNS suffix) beats both the profile name (almost
- * always "default") and the raw instance GUID for recognizing a peer.
- */
-export function defaultInstanceLabel(): string {
-  const host = hostname().trim().replace(/\.local$/i, "");
-  return host || "PwrAgent";
 }
 
 let messagingPlatformStatusReader:


### PR DESCRIPTION
## Summary

- I fixed automatic federation instance labels on macOS to use the configured LocalHostName. A Mac whose network hostname changes to `ip-192-168-10-2.ec2.internal` now continues advertising its stable local name in thread chips and instance listings.
- I kept explicitly configured instance names first and cached the automatic lookup so health polling does not repeatedly spawn a process.

## Verification

- I passed 118 focused tests covering the name resolver, federation runtime, startup, configuration, and agent tools.
- I passed ESLint, workspace package typechecks and the final desktop typecheck, dependency-boundary checks, and `git diff --check`.

## Notes

- The affected Mac needs this build and an app restart to advertise the corrected name.
- If the macOS name lookup fails or returns nothing, I retain the existing hostname fallback. Other platforms keep their existing fallback.
