### PR TITLE
perf(desktop): coalesce navigation invalidation renders

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/navigation-window-queries.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/navigation-window-queries.test.ts
@@ -253,3 +253,63 @@ it("explicit restart drops tail acknowledgments even when requested during a ref
   expect(queries.getSnapshot().resources.get("pins")?.state.page?.rangeStart).toBe(0);
   queries.dispose();
 });
+
+
+it("publishes one invalidation per read generation across a hundred-event burst", async () => {
+  const gates: ReturnType<typeof deferred<NavigationQueryPage>>[] = [];
+  const read = vi.fn(() => { const gate = deferred<NavigationQueryPage>(); gates.push(gate); return gate.promise; });
+  const queries = new NavigationWindowQueries({ getNavigationQueryPage: read });
+  const notify = vi.fn();
+  queries.subscribe(notify);
+  try {
+    queries.setDemand(new Map([["lens", request()]]));
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(1));
+    notify.mockClear();
+    queries.invalidate();
+    const invalidated = queries.getSnapshot();
+    for (let index = 0; index < 99; index += 1) queries.invalidate();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(queries.getSnapshot()).toBe(invalidated);
+    gates[0]!.resolve(page({ countsRevision: "late-first" }));
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2));
+    // A new event must fence the replacement even though its baseline is stale.
+    notify.mockClear();
+    for (let index = 0; index < 100; index += 1) queries.invalidate();
+    expect(notify).toHaveBeenCalledTimes(1);
+    gates[1]!.resolve(page({ countsRevision: "late-second" }));
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(3));
+    expect(queries.getSnapshot().resources.get("lens")?.state.page).toBeUndefined();
+    gates[2]!.resolve(page({ countsRevision: "fresh" }));
+    await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.loading).toBe(false));
+    expect(queries.getSnapshot().resources.get("lens")?.state.page?.countsRevision).toBe("fresh");
+    notify.mockClear();
+    for (let index = 0; index < 100; index += 1) queries.invalidate();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(read).toHaveBeenCalledTimes(3);
+  } finally {
+    queries.dispose();
+    for (const gate of gates) gate.resolve(page());
+  }
+});
+
+it("does not publish or refetch for identical demand or absent-resource invalidations", async () => {
+  const read = vi.fn(async () => page());
+  const queries = new NavigationWindowQueries({ getNavigationQueryPage: read });
+  try {
+    queries.setDemand(new Map([["lens", request()]]));
+    await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.loading).toBe(false));
+    const snapshot = queries.getSnapshot();
+    const notify = vi.fn();
+    queries.subscribe(notify);
+    for (let index = 0; index < 100; index += 1) {
+      queries.setDemand(new Map([["lens", request()]]));
+      queries.invalidate("removed-directory");
+    }
+    expect(queries.getSnapshot()).toBe(snapshot);
+    expect(notify).not.toHaveBeenCalled();
+    expect(read).toHaveBeenCalledTimes(1);
+    queries.setDemand(new Map());
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(queries.getSnapshot().resources.size).toBe(0);
+  } finally { queries.dispose(); }
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
@@ -221,3 +221,33 @@ it.each([false, true])("preserves thirty loaded pins when selecting a new last p
   expect(result.current.resources.get(id)?.state.page?.entries).toHaveLength(31);
   unmount();
 });
+
+
+it("bounds React renders for separately delivered navigation events before the refresh timer", async () => {
+  const fixture = api();
+  const render = vi.fn();
+  const { result, unmount } = renderHook(() => {
+    render();
+    return useBoundedNavigationWindow({ ...base, desktopApi: fixture.desktopApi });
+  });
+  try {
+    await waitFor(() => expect(result.current.resources.get("directory-index")?.loading).toBe(false));
+    vi.useFakeTimers();
+    render.mockClear();
+    fixture.read.mockClear();
+    for (let index = 0; index < 100; index += 1) {
+      // Separate act boundaries model separately delivered IPC events, not
+      // one React batch that would conceal redundant snapshot notifications.
+      fixture.emit({ backend: "codex", notification: { method: "thread/status/changed",
+        params: { threadId: `thread-${index}`, status: { type: "active" } } } });
+    }
+    expect(render).toHaveBeenCalledTimes(1);
+    expect(fixture.read).not.toHaveBeenCalled();
+    await act(async () => { await vi.advanceTimersByTimeAsync(250); });
+    expect(fixture.read).toHaveBeenCalledTimes(1);
+    expect(result.current.resources.get("directory-index")?.state.stale).toBe(false);
+  } finally {
+    unmount();
+    vi.useRealTimers();
+  }
+});

--- a/apps/desktop/src/renderer/src/lib/navigation-window-queries.ts
+++ b/apps/desktop/src/renderer/src/lib/navigation-window-queries.ts
@@ -26,6 +26,7 @@ type Resource = {
   value: NavigationWindowResource;
   pending?: Promise<void>;
   refreshAfterPending: boolean;
+  invalidated: boolean;
   released: boolean;
   anchor?: NavigationQueryAnchor;
 };
@@ -72,6 +73,7 @@ export class NavigationWindowQueries {
       if (demandBytes > MAX_DEMAND_BYTES) break;
       admitted.set(id, request);
     }
+    let changed = false;
     const admissionError = admitted.size !== demand.size
       ? "Navigation request metadata exceeds its memory budget." : undefined;
     for (const [id, resource] of this.resources) {
@@ -79,6 +81,7 @@ export class NavigationWindowQueries {
       if (!request || JSON.stringify(request) !== resource.requestKey) {
         this.release(resource);
         this.resources.delete(id);
+        changed = true;
       }
     }
     const added: Resource[] = [];
@@ -87,13 +90,16 @@ export class NavigationWindowQueries {
       const resource: Resource = {
         requestKey: JSON.stringify(request), token: `${this.prefix}:${++this.nextResource}`,
         value: { id, state: createNavigationPageState(request), loading: false },
-        refreshAfterPending: false, released: !this.visible, anchor: request.anchor,
+        refreshAfterPending: false, invalidated: false, released: !this.visible, anchor: request.anchor,
       };
       this.resources.set(id, resource);
       added.push(resource);
+      changed = true;
     }
-    this.snapshot = { ...this.snapshot, admissionError };
-    this.publish();
+    if (changed || admissionError !== this.snapshot.admissionError) {
+      this.snapshot = { ...this.snapshot, admissionError };
+      this.publish();
+    }
     if (this.visible) for (const resource of added) void this.read(resource, false);
   }
 
@@ -107,7 +113,7 @@ export class NavigationWindowQueries {
       } else {
         // Replace the lifetime rather than revive a released token or pending read.
         const next: Resource = { ...resource, token: `${this.prefix}:${++this.nextResource}`,
-          released: false, pending: undefined, refreshAfterPending: false };
+          released: false, pending: undefined, refreshAfterPending: false, invalidated: false };
         this.resources.set(resource.value.id, next);
         void this.read(next, false);
       }
@@ -129,8 +135,14 @@ export class NavigationWindowQueries {
 
   /** Invalidate transport baselines before canonical owner events can race a late page. */
   invalidate(id?: string): void {
+    let changed = false;
     for (const resource of this.resources.values()) {
       if (id && resource.value.id !== id) continue;
+      // Fence each physical read once. Further events before its replacement
+      // carry no new presentation state and must not rerender every row.
+      if (resource.invalidated) continue;
+      resource.invalidated = true;
+      changed = true;
       // Some canonical events patch settled rows without scheduling a read.
       // If they fence a pending page, replace that discarded read so initial
       // readiness and refreshed counts cannot remain stranded indefinitely.
@@ -138,7 +150,7 @@ export class NavigationWindowQueries {
       resource.value = { ...resource.value, state: { ...resource.value.state,
         pendingSequence: resource.value.state.pendingSequence + 1, stale: true } };
     }
-    this.publish();
+    if (changed) this.publish();
   }
 
   setVisibleAnchor(id: string, anchor: NavigationQueryAnchor | undefined): void {
@@ -203,6 +215,7 @@ export class NavigationWindowQueries {
     const cursor = continuation ? resource.value.state.page?.nextCursor : undefined;
     if (continuation && !cursor) return Promise.resolve();
     const started = beginNavigationPageRead(resource.value.state);
+    resource.invalidated = false;
     resource.value = { ...resource.value, state: started, loading: true };
     this.publish();
     const promise = Promise.resolve().then(async () => {


### PR DESCRIPTION
Navigation refresh requests were debounced, but every canonical event still published a new navigation snapshot and rerendered its React consumers. A burst of 100 separately delivered events caused 100 hook renders before the single refresh. Reapplying identical demand also published snapshots with no changed resources.

Fence each resource once per read generation and publish only its first invalidation. A new read resets that fence, so subsequent events still reject late pages and request a replacement. Identical demand and invalidations targeting absent resources preserve snapshot identity; real demand and admission-error changes remain observable.

Regression tests fail against the original code and pass with this change:
- 100 separately delivered events: 100 React hook renders before, 1 after, with one debounced query refresh.
- Repeated invalidations during both initial and replacement reads: one notification per generation, stale responses rejected, fresh response accepted.
- 100 identical demand updates and absent-resource invalidations: no notifications or extra reads.

Validation: all 205 tests across six navigation suites, pnpm lint:eslint, desktop TypeScript checking, and git diff --check pass. No visible layout change. This establishes and removes one renderer amplification path; it does not claim to explain every sample in the operator’s CPU capture.
