### PR TITLE
fix(desktop): make star map load effects safe under Strict Mode

### DIFF
--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-strict-mode.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-strict-mode.test.tsx
@@ -1,0 +1,144 @@
+import { StrictMode } from "react";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, expect, it, vi } from "vitest";
+import type { FederationPeerSummary, NavigationDirectoryRow, NavigationQueryPage, NavigationQueryRequest } from "@pwragent/shared";
+import type { DesktopApi } from "../../../lib/desktop-api";
+import { navigationQueryFixture } from "../../../test/navigation-query-fixture";
+import { useStarMapInstanceLoad } from "../useStarMapInstanceLoad";
+import { useStarMapThreads } from "../useStarMapThreads";
+import { useStarMapProjectPages } from "../useStarMapProjectPages";
+import { useNavigationQueryResource } from "../../../lib/useNavigationQueryResource";
+import { useFederationHealth } from "../../../lib/useFederationHealth";
+import { useLocalStarMapThreads } from "../useLocalStarMapThreads";
+
+afterEach(() => { cleanup(); vi.useRealTimers(); });
+const options = { wrapper: StrictMode };
+const request: NavigationQueryRequest = {
+  protocol: 2, consumer: "star-map", query: { kind: "lens", lens: "attention" }, pageSize: 10,
+};
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((complete) => { resolve = complete; });
+  return { promise, resolve };
+}
+function queryApi(read = vi.fn(async (query: NavigationQueryRequest, _consumer?: string) => navigationQueryFixture(query, {}))) {
+  const release = vi.fn(async () => {});
+  const api = { getNavigationQueryPage: read, releaseNavigationQuery: release } as unknown as DesktopApi;
+  return { api, read, release };
+}
+function peer(id: string): FederationPeerSummary {
+  return { id, status: "connected", capabilities: ["thread_navigation"], navigationQueryProtocol: 2 } as FederationPeerSummary;
+}
+
+it("samples load once on mount and keeps one polling loop across suspension", async () => {
+  vi.useFakeTimers();
+  const read = vi.fn(async () => ({}));
+  const desktopApi = { readFederationInstanceLoad: read } as unknown as DesktopApi;
+  const view = renderHook(({ active }) => useStarMapInstanceLoad({ desktopApi,
+    instanceIds: ["pwr_peer"], active }), { ...options, initialProps: { active: true } });
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(1);
+  await act(async () => vi.advanceTimersByTimeAsync(8_000));
+  expect(read).toHaveBeenCalledTimes(2);
+  view.rerender({ active: false });
+  await act(async () => vi.advanceTimersByTimeAsync(16_000));
+  expect(read).toHaveBeenCalledTimes(2);
+  view.rerender({ active: true });
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(3);
+  view.unmount();
+  await act(async () => vi.advanceTimersByTimeAsync(16_000));
+  expect(read).toHaveBeenCalledTimes(3);
+});
+
+it("reads health once on mount while retaining explicit refresh and resume", async () => {
+  const read = vi.fn(async () => ({ health: { instanceId: "pwr_local" } }));
+  const desktopApi = { readFederationHealth: read } as unknown as DesktopApi;
+  const view = renderHook(({ suspended }) => useFederationHealth({ desktopApi, suspended }),
+    { ...options, initialProps: { suspended: false } });
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(1);
+  expect(view.result.current.health?.instanceId).toBe("pwr_local");
+  await act(async () => view.result.current.refresh());
+  expect(read).toHaveBeenCalledTimes(2);
+  view.rerender({ suspended: true });
+  await act(async () => view.result.current.refresh());
+  expect(read).toHaveBeenCalledTimes(2);
+  view.rerender({ suspended: false });
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(3);
+});
+
+it("dispatches one navigation read and releases its actual lease on unmount", async () => {
+  const pending = deferred<NavigationQueryPage>();
+  const { api, read, release } = queryApi(vi.fn((_query: NavigationQueryRequest, _consumer?: string) => pending.promise));
+  const view = renderHook(() => useNavigationQueryResource({ desktopApi: api, request }), options);
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(1);
+  await act(async () => pending.resolve(navigationQueryFixture(request, {})));
+  expect(view.result.current.state?.page).toBeDefined();
+  await act(async () => view.result.current.refresh());
+  expect(read).toHaveBeenCalledTimes(2);
+  view.unmount();
+  expect(release).toHaveBeenCalledWith(read.mock.calls[0]![1]);
+});
+
+it("does not dispatch an unmounted navigation resource or load card", async () => {
+  const { api, read } = queryApi();
+  const load = vi.fn(async () => ({}));
+  const desktopApi = { ...api, readFederationInstanceLoad: load } as DesktopApi;
+  const view = renderHook(() => {
+    useNavigationQueryResource({ desktopApi, request });
+    useStarMapInstanceLoad({ desktopApi, instanceIds: ["pwr_peer"] });
+  }, options);
+  view.unmount();
+  await act(async () => {});
+  expect(read).not.toHaveBeenCalled();
+  expect(load).not.toHaveBeenCalled();
+});
+
+it("reads each connected owner's rows and geometry once and still refreshes", async () => {
+  const { api, read } = queryApi();
+  const view = renderHook(({ peers }) => useStarMapThreads({ desktopApi: api, peers, enabled: true }),
+    { ...options, initialProps: { peers: [peer("pwr_first")] } });
+  await act(async () => {});
+  expect(read.mock.calls.map(([query]) => query.query.kind).sort()).toEqual(["lens", "star-map-geometry"]);
+  expect(view.result.current.geometryReadyInstanceIds.has("pwr_first")).toBe(true);
+  await act(async () => view.result.current.refreshInstance("pwr_first"));
+  expect(read).toHaveBeenCalledTimes(4);
+  view.rerender({ peers: [peer("pwr_first"), peer("pwr_second")] });
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(6);
+  expect(view.result.current.geometryReadyInstanceIds.has("pwr_second")).toBe(true);
+});
+
+it("admits local geometry and exact metadata only once", async () => {
+  const { api, read } = queryApi();
+  renderHook(() => useLocalStarMapThreads({ desktopApi: api, enabled: true, filters: {},
+    demandedIdentities: [{ backend: "codex", threadId: "thread" }] }), options);
+  await act(async () => {});
+  expect(read.mock.calls.map(([query]) => query.query.kind).sort()).toEqual(["exact", "star-map", "star-map-geometry"]);
+});
+
+it.each([false, true])("loads project descriptors arriving after mount (Strict Mode=%s)", async (strict) => {
+  const { api, read, release } = queryApi();
+  const descriptors = new Map([["pwr_peer", [{ key: "project" } as NavigationDirectoryRow]]]);
+  const view = renderHook(({ ready, active }) => useStarMapProjectPages({ desktopApi: api, enabled: true, active,
+    localInstanceId: "pwr_local", descriptors: ready ? descriptors : new Map(), filters: {} }),
+    { initialProps: { ready: false, active: true }, ...(strict ? options : {}) });
+  view.rerender({ ready: true, active: true });
+  await act(async () => {});
+  expect(view.result.current.state.resources.size).toBe(1);
+  expect(read).toHaveBeenCalledTimes(1);
+  expect([...view.result.current.state.resources.values()][0]!.state.page).toBeDefined();
+  await act(async () => view.result.current.controller.refresh());
+  expect(read).toHaveBeenCalledTimes(2);
+  view.rerender({ ready: true, active: false });
+  await act(async () => view.result.current.controller.refresh());
+  expect(read).toHaveBeenCalledTimes(2);
+  view.rerender({ ready: true, active: true });
+  await act(async () => {});
+  expect(read).toHaveBeenCalledTimes(3);
+  view.unmount();
+  expect(release).toHaveBeenCalledWith(read.mock.calls[2]![1]);
+});

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapInstanceLoad.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapInstanceLoad.ts
@@ -81,7 +81,9 @@ export function useStarMapInstanceLoad(params: {
       await sample();
       if (!cancelled) timer = setTimeout(() => { void tick(); }, intervalMs);
     };
-    void tick();
+    // Admit network work only after this effect survives synchronous cleanup
+    // (including Strict Mode replay). tick checks this lifetime's cancellation.
+    queueMicrotask(() => { void tick(); });
 
     return () => {
       cancelled = true;

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapProjectPages.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapProjectPages.ts
@@ -1,7 +1,7 @@
-import { useEffect, useId, useMemo, useRef, useSyncExternalStore } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { NavigationDirectoryRow, NavigationQueryRequest, NavigationStarMapFilterSelection } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
-import { NavigationWindowQueries } from "../../lib/navigation-window-queries";
+import { NavigationWindowQueries, type NavigationWindowQueriesState } from "../../lib/navigation-window-queries";
 import { threadProjectKey } from "./star-map-projects";
 import { navigationQueryEventRequiresRefresh } from "../../lib/navigation-query-events";
 
@@ -25,7 +25,17 @@ export function useStarMapProjectPages(params: {
   const active = params.active ?? true;
   const viewId = useId();
   const owners = useRef(new Set<string>());
-  const controller = useMemo(() => {
+  const controllerRef = useRef<NavigationWindowQueries | undefined>(undefined);
+  const [state, setState] = useState<NavigationWindowQueriesState>({ resources: new Map() });
+  // Public operations always address the currently mounted controller. A
+  // disposed controller must never survive an effect cleanup/setup cycle.
+  const controller = useMemo(() => ({
+    refresh: (...args: Parameters<NavigationWindowQueries["refresh"]>) => controllerRef.current?.refresh(...args) ?? Promise.resolve(),
+    restart: (...args: Parameters<NavigationWindowQueries["restart"]>) => controllerRef.current?.restart(...args) ?? Promise.resolve(),
+    loadMore: (...args: Parameters<NavigationWindowQueries["loadMore"]>) => controllerRef.current?.loadMore(...args) ?? Promise.resolve(),
+    setVisibleAnchor: (...args: Parameters<NavigationWindowQueries["setVisibleAnchor"]>) => controllerRef.current?.setVisibleAnchor(...args),
+  }), []);
+  useEffect(() => {
     const result = new NavigationWindowQueries({
       releaseNavigationQuery: api?.releaseNavigationQuery,
       getNavigationQueryPage: async (request, consumer) => {
@@ -40,13 +50,21 @@ export function useStarMapProjectPages(params: {
       },
     });
     result.setVisible(false);
-    return result;
+    controllerRef.current = result;
+    const unsubscribe = result.subscribe(() => setState(result.getSnapshot()));
+    setState(result.getSnapshot());
+    return () => {
+      unsubscribe();
+      result.dispose();
+      if (controllerRef.current === result) controllerRef.current = undefined;
+    };
   }, [api]);
-  const state = useSyncExternalStore(controller.subscribe, controller.getSnapshot);
   const demandKey = JSON.stringify(params.enabled ? [...params.descriptors].flatMap(([owner, projects]) =>
     projects.map((project) => [owner, project.key])) : []);
   const filterKey = JSON.stringify(params.filters);
   useEffect(() => {
+    const controller = controllerRef.current;
+    if (!controller) return;
     const demand = new Map<string, NavigationQueryRequest>();
     for (const [owner, projectKey] of JSON.parse(demandKey) as [string, string][]) {
       owners.current.add(owner === params.localInstanceId ? "" : owner);
@@ -60,10 +78,10 @@ export function useStarMapProjectPages(params: {
     if (!active) controller.setVisible(false);
     controller.setDemand(demand);
     controller.setVisible(active);
-  }, [active, controller, demandKey, filterKey, params.localInstanceId, viewId]);
-  useEffect(() => () => controller.dispose(), [controller]);
+  }, [active, api, demandKey, filterKey, params.localInstanceId, viewId]);
   useEffect(() => {
-    if (!active) return;
+    const controller = controllerRef.current;
+    if (!active || !controller) return;
     let pending: ReturnType<typeof setTimeout> | undefined;
     const dirty = new Set<string>();
     const unsubscribe = api?.onAgentEvent?.((event) => {
@@ -98,7 +116,7 @@ export function useStarMapProjectPages(params: {
       clearInterval(timer);
       if (pending) clearTimeout(pending);
     };
-  }, [active, api, controller, params.localInstanceId]);
+  }, [active, api, params.localInstanceId]);
   useEffect(() => {
     const admittedOwners = owners.current;
     return () => {

--- a/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/useStarMapThreads.ts
@@ -229,6 +229,10 @@ export function useStarMapThreads(params: {
       const ownerGeneration = ownerGenerations.current.get(instanceId);
       if (ownerGeneration === undefined) throw new Error("This owner is not connected with navigation query protocol 2.");
       const isCurrent = () => generationRef.current === generation && ownerGenerations.current.get(instanceId) === ownerGeneration;
+      // Let synchronous effect cleanup revoke admission before sending either
+      // the row or geometry query. Pending reads remain scoped to this owner.
+      await Promise.resolve();
+      if (!isCurrent()) return;
       attentionOwnersRef.current.add(instanceId);
       const request = attentionRequest({ instanceId, filters, attentionView });
       const selectionKey = JSON.stringify(request.query);

--- a/apps/desktop/src/renderer/src/lib/__tests__/navigation-settings-preview.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/navigation-settings-preview.test.tsx
@@ -1,4 +1,4 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { NavigationDirectoryRow, NavigationQueryPage } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
@@ -53,9 +53,21 @@ describe("bounded settings previews", () => {
     const api = apiWith(read);
     const hook = renderHook(() => useNavigationSettingsPreview(api));
     const result = hook.result.current.readModelInventory("codex").catch((error: unknown) => error);
+    await waitFor(() => expect(read).toHaveBeenCalledTimes(1));
     hook.unmount();
     expect(api.releaseNavigationQuery).toHaveBeenCalledWith(read.mock.calls[0]![1]);
     await act(async () => resolve(page({ modelGroups: [] })));
     expect(await result).toMatchObject({ name: "AbortError" });
+  });
+
+  it("cancels a preview closed before dispatch without sending a query", async () => {
+    const read = vi.fn().mockResolvedValue(page({ modelGroups: [] }));
+    const api = apiWith(read);
+    const hook = renderHook(() => useNavigationSettingsPreview(api));
+    const result = hook.result.current.readModelInventory("codex").catch((error: unknown) => error);
+    hook.unmount();
+    expect(await result).toMatchObject({ name: "AbortError" });
+    expect(read).not.toHaveBeenCalled();
+    expect(api.releaseNavigationQuery).toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useNavigationSelectedDetail.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useNavigationSelectedDetail.test.tsx
@@ -232,9 +232,13 @@ it("retains live Token Miser subagents while the authoritative collection refres
   act(() => listener!({ backend: "codex", notification: { method: "thread/subAgents/updated",
     params: { threadId: ref.threadId, subAgents: [gate] } } }));
   expect(result.current.state?.detail?.thread?.subAgents).toEqual([gate]);
-  await waitFor(() => expect(read).toHaveBeenCalledTimes(3));
-  expect(result.current.state?.collectionReadiness).toBe("loading");
-  expect(result.current.state?.detail?.thread?.subAgents).toEqual([gate]);
+  // Dispatch precedes React's commit. Observe the pending collection state,
+  // not just the mock call, before checking the retained live subagents.
+  await waitFor(() => {
+    expect(result.current.state?.collectionReadiness).toBe("loading");
+    expect(read).toHaveBeenCalledTimes(3);
+    expect(result.current.state?.detail?.thread?.subAgents).toEqual([gate]);
+  });
   await act(async () => refreshed.resolve({ ...detail("fresh", true), collectionPage: {
     name: "subAgents", revision: "live", complete: true, values: { subAgents: [gate] },
   } }));

--- a/apps/desktop/src/renderer/src/lib/read-navigation-query-range.ts
+++ b/apps/desktop/src/renderer/src/lib/read-navigation-query-range.ts
@@ -19,6 +19,8 @@ export async function readNavigationQueryRange(params: {
   let restarted = false;
   let retainedBytes = 0;
   const encoder = new TextEncoder();
+  // Range owners can be replaced during mount replay before any IPC starts.
+  await Promise.resolve();
   while (true) {
     if (params.isCancelled()) throw new Error("Navigation metadata read cancelled.");
     if (Date.now() >= deadlineAt) throw new Error("Navigation metadata read deadline expired.");

--- a/apps/desktop/src/renderer/src/lib/useFederationHealth.ts
+++ b/apps/desktop/src/renderer/src/lib/useFederationHealth.ts
@@ -26,9 +26,12 @@ export function useFederationHealth(params: {
   const refresh = useCallback(() => {
     if (!active.current) return;
     const generation = lifetime.current;
-    void desktopApi
-      ?.readFederationHealth?.({})
-      .then((response) => { if (active.current && lifetime.current === generation) setHealth(response.health); })
+    void Promise.resolve().then(async () => {
+      // Cleanup must be able to revoke a mount read before it reaches IPC.
+      if (!active.current || lifetime.current !== generation) return;
+      const response = await desktopApi?.readFederationHealth?.({});
+      if (response && active.current && lifetime.current === generation) setHealth(response.health);
+    })
       .catch(() => {
         // Keep the last known topology; peer events retrigger the read.
       });

--- a/apps/desktop/src/renderer/src/lib/useNavigationQueryResource.ts
+++ b/apps/desktop/src/renderer/src/lib/useNavigationQueryResource.ts
@@ -57,6 +57,10 @@ export function useNavigationQueryResource(params: {
     setLoading(true);
     const promise = (async () => {
       try {
+        // The effect owns admission as well as result application. A replayed
+        // or replaced lifetime must not dispatch a request after cleanup.
+        await Promise.resolve();
+        if (lifetimeRef.current !== lifetime || !activeRef.current) return;
         const page = await api.getNavigationQueryPage!({
           ...started.request,
           cursor,


### PR DESCRIPTION
## Summary

Strict Mode's mount cleanup/setup cycle could permanently dispose the Star Map project-page controller, leaving later project descriptors unloaded. The same cycle also dispatched duplicate initial load-card, federation-health, navigation-page, and metadata requests.

- Create and dispose the project-page controller within each effect lifetime. Stable public actions address the current controller, so project loading, pagination, refresh, and resume remain usable after replay.
- Admit initial asynchronous reads at a microtask boundary and check the existing lifetime/owner cancellation before dispatch. A cleaned-up effect cannot send its abandoned request. Preserve normal refreshes, polling, owner changes, and lease release.
- Apply the cancellation check to compact navigation ranges as well, covering local geometry and exact metadata reads.

## Verification

- Eight new lifecycle regressions cover Strict Mode request counts, response application, explicit refresh, polling and suspension, unmount cancellation, lease release, peer arrival, local metadata, and project descriptors arriving after mount. Project loading is checked with and without Strict Mode.
- All 50 Star Map test files passed: 725 tests.
- Seven focused Star Map/navigation/range test files passed: 54 tests (overlaps the Star Map suite).
- `pnpm --filter @pwragent/desktop typecheck` passed.
- `pnpm lint:eslint` passed with existing warnings only.
- `git diff --check` passed.

## Notes

Based on origin/main after the squash of #2039. No capture UI or persistent diagnostics are added. Verification uses component/hook tests; the running desktop app was not restarted. Renderer request counts are covered directly; this does not claim a measured reduction for the entire original network burst.
