### PR TITLE
fix(desktop): lower Token Miser evaluation threshold to 2000 characters

### DIFF
--- a/apps/desktop/src/main/token-miser/token-miser-types.ts
+++ b/apps/desktop/src/main/token-miser/token-miser-types.ts
@@ -1,4 +1,4 @@
-export const TOKEN_MISER_DEFAULT_THRESHOLD_CHARACTERS = 5_000;
+export const TOKEN_MISER_DEFAULT_THRESHOLD_CHARACTERS = 2_000;
 // Keep this aligned with codex_utils_string::APPROX_BYTES_PER_TOKEN. Codex
 // budgets model-visible tool output in UTF-8 bytes, not JavaScript UTF-16 code
 // units, so non-ASCII output must use the same accounting basis.


### PR DESCRIPTION
Lower the default Token Miser evaluation threshold from 5,000 to 2,000 characters so smaller tool outputs can be evaluated by Luna. Outputs of exactly 2,000 characters still pass through; larger eligible outputs reach the existing classifier. This applies to direct hooks and new output emitted by Code Mode cells.

The operator chose to broaden eligibility given the helper's low cost. In the saved recent Astra cohort, approximately 150 additional cells would qualify. This is an eligibility change; improved net savings remain to be measured after helper cost and retrieval. Existing source-preservation, retrieval exemptions, and acceptance behavior remain in effect.

Validation: 64 TokenMiserService tests passed; `pnpm lint:eslint`, `pnpm lint:boundaries`, and `git diff --check` passed.
