### PR TITLE
fix(desktop): style every sidebar paging control

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -54,6 +54,8 @@ import {
   beginNativeDragInteraction,
   endNativeDragInteraction,
 } from "../../lib/native-drag-interaction";
+import { SidebarShowMore } from "./SidebarShowMore";
+import { SubthreadPagination } from "./SubthreadPagination";
 import { ThinkingScanner } from "../thread-detail/ThinkingScanner";
 import {
   SignalCount,
@@ -1262,17 +1264,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
               ];
             })}
             {childResources.filter((resource) => !isNavigationPeerUnavailable(resource.state.error)).map((childResource) => (
-              <Fragment key={childResource.id}>
-                {childResource.state.error ? <p role="alert">{childResource.state.error}</p> : null}
-                {childResource.loading && !childResource.state.page ? <p>Loading sub-threads…</p> : null}
-                {childResource.state.rebaselineRequired ? (
-                  <button type="button" data-hover-stable-release="pagination" onClick={() => void props.pagedNavigation?.restart(childResource.id)}>Reload sub-threads</button>
-                ) : childResource.state.page?.nextCursor ? (
-                  <button type="button" data-hover-stable-release="pagination" disabled={childResource.loading} onClick={() => void props.pagedNavigation?.loadMore(childResource.id)}>
-                    {childResource.id.endsWith(":viewer") ? "Load more sub-threads on this machine" : "Load more sub-threads"}
-                  </button>
-                ) : null}
-              </Fragment>
+              <SubthreadPagination
+                key={childResource.id}
+                resource={childResource}
+                pagedNavigation={props.pagedNavigation}
+              />
             ))}
           </div>
         </div>
@@ -1829,12 +1825,12 @@ export function DirectoriesList(props: DirectoriesListProps) {
                         {pinResource.state.error ? <p className="sidebar-error">{pinResource.state.error}</p> : null}
                         {pinResource.loading && !pinResource.state.page ? <p className="sidebar-empty">Loading pinned threads…</p> : null}
                         {(pinResource.state.page?.rangeStart ?? 0) > 0 && !pinResource.state.rebaselineRequired ? (
-                          <button type="button" className="directory-row__show-more" data-hover-stable-release="pagination" disabled={pinResource.loading} onClick={() => void props.pagedNavigation?.restart(pinResourceId)}>Show pinned threads from beginning</button>
+                          <SidebarShowMore busy={pinResource.loading} label="Show pinned threads from beginning" onClick={() => void props.pagedNavigation?.restart(pinResourceId)} />
                         ) : null}
                         {pinResource.state.rebaselineRequired ? (
-                          <button type="button" className="directory-row__show-more" data-hover-stable-release="pagination" onClick={() => void props.pagedNavigation?.restart(pinResourceId)}>Reload pinned threads</button>
+                          <SidebarShowMore label="Reload pinned threads" onClick={() => void props.pagedNavigation?.restart(pinResourceId)} />
                         ) : pinResource.state.page?.nextCursor ? (
-                          <button type="button" className="directory-row__show-more" data-hover-stable-release="pagination" disabled={pinResource.loading} onClick={() => void props.pagedNavigation?.loadMore(pinResourceId)}>Load more pinned threads</button>
+                          <SidebarShowMore busy={pinResource.loading} label="Load more pinned threads" onClick={() => void props.pagedNavigation?.loadMore(pinResourceId)} />
                         ) : null}
                       </div>
                     ) : null}
@@ -1895,9 +1891,9 @@ export function DirectoriesList(props: DirectoriesListProps) {
                 {rootResource?.state.error ? <p className="sidebar-error">{rootResource.state.error}</p> : null}
                 {rootResource?.loading && !rootResource.state.page ? <p className="sidebar-empty">Loading threads…</p> : null}
                 {rootResource?.state.rebaselineRequired ? (
-                  <button type="button" className="directory-row__show-more" data-hover-stable-release="pagination" onClick={() => void props.pagedNavigation?.restart(rootResourceId)}>Reload this directory</button>
+                  <SidebarShowMore label="Reload this directory" onClick={() => void props.pagedNavigation?.restart(rootResourceId)} />
                 ) : rootResource?.state.page?.nextCursor ? (
-                  <button type="button" className="directory-row__show-more" data-hover-stable-release="pagination" disabled={rootResource.loading} onClick={() => void props.pagedNavigation?.loadMore(rootResourceId)}>Load more threads</button>
+                  <SidebarShowMore busy={rootResource.loading} label="Load more threads" onClick={() => void props.pagedNavigation?.loadMore(rootResourceId)} />
                 ) : null}
               </div>
             ) : null}

--- a/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/RecentsList.tsx
@@ -2,7 +2,7 @@ import { readNavigationPresentationOrder, type NavigationPresentationOrder } fro
 import type { NavigationPresentedThread } from "../../lib/navigation-loaded-rows";
 import type { useBoundedNavigationWindow } from "../../lib/useBoundedNavigationWindow";
 import { isNavigationPeerUnavailable, navigationIdentityKey, navigationThreadSelectionKey } from "../../lib/navigation-query-state";
-import { Fragment, useState, type MouseEvent } from "react";
+import { useState, type MouseEvent } from "react";
 import type {
   MessagingThreadBindingSummary,
   NavigationThreadSummary,
@@ -28,6 +28,7 @@ import {
   isSubthreadSectionCollapsed,
   NativeSubAgentsDisclosure,
 } from "./NativeSubAgentsDisclosure";
+import { SubthreadPagination } from "./SubthreadPagination";
 import { ThreadRow } from "./ThreadRow";
 
 type RecentsListProps = {
@@ -271,17 +272,11 @@ export function RecentsList(props: RecentsListProps) {
           ];
         })}
         {childResources.filter((resource) => !isNavigationPeerUnavailable(resource.state.error)).map((childResource) => (
-          <Fragment key={childResource.id}>
-            {childResource.state.error ? <p role="alert">{childResource.state.error}</p> : null}
-            {childResource.loading && !childResource.state.page ? <p>Loading sub-threads…</p> : null}
-            {childResource.state.rebaselineRequired ? (
-              <button type="button" onClick={() => void props.pagedNavigation?.restart(childResource.id)}>Reload sub-threads</button>
-            ) : childResource.state.page?.nextCursor ? (
-              <button type="button" disabled={childResource.loading} onClick={() => void props.pagedNavigation?.loadMore(childResource.id)}>
-                {childResource.id.endsWith(":viewer") ? "Load more sub-threads on this machine" : "Load more sub-threads"}
-              </button>
-            ) : null}
-          </Fragment>
+          <SubthreadPagination
+            key={childResource.id}
+            resource={childResource}
+            pagedNavigation={props.pagedNavigation}
+          />
         ))}
       </div>
     );

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -563,6 +563,7 @@ export function Sidebar(props: SidebarProps) {
     : undefined;
   const lensResources = [...props.pagedNavigation?.resources.values() ?? []]
     .filter((resource) => props.browseMode === "drafts" ? resource.id.startsWith("drafts:") : resource.id === "lens");
+  const directoryIndexResource = props.pagedNavigation?.resources.get("directory-index");
   const rowsByKey = useMemo(() => new Map(props.threads.map((thread) => [threadSummaryIdentityKey(thread), thread])), [props.threads]);
   const visibleThreads = [...new Map(lensResources.flatMap((resource) => resource.state.page?.entries ?? [])
     .map((entry) => [navigationThreadSelectionKey(entry.row.ref), rowsByKey.get(navigationThreadSelectionKey(entry.row.ref))])).values()].filter((thread): thread is NavigationThreadSummary => Boolean(thread));
@@ -2096,8 +2097,13 @@ export function Sidebar(props: SidebarProps) {
               ) : null}
             </div>
           )) : null}
-          {props.browseMode === "directories" && props.pagedNavigation?.resources.get("directory-index")?.state.page?.nextCursor ? (
-            <SidebarShowMore label="Load more directories" onClick={() => void props.pagedNavigation?.loadMore("directory-index")} />
+          {props.browseMode === "directories" && directoryIndexResource?.state.page?.nextCursor ? (
+            // `loadMore` has no reentrancy guard of its own — it awaits any
+            // pending read and then unconditionally starts another — so the
+            // in-flight guard is the only thing standing between a double
+            // click and two page advances. This was the one load-more control
+            // without it.
+            <SidebarShowMore busy={directoryIndexResource.loading} label="Load more directories" onClick={() => void props.pagedNavigation?.loadMore("directory-index")} />
           ) : null}
         </div>
       </section>

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -50,6 +50,7 @@ import { FederationRemoteBadge } from "../chrome/FederationRemoteBadge";
 import type { FederationThreadTarget } from "../chrome/federation-thread-targets";
 import { FederationTargetMenuSection } from "../chrome/FederationTargetMenuSection";
 import { NewThreadButton } from "../chrome/NewThreadButton";
+import { SidebarShowMore } from "./SidebarShowMore";
 import type {
   ArchiveThreadOptions,
   BrowseMode,
@@ -2089,14 +2090,14 @@ export function Sidebar(props: SidebarProps) {
             <div key={resource.id}>
               {resource.state.error ? <p className="sidebar-error">{resource.state.error}</p> : null}
               {resource.state.rebaselineRequired ? (
-                <button type="button" onClick={() => void props.pagedNavigation?.restart(resource.id)}>Reload this lens</button>
+                <SidebarShowMore label="Reload this lens" onClick={() => void props.pagedNavigation?.restart(resource.id)} />
               ) : resource.state.page?.nextCursor ? (
-                <button type="button" disabled={resource.loading} onClick={() => void props.pagedNavigation?.loadMore(resource.id)}>Load more threads</button>
+                <SidebarShowMore busy={resource.loading} label="Load more threads" onClick={() => void props.pagedNavigation?.loadMore(resource.id)} />
               ) : null}
             </div>
           )) : null}
           {props.browseMode === "directories" && props.pagedNavigation?.resources.get("directory-index")?.state.page?.nextCursor ? (
-            <button type="button" onClick={() => void props.pagedNavigation?.loadMore("directory-index")}>Load more directories</button>
+            <SidebarShowMore label="Load more directories" onClick={() => void props.pagedNavigation?.loadMore("directory-index")} />
           ) : null}
         </div>
       </section>

--- a/apps/desktop/src/renderer/src/features/navigation/SidebarShowMore.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SidebarShowMore.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from "react";
+
+/**
+ * The sidebar's "reveal more rows" control.
+ *
+ * Every paging affordance in the rail routes through here. Seven of the twelve
+ * call sites used to render a bare `<button>` with no class at all — both
+ * sub-thread controls in DirectoriesList, both in RecentsList, and all three
+ * lens controls in Sidebar — so they came out as native Chromium buttons: an
+ * opaque grey slab, centre-aligned, stretched to the full width of the
+ * `display: grid` list that held them. Beside a rail built from transparent
+ * 12px text buttons, that read as the loudest element on screen.
+ *
+ * The five styled ones carried `directory-row__show-more`, a name that reads
+ * as private to one parent, which is a good part of why nobody reached for it
+ * from the other two files. The class is `sidebar-show-more` now and this
+ * component is the only thing that applies it.
+ */
+export function SidebarShowMore(props: {
+  label: string;
+  onClick: () => void;
+  /** In flight. Blocks the click and shows the control is working. */
+  busy?: boolean;
+}): ReactElement {
+  return (
+    <button
+      type="button"
+      className="sidebar-show-more"
+      // Load-bearing in the directories lens: `data-hover-stable-row="directory"`
+      // wraps a whole directory including its paging controls, so the pointer
+      // never leaves the frozen row on the way here and `onPointerOut` never
+      // releases the snapshot — without this the rows the click just loaded
+      // stay hidden until the pointer leaves the directory. In the flat lenses
+      // the control sits outside any hover-stable row and the move releases on
+      // its own; applied unconditionally so no call site has to know which it
+      // is in. Five of the twelve were missing it.
+      data-hover-stable-release="pagination"
+      // Reported instead of a label swap: the visible text is the accessible
+      // name here, so renaming it to "Loading…" mid-flight would move the
+      // control out from under anyone searching for it by name.
+      aria-busy={props.busy ? true : undefined}
+      disabled={props.busy}
+      onClick={props.onClick}
+    >
+      {props.label}
+    </button>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/navigation/SubthreadPagination.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/SubthreadPagination.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from "react";
+import type { NavigationWindowResource } from "../../lib/navigation-window-queries";
+import type { useBoundedNavigationWindow } from "../../lib/useBoundedNavigationWindow";
+import { SidebarShowMore } from "./SidebarShowMore";
+
+/**
+ * The paging tail of one sub-thread tray, shared by DirectoriesList and
+ * RecentsList.
+ *
+ * The wrapper is not decoration. `.subthread-list` carries `role="list"`,
+ * which owns `listitem` children and nothing else, so the bare `<button>` and
+ * `<p>` this used to render were an `aria-required-children` violation on
+ * every tray with a second page. The sibling pinned-thread block a few
+ * hundred lines down already wraps its identical controls in a `listitem`;
+ * this one never did. The `nothingToShow` guard keeps the list free of an
+ * empty item when the tray is fully loaded — the common case.
+ */
+export function SubthreadPagination(props: {
+  resource: NavigationWindowResource;
+  pagedNavigation?: ReturnType<typeof useBoundedNavigationWindow>;
+}): ReactElement | null {
+  const { resource } = props;
+  const initialLoad = resource.loading && !resource.state.page;
+  const nothingToShow =
+    !resource.state.error
+    && !initialLoad
+    && !resource.state.rebaselineRequired
+    && !resource.state.page?.nextCursor;
+  if (nothingToShow) return null;
+  return (
+    <div role="listitem">
+      {resource.state.error ? <p className="sidebar-error" role="alert">{resource.state.error}</p> : null}
+      {initialLoad ? <p className="sidebar-empty">Loading sub-threads…</p> : null}
+      {resource.state.rebaselineRequired ? (
+        <SidebarShowMore
+          label="Reload sub-threads"
+          onClick={() => void props.pagedNavigation?.restart(resource.id)}
+        />
+      ) : resource.state.page?.nextCursor ? (
+        <SidebarShowMore
+          busy={resource.loading}
+          label={resource.id.endsWith(":viewer") ? "Load more sub-threads on this machine" : "Load more sub-threads"}
+          onClick={() => void props.pagedNavigation?.loadMore(resource.id)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/paged-pin-moves.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/paged-pin-moves.test.tsx
@@ -189,3 +189,47 @@ it.each(["directories", "inbox"] as const)("keeps expected disconnected child-pa
   expect(screen.getByRole("button", { name: /^Pin 5/ })).toBeInTheDocument();
   view.unmount();
 });
+
+
+// `.subthread-list` is a `role="list"`, which owns `listitem` children and
+// nothing else. Its paging controls used to render as a bare <button> and two
+// bare <p>s directly in that list — a critical axe `aria-required-children`
+// violation on every tray with a second page — so `SubthreadPagination` wraps
+// them the way the pinned block beside it always did. Nothing else pins that
+// wrapper: the e2e a11y spec seeds directory-level pagination only, so no
+// fixture there ever gives a sub-thread resource a cursor.
+it("keeps a paged sub-thread tray a valid list", () => {
+  const parent = { ...rows[0]!, ordinaryChildCount: 1 };
+  const child = { ...rows[1]!, id: "child-1", title: "Child 1", pinnedRank: undefined,
+    parentThreadId: parent.id, ref: { backend: "codex" as const, threadId: "child-1" } };
+  const childId = 'children:[null,"codex","pin-5"]';
+  const children = resource(childId, { kind: "children", parent: parent.ref }, {
+    complete: false, nextCursor: "more",
+    entries: [{ row: child, placement: { kind: "child", parent: parent.ref }, orderKey: "0" }],
+  });
+  const pinsId = `directory-pins:${directory.key}`;
+  const resources = new Map([[childId, children], [pinsId, resource(pinsId,
+    { kind: "directory", directoryKey: directory.key, roots: "pinned" },
+    { entries: [{ row: parent, placement: { kind: "root" }, orderKey: "0" }] })]]);
+  const navigation = { resources, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
+    invalidate: () => undefined, refresh: async () => undefined, loadMore: async () => undefined,
+    rebaseline: async () => undefined, restart: async () => undefined, setVisibleAnchor: () => undefined };
+  const view = render(<Sidebar backends={[]} browseMode="directories" directories={[directory]} threads={[parent, child]}
+    loading={false} selectedItemKey={`codex:${parent.id}`} selectedThreadDirectoryKeys={[directory.key]}
+    pagedNavigation={navigation} onBrowseModeChange={() => undefined} onSelectThread={() => undefined}
+    onCreateThread={async () => undefined} onOpenLaunchpad={async () => undefined} />);
+
+  const more = screen.getByRole("button", { name: "Load more sub-threads" });
+  expect(more).toHaveClass("sidebar-show-more");
+
+  const tray = view.container.querySelector(".subthread-list");
+  expect(tray).not.toBeNull();
+  expect(tray).toContainElement(more);
+  // The contract itself, asserted over the tray's DIRECT children: a list may
+  // own listitems only, so an unwrapped control is a violation no matter how
+  // it is styled.
+  expect([...tray!.children].map((item) => item.getAttribute("role"))).toEqual(
+    Array.from({ length: tray!.children.length }, () => "listitem"),
+  );
+  view.unmount();
+});

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -242,8 +242,25 @@ describe("Tangerine Terminal theme contract", () => {
     expect(extractRuleBody(css, ".directory-row__thread-divider")).toMatch(
       /min-height:\s*24px;/,
     );
-    expect(extractRuleBody(css, ".directory-row__show-more")).toMatch(
+    expect(extractRuleBody(css, ".sidebar-show-more")).toMatch(
       /min-height:\s*24px;/,
+    );
+
+    // The rail's paging control is transparent, left-aligned and 12px — the
+    // shape every one of these must have. Seven of the twelve call sites used
+    // to render a classless <button>, which Chromium draws as an opaque grey
+    // slab stretched across the `display: grid` sub-thread list. Pinned here
+    // because a missing class has no other visible symptom in a unit test.
+    const showMore = extractRuleBody(css, ".sidebar-show-more");
+    expect(showMore).toMatch(/background:\s*transparent;/);
+    expect(showMore).toMatch(/justify-self:\s*start;/);
+    expect(showMore).toMatch(/align-self:\s*flex-start;/);
+    // `:hover` matches a disabled button, so the hover rule has to exclude
+    // one or a control with a page already in flight lights up on a click
+    // that goes nowhere.
+    expect(css).toContain(".sidebar-show-more:hover:not(:disabled)");
+    expect(extractRuleBody(css, ".sidebar-show-more:disabled")).toMatch(
+      /color:\s*var\(--text-muted\);/,
     );
 
     // Same floor for the thread-row hover cluster: the transcript-gaps

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4049,6 +4049,18 @@ a.button {
   margin-left: 14px;
 }
 
+/* The tray's status text. `.sidebar-empty` and `.sidebar-error` are
+   sidebar-level and set 14px, which inside a sub-list lands above both the
+   13px `--sidebar-title-size` of the rows around it and the 12px paging
+   control below it — so a transient "Loading…" became the loudest thing in
+   the tray, the same way the unstyled paging button did. Scope the tray's
+   copies to the tray's own scale. */
+.subthread-list .sidebar-empty,
+.subthread-list .sidebar-error {
+  margin-top: 4px;
+  font-size: 12px;
+}
+
 .native-subagents {
   min-width: 0;
 }
@@ -6561,9 +6573,14 @@ a.button {
 .sidebar-show-more {
   overflow-anchor: none;
   align-self: flex-start;
-  /* `.subthread-list` is a grid, where `align-self` answers the block axis
-     and leaves the inline one on the default `stretch`. That is precisely
-     how the unstyled sub-thread button came out full-bleed. */
+  /* Defensive, not load-bearing today. `.subthread-list` is a grid, where
+     `align-self` answers the block axis and leaves the inline one on the
+     default `stretch` — which is how the unstyled sub-thread button came out
+     full-bleed. `SubthreadPagination` now wraps the control in the
+     `role="listitem"` its list requires, and that wrapper is the grid item,
+     so the inline-block button shrink-wraps on its own. This keeps a control
+     narrow if one is ever a direct grid child again; it is not a substitute
+     for the wrapper, which the list's validity depends on. */
   justify-self: start;
   margin-top: 2px;
   /* WCAG 2.5.8, same as the divider above. Without it this lands at

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6547,14 +6547,24 @@ a.button {
   padding-left: 8px;
 }
 
-/* "Show N more / Show less" toggle for a directory's unpinned threads
-   past the cap (DirectoriesList caps unpinned rows so a project with
-   dozens of threads doesn't push the next directory off-screen). Reads
-   as a quiet index control, not a card; left padding aligns its label
-   with the thread-row titles above it. */
-.directory-row__show-more {
+/* The rail's one paging affordance: directory, pinned, lens and sub-thread
+   all reach it through `SidebarShowMore`. Reads as a quiet index control,
+   not a card; left padding aligns its label with the thread-row titles
+   above it.
+
+   It was `directory-row__show-more`, a name that reads as private to one
+   parent — and the seven call sites that did not sit beside the rule (five
+   outside DirectoriesList, two inside it) styled nothing at all rather than
+   reach for it, so they shipped as native Chromium buttons. (The old comment here described a "Show N more / Show
+   less" thread-cap toggle; that control moved to
+   `.directory-row__thread-divider` and left this text behind.) */
+.sidebar-show-more {
   overflow-anchor: none;
   align-self: flex-start;
+  /* `.subthread-list` is a grid, where `align-self` answers the block axis
+     and leaves the inline one on the default `stretch`. That is precisely
+     how the unstyled sub-thread button came out full-bleed. */
+  justify-self: start;
   margin-top: 2px;
   /* WCAG 2.5.8, same as the divider above. Without it this lands at
      ~24.4px — 8px padding + 2px border + a 12px font's `normal` line box —
@@ -6575,14 +6585,25 @@ a.button {
     color 120ms ease;
 }
 
-.directory-row__show-more:hover {
+/* `:hover` matches a disabled button, so the unqualified rule lit this up
+   while the page it asks for was already in flight and the click went
+   nowhere. */
+.sidebar-show-more:hover:not(:disabled) {
   background: var(--bg-panel-hover);
   color: var(--text-primary);
 }
 
-.directory-row__show-more:focus-visible {
+.sidebar-show-more:focus-visible {
   outline: 2px solid var(--focus-ring);
   outline-offset: 2px;
+}
+
+/* A page in flight. `disabled` has been set on every one of these since they
+   shipped and styled on none of them, so the rail looked the same whether a
+   click would do something or nothing. */
+.sidebar-show-more:disabled {
+  color: var(--text-muted);
+  cursor: default;
 }
 
 .directory-group {


### PR DESCRIPTION
## The control

`Load more sub-threads` had no class at all, so Chromium drew its own button widget inside a rail built from transparent 12px text controls.

## Before

![sub-thread tray before](https://github.com/user-attachments/assets/79aa5504-4a80-4fdc-917f-4ebb03452912)

## After

![sub-thread tray after](https://github.com/user-attachments/assets/6d8a1732-d518-494c-a75d-9222f8098ac1)

Both frames are 100% contrived fixture data, rendered headlessly against the real `app.css`.

## What was wrong

Seven of the rail's twelve paging controls carried no class: both sub-thread controls in `DirectoriesList`, both in `RecentsList`, all three lens controls in `Sidebar`. The five that were styled used `directory-row__show-more` — a name that reads as private to one parent, which is a good part of why the other two files styled nothing rather than reach across for it.

| Sev | Finding | Was | Now |
|---|---|---|---|
| A | Seven of twelve controls classless | Opaque `#6b6b6b`, 2px outset border, square corners; `button { font: inherit }` pulls it to 16px/400 — heavier than any thread title beside it | One `SidebarShowMore` component owns the class. Twelve controls, ten JSX sites |
| A | Full-bleed, because the sub-list is a grid | `.subthread-list` is `display: grid`; `align-self: flex-start` answers the block axis and leaves the inline axis on `stretch`, so the control spanned **243px** of a 254px list | `justify-self: start`. Shrink-wraps to **160px** |
| A | Bare `<button>` inside `role="list"` | A list owns `listitem` children only — axe `aria-required-children`, **critical**, on every tray with a second page | `SubthreadPagination` wraps them, the shape the pinned-thread block already used |
| B | In-flight state invisible | `disabled={resource.loading}` was set on every one of these from the day they shipped and styled on none of them | `:disabled` → `--text-muted`, cursor `default`, `aria-busy` set |
| B | Hover lit up a dead control | `:hover` matches a disabled button, so it brightened under the pointer while the click went nowhere | `:hover:not(:disabled)` |
| B | `data-hover-stable-release` missing on five | In the directories lens a whole directory is one hover-stable row, so the snapshot stays frozen past the click that loaded new rows | Applied by the component, unconditionally |
| C | Primitive named for one parent | `.directory-row__show-more` | `.sidebar-show-more`, applied in exactly one component |

## Not addressed

The label still says nothing about how many threads remain — the largest improvement left in this affordance. It needs backend work, not CSS: `NavigationQueryPage.collectionSize` is populated only for `directory-index` and `messaging-threads` queries, so thread and sub-thread pages carry no total and a count would have to be invented. Left as a label without a number rather than a number that is wrong.

## Verification

- **Geometry**, headless Chromium against the real `app.css`: 243×24 opaque, centred, `cursor: default` → 160×25 transparent, left-aligned, `cursor: pointer`, 12px/600 `--text-secondary` — identical to the directory-level control it now shares a rule with.
- **axe-core** over the real `role="list"` structure: one `critical` `aria-required-children` violation → clean.
- `pnpm test apps/desktop/src/renderer` — 275 files, 4151 tests pass.
- `theme-contract.test.tsx` gains assertions for the transparent background, both alignment axes, the `:not(:disabled)` hover guard and the `:disabled` rule, because a missing class has no other visible symptom in a unit test.

## Design review

Frames, states, findings and coverage: [Sidebar Load More UX Review](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Sidebar+Load+More+UX+Review.dc.html) in the PwrAgent Claude Design project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
