### PR TITLE
perf(desktop): index pending spend alert recovery

### DIFF
--- a/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
+++ b/apps/desktop/e2e/context-rail-linked-directory-tooltips.spec.ts
@@ -83,7 +83,12 @@ async function expectVisibleTooltip(page: Page, text: string) {
   await expect(tooltip).toHaveText(text);
   await expect
     .poll(async () =>
-      await tooltip.evaluate((element) => {
+      // Resolve and measure in the same browser task. Locator.evaluate first
+      // resolves a handle; a portal replacement between those calls can leave
+      // the geometry check reading a detached element.
+      await tooltip.evaluateAll((elements) => {
+        const element = elements[0];
+        if (!element || elements.length !== 1) return null;
         const rect = element.getBoundingClientRect();
         return {
           inBody: element.parentElement === document.body,

--- a/apps/desktop/src/main/__tests__/pending-spend-alert-page.test.ts
+++ b/apps/desktop/src/main/__tests__/pending-spend-alert-page.test.ts
@@ -62,6 +62,7 @@ it("uses the pending-only index for the actual alert query amid unrelated histor
   const store = new SqliteOverlayStore(db);
   try {
     const insert = db.raw.prepare("INSERT INTO threads(thread_id, payload) VALUES (?, ?)");
+    insert.run("malformed", "not-json");
     db.raw.transaction(() => {
       for (let index = 0; index < 2000; index += 1) {
         insert.run(`history-${index}`, JSON.stringify({ backend: "codex", history: "x".repeat(4096) }));
@@ -93,12 +94,13 @@ it("indexes existing pending alerts when reopening a current-version profile", a
       currency: "USD", spendMicros: 2, thresholdMicros: 1,
     } });
     db.raw.exec("DROP INDEX idx_threads_pending_spend_alert");
+    db.raw.prepare("INSERT INTO threads(thread_id, payload) VALUES (?, ?)").run("malformed-legacy", "not-json");
     const version = db.raw.pragma("user_version", { simple: true });
     db.close();
     db = StateDb.open(dbPath);
     expect(db.raw.pragma("user_version", { simple: true })).toBe(version);
     const indexed = db.raw.prepare(`SELECT thread_id FROM threads INDEXED BY idx_threads_pending_spend_alert
-      WHERE json_type(payload, '$.threadSpendAlertPending') = 'object'`).all();
+      WHERE CASE WHEN json_valid(payload) THEN json_type(payload, '$.threadSpendAlertPending') END = 'object'`).all();
     expect(indexed).toEqual([{ thread_id: "codex:existing" }]);
     expect((await new SqliteOverlayStore(db).listPendingThreadSpendAlerts({})).alerts[0]?.alert.alertId).toBe("existing-alert");
     db.close();

--- a/apps/desktop/src/main/__tests__/pending-spend-alert-page.test.ts
+++ b/apps/desktop/src/main/__tests__/pending-spend-alert-page.test.ts
@@ -2,7 +2,8 @@ import { afterEach, expect, it, vi } from "vitest";
 import { SqliteOverlayStore } from "../state/overlay-store-sqlite";
 import { measureSqliteWrites, SQLITE_WRITE_METRICS_ENV } from "../state/sqlite-write-metrics";
 import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
-import { openInMemoryStateDb } from "./sqlite-test-utils";
+import { openInMemoryStateDb, createTempStateDb, removeTempStateDbDir } from "./sqlite-test-utils";
+import { StateDb } from "../state/state-db";
 
 afterEach(() => vi.unstubAllEnvs());
 
@@ -53,4 +54,55 @@ it("rejects an oversized stored alert before transferring its payload out of SQL
     } });
     await expect(store.listPendingThreadSpendAlerts({})).rejects.toThrow("bounded payload budget");
   } finally { db.close(); }
+});
+
+
+it("uses the pending-only index for the actual alert query amid unrelated history", async () => {
+  const db = openInMemoryStateDb();
+  const store = new SqliteOverlayStore(db);
+  try {
+    const insert = db.raw.prepare("INSERT INTO threads(thread_id, payload) VALUES (?, ?)");
+    db.raw.transaction(() => {
+      for (let index = 0; index < 2000; index += 1) {
+        insert.run(`history-${index}`, JSON.stringify({ backend: "codex", history: "x".repeat(4096) }));
+      }
+    })();
+    await store.setThreadSpendAlertPending({ backend: "codex", threadId: "pending", alert: {
+      alertId: "pending-alert", kind: "thread-spend", threadId: "pending", createdAt: 1,
+      currency: "USD", spendMicros: 2, thresholdMicros: 1,
+    } });
+    const prepare = vi.spyOn(db.raw, "prepare");
+    expect((await store.listPendingThreadSpendAlerts({})).alerts).toHaveLength(1);
+    const sql = prepare.mock.calls.find(([query]) => query.includes("FROM threads WHERE"))![0];
+    prepare.mockRestore();
+    const plan = db.raw.prepare(`EXPLAIN QUERY PLAN ${sql}`).all(11) as Array<{ detail: string }>;
+    expect(plan.map((row) => row.detail).join("\n")).toContain("idx_threads_pending_spend_alert");
+    expect(plan.some((row) => row.detail.includes("TEMP B-TREE"))).toBe(false);
+    await store.acknowledgeThreadSpendAlert({ backend: "codex", threadId: "pending", alertId: "pending-alert" });
+    expect(await store.listPendingThreadSpendAlerts({})).toEqual({ alerts: [], hasMore: false });
+  } finally { db.close(); }
+});
+
+
+it("indexes existing pending alerts when reopening a current-version profile", async () => {
+  const { dbPath, tempDir } = createTempStateDb("pending-alert-index-");
+  let db = StateDb.open(dbPath);
+  try {
+    await new SqliteOverlayStore(db).setThreadSpendAlertPending({ backend: "codex", threadId: "existing", alert: {
+      alertId: "existing-alert", kind: "thread-spend", threadId: "existing", createdAt: 1,
+      currency: "USD", spendMicros: 2, thresholdMicros: 1,
+    } });
+    db.raw.exec("DROP INDEX idx_threads_pending_spend_alert");
+    const version = db.raw.pragma("user_version", { simple: true });
+    db.close();
+    db = StateDb.open(dbPath);
+    expect(db.raw.pragma("user_version", { simple: true })).toBe(version);
+    const indexed = db.raw.prepare(`SELECT thread_id FROM threads INDEXED BY idx_threads_pending_spend_alert
+      WHERE json_type(payload, '$.threadSpendAlertPending') = 'object'`).all();
+    expect(indexed).toEqual([{ thread_id: "codex:existing" }]);
+    expect((await new SqliteOverlayStore(db).listPendingThreadSpendAlerts({})).alerts[0]?.alert.alertId).toBe("existing-alert");
+    db.close();
+    db = StateDb.open(dbPath);
+    expect((await new SqliteOverlayStore(db).listPendingThreadSpendAlerts({})).alerts).toHaveLength(1);
+  } finally { db.close(); removeTempStateDbDir(tempDir); }
 });

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -3150,7 +3150,7 @@ export class SqliteOverlayStore implements RemoteThreadTargetStore {
       COALESCE(json_extract(payload, '$.backend'), 'codex') AS backend,
       CASE WHEN length(CAST(json_extract(payload, '$.threadSpendAlertPending') AS BLOB)) <= 16384
         THEN json_extract(payload, '$.threadSpendAlertPending') END AS alert
-      FROM threads WHERE json_type(payload, '$.threadSpendAlertPending') = 'object'
+      FROM threads WHERE CASE WHEN json_valid(payload) THEN json_type(payload, '$.threadSpendAlertPending') END = 'object'
       ORDER BY thread_id LIMIT ?`).all(limit + 1) as Array<{ backend: AppServerBackendKind; alert: string | null }>;
     const alerts = rows.slice(0, limit).map((row) => {
       if (row.alert === null) throw new Error("Pending spend alert exceeds its bounded payload budget.");

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1792,7 +1792,7 @@ export class StateDb {
       if (tableExists(db, "threads")) {
         db.exec(`CREATE INDEX IF NOT EXISTS idx_threads_pending_spend_alert
           ON threads(thread_id)
-          WHERE json_type(payload, '$.threadSpendAlertPending') = 'object'`);
+          WHERE CASE WHEN json_valid(payload) THEN json_type(payload, '$.threadSpendAlertPending') END = 'object'`);
       }
 
     };

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1787,6 +1787,14 @@ export class StateDb {
       // Keep current-version databases converged without asking pre-v36 profiles
       // to install the unique index before the migration above removes duplicates.
       db.exec(PR_AUTO_DISPATCH_GLOBAL_FINGERPRINT_INDEX);
+      // Additive index for current-version profiles too. Partial-schema repair
+      // fixtures may omit threads; normal profiles always have this table.
+      if (tableExists(db, "threads")) {
+        db.exec(`CREATE INDEX IF NOT EXISTS idx_threads_pending_spend_alert
+          ON threads(thread_id)
+          WHERE json_type(payload, '$.threadSpendAlertPending') = 'object'`);
+      }
+
     };
 
     // A brand-new file has no previous version to fall back to, so the


### PR DESCRIPTION
Pending spend-alert recovery scanned thread JSON payloads even when returning no alerts or a ten-alert page. The main CPU capture attributed about 100 ms to this query. Add a partial index ordered by thread ID containing only rows with pending spend alerts, so the existing query visits pending entries and can stop after limit + 1 matches.

Index creation is additive and idempotent on database open, including current-version profiles; existing pending alerts are indexed automatically. SQLite updates membership in the same transaction as alert creation and acknowledgement. Initial installation must scan existing threads once.

Validation: the query-plan regression fails before the change and verifies the actual store query uses the pending-only index amid 2,000 unrelated history rows afterward, with no temporary sort. Tests also cover existing-profile installation, repeated open, delivery pagination, acknowledgement and oversized payload rejection. All 88 tests across pending alerts, StateDb and SQLite write metrics pass, as do ESLint, SQL lint, desktop typechecking and diff checks.

Write budget: recovery remains zero commits (0 MB/day added polling WAL); alert creation and acknowledgement remain two commits total, enforced by the existing checked-in budget. The index adds dirty pages to those existing commits. As a rough small-index estimate, one additional 4 KB page per boundary at 100 alerts/day adds about 0.8 MB/day; actual WAL depends on page layout and other updates to pending rows. No timer or new write operation is introduced.
