### PR TITLE
fix(desktop): keep tooltips through their anchor's mount animation

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -19,6 +19,9 @@ afterEach(() => {
   vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
+  // jsdom has no Web Animations API; only a test that stubbed one leaves this
+  // behind, and it must not reach the next one.
+  delete (document as Partial<Document>).getAnimations;
 });
 
 function TooltipFixture() {
@@ -151,6 +154,53 @@ function rectangle(rect: Partial<DOMRect>): DOMRect {
   };
 }
 
+/** Anchor rectangles driven by the fixture's `data-anchor-top`. */
+function mockAnchorRectangleFromLayout(): void {
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function getBoundingClientRect(this: HTMLElement) {
+      if (this.getAttribute("role") === "tooltip") {
+        return rectangle({ width: 240, height: 40 });
+      }
+      if (this.tagName === "BUTTON") {
+        const top = Number(
+          this.closest("[data-anchor-top]")?.getAttribute("data-anchor-top"),
+        );
+        return rectangle({ left: 20, top, width: 160, height: 26 });
+      }
+      return rectangle({});
+    },
+  );
+  vi.stubGlobal("innerWidth", 1200);
+  vi.stubGlobal("innerHeight", 800);
+}
+
+/**
+ * A running animation on the anchor's ancestor, the shape
+ * `document.getAnimations` returns for a CSS animation. jsdom implements no
+ * Web Animations API, so the hook sees nothing there unless a test says so.
+ */
+function stubAncestorAnimation(): { finish: () => void } {
+  let settle = (): void => undefined;
+  const finished = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  let playState = "running";
+  document.getAnimations = () =>
+    [
+      {
+        effect: { target: document.querySelector("[data-anchor-top]") },
+        finished,
+        playState,
+      },
+    ].filter(() => playState === "running") as unknown as Animation[];
+  return {
+    finish: () => {
+      playState = "finished";
+      settle();
+    },
+  };
+}
+
 describe("useViewportTooltip", () => {
   it("keeps a tooltip open when an unrelated pane scrolls", () => {
     render(<TooltipFixture />);
@@ -263,26 +313,73 @@ describe("useViewportTooltip", () => {
   });
 
   it("closes a tooltip when its connected anchor moves", async () => {
-    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
-      function getBoundingClientRect(this: HTMLElement) {
-        if (this.getAttribute("role") === "tooltip") {
-          return rectangle({ width: 240, height: 40 });
-        }
-        if (this.tagName === "BUTTON") {
-          const top = Number(
-            this.closest("[data-anchor-top]")?.getAttribute("data-anchor-top"),
-          );
-          return rectangle({ left: 20, top, width: 160, height: 26 });
-        }
-        return rectangle({});
-      },
-    );
-    vi.stubGlobal("innerWidth", 1200);
-    vi.stubGlobal("innerHeight", 800);
+    mockAnchorRectangleFromLayout();
     const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
 
     fireEvent.mouseEnter(screen.getByRole("button"));
     rerender(<AnchorLifecycleFixture anchorTop={180} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps a tooltip open while an animation moves its anchor", async () => {
+    // The context rail's panel plays a 220ms `translateX(12px) -> 0` on mount,
+    // so a tooltip opened during it measured coordinates the anchor was about
+    // to leave. Every later mutation read that as a move and tore the portal
+    // down mid-assertion — the `context-rail-linked-directory-tooltips` flake.
+    mockAnchorRectangleFromLayout();
+    stubAncestorAnimation();
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+  });
+
+  it("re-anchors a tooltip when the animation that moved it finishes", async () => {
+    mockAnchorRectangleFromLayout();
+    const animation = stubAncestorAnimation();
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    // Placed against the anchor's position at the moment it opened.
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "30px" });
+    });
+
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+    await act(async () => {
+      animation.finish();
+      await Promise.resolve();
+    });
+
+    // Settled geometry, not the position it was opened at.
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "130px" });
+    });
+  });
+
+  it("closes a tooltip that moves once its animation has finished", async () => {
+    // Re-baselining must not leave an anchor permanently undismissable: after
+    // the motion stops, an ordinary relocation closes the tooltip as before.
+    mockAnchorRectangleFromLayout();
+    const animation = stubAncestorAnimation();
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    await act(async () => {
+      animation.finish();
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+
+    rerender(<AnchorLifecycleFixture anchorTop={280} />);
 
     await waitFor(() => {
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();

--- a/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useViewportTooltip.test.tsx
@@ -21,7 +21,8 @@ afterEach(() => {
   vi.unstubAllGlobals();
   // jsdom has no Web Animations API; only a test that stubbed one leaves this
   // behind, and it must not reach the next one.
-  delete (document as Partial<Document>).getAnimations;
+  Reflect.deleteProperty(HTMLElement.prototype, "getAnimations");
+  stubbedAnimations.length = 0;
 });
 
 function TooltipFixture() {
@@ -136,6 +137,39 @@ function AnchorLifecycleFixture(props: {
   );
 }
 
+/** Anchor fixed in place, bounding surface moved by `boundsLeft`. */
+function BoundedAnchorFixture(props: { boundsLeft: number }) {
+  const tooltip = useViewportTooltip({
+    className: "viewport-tooltip",
+    getHorizontalBounds: (target) => {
+      const bounds = target.closest<HTMLElement>("[data-tooltip-bounds]");
+      if (!bounds) {
+        return undefined;
+      }
+      const { left, right } = bounds.getBoundingClientRect();
+      return { left, right };
+    },
+  });
+
+  return (
+    <div
+      data-anchor-top={80}
+      data-bounds-left={props.boundsLeft}
+      data-tooltip-bounds
+    >
+      <button
+        type="button"
+        onMouseEnter={(event) =>
+          tooltip.show(event.currentTarget, "Branch details")
+        }
+      >
+        agent/bounded-tooltip
+      </button>
+      {tooltip.tooltipNode}
+    </div>
+  );
+}
+
 function rectangle(rect: Partial<DOMRect>): DOMRect {
   const x = rect.x ?? rect.left ?? 0;
   const y = rect.y ?? rect.top ?? 0;
@@ -174,28 +208,61 @@ function mockAnchorRectangleFromLayout(): void {
   vi.stubGlobal("innerHeight", 800);
 }
 
+type StubbedAnimation = {
+  /** Stop reporting as running, without resolving `finished` yet. */
+  stop: () => void;
+  /** Resolve `finished`, releasing the settle callback. */
+  settle: () => void;
+  /** Both, in the order a real animation ends. */
+  finish: () => void;
+};
+
 /**
- * A running animation on the anchor's ancestor, the shape
- * `document.getAnimations` returns for a CSS animation. jsdom implements no
- * Web Animations API, so the hook sees nothing there unless a test says so.
+ * A running animation on the anchor's ancestor, in the shape
+ * `Element.getAnimations` returns for a CSS animation. jsdom implements no Web
+ * Animations API, so the hook sees nothing unless a test says so.
+ *
+ * `keyframes` decides whether the hook should treat it as motion at all, and
+ * `pseudoElement` whether it can move the anchor's box.
  */
-function stubAncestorAnimation(): { finish: () => void } {
+const stubbedAnimations: unknown[] = [];
+
+function stubAncestorAnimation(options?: {
+  activeDuration?: number;
+  keyframes?: Record<string, unknown>[];
+  pseudoElement?: string | null;
+}): StubbedAnimation {
   let settle = (): void => undefined;
   const finished = new Promise<void>((resolve) => {
     settle = resolve;
   });
   let playState = "running";
-  document.getAnimations = () =>
-    [
-      {
-        effect: { target: document.querySelector("[data-anchor-top]") },
-        finished,
-        playState,
-      },
-    ].filter(() => playState === "running") as unknown as Animation[];
+  stubbedAnimations.push({
+    effect: {
+      getComputedTiming: () => ({ activeDuration: options?.activeDuration ?? 220 }),
+      getKeyframes: () =>
+        options?.keyframes ?? [{ offset: 0, transform: "translateX(12px)" }],
+      pseudoElement: options?.pseudoElement ?? null,
+    },
+    finished,
+    get playState() {
+      return playState;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, "getAnimations", {
+    configurable: true,
+    value: function getAnimations(this: HTMLElement) {
+      return this.hasAttribute("data-anchor-top") ? [...stubbedAnimations] : [];
+    },
+  });
+  const stop = (): void => {
+    playState = "finished";
+  };
   return {
+    stop,
+    settle,
     finish: () => {
-      playState = "finished";
+      stop();
       settle();
     },
   };
@@ -383,6 +450,153 @@ describe("useViewportTooltip", () => {
 
     await waitFor(() => {
       expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes a tooltip when only paint properties are animating", async () => {
+    // `.pr-chip` transitions `background`/`border-color` on hover and is itself
+    // a tooltip anchor, so a repaint must not suspend the dismissal rule.
+    mockAnchorRectangleFromLayout();
+    stubAncestorAnimation({
+      keyframes: [{ backgroundColor: "red", offset: 0, opacity: 0 }],
+    });
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes a tooltip when the animation is on a pseudo-element", async () => {
+    // app.css transitions eleven `::before`/`::after` rules. A pseudo-element
+    // lays out nothing beneath its host, so none of them move an anchor.
+    mockAnchorRectangleFromLayout();
+    stubAncestorAnimation({ pseudoElement: "::after" });
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("closes a tooltip when the anchor is endlessly animating", async () => {
+    // Six `infinite` animations run in app.css. One never resolves `finished`,
+    // so treating it as motion would disable dismissal for the tooltip's life.
+    mockAnchorRectangleFromLayout();
+    stubAncestorAnimation({ activeDuration: Number.POSITIVE_INFINITY });
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps a tooltip open between the animation ending and the re-anchor", async () => {
+    // The gap `anchorSettlingRef` exists for: `playState` flips to finished
+    // while a mutation callback is still queued, so the live animation check
+    // reports nothing and the baseline is still the in-flight rectangle.
+    mockAnchorRectangleFromLayout();
+    const animation = stubAncestorAnimation();
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    animation.stop();
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Branch details");
+
+    await act(async () => {
+      animation.settle();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "130px" });
+    });
+  });
+
+  it("re-measures horizontal bounds when the animation finishes", async () => {
+    // The bounds come from `getHorizontalBounds` at the same instant as the
+    // anchor rectangle, so they are measured off the same moving layout and go
+    // stale for exactly as long. `Composer.tsx` is the caller that supplies
+    // them, and they drive both the clamp and the tooltip's max width.
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function getBoundingClientRect(this: HTMLElement) {
+        if (this.getAttribute("role") === "tooltip") {
+          return rectangle({ width: 100, height: 40 });
+        }
+        if (this.hasAttribute("data-tooltip-bounds")) {
+          const left = Number(this.getAttribute("data-bounds-left"));
+          return rectangle({ left, top: 40, width: 300, height: 400 });
+        }
+        if (this.tagName === "BUTTON") {
+          return rectangle({ left: 408, top: 80, width: 28, height: 26 });
+        }
+        return rectangle({});
+      },
+    );
+    vi.stubGlobal("innerWidth", 1200);
+    vi.stubGlobal("innerHeight", 800);
+    const animation = stubAncestorAnimation();
+    const { rerender } = render(<BoundedAnchorFixture boundsLeft={408} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ left: "408px" });
+    });
+
+    rerender(<BoundedAnchorFixture boundsLeft={200} />);
+    await act(async () => {
+      animation.finish();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ left: "372px" });
+    });
+  });
+
+  it("waits for motion that starts before the first animation ends", async () => {
+    // The settle callback only ever waited on the animations that existed when
+    // the tooltip opened. Anything that starts before those finish leaves the
+    // anchor just as unsettled, so re-anchoring then picks another rectangle
+    // the anchor is about to leave.
+    mockAnchorRectangleFromLayout();
+    const first = stubAncestorAnimation();
+    const { rerender } = render(<AnchorLifecycleFixture anchorTop={80} />);
+
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "30px" });
+    });
+
+    const second = stubAncestorAnimation();
+    rerender(<AnchorLifecycleFixture anchorTop={180} />);
+    await act(async () => {
+      first.finish();
+      await Promise.resolve();
+    });
+
+    // Still moving: hold the position rather than anchor to a passing rect.
+    expect(screen.getByRole("tooltip")).toHaveStyle({ top: "30px" });
+
+    await act(async () => {
+      second.finish();
+      await Promise.resolve();
+    });
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveStyle({ top: "130px" });
     });
   });
 

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -113,7 +113,96 @@ type TooltipTargetRect = {
   top: number;
 };
 
+/** What a mutation revealed about the anchor a visible tooltip points at. */
+type AnchorState =
+  | { status: "gone" }
+  | { status: "unchanged" }
+  | { status: "relocated" }
+  | { status: "settling"; rect: TooltipTargetRect };
+
 type DelayedTooltipContent = ReactNode | (() => ReactNode);
+
+/**
+ * Keyframe keys that describe the keyframe rather than an animated property.
+ */
+const KEYFRAME_METADATA_KEYS = new Set([
+  "composite",
+  "computedOffset",
+  "easing",
+  "offset",
+]);
+
+/**
+ * Properties whose animation repaints a box without moving it. Anything absent
+ * from this list counts as motion — the safe direction, since a missed motion
+ * is the flake this guard exists to prevent, while a false one only delays a
+ * dismissal.
+ */
+const PAINT_ONLY_ANIMATED_PROPERTIES = new Set([
+  "backdropFilter",
+  "background",
+  "backgroundColor",
+  "backgroundImage",
+  "backgroundPosition",
+  "borderBottomColor",
+  "borderColor",
+  "borderLeftColor",
+  "borderRightColor",
+  "borderTopColor",
+  "boxShadow",
+  "color",
+  "fill",
+  "filter",
+  "opacity",
+  "outlineColor",
+  "stroke",
+  "textShadow",
+  "visibility",
+]);
+
+/**
+ * The parts of `KeyframeEffect` this needs, read structurally: `AnimationEffect`
+ * declares none of them, and a test double implements only these.
+ */
+type AnimatedEffect = {
+  // `CSSNumberish` in lib.dom, so it is read defensively below.
+  getComputedTiming?: () => { activeDuration?: unknown };
+  getKeyframes?: () => Record<string, unknown>[];
+  pseudoElement?: string | null;
+};
+
+function effectMovesAnchor(effect: AnimatedEffect): boolean {
+  // A pseudo-element is painted by its host and lays out nothing beneath it, so
+  // the `::before`/`::after` fades and slides all over app.css never move an
+  // anchor — and counting them would suspend the dismissal rule during an
+  // ordinary hover.
+  if (effect.pseudoElement) {
+    return false;
+  }
+  // An endlessly animating ancestor never settles, so there is no resting
+  // rectangle to re-baseline to and waiting on it would disable dismissal for
+  // the tooltip's whole life. Leave those to the ordinary movement rules.
+  const activeDuration = effect.getComputedTiming?.().activeDuration;
+  if (typeof activeDuration === "number" && !Number.isFinite(activeDuration)) {
+    return false;
+  }
+  if (typeof effect.getKeyframes !== "function") {
+    return true;
+  }
+  let animatedAProperty = false;
+  for (const keyframe of effect.getKeyframes()) {
+    for (const property of Object.keys(keyframe)) {
+      if (KEYFRAME_METADATA_KEYS.has(property)) {
+        continue;
+      }
+      animatedAProperty = true;
+      if (!PAINT_ONLY_ANIMATED_PROPERTIES.has(property)) {
+        return true;
+      }
+    }
+  }
+  return !animatedAProperty;
+}
 
 /**
  * The running animations and transitions that are moving `target` — its own,
@@ -124,21 +213,44 @@ type DelayedTooltipContent = ReactNode | (() => ReactNode);
  * apart: `getBoundingClientRect` reports the transformed position, so an
  * anchor halfway through a slide-in measures somewhere it is about to leave.
  *
+ * Walks the ancestors instead of filtering `document.getAnimations()`. This
+ * runs on every hover of every tooltip anchor in the app, and the document-wide
+ * list grows with every scanner, spinner and blinking dot on screen, none of
+ * which can contain the anchor.
+ *
  * jsdom implements no Web Animations API, so this reports nothing there and
  * the movement rules below behave exactly as they did before.
  */
 function animationsMovingAnchor(target: HTMLElement): Animation[] {
-  if (typeof document.getAnimations !== "function") {
-    return [];
-  }
-  return document.getAnimations().filter((animation) => {
-    if (animation.playState !== "running") {
-      return false;
+  const moving: Animation[] = [];
+  for (
+    let element: Element | null = target;
+    element;
+    element = element.parentElement
+  ) {
+    if (typeof element.getAnimations !== "function") {
+      break;
     }
-    const effect = animation.effect;
-    const animated = effect && "target" in effect ? effect.target : undefined;
-    return animated instanceof Element && animated.contains(target);
-  });
+    for (const animation of element.getAnimations()) {
+      if (animation.playState !== "running") {
+        continue;
+      }
+      const effect: AnimatedEffect | null = animation.effect;
+      if (effect && effectMovesAnchor(effect)) {
+        moving.push(animation);
+      }
+    }
+  }
+  return moving;
+}
+
+function toTargetRect(rect: DOMRect | TooltipTargetRect): TooltipTargetRect {
+  return {
+    bottom: rect.bottom,
+    left: rect.left,
+    right: rect.right,
+    top: rect.top,
+  };
 }
 
 /**
@@ -213,9 +325,18 @@ export function useViewportTooltip(options: {
   const hoverDelayTimerRef = useRef<number | null>(null);
   /** True while the anchor is animating and its settled baseline is pending. */
   const anchorSettlingRef = useRef(false);
+  // Read from the settle callback below, which re-measures the bounds after the
+  // motion stops. A ref rather than a dependency: consumers pass an inline
+  // arrow, and threading that identity through `rememberTarget` would rebuild
+  // `show` every render and defeat the memoized panels it is passed to.
+  const getHorizontalBoundsRef = useRef(getHorizontalBounds);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
   const [delayPending, setDelayPending] = useState(false);
+
+  useEffect(() => {
+    getHorizontalBoundsRef.current = getHorizontalBounds;
+  }, [getHorizontalBounds]);
 
   const clearHoverDelay = useCallback((): void => {
     if (hoverDelayTimerRef.current === null) {
@@ -234,49 +355,47 @@ export function useViewportTooltip(options: {
     setState(undefined);
   }, [clearHoverDelay]);
 
-  const rememberTarget = useCallback((target: HTMLElement): DOMRect | undefined => {
-    if (!target.isConnected) {
-      targetRef.current = null;
-      targetRectRef.current = null;
-      return undefined;
-    }
-    const rect = target.getBoundingClientRect();
-    targetRef.current = target;
-    targetRectRef.current = {
-      bottom: rect.bottom,
-      left: rect.left,
-      right: rect.right,
-      top: rect.top,
-    };
-    // A rectangle measured mid-animation is a position the anchor is leaving,
-    // and it would stay the baseline for the rest of the tooltip's life: the
-    // context rail's panel plays a 220ms `translateX(12px) -> 0` on mount, so
-    // a tooltip opened during it recorded coordinates the anchor never returns
-    // to, and the next mutation anywhere in the document read that as a move
-    // and tore the portal down. Re-baseline once the motion stops, and give
-    // the tooltip the settled geometry so it is not left the animation's
-    // remaining offset away from its anchor.
-    const animations = animationsMovingAnchor(target);
-    anchorSettlingRef.current = animations.length > 0;
-    if (animations.length > 0) {
+  /**
+   * Wait out the motion, then re-baseline the anchor and re-anchor the tooltip
+   * to where it actually came to rest.
+   *
+   * A rectangle measured mid-animation is a position the anchor is leaving, and
+   * it would stay the baseline for the rest of the tooltip's life: the context
+   * rail's panel plays a 220ms `translateX(12px) -> 0` on mount, so a tooltip
+   * opened during it recorded coordinates the anchor never returns to, and the
+   * next mutation anywhere in the document read that as a move and tore the
+   * portal down.
+   */
+  const scheduleAnchorSettle = useCallback(
+    function schedule(target: HTMLElement): void {
+      const animations = animationsMovingAnchor(target);
+      anchorSettlingRef.current = animations.length > 0;
+      if (!anchorSettlingRef.current) {
+        return;
+      }
       void Promise.allSettled(
         animations.map((animation) => animation.finished),
       ).then(() => {
         if (targetRef.current !== target || !target.isConnected) {
           return;
         }
+        // Motion that started while this was waiting leaves the anchor just as
+        // unsettled: re-arm on the new set rather than re-anchoring the tooltip
+        // to another rectangle it is about to leave.
+        if (animationsMovingAnchor(target).length > 0) {
+          schedule(target);
+          return;
+        }
         anchorSettlingRef.current = false;
         const settled = target.getBoundingClientRect();
-        targetRectRef.current = {
-          bottom: settled.bottom,
-          left: settled.left,
-          right: settled.right,
-          top: settled.top,
-        };
+        targetRectRef.current = toTargetRect(settled);
         setState((current) =>
           current
             ? {
                 ...current,
+                // Measured from the same moving layout as the rectangle, so it
+                // is stale for exactly as long.
+                horizontalBounds: getHorizontalBoundsRef.current?.(target),
                 targetTop: settled.top,
                 targetBottom: settled.bottom,
                 targetCenter: settled.left + settled.width / 2,
@@ -284,9 +403,23 @@ export function useViewportTooltip(options: {
             : current,
         );
       });
+    },
+    [],
+  );
+
+  const rememberTarget = useCallback((target: HTMLElement): DOMRect | undefined => {
+    if (!target.isConnected) {
+      targetRef.current = null;
+      targetRectRef.current = null;
+      anchorSettlingRef.current = false;
+      return undefined;
     }
+    const rect = target.getBoundingClientRect();
+    targetRef.current = target;
+    targetRectRef.current = toTargetRect(rect);
+    scheduleAnchorSettle(target);
     return rect;
-  }, []);
+  }, [scheduleAnchorSettle]);
 
   // Measure the rendered tooltip and clamp position so it stays in the
   // viewport and on the side of the target where it fits. The first
@@ -354,6 +487,7 @@ export function useViewportTooltip(options: {
     if (isNativeDragInteractionActive()) {
       targetRef.current = null;
       targetRectRef.current = null;
+      anchorSettlingRef.current = false;
       setState(undefined);
       return;
     }
@@ -405,7 +539,7 @@ export function useViewportTooltip(options: {
   // DOM element connected at a new position. Watch the document only while a
   // tooltip is armed or visible, and dismiss when its anchor disappears, is
   // replaced, or is laid out somewhere new. Motion under a running animation
-  // is none of those (see `targetChanged`), and attribute and content updates
+  // is none of those (see `readAnchorState`), and attribute and content updates
   // alone are not replacement: live cards update both their trigger state and
   // tooltip content while they remain open.
   // Unrelated mutations are intentionally ignored when the anchor stays put;
@@ -430,11 +564,15 @@ export function useViewportTooltip(options: {
         hide();
       }
     };
-    const targetChanged = (): boolean => {
+    // Pure: it reports what the anchor did, and the observer below decides.
+    // The re-baseline is a write the call site has to make on purpose, because
+    // a check that quietly moves the goalposts is the kind a second caller
+    // would get wrong.
+    const readAnchorState = (): AnchorState => {
       const target = targetRef.current;
       const rememberedRect = targetRectRef.current;
       if (!target || !rememberedRect || !target.isConnected) {
-        return true;
+        return { status: "gone" };
       }
       const currentRect = target.getBoundingClientRect();
       if (
@@ -443,37 +581,36 @@ export function useViewportTooltip(options: {
         && currentRect.bottom === rememberedRect.bottom
         && currentRect.left === rememberedRect.left
       ) {
-        return false;
+        return { status: "unchanged" };
       }
       // Moved — but an anchor still being animated has not gone anywhere the
-      // operator can follow it to, so re-baseline rather than dismiss. Without
-      // this every mutation that lands during a 220ms panel slide-in closes a
-      // tooltip that just opened, which is what made
-      // `context-rail-linked-directory-tooltips` flaky on the Linux E2E lane.
-      // Only a ref write: repositioning here would mutate the portal's own
-      // style attribute, and this observer watches document.body, so a moving
-      // anchor would feed itself renders. `rememberTarget` owns the one
-      // reposition, when the motion stops — and `anchorSettlingRef` keeps this
-      // rule in force until that runs, so a mutation delivered in the gap
-      // between the animation ending and the settled baseline landing does not
-      // read the last in-flight rectangle as a relocation.
+      // operator can follow it to. Without this, every mutation that lands
+      // during a 220ms panel slide-in closes a tooltip that just opened, which
+      // is what made `context-rail-linked-directory-tooltips` flaky on the
+      // Linux E2E lane. `anchorSettlingRef` keeps the rule in force until the
+      // settled baseline lands, so a mutation delivered in the gap between the
+      // animation ending and that callback running does not read the last
+      // in-flight rectangle as a relocation.
       if (
         !anchorSettlingRef.current
         && animationsMovingAnchor(target).length === 0
       ) {
-        return true;
+        return { status: "relocated" };
       }
-      targetRectRef.current = {
-        bottom: currentRect.bottom,
-        left: currentRect.left,
-        right: currentRect.right,
-        top: currentRect.top,
-      };
-      return false;
+      return { status: "settling", rect: toTargetRect(currentRect) };
     };
     const mutationObserver = new MutationObserver(() => {
-      if (targetChanged()) {
+      const anchor = readAnchorState();
+      if (anchor.status === "gone" || anchor.status === "relocated") {
         hide();
+        return;
+      }
+      if (anchor.status === "settling") {
+        // Only a ref write: repositioning here would mutate the portal's own
+        // style attribute, and this observer watches document.body, so a moving
+        // anchor would feed itself renders. `scheduleAnchorSettle` owns the one
+        // reposition, when the motion stops.
+        targetRectRef.current = anchor.rect;
       }
     });
     mutationObserver.observe(document.body, {

--- a/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
+++ b/apps/desktop/src/renderer/src/lib/useViewportTooltip.tsx
@@ -116,6 +116,32 @@ type TooltipTargetRect = {
 type DelayedTooltipContent = ReactNode | (() => ReactNode);
 
 /**
+ * The running animations and transitions that are moving `target` — its own,
+ * or any ancestor's, since a transformed ancestor drags every rectangle
+ * beneath it.
+ *
+ * An animated anchor is in motion, not relocated, and the two have to be told
+ * apart: `getBoundingClientRect` reports the transformed position, so an
+ * anchor halfway through a slide-in measures somewhere it is about to leave.
+ *
+ * jsdom implements no Web Animations API, so this reports nothing there and
+ * the movement rules below behave exactly as they did before.
+ */
+function animationsMovingAnchor(target: HTMLElement): Animation[] {
+  if (typeof document.getAnimations !== "function") {
+    return [];
+  }
+  return document.getAnimations().filter((animation) => {
+    if (animation.playState !== "running") {
+      return false;
+    }
+    const effect = animation.effect;
+    const animated = effect && "target" in effect ? effect.target : undefined;
+    return animated instanceof Element && animated.contains(target);
+  });
+}
+
+/**
  * Hook for portal-rendered tooltips that escape any clipping ancestor
  * (sidebar scroll regions, overflow:hidden chips, etc.) and clamp
  * themselves to viewport bounds. Use when CSS-pseudo-element tooltips
@@ -185,6 +211,8 @@ export function useViewportTooltip(options: {
   const targetRef = useRef<HTMLElement | null>(null);
   const targetRectRef = useRef<TooltipTargetRect | null>(null);
   const hoverDelayTimerRef = useRef<number | null>(null);
+  /** True while the anchor is animating and its settled baseline is pending. */
+  const anchorSettlingRef = useRef(false);
   const tooltipId = useId();
   const [state, setState] = useState<TooltipState | undefined>(undefined);
   const [delayPending, setDelayPending] = useState(false);
@@ -202,6 +230,7 @@ export function useViewportTooltip(options: {
     setDelayPending(false);
     targetRef.current = null;
     targetRectRef.current = null;
+    anchorSettlingRef.current = false;
     setState(undefined);
   }, [clearHoverDelay]);
 
@@ -219,6 +248,43 @@ export function useViewportTooltip(options: {
       right: rect.right,
       top: rect.top,
     };
+    // A rectangle measured mid-animation is a position the anchor is leaving,
+    // and it would stay the baseline for the rest of the tooltip's life: the
+    // context rail's panel plays a 220ms `translateX(12px) -> 0` on mount, so
+    // a tooltip opened during it recorded coordinates the anchor never returns
+    // to, and the next mutation anywhere in the document read that as a move
+    // and tore the portal down. Re-baseline once the motion stops, and give
+    // the tooltip the settled geometry so it is not left the animation's
+    // remaining offset away from its anchor.
+    const animations = animationsMovingAnchor(target);
+    anchorSettlingRef.current = animations.length > 0;
+    if (animations.length > 0) {
+      void Promise.allSettled(
+        animations.map((animation) => animation.finished),
+      ).then(() => {
+        if (targetRef.current !== target || !target.isConnected) {
+          return;
+        }
+        anchorSettlingRef.current = false;
+        const settled = target.getBoundingClientRect();
+        targetRectRef.current = {
+          bottom: settled.bottom,
+          left: settled.left,
+          right: settled.right,
+          top: settled.top,
+        };
+        setState((current) =>
+          current
+            ? {
+                ...current,
+                targetTop: settled.top,
+                targetBottom: settled.bottom,
+                targetCenter: settled.left + settled.width / 2,
+              }
+            : current,
+        );
+      });
+    }
     return rect;
   }, []);
 
@@ -337,10 +403,11 @@ export function useViewportTooltip(options: {
   // anchor changed. React does not fire `mouseleave` when a refresh removes or
   // replaces the hovered element, and moving a keyed row can leave the same
   // DOM element connected at a new position. Watch the document only while a
-  // tooltip is armed or visible, and dismiss when its anchor disappears,
-  // is replaced, or moves from its recorded viewport rectangle. Attribute and
-  // content updates alone are not replacement: live cards update both their
-  // trigger state and tooltip content while they remain open.
+  // tooltip is armed or visible, and dismiss when its anchor disappears, is
+  // replaced, or is laid out somewhere new. Motion under a running animation
+  // is none of those (see `targetChanged`), and attribute and content updates
+  // alone are not replacement: live cards update both their trigger state and
+  // tooltip content while they remain open.
   // Unrelated mutations are intentionally ignored when the anchor stays put;
   // transcript streaming must not close a sidebar tooltip.
   const visible = state !== undefined;
@@ -370,10 +437,39 @@ export function useViewportTooltip(options: {
         return true;
       }
       const currentRect = target.getBoundingClientRect();
-      return currentRect.top !== rememberedRect.top
-        || currentRect.right !== rememberedRect.right
-        || currentRect.bottom !== rememberedRect.bottom
-        || currentRect.left !== rememberedRect.left;
+      if (
+        currentRect.top === rememberedRect.top
+        && currentRect.right === rememberedRect.right
+        && currentRect.bottom === rememberedRect.bottom
+        && currentRect.left === rememberedRect.left
+      ) {
+        return false;
+      }
+      // Moved — but an anchor still being animated has not gone anywhere the
+      // operator can follow it to, so re-baseline rather than dismiss. Without
+      // this every mutation that lands during a 220ms panel slide-in closes a
+      // tooltip that just opened, which is what made
+      // `context-rail-linked-directory-tooltips` flaky on the Linux E2E lane.
+      // Only a ref write: repositioning here would mutate the portal's own
+      // style attribute, and this observer watches document.body, so a moving
+      // anchor would feed itself renders. `rememberTarget` owns the one
+      // reposition, when the motion stops — and `anchorSettlingRef` keeps this
+      // rule in force until that runs, so a mutation delivered in the gap
+      // between the animation ending and the settled baseline landing does not
+      // read the last in-flight rectangle as a relocation.
+      if (
+        !anchorSettlingRef.current
+        && animationsMovingAnchor(target).length === 0
+      ) {
+        return true;
+      }
+      targetRectRef.current = {
+        bottom: currentRect.bottom,
+        left: currentRect.left,
+        right: currentRect.right,
+        top: currentRect.top,
+      };
+      return false;
     };
     const mutationObserver = new MutationObserver(() => {
       if (targetChanged()) {


### PR DESCRIPTION
## What

`useViewportTooltip` dismissed a tooltip whenever its anchor's viewport rectangle stopped matching the one recorded at `show`. A CSS animation moves that rectangle without moving the anchor anywhere the operator can follow it to.

`.context-panel` plays a 220ms `translateX(12px) -> 0` on mount. A tooltip opened during it records coordinates the anchor then leaves for good, so the **next mutation anywhere in the document** — the observer watches all of `document.body` — reads the stale baseline as a relocation and tears the portal down.

## Why now

`e2e/context-rail-linked-directory-tooltips.spec.ts` had started failing both the initial attempt and the retry on Linux lane 1 (run 34303367097 attempt 1, job 102314917764; also `1 flaky` on main at b25661d95).

The trace is unambiguous about the shape of it. The spec focuses `Path for PwrAgent` ~80ms after the rail opens — inside the animation — and:

| t (ms) | step | result |
|---|---|---|
| 127558→127567 | `.focus()` | ok |
| 127568→127570 | `toBeVisible` | ✓ |
| 127571→127574 | `toHaveText` | ✓ |
| 127576→127612 | first `evaluate` | detached |
| 127718→ | second `evaluate` | **never returns** |

The tooltip was gone entirely, not hidden — which is why the reported diff (`inBody: false`, `visibility: ""`) was a stale value from the *first* poll iteration: with no action timeout, `locator.evaluate` blocked waiting for an element that never came back, and `expect.poll` timed out around it.

The anchor-re-creation hypothesis is discarded: React reuses the keyed rows, the anchor stays connected, and nothing unmounts. It is the baseline that is wrong, not the element.

## Verification

Measured against the real `context-panel-in` keyframes in headless Chromium:

- `document.getAnimations()` reports it as a `CSSAnimation`, `playState: "running"`, `effect.target` the panel (an ancestor of the anchor), with a working `finished`.
- The anchor's `left` drifts `20 → 8` across the animation, and **never returns** to the value recorded at open — so the tooltip is doomed by the next mutation whenever it arrives, not only during the 220ms.
- Driving the new decision logic against that: a mutation 60ms in is kept (re-baselined to 16.3), a mutation after settling is a no-op, and a genuine relocation with nothing animating still dismisses.

`pnpm test --project desktop-renderer` — 4154 passed. Typecheck, `lint:eslint` (0 errors), `lint:boundaries` clean.

The E2E suite itself was not run: the PwrSuiteLab guest's E2E lock is stranded in the state where the controller stops the guest it started, so `recover-stale-lock.sh` never sees the running-guest + no-controller pair it needs, and `scripts/e2e/run-docker.sh` does not exist in this repo. The Linux lane on this PR is the confirmation.

## How

Motion is told apart from relocation. While a running animation or transition targets the anchor or an ancestor, a moved anchor is re-baselined instead of dismissed; `rememberTarget` takes the settled rectangle once they finish, which also re-anchors the tooltip so one opened mid-slide does not keep the animation's remaining offset. `anchorSettlingRef` holds the rule across the gap between the animation ending and that baseline landing.

An anchor that relocates with nothing animating still dismisses, as it has since #1726. jsdom implements no Web Animations API, so every existing test keeps its old semantics unchanged; the three new ones stub the shape Chromium returns.

## Not changed

The spec's `expectVisibleTooltip` helper still makes three sequential round-trips against a live app, and its `expect.poll` still reports a stale value rather than "the tooltip is gone" when a teardown is legitimate. That is a diagnosability problem worth fixing separately — it is what pointed this investigation at a detached element — but it is not the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
