### PR TITLE
fix(desktop): coalesce provider listings and directory enrichment

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2140,6 +2140,78 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("shares provider scans and enrichment across concurrent listing consumers", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadListResultBySearchTerm.set("shared-list", Array.from(
+      { length: 500 }, (_, index) => ({
+        id: `shared-${index}`, name: `Thread ${index}`, source: "vscode",
+        cwd: `/repo/shared-${index % 25}`,
+      }),
+    ));
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const enrich = vi.fn(async () => { await gate; return { linkedDirectories: [] }; });
+    const client = new CodexAppServerClient({ command: "codex", threadDirectoryEnricher: enrich });
+    const params = { filter: "shared-list", skipArchivedMetadataRefresh: true };
+    const countLists = () => MockTransport.instances.at(-1)!.sentMessages
+      .map((message) => JSON.parse(message)).filter((message) => message.method === "thread/list").length;
+    try {
+      const reads = Array.from({ length: 8 }, (_, index) => client.listThreads(params, {
+        callerReason: `consumer-${index}`,
+      }));
+      await vi.waitFor(() => expect(enrich).toHaveBeenCalled());
+      expect(countLists()).toBe(1);
+      release();
+      const results = await Promise.all(reads);
+      expect(results.every((rows) => rows.length === 500)).toBe(true);
+      expect(enrich).toHaveBeenCalledTimes(25);
+      await client.listThreads(params);
+      expect(countLists()).toBe(2);
+      expect(enrich).toHaveBeenCalledTimes(50);
+    } finally {
+      release();
+      await client.close();
+    }
+  });
+
+  it("starts a new listing after a row event without losing the newer pending owner", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadListResultBySearchTerm.set("changed-list", [{
+      id: "changed-thread", name: "Thread", source: "vscode", cwd: "/repo/changed",
+    }]);
+    const releases: Array<() => void> = [];
+    const enrich = vi.fn(async () => {
+      await new Promise<void>((resolve) => { releases.push(resolve); });
+      return { linkedDirectories: [] };
+    });
+    const client = new CodexAppServerClient({ command: "codex", threadDirectoryEnricher: enrich });
+    const params = { filter: "changed-list", skipArchivedMetadataRefresh: true };
+    try {
+      const first = client.listThreads(params);
+      await vi.waitFor(() => expect(releases).toHaveLength(1));
+      const transport = MockTransport.instances.at(-1)!;
+      transport.emitInbound({ jsonrpc: "2.0", method: "thread/status/changed",
+        params: { threadId: "changed-thread", status: { type: "active" } } });
+      const second = client.listThreads(params);
+      await vi.waitFor(() => expect(releases).toHaveLength(2));
+      releases[0]();
+      await first;
+      const third = client.listThreads(params);
+      // Streamed deltas do not invalidate membership or multiply scans.
+      transport.emitInbound({ jsonrpc: "2.0", method: "item/agentMessage/delta",
+        params: { threadId: "changed-thread", delta: "text" } });
+      const fourth = client.listThreads(params);
+      releases[1]();
+      await Promise.all([second, third, fourth]);
+      expect(enrich).toHaveBeenCalledTimes(2);
+      expect(transport.sentMessages.map((message) => JSON.parse(message))
+        .filter((message) => message.method === "thread/list")).toHaveLength(2);
+    } finally {
+      for (const release of releases) release();
+      await client.close();
+    }
+  });
+
   it("validates each directory once per listing even across mapper batches", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const threadDirectoryEnricher = vi.fn(async () => ({ linkedDirectories: [] }));

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -9,6 +9,7 @@ import {
   formatTokenUsageUsd,
   formatTokenUsageUsdPerMillion,
   isToolManagedWorktreePath,
+  navigationQueryEventRequiresRefresh,
   parseCodexTurnErrorMessage,
   resolveOpenAiPricingServiceTier,
   resolveTokenUsagePriceUnavailableReason,
@@ -7396,6 +7397,7 @@ export class CodexAppServerClient {
       }
     >
   >();
+  private readonly pendingThreadListings = new Map<string, Promise<AppServerThreadSummary[]>>();
   private readonly recordedThreadNames = new Map<string, string>();
   private readonly requestListeners = new Set<
     (
@@ -7448,6 +7450,7 @@ export class CodexAppServerClient {
           })
         : createThreadDirectoryEnricher());
     this.connection.setNotificationHandler(async (method, params) => {
+      if (navigationQueryEventRequiresRefresh(method)) this.pendingThreadListings.clear();
       const isKnownCodexMethod = isKnownCodexNotificationMethod(method);
       if (!isKnownCodexMethod) {
         logUnhandledCodexMessage({
@@ -7554,6 +7557,7 @@ export class CodexAppServerClient {
     this.initializationPromise = null;
     this.initializeResult = null;
     this.rejectHelperTurnWaiters(new Error("codex app server client closed"));
+    this.pendingThreadListings.clear();
     this.pendingFirstTurnThreadResults.clear();
     this.recordedThreadNames.clear();
     this.helperThreadIds.clear();
@@ -8091,6 +8095,29 @@ export class CodexAppServerClient {
   }, diagnostics?: JsonRpcObserverDiagnostics): Promise<AppServerThreadSummary[]> {
     await this.ensureInitialized();
 
+    // Registry scopes and federation consumers can reach the same provider
+    // through different cache keys. Share the complete listing, including
+    // directory observations, until it settles. Never retain a completed scan.
+    const key = JSON.stringify([
+      params?.archived === true, params?.enrichDirectories ?? true,
+      params?.filter?.trim() || "", params?.limit, params?.maxPages,
+      params?.skipArchivedMetadataRefresh === true, params?.deadlineAt,
+    ]);
+    const existing = this.pendingThreadListings.get(key);
+    if (existing) return await existing;
+    const pending = this.loadThreadListing(params, diagnostics);
+    this.pendingThreadListings.set(key, pending);
+    try {
+      return await pending;
+    } finally {
+      if (this.pendingThreadListings.get(key) === pending) this.pendingThreadListings.delete(key);
+    }
+  }
+
+  private async loadThreadListing(
+    params: Parameters<CodexAppServerClient["listThreads"]>[0],
+    diagnostics?: JsonRpcObserverDiagnostics,
+  ): Promise<AppServerThreadSummary[]> {
     const requestParams = {
       client: this.connection,
       diagnostics,


### PR DESCRIPTION
Concurrent navigation consumers can bypass one another’s registry cache keys and start identical Codex provider listings, repeating directory enrichment even though each individual listing already deduplicates paths. Coalesce the complete in-flight listing at the shared Codex client boundary, including its directory observations.

Requests share only when their result-affecting options and deadlines match. Navigation-changing notifications detach pending reads so subsequent callers get fresh state; completion only removes its own entry. Settled results are not retained, and client close clears joinability. Selected-thread read/Strict Mode dispatch work is outside this change.

Validation: a 500-thread, 25-directory regression with eight consumers produces eight provider scans before this change and one afterward, with 25 enrichment calls. A subsequent read revalidates all 25 directories. Another regression covers event invalidation, old-promise completion, and streamed deltas. All 184 Codex client tests, pnpm lint:eslint, desktop TypeScript checking, and git diff --check pass.

The hot profile recorded 4,196 enrichment requests in two seconds. This regression establishes one amplification mechanism; it does not claim every request in that production capture came from concurrent identical listings.
