### PR TITLE
fix(desktop): retain live Token Miser data during turns

### DIFF
--- a/apps/desktop/src/main/__tests__/navigation-detail-service.test.ts
+++ b/apps/desktop/src/main/__tests__/navigation-detail-service.test.ts
@@ -5,7 +5,7 @@ import type {
   NavigationThreadSummary,
   ThreadQueuedTurnSummary,
 } from "@pwragent/shared";
-import type { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { DesktopBackendRegistry } from "../app-server/backend-registry";
 
 const mocks = vi.hoisted(() => ({
   reconcileNavigationSnapshot: vi.fn(),
@@ -158,6 +158,7 @@ describe("NavigationDetailService", () => {
       getQueuedTurnsSnapshot: vi.fn(() => { throw new Error("FIFO must remain independent"); }),
       hydrateThreadGitWorkingStates: vi.fn(async (threads) => threads),
       canonicalizeNavigationThreadPullRequests: vi.fn(async (threads) => threads),
+      mergeLiveTokenMiserSubAgents: (_id: string, persisted: unknown[]) => persisted ?? [],
     } as unknown as DesktopBackendRegistry;
     const service = new NavigationDetailService(registry);
     const first = await service.readSelectedDetail({
@@ -207,6 +208,48 @@ describe("NavigationDetailService", () => {
     expect(workspace.workspaceDirectories).toEqual([{ key: "selected-repo", label: "Selected", path: "/repo/selected",
       gitStatus: { currentBranch: "feature", handoffBranches: ["main"] } }]);
     expect(registry.readSelectedWorkspaceGitStatus).toHaveBeenCalledExactlyOnceWith("/repo/selected");
+  });
+
+  it("keeps live Token Miser parent links through selected-detail refresh and paging", async () => {
+    const selected = thread("selected");
+    const persisted = Array.from({ length: 101 }, (_, index) => ({
+      monitorId: `historical-${index}`, task: "Historical helper", status: "success" as const,
+      createdAt: index, updatedAt: index,
+    }));
+    selected.subAgents = persisted;
+    const live = {
+      monitorId: "system:token-miser:live", task: "Evaluate output", status: "success" as const,
+      createdAt: 200, updatedAt: 200, parentTurnId: "running-turn",
+    };
+    const liveAgents = new Map([[live.monitorId, live]]);
+    mocks.getThreadOverlayState.mockResolvedValue({ subAgents: persisted });
+    mocks.reconcileNavigationSnapshot.mockResolvedValue({ threads: [selected] });
+    const registry = {
+      getCachedThreadSummary: () => selected,
+      getQueuedExecutionModeForThread: () => undefined,
+      canonicalizeNavigationThreadPullRequests: async (threads: unknown[]) => threads,
+      hydrateThreadGitWorkingStates: async (threads: unknown[]) => threads,
+      liveTokenMiserSubAgents: new Map([[selected.id, liveAgents]]),
+      mergeLiveTokenMiserSubAgents: DesktopBackendRegistry.prototype["mergeLiveTokenMiserSubAgents"],
+    } as unknown as DesktopBackendRegistry;
+    const service = new NavigationDetailService(registry);
+    const request = { protocol: 2 as const, ref: { backend: "codex" as const, threadId: selected.id } };
+    const first = await service.readSelectedDetail(request);
+    expect(first.collections).toContainEqual(expect.objectContaining({ name: "subAgents", count: 102 }));
+    const page = await service.readSelectedDetail({ ...request, collection: { name: "subAgents" } });
+    expect(page.collectionPage?.revision).toBe(first.collections?.find((entry) => entry.name === "subAgents")?.revision);
+    expect(page.collectionPage?.values.subAgents).toContainEqual(live);
+    const next = await service.readSelectedDetail({ ...request, collection: { name: "subAgents", cursor: page.collectionPage?.nextCursor } });
+    expect(next.collectionPage?.complete).toBe(true);
+    expect(next.collectionPage?.values.subAgents).toHaveLength(2);
+
+    liveAgents.set(live.monitorId, { ...live, updatedAt: 201 });
+    const refreshed = await service.readSelectedDetail({ ...request, knownRevision: first.revision });
+    expect(refreshed.unchanged).toBe(true);
+    expect(refreshed.collections?.find((entry) => entry.name === "subAgents")?.revision)
+      .not.toBe(page.collectionPage?.revision);
+    await expect(service.readSelectedDetail({ ...request, collection: { name: "subAgents", cursor: page.collectionPage?.nextCursor } }))
+      .rejects.toMatchObject({ code: "navigation_cursor_expired" });
   });
 
   it("pages a complete FIFO projection with its own revision", () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -14152,7 +14152,7 @@ export class DesktopBackendRegistry {
     return changed ? { ...snapshot, threads, unchanged: false } : snapshot;
   }
 
-  private mergeLiveTokenMiserSubAgents(
+  mergeLiveTokenMiserSubAgents(
     threadId: string,
     persisted: readonly ThreadSubAgentSummary[] | undefined,
   ): ThreadSubAgentSummary[] {

--- a/apps/desktop/src/main/app-server/navigation-detail-service.ts
+++ b/apps/desktop/src/main/app-server/navigation-detail-service.ts
@@ -164,7 +164,9 @@ export class NavigationDetailService {
       const name = request.collection.name;
       if (!NAVIGATION_DETAIL_COLLECTION_NAMES.includes(name)) throw new NavigationQueryError("navigation_invalid_request", "Unknown selected-detail collection.");
       const overlay = await getDesktopOverlayStore().getThreadOverlayState({ backend: summary.source, threadId: summary.id });
-      const values = name === "codexNativeSubAgents" ? summary.codexNativeSubAgents ?? []
+      const values = name === "subAgents" && summary.source === "codex"
+        ? this.registry.mergeLiveTokenMiserSubAgents(summary.id, overlay?.subAgents)
+        : name === "codexNativeSubAgents" ? summary.codexNativeSubAgents ?? []
         : overlay?.[name] ?? (name === "worktreeSnapshots" ? summary.worktreeSnapshots : undefined) ?? [];
       const manifest = { name, revision: revision({ ref: request.ref, name, values }) };
       const cursor = request.collection.cursor ? decodeQueueCursor(request.collection.cursor) : undefined;
@@ -208,6 +210,13 @@ export class NavigationDetailService {
     const projected = snapshot.threads.find(
       (thread) => buildThreadIdentityKey(thread.source, thread.id) === threadKey,
     );
+    // Live gate events and selected-detail refreshes must expose the same
+    // helpers, including their parent-turn links, before persistence at turn end.
+    if (projected?.source === "codex") {
+      projected.subAgents = this.registry.mergeLiveTokenMiserSubAgents(
+        projected.id, projected.subAgents,
+      );
+    }
     const canonical = projected
       ? await this.registry.canonicalizeNavigationThreadPullRequests([projected]) : [];
     const hydrated = (await this.registry.hydrateThreadGitWorkingStates(canonical, {


### PR DESCRIPTION
During an active Codex turn, Token Miser events publish in-memory helper records with parent-turn links. Selected-detail refreshes loaded only persisted sub-agents, removing those links and making the running turn's Token Miser section disappear until another live event arrived.

Merge the registry's live helpers into both the selected-detail collection manifest and paginated sub-agent reads. Both paths now use the same records and revisions, retaining pagination limits and invalidating cursors when live records change. This adds no persistence or SQLite writes.

Validation: the new regression test failed before the fix and passes afterward. It covers retained parent-turn links, manifest/page revision agreement, pagination, and cursor invalidation after a live update. All 29 focused navigation-detail and Token Miser ledger tests pass, as do typecheck, ESLint (existing warnings only), SQL/storage/color lint, license checks, and dependency boundaries. The reported running instance was not modified; the exact visual timing was not reproduced live.
