### PR TITLE
fix(desktop): respect configured federation endpoint order

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoint-fallback.test.ts
@@ -62,7 +62,7 @@ describe("federation endpoint fallback", () => {
     });
   });
 
-  it("tries the last endpoint that worked first", async () => {
+  it("starts in configured order despite a saved successful fallback from a previous app run", async () => {
     metaStore.set(LAST_ENDPOINT_KEY, CLOUDFLARE);
     const runtime = createHarness([LAN, TAILSCALE, CLOUDFLARE]);
     const attempts: string[] = [];
@@ -72,7 +72,28 @@ describe("federation endpoint fallback", () => {
 
     await runtime.connectToGateway();
 
-    expect(attempts).toEqual([CLOUDFLARE]);
+    expect(attempts).toEqual([LAN]);
+  });
+
+  it("starts again at the first configured endpoint after a fallback succeeds", async () => {
+    const runtime = createHarness([LAN, TAILSCALE, CLOUDFLARE]);
+    const attempts: string[] = [];
+    let lanAvailable = false;
+    runtime.connectClient = async (gatewayUrl) => {
+      attempts.push(gatewayUrl);
+      if (gatewayUrl === LAN && !lanAvailable) {
+        throw new Error("connect ECONNREFUSED");
+      }
+      runtime.markEndpointConnected(gatewayUrl);
+    };
+
+    await runtime.connectToGateway();
+    expect(attempts).toEqual([LAN, TAILSCALE]);
+
+    attempts.length = 0;
+    lanAvailable = true;
+    await runtime.connectToGateway();
+    expect(attempts).toEqual([LAN]);
   });
 
   it("ignores a remembered endpoint that is no longer configured", async () => {
@@ -133,7 +154,7 @@ describe("federation endpoint fallback", () => {
     );
   });
 
-  it("falls back to LAN when the last-good Tailscale endpoint cannot resolve", async () => {
+  it("tries LAN before a remembered Tailscale endpoint that cannot resolve", async () => {
     metaStore.set(LAST_ENDPOINT_KEY, TAILSCALE);
     const runtime = createHarness([LAN, TAILSCALE]);
     const attempts: string[] = [];
@@ -146,7 +167,7 @@ describe("federation endpoint fallback", () => {
 
     await runtime.connectToGateway();
 
-    expect(attempts).toEqual([TAILSCALE, LAN]);
+    expect(attempts).toEqual([LAN]);
   });
 
   it("continues to a healthy fallback after a malformed endpoint", async () => {
@@ -196,13 +217,13 @@ describe("federation endpoint fallback", () => {
     );
   });
 
-  it("records the last-good endpoint only from an established connection", () => {
+  it("records active endpoint status without persisting a preferred endpoint", () => {
     const runtime = createHarness([LAN, TAILSCALE]);
     expect(metaStore.get(LAST_ENDPOINT_KEY)).toBeUndefined();
 
     runtime.markEndpointConnected(TAILSCALE);
 
-    expect(metaStore.get(LAST_ENDPOINT_KEY)).toBe(TAILSCALE);
+    expect(metaStore.get(LAST_ENDPOINT_KEY)).toBeUndefined();
     expect(runtime.endpointStatuses.get(TAILSCALE)).toMatchObject({
       state: "active",
     });

--- a/apps/desktop/src/main/__tests__/federation-endpoints.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-endpoints.test.ts
@@ -6,22 +6,10 @@ const TAILSCALE = "wss://studio.example.ts.net/pwragent-federation";
 const CLOUDFLARE = "wss://federation.example.com";
 
 describe("orderFederationEndpointAttempts", () => {
-  it("keeps configured order without a last-good endpoint", () => {
+  it("keeps configured order", () => {
     expect(orderFederationEndpointAttempts([LAN, TAILSCALE, CLOUDFLARE])).toEqual(
       [LAN, TAILSCALE, CLOUDFLARE],
     );
-  });
-
-  it("moves the last-good endpoint to the front", () => {
-    expect(
-      orderFederationEndpointAttempts([LAN, TAILSCALE, CLOUDFLARE], CLOUDFLARE),
-    ).toEqual([CLOUDFLARE, LAN, TAILSCALE]);
-  });
-
-  it("ignores a last-good endpoint that is no longer configured", () => {
-    expect(
-      orderFederationEndpointAttempts([LAN, TAILSCALE], "wss://removed.example"),
-    ).toEqual([LAN, TAILSCALE]);
   });
 
   it("trims and de-duplicates configured endpoints", () => {
@@ -31,6 +19,6 @@ describe("orderFederationEndpointAttempts", () => {
   });
 
   it("returns an empty list for no endpoints", () => {
-    expect(orderFederationEndpointAttempts([], LAN)).toEqual([]);
+    expect(orderFederationEndpointAttempts([])).toEqual([]);
   });
 });

--- a/apps/desktop/src/main/federation/federation-endpoints.ts
+++ b/apps/desktop/src/main/federation/federation-endpoints.ts
@@ -4,13 +4,11 @@
 // different endpoint can never reach a different gateway identity.
 
 /**
- * Attempt order for one reconnect cycle: the last endpoint that carried a
- * fully authenticated session first (when it is still configured), then the
- * remaining endpoints in configured order.
+ * Attempt order for every startup and reconnect cycle follows Settings.
+ * A successful fallback must never override the configured preference.
  */
 export function orderFederationEndpointAttempts(
   endpoints: readonly string[],
-  lastGoodEndpoint?: string,
 ): string[] {
   const seen = new Set<string>();
   const ordered: string[] = [];
@@ -20,9 +18,5 @@ export function orderFederationEndpointAttempts(
     seen.add(trimmed);
     ordered.push(trimmed);
   }
-  const lastGood = lastGoodEndpoint?.trim();
-  if (!lastGood || !seen.has(lastGood)) {
-    return ordered;
-  }
-  return [lastGood, ...ordered.filter((endpoint) => endpoint !== lastGood)];
+  return ordered;
 }

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -380,6 +380,7 @@ const INSTANCE_ID_META_KEY = "federation_instance_id";
 const GATEWAY_INSTANCE_ID_META_KEY = "federation_gateway_instance_id";
 const GATEWAY_PUBLIC_KEY_META_KEY = "federation_gateway_public_key_pem";
 const GATEWAY_NOISE_PUBLIC_KEY_META_KEY = "federation_gateway_noise_public_key";
+// Legacy preference: only cleared when changing pairings; never used for ordering.
 const GATEWAY_LAST_ENDPOINT_META_KEY = "federation_gateway_last_endpoint";
 const PENDING_INVITE_TOKEN_META_KEY = "federation_pending_invite_token";
 const GATEWAY_ENROLLED_AT_META_KEY = "federation_gateway_enrolled_at";
@@ -2834,7 +2835,7 @@ export class DesktopFederationRuntime {
     }
   }
 
-  // One reconnect cycle: walk the configured endpoints (last-good first) and
+  // One reconnect cycle: walk the endpoints in configured order and
   // stop at the first fully authenticated connection. Every endpoint runs the
   // identical pinned-identity + Noise handshake, so fallback can only change
   // reachability, never which gateway the client will trust.
@@ -2853,12 +2854,7 @@ export class DesktopFederationRuntime {
   private async walkGatewayEndpoints(): Promise<void> {
     const endpoints = this.configuredEndpoints;
     if (endpoints.length === 0) return;
-    const lastGoodEndpoint =
-      getAppStateDb().getMeta(GATEWAY_LAST_ENDPOINT_META_KEY) || undefined;
-    const attempts = orderFederationEndpointAttempts(
-      endpoints,
-      lastGoodEndpoint,
-    );
+    const attempts = orderFederationEndpointAttempts(endpoints);
     // A restart during the walk flips `stopping` back to false, so `stopping`
     // alone would let a superseded walk keep dialing a stale endpoint list and
     // race the new one into `this.client`. `connectionGeneration` can't serve
@@ -3193,8 +3189,7 @@ export class DesktopFederationRuntime {
     log.info("federation client connected", { gatewayUrl });
   }
 
-  // Only a fully authenticated session ever updates the last-good endpoint
-  // memory, so a hostile endpoint can never steer future attempt ordering.
+  // Track the active connection without changing configured endpoint priority.
   private markEndpointConnected(gatewayUrl: string): void {
     this.endpointStatuses.set(gatewayUrl, {
       ...this.endpointStatuses.get(gatewayUrl),
@@ -3202,7 +3197,6 @@ export class DesktopFederationRuntime {
       lastConnectedAt: Date.now(),
       lastError: undefined,
     });
-    getAppStateDb().setMeta(GATEWAY_LAST_ENDPOINT_META_KEY, gatewayUrl);
   }
 
   private recordClientConnection(params: {
@@ -3266,7 +3260,7 @@ export class DesktopFederationRuntime {
   }
 
   // Backoff applies per full cycle through the endpoint list; every cycle
-  // re-walks the endpoints last-good-first via connectToGateway.
+  // re-walks the endpoints in configured order via connectToGateway.
   private scheduleReconnect(): void {
     if (this.stopping || this.reconnectTimer) return;
     if (

--- a/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/FederationSettings.tsx
@@ -609,7 +609,7 @@ export function FederationSettings(props: FederationSettingsProps) {
             label="Gateway endpoints"
             sub={
               dialsGateway
-                ? "Endpoints for one pinned gateway, one per line in fallback order. Reconnects try the last successful endpoint first. ws://, wss://, and ssh:// (user@host, optional ?forward=host:port) are supported."
+                ? "Endpoints for one pinned gateway, one per line in fallback order. Startup and reconnects always try endpoints in this order. ws://, wss://, and ssh:// (user@host, optional ?forward=host:port) are supported."
                 : "Only used when Mode is client or dual."
             }
             control={
@@ -993,7 +993,7 @@ export function FederationSettings(props: FederationSettingsProps) {
           />
           <SettingsField
             label="Gateway endpoints"
-            sub="Outbound candidates used by client mode. Reconnects try the last successful endpoint first, then the remaining endpoints in configured order. The active endpoint carries the current session."
+            sub="Outbound candidates used by client mode. Startup and reconnects always try endpoints in configured order. The active endpoint carries the current session."
             control={
               gatewayEndpointStatuses.length === 0 ? (
                 <span>Not configured</span>


### PR DESCRIPTION
## Summary
A successful fallback connection used to become the first endpoint tried on subsequent reconnects and app restarts. For example, a temporary LAN failure could leave Tailscale preferred indefinitely despite LAN appearing first in Settings.

Always try gateway endpoints in configured order on startup and every reconnect cycle. Ignore previously saved endpoint preference, stop persisting successful endpoints as preferences, and update Settings help text. Existing fallback, authentication checks, and backoff after a full failed cycle remain intact; an active fallback connection stays connected until a reconnect is needed.

## Validation
- Updated the runtime regression tests first: observed 4 expected failures before applying the fix.
- 125 tests passed across endpoint ordering, fallback, reconnect policy, enrollment reset, runtime startup, and runtime suites.
- `pnpm lint:eslint` passed.
- `pnpm typecheck` passed.
- `git diff --check` passed.
