### PR TITLE
fix(desktop): prevent duplicate star map hydration on mount

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/StarMapChatCard.test.tsx
@@ -1,3 +1,4 @@
+import { StrictMode } from "react";
 import { buildThreadComposerScopeKey } from "../../composer/useComposerDraftStore";
 import {
   act,
@@ -11,6 +12,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type {
   AgentEvent,
+  AppServerReadThreadResponse,
   BackendCapabilities,
   CelestialIconId,
   DesktopSettingsSnapshot,
@@ -335,6 +337,36 @@ describe("StarMapChatCard gesture persistence", () => {
 });
 
 describe("StarMapChatCard transcript loading", () => {
+  it("reads a restored remote card once during Strict Mode mount replay", async () => {
+    const pending = deferred<AppServerReadThreadResponse>();
+    const response: AppServerReadThreadResponse = {
+      backend: "codex",
+      fetchedAt: 1,
+      threadId: "t-remote",
+      replay: {
+        entries: [], messages: [],
+        pagination: { supportsPagination: false, hasPreviousPage: false },
+      },
+    };
+    const desktopApi = buildApi({
+      readThread: vi.fn().mockReturnValueOnce(pending.promise).mockResolvedValue(response),
+    });
+    const view = render(<StrictMode>{card({ desktopApi, thread: remoteThread() })}</StrictMode>);
+    await act(async () => {});
+    expect(desktopApi.readThread).toHaveBeenCalledTimes(1);
+    await act(async () => pending.resolve(response));
+    expect(desktopApi.readThread).toHaveBeenCalledTimes(1);
+
+    // A later owner update still hydrates, and reopening owns a fresh read.
+    view.rerender(<StrictMode>{card({ desktopApi, thread: remoteThread({ updatedAt: 2 }) })}</StrictMode>);
+    await act(async () => {});
+    expect(desktopApi.readThread).toHaveBeenCalledTimes(2);
+    view.unmount();
+    render(<StrictMode>{card({ desktopApi, thread: remoteThread({ updatedAt: 2 }) })}</StrictMode>);
+    await act(async () => {});
+    expect(desktopApi.readThread).toHaveBeenCalledTimes(3);
+  });
+
   it("asks for the last few turns rather than the whole thread", async () => {
     const desktopApi = buildApi();
     renderCard({ desktopApi, thread: remoteThread() });

--- a/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadSessionState.ts
@@ -4745,6 +4745,10 @@ export function useThreadSessionState(params: {
     Record<string, Map<string, AppServerThreadEntry>>
   >({});
   const requestVersionsRef = useRef<Record<string, number>>({});
+  // React can replay the hydration effect before its loading state commits.
+  // Track the owning read synchronously so automatic hydration cannot send
+  // the same initial request twice. Explicit reloads may still supersede it.
+  const inFlightHydrationsRef = useRef(new Map<string, number>());
   const staleThinkingLogKeysRef = useRef<Set<string>>(new Set());
   const threadStatusSummarySeedRef = useRef<Record<string, string>>({});
   const [sessions, setSessions] = useState<ThreadSessionState>({});
@@ -4914,6 +4918,7 @@ export function useThreadSessionState(params: {
 
       const requestVersion = (requestVersionsRef.current[targetThreadKey] ?? 0) + 1;
       requestVersionsRef.current[targetThreadKey] = requestVersion;
+      inFlightHydrationsRef.current.set(targetThreadKey, requestVersion);
 
       updateSession(targetThreadKey, (current) => ({
         ...current,
@@ -5227,6 +5232,10 @@ export function useThreadSessionState(params: {
           lastTouchedAt: Date.now(),
           loading: false,
         }));
+      } finally {
+        if (inFlightHydrationsRef.current.get(targetThreadKey) === requestVersion) {
+          inFlightHydrationsRef.current.delete(targetThreadKey);
+        }
       }
     },
     [
@@ -5437,6 +5446,9 @@ export function useThreadSessionState(params: {
 
     const session = sessions[threadKey];
     const hydrationVersion = getThreadHydrationVersion(thread);
+    if (inFlightHydrationsRef.current.has(threadKey)) {
+      return;
+    }
     if (!session?.response) {
       if (
         !session?.loading &&


### PR DESCRIPTION
## Summary

Opening a remote Star Map chat card under React Strict Mode sent two `backend.readThread` requests before either response arrived. The mount effect replay ran before the loading state committed. Track the owning hydration request synchronously so automatic hydration sends one request; explicit reloads can still supersede an earlier read, and only the current owner clears the in-flight marker.

## Verification

- Reproduced with the actual StarMapChatCard component under Strict Mode: the regression failed with two reads before the fix and passes with one afterward.
- The regression also checks that an owner update and closing/reopening the card each fetch fresh data.
- StarMapChatCard and useThreadSessionState suites: 241 tests passed. The extended regression passed again after completing the fixture.
- `pnpm lint:eslint` passed (existing warnings only).
- Workspace package type checks passed; desktop type checking passed after correcting the new test fixture.
- `git diff --check` passed.

## Notes

This fixes the reproduced mount lifecycle issue. It does not attribute all traffic from the reported burst, and no network capture UI is included. Verification used component tests; the running application was not restarted.
