### PR TITLE
fix(desktop): keep the launchpad's send controls on screen under the PwrSuite cards

### DIFF
--- a/apps/desktop/e2e/composer-height-growth.spec.ts
+++ b/apps/desktop/e2e/composer-height-growth.spec.ts
@@ -114,6 +114,9 @@ async function createComposerHeightFixture(): Promise<{
 // can never contribute surplus of its own (see the symmetry
 // assertion below for why that matters).
 const COMPOSER_MIN_HEIGHT = 48;
+// The fixed half of `max-height: min(280px, 34vh)`. The `vh` half binds
+// only below ~825px of window height, which is why this spec pins its
+// window above that — see `launchElectronApp` below.
 const COMPOSER_MAX_HEIGHT = 280;
 
 // `box-sizing: border-box` is the renderer-wide default, so the
@@ -152,6 +155,12 @@ test("composer is compact when empty, grows with content, clamps at max-height",
   try {
     const app = await launchElectronApp({
       fixturePath: fixture.fixturePath,
+      // Pin the window: the 280px cap is now `min(280px, 34vh)`, so the
+      // fixed half only governs above ~825px of window height. Without a
+      // pinned size this spec's expectations would depend on whatever
+      // display the runner happens to have — the cap the constants below
+      // describe would silently become the `vh` half on a small screen.
+      windowSize: { width: 1280, height: 900 },
     });
 
     try {

--- a/apps/desktop/e2e/launchpad-composer-bounds.spec.ts
+++ b/apps/desktop/e2e/launchpad-composer-bounds.spec.ts
@@ -1,0 +1,302 @@
+import { execFileSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, test, type Locator } from "@playwright/test";
+import { launchElectronApp } from "./fixtures/electron-app";
+
+/**
+ * The launchpad's send controls must stay reachable no matter how much
+ * sits above them.
+ *
+ * `.thread-view__primary` is a flex column whose only flexible child used
+ * to be nothing at all: the two PwrSuite connection cards were direct
+ * children sized to their own content, and the composer was pinned under
+ * them with `margin-top: auto` at `flex: 0 0 auto`. Nothing in that column
+ * could shrink, and `.thread-view` clips with `overflow: hidden`, so once
+ * the cards plus a composer holding pasted images exceeded the pane the
+ * whole composer simply walked off the bottom edge — no scrollbar, no way
+ * to reach "Start thread". Measured in headless Chromium against the
+ * shipped stylesheet: at a 800px-tall window the send row landed 56px past
+ * the clip and `document.elementFromPoint` at its centre returned null; at
+ * 700px it was 142px past.
+ *
+ * The invariant this pins is deliberately framed against the clipping
+ * ancestor, not against any box the broken layout produces — an assertion
+ * derived from the geometry under test agrees with the bug by
+ * construction. The preconditions below exist for the same reason: without
+ * them a taller window (or a card that stopped rendering) would make this
+ * pass while proving nothing.
+ */
+
+// Short enough that the two connection cards plus a composer holding three
+// pasted images cannot all fit. The precondition assertion below re-checks
+// that on the machine actually running this rather than trusting the
+// number, because a window that quietly grew past the crowding would make
+// every assertion here pass while proving nothing.
+const WINDOW = { width: 1280, height: 600 };
+
+// Sub-pixel rounding on HiDPI. A real regression moves the send row by
+// tens of pixels (56 and 142 above), so this is nowhere near it.
+const BOUNDS_TOLERANCE_PX = 2;
+
+async function createLaunchpadBoundsFixture(): Promise<{
+  cleanup: () => Promise<void>;
+  fixturePath: string;
+}> {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "pwragent-launchpad-bounds-"));
+  const repoDir = path.join(rootDir, "FixtureRepo");
+  await mkdir(repoDir, { recursive: true });
+
+  execFileSync("git", ["init"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync("git", ["checkout", "-B", "main"], { cwd: repoDir, stdio: "ignore" });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "user.name=PwrAgent Tests",
+      "-c",
+      "user.email=pwragent-tests@example.invalid",
+      "commit",
+      "--allow-empty",
+      "-m",
+      "Seed fixture repo",
+    ],
+    { cwd: repoDir, stdio: "ignore" },
+  );
+
+  const fixturePath = path.join(rootDir, "launchpad-composer-bounds.fixture.json");
+  await writeFile(
+    fixturePath,
+    JSON.stringify(
+      {
+        metadata: {
+          backend: "codex",
+          scenario: "launchpad-composer-bounds",
+        },
+        steps: [
+          {
+            id: "initialize-1",
+            kind: "response",
+            method: "initialize",
+            result: {
+              serverInfo: { name: "Replay Codex", version: "1.0.0" },
+              methods: ["thread/list", "thread/read", "skills/list", "thread/start", "turn/start"],
+            },
+          },
+          {
+            id: "thread-list-1",
+            kind: "response",
+            method: "thread/list",
+            result: [
+              {
+                id: "thread-existing",
+                title: "Existing directory thread",
+                titleSource: "explicit",
+                source: "codex",
+                executionMode: "default",
+                linkedDirectories: [
+                  {
+                    id: "fixture-repo",
+                    label: "FixtureRepo",
+                    path: repoDir,
+                    kind: "local",
+                  },
+                ],
+                updatedAt: 1_000,
+              },
+            ],
+          },
+          {
+            id: "thread-read-1",
+            kind: "response",
+            method: "thread/read",
+            result: {
+              entries: [
+                {
+                  type: "message",
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing directory thread",
+                },
+              ],
+              messages: [
+                {
+                  id: "thread-existing-message-1",
+                  role: "assistant",
+                  text: "Existing directory thread",
+                },
+              ],
+              lastAssistantMessage: "Existing directory thread",
+              pagination: {
+                supportsPagination: false,
+                hasPreviousPage: false,
+              },
+            },
+          },
+        ],
+      },
+      null,
+      2,
+    ),
+    "utf8",
+  );
+
+  return {
+    fixturePath,
+    cleanup: async () => {
+      await rm(rootDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Pastes one solid-colour PNG into the composer, the way the operator does. */
+async function pastePng(input: Locator, name: string, color: string): Promise<void> {
+  await input.evaluate(async (element, params) => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 320;
+    canvas.height = 200;
+    const context = canvas.getContext("2d");
+    if (!context) throw new Error("Canvas context not available");
+    context.fillStyle = params.color;
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob((value) => {
+        if (value) resolve(value);
+        else reject(new Error("Could not create PNG blob"));
+      }, "image/png");
+    });
+    const dataTransfer = new DataTransfer();
+    dataTransfer.items.add(new File([blob], params.name, { type: "image/png" }));
+    element.dispatchEvent(
+      new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dataTransfer,
+      }),
+    );
+  }, { color, name });
+}
+
+test("launchpad send controls stay on screen under both connection cards and pasted images", async () => {
+  const fixture = await createLaunchpadBoundsFixture();
+  const app = await launchElectronApp({
+    fixturePath: fixture.fixturePath,
+    windowSize: WINDOW,
+  });
+
+  try {
+    await app.window.getByRole("tab", { name: "directories" }).click();
+    await app.window
+      .getByRole("button", { name: "Open new thread launchpad for FixtureRepo" })
+      .click();
+
+    const composerInput = app.window.getByRole("textbox", { name: "New thread" });
+    await expect(composerInput).toBeVisible();
+
+    // Precondition: both PwrSuite cards render. If a product change drops
+    // one, the crowding this spec exists to survive is gone and the gate
+    // below would pass for the wrong reason.
+    const cards = app.window.locator(".mcp-connection");
+    await expect(cards).toHaveCount(2);
+
+    await pastePng(composerInput, "bounds-one.png", "#3478f6");
+    await expect(app.window.getByAltText("bounds-one.png")).toBeVisible();
+    await pastePng(composerInput, "bounds-two.png", "#f59e0b");
+    await expect(app.window.getByAltText("bounds-two.png")).toBeVisible();
+    await pastePng(composerInput, "bounds-three.png", "#10b981");
+    await expect(app.window.getByAltText("bounds-three.png")).toBeVisible();
+
+    await composerInput.fill(
+      ["Describe each pasted image.", "", "Then summarise them together."].join("\n"),
+    );
+
+    const startButton = app.window.getByRole("button", { name: "Start thread" });
+    await expect(startButton).toBeVisible();
+
+    const measured = await app.window.evaluate(() => {
+      const clip = document.querySelector(".thread-view--launchpad");
+      const composer = document.querySelector(".thread-view__launchpad-composer");
+      const start = [...document.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Start thread",
+      );
+      if (!clip || !composer || !start) {
+        return null;
+      }
+      const startRect = start.getBoundingClientRect();
+      const hit = document.elementFromPoint(
+        startRect.left + startRect.width / 2,
+        startRect.top + startRect.height / 2,
+      );
+      const list = document.querySelector(".thread-view__connections");
+      return {
+        // Natural, unclipped height of each card — the cards themselves
+        // keep their content height in both the broken and fixed layouts,
+        // so this measures the same thing either way.
+        cardHeights: [...document.querySelectorAll(".mcp-connection")].map(
+          (card) => card.scrollHeight,
+        ),
+        listOverflowPx: list ? list.scrollHeight - list.clientHeight : null,
+        clipBottom: clip.getBoundingClientRect().bottom,
+        clipHeight: clip.getBoundingClientRect().height,
+        composerHeight: composer.getBoundingClientRect().height,
+        startBottom: startRect.bottom,
+        startHitsItself: hit === start || start.contains(hit),
+      };
+    });
+
+    expect(measured, "expected the launchpad, composer and send button to render").not.toBeNull();
+    const {
+      cardHeights,
+      clipBottom,
+      clipHeight,
+      composerHeight,
+      listOverflowPx,
+      startBottom,
+      startHitsItself,
+    } = measured!;
+
+    // Precondition: the scenario really is over-full. Everything the pane
+    // has to hold, measured at its natural height, exceeds the pane.
+    const naturalContentHeight =
+      cardHeights.reduce((total, height) => total + height, 0) + composerHeight;
+    expect(
+      naturalContentHeight,
+      `this window (${WINDOW.width}x${WINDOW.height}) is not tight enough to test anything: `
+        + `${Math.round(naturalContentHeight)}px of content in a ${Math.round(clipHeight)}px pane. `
+        + "Shrink the window rather than relaxing the assertions below.",
+    ).toBeGreaterThan(clipHeight);
+
+    // The gate. `.thread-view` clips with `overflow: hidden`, so anything
+    // past its bottom edge is simply gone.
+    expect(
+      startBottom,
+      `"Start thread" is ${Math.round(startBottom - clipBottom)}px below the pane's `
+        + "clipped bottom edge — the operator cannot reach it by any means",
+    ).toBeLessThanOrEqual(clipBottom + BOUNDS_TOLERANCE_PX);
+
+    // Being inside the box is not the same as being clickable: a taller
+    // sibling drawn over it would satisfy the bound above.
+    expect(
+      startHitsItself,
+      "the centre of \"Start thread\" should hit the button itself",
+    ).toBe(true);
+
+    // The structural half: the cards absorb the deficit by scrolling in
+    // their own list, which is the only thing in this column allowed to.
+    // A refactor that lifts them back out to be siblings of the composer
+    // breaks here rather than silently reintroducing the bug at some
+    // window height nobody tests.
+    expect(
+      listOverflowPx,
+      "the connection cards should live in a `.thread-view__connections` list",
+    ).not.toBeNull();
+    expect(
+      listOverflowPx,
+      "at this window the card list should be the box that scrolls",
+    ).toBeGreaterThan(0);
+  } finally {
+    await app.close();
+    await fixture.cleanup();
+  }
+});

--- a/apps/desktop/e2e/launchpad-composer-bounds.spec.ts
+++ b/apps/desktop/e2e/launchpad-composer-bounds.spec.ts
@@ -16,10 +16,16 @@ import { launchElectronApp } from "./fixtures/electron-app";
  * could shrink, and `.thread-view` clips with `overflow: hidden`, so once
  * the cards plus a composer holding pasted images exceeded the pane the
  * whole composer simply walked off the bottom edge — no scrollbar, no way
- * to reach "Start thread". Measured in headless Chromium against the
- * shipped stylesheet: at a 800px-tall window the send row landed 56px past
- * the clip and `document.elementFromPoint` at its centre returned null; at
- * 700px it was 142px past.
+ * to reach "Start thread".
+ *
+ * Negative-controlled on the macOS CI lane against the shipped layout (a
+ * `TEMP:` commit reverting only the fix, since a geometry assertion written
+ * after a fix agrees with the fix by construction): both cards render at
+ * 253px and 316px, the composer at 401px, and the send row's bottom lands
+ * at 725px in a 600px pane — 125px past the clip, with `startHitsItself`
+ * false, on the run and on the retry. The same failure measured 56px past
+ * at 800px and 142px at 700px in a headless-Chromium harness over the
+ * shipped stylesheet.
  *
  * The invariant this pins is deliberately framed against the clipping
  * ancestor, not against any box the broken layout produces — an assertion

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3313,7 +3313,13 @@ export function ThreadView(props: ThreadViewProps) {
         >
           <div className="thread-view__primary">
             {!launchpadMaterializing ? (
-              <>
+              /* One list, and the only box in this column that may shrink.
+                 The composer below is `flex: 0 0 auto`, so while these
+                 cards were direct siblings of it nothing could absorb a
+                 deficit and the composer left the pane's clipped bottom
+                 edge with its send controls. See `.thread-view__connections`
+                 in app.css. */
+              <div className="thread-view__connections">
                 <PwrSnapConnectionPrompt
                   backend={selectedLaunchpad.backend}
                   desktopApi={props.desktopApi}
@@ -3364,7 +3370,7 @@ export function ThreadView(props: ThreadViewProps) {
                     );
                   }}
                 />
-              </>
+              </div>
             ) : null}
             <div className={`thread-view__launchpad-composer${launchpadMaterializing ? " is-materializing" : ""}`}>
               {launchpadMaterializing ? (

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3319,7 +3319,18 @@ export function ThreadView(props: ThreadViewProps) {
                  deficit and the composer left the pane's clipped bottom
                  edge with its send controls. See `.thread-view__connections`
                  in app.css. */
-              <div className="thread-view__connections">
+              <div
+                aria-label="PwrSuite connections"
+                className="thread-view__connections"
+                role="group"
+                /* The list scrolls, and until both status IPCs resolve every
+                   card renders only "Checking…" — no button, no switch — so
+                   there is nothing inside for a keyboard user to Tab to and
+                   scroll it by. Own the tab stop rather than depending on
+                   whichever control a card happens to be showing (axe
+                   `scrollable-region-focusable`, wcag2a/wcag21a). */
+                tabIndex={0}
+              >
                 <PwrSnapConnectionPrompt
                   backend={selectedLaunchpad.backend}
                   desktopApi={props.desktopApi}

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/thread-view.test.tsx
@@ -2101,6 +2101,22 @@ describe("ThreadView", () => {
     const launchpadRail = screen.getByLabelText("New thread context");
     expect(launchpadRail.parentElement).toHaveClass("thread-view__layout");
     expect(launchpadRail.parentElement?.parentElement).toHaveClass("thread-view");
+    // Both PwrSuite connection cards render into ONE list, and that list is
+    // a sibling of the composer inside `.thread-view__primary`. The list is
+    // the only box in that column allowed to shrink and scroll; while the
+    // cards were direct siblings of the composer, nothing in the column
+    // could absorb a deficit and the composer walked off the clipped bottom
+    // edge with "Start thread" on it. Structure is the half of that fix a
+    // refactor breaks — the geometry half is pinned in
+    // `styles/__tests__/launchpad-connection-bounds.test.ts` and asserted
+    // against a real render in `e2e/launchpad-composer-bounds.spec.ts`.
+    const connectionList = document.querySelector(".thread-view__connections");
+    expect(connectionList).not.toBeNull();
+    expect(connectionList?.querySelectorAll(".mcp-connection")).toHaveLength(2);
+    expect(connectionList?.parentElement).toHaveClass("thread-view__primary");
+    expect(connectionList?.nextElementSibling).toHaveClass(
+      "thread-view__launchpad-composer",
+    );
     expect(screen.getByRole("tab", { name: "AI provider info" })).toBeInTheDocument();
     expect(screen.queryByRole("tab", { name: "Edits" })).not.toBeInTheDocument();
     await waitFor(() => {

--- a/apps/desktop/src/renderer/src/styles/__tests__/launchpad-connection-bounds.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/launchpad-connection-bounds.test.ts
@@ -12,8 +12,10 @@ import { cssRuleBody as ruleBody, firstCssRuleBody } from "./css-rule-body";
  * clips with `overflow: hidden` and shows no scrollbar, so once the cards
  * plus a composer holding pasted images exceeded the pane, the composer
  * walked off the bottom edge and "Start thread" could not be reached by
- * any means. Measured in headless Chromium against this stylesheet: 56px
- * past the clip at a 800px-tall window, 142px at 700px.
+ * any means. Measured on the macOS CI lane against the shipped layout:
+ * 125px past the clip at a 600px-tall window, the button's centre
+ * hit-testing to nothing. (56px past at 800px and 142px at 700px in a
+ * headless-Chromium harness over this stylesheet.)
  *
  * jsdom performs no layout, so the invariant is pinned here as the
  * declarations that produce it. `launchpad-composer-bounds.spec.ts`

--- a/apps/desktop/src/renderer/src/styles/__tests__/launchpad-connection-bounds.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/launchpad-connection-bounds.test.ts
@@ -59,8 +59,24 @@ describe("launchpad connection card bounds", () => {
   it("pays the list's outer air once, on the list, not once per card", () => {
     // Each card used to carry `margin: clamp(28px, 7vh, 72px) 16px 0`, so
     // two cards bought two lots of it — up to 144px of air stacked into a
-    // column that had none to give.
-    expect(firstCssRuleBody(".mcp-connection")).not.toMatch(/\n\s*margin:/);
+    // column that had none to give. Longhands too: matching only the
+    // shorthand would wave through a `margin-top` that reintroduces exactly
+    // that.
+    expect(firstCssRuleBody(".mcp-connection")).not.toMatch(
+      /\n\s*margin(?:-top|-block|-block-start)?:/,
+    );
+  });
+
+  it("keeps the scrolling list's centred column aligned with the composer's", () => {
+    // `align-items: center` and the cards' `calc(100% - 32px)` resolve
+    // against the content box, which a space-taking scrollbar narrows — the
+    // Windows and Linux default. Without a symmetric gutter the card column
+    // sits half a scrollbar left of the composer column below it, and the
+    // headless shell cannot catch it because it only ever draws overlay
+    // scrollbars.
+    expect(ruleBody(".thread-view__connections")).toMatch(
+      /scrollbar-gutter:\s*stable\s+both-edges;/,
+    );
   });
 
   it("bounds the composer's attachment strip so pasted images cannot grow it without limit", () => {
@@ -69,5 +85,23 @@ describe("launchpad connection card bounds", () => {
     // full height to a composer that is `flex: 0 0 auto`.
     expect(body).toMatch(/max-height:/);
     expect(body).toMatch(/overflow-y:\s*auto;/);
+    // Window-relative, or the cap stops shrinking with the pane it has to
+    // fit inside and the strip reclaims the send row at short windows.
+    expect(body).toMatch(/max-height:[^;]*\d+vh/);
+  });
+
+  it("keeps the attachment scroller from clipping each thumbnail's remove control", () => {
+    // `.composer__attachment-remove` is positioned at `top: -6px;
+    // right: -6px` — outside its own thumbnail's box — so the scroller the
+    // cap above introduced would cut the top row's remove buttons and the
+    // last column's off. The padding buys the two edges it overhangs and the
+    // negative margin puts the strip back where it was, which is why the
+    // pair only ever makes sense together.
+    const body = ruleBody(".composer__attachments");
+    expect(body).toMatch(/padding:\s*8px\s+8px\s+0\s+0;/);
+    expect(body).toMatch(/margin-top:\s*-8px;/);
+    expect(firstCssRuleBody(".composer__attachment-remove")).toMatch(
+      /top:\s*-6px;/,
+    );
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/launchpad-connection-bounds.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/launchpad-connection-bounds.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { cssRuleBody as ruleBody, firstCssRuleBody } from "./css-rule-body";
+
+/**
+ * Locks the declarations that keep the launchpad's send controls on screen.
+ *
+ * The bug this exists to prevent: the two PwrSuite connection cards were
+ * direct children of `.thread-view__primary`, a flex column in which
+ * nothing could shrink — each card sized to its own content, and the
+ * composer was pinned beneath them at `flex: 0 0 auto`. `.thread-view`
+ * clips with `overflow: hidden` and shows no scrollbar, so once the cards
+ * plus a composer holding pasted images exceeded the pane, the composer
+ * walked off the bottom edge and "Start thread" could not be reached by
+ * any means. Measured in headless Chromium against this stylesheet: 56px
+ * past the clip at a 800px-tall window, 142px at 700px.
+ *
+ * jsdom performs no layout, so the invariant is pinned here as the
+ * declarations that produce it. `launchpad-composer-bounds.spec.ts`
+ * asserts the rendered result.
+ */
+describe("launchpad connection card bounds", () => {
+  it("keeps the pane that clips the launchpad clipped", () => {
+    // The premise of the whole fix: nothing pushed past this box's bottom
+    // edge is reachable. If this ever becomes a scroll container the
+    // assertions below have lost their reason and should be revisited,
+    // not deleted.
+    expect(firstCssRuleBody(".thread-view")).toMatch(/overflow:\s*hidden;/);
+  });
+
+  it("makes the card list the one box in the column that absorbs a deficit", () => {
+    const body = ruleBody(".thread-view__connections");
+    // `0 1 auto`: never grows into the space the composer wants, always
+    // shrinks before the composer has to.
+    expect(body).toMatch(/flex:\s*0\s+1\s+auto;/);
+    // Without this the flex item's `auto` min-height floor holds it at its
+    // content height and the shrink above never happens.
+    expect(body).toMatch(/min-height:\s*0;/);
+    // A shrink with no scroller just moves the clip inside the list.
+    expect(body).toMatch(/overflow-y:\s*auto;/);
+  });
+
+  it("keeps the composer at its natural height so the send row never shrinks", () => {
+    expect(ruleBody(".thread-view__launchpad-composer")).toMatch(
+      /flex:\s*0\s+0\s+auto;/,
+    );
+  });
+
+  it("keeps each card at its natural height inside the scrolling list", () => {
+    // Shrinkable cards inside a scroller squeeze rather than scroll, which
+    // is the same unreachable-content trap one level down.
+    expect(ruleBody(".thread-view__connections > .mcp-connection")).toMatch(
+      /flex:\s*0\s+0\s+auto;/,
+    );
+  });
+
+  it("pays the list's outer air once, on the list, not once per card", () => {
+    // Each card used to carry `margin: clamp(28px, 7vh, 72px) 16px 0`, so
+    // two cards bought two lots of it — up to 144px of air stacked into a
+    // column that had none to give.
+    expect(firstCssRuleBody(".mcp-connection")).not.toMatch(/\n\s*margin:/);
+  });
+
+  it("bounds the composer's attachment strip so pasted images cannot grow it without limit", () => {
+    const body = ruleBody(".composer__attachments");
+    // The strip wraps, so every additional row of pasted images added its
+    // full height to a composer that is `flex: 0 0 auto`.
+    expect(body).toMatch(/max-height:/);
+    expect(body).toMatch(/overflow-y:\s*auto;/);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
+++ b/apps/desktop/src/renderer/src/styles/__tests__/theme-contract.test.tsx
@@ -1422,7 +1422,7 @@ describe("Tangerine Terminal theme contract", () => {
     expect(directoryMetaRule).toContain("white-space: nowrap;");
   });
 
-  it("locks composer height contract — compact when empty, grows, capped at 280px", () => {
+  it("locks composer height contract — compact when empty, grows, capped at min(280px, 34vh)", () => {
     // Issue #240 follow-up: the composer's min-height is the
     // empty-state floor; max-height is the clamp the editor scrolls
     // inside once the user has typed enough to fill it. Both values
@@ -1439,9 +1439,17 @@ describe("Tangerine Terminal theme contract", () => {
     // BELOW the caret line, so the empty composer read as 12px above
     // the text and ~19.6px below. The floor must never exceed the
     // natural one-line height or the asymmetry comes back.
+    //
+    // The cap gained a window-relative half. 280px is 44% of the pane at
+    // the app's own 640px minimum window height, tall enough that a full
+    // draft could still put the send controls past `.thread-view`'s
+    // `overflow: hidden` edge with everything above the composer already
+    // collapsed. Both halves are locked: dropping the fixed one lets the
+    // editor grow past the design cap on a tall display, and dropping the
+    // `vh` one brings the short-window overflow back.
     const tiptapRule = extractRuleBody(css, ".composer-tiptap-input");
     expect(tiptapRule).toMatch(/min-height:\s*48px;/);
-    expect(tiptapRule).toMatch(/max-height:\s*280px;/);
+    expect(tiptapRule).toMatch(/max-height:\s*min\(280px,\s*34vh\);/);
     expect(tiptapRule).toMatch(/overflow-y:\s*auto;/);
 
     // The inner editor's min-height tracks the outer container's

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16042,24 +16042,75 @@ a.button {
   border-top: 0;
 }
 
+/* The launchpad's PwrSuite connection cards, as ONE list.
+   `.thread-view__primary` is a flex column and `.thread-view` clips with
+   `overflow: hidden`, so every box in that column that cannot shrink is
+   height the composer below it does not get. The cards used to be direct
+   children sized to their own content, each carrying its own
+   `clamp(28px, 7vh, 72px)` top margin — two cards bought two lots of that
+   air — and the composer was pinned under them at `flex: 0 0 auto`.
+   Nothing could give, so a composer holding pasted images simply walked
+   off the clipped bottom edge with "Start thread" on it: measured in
+   headless Chromium at 56px past the clip in an 800px-tall window and
+   142px at 700px, with `elementFromPoint` at the button's centre
+   returning null.
+
+   This list is now the one box in the column allowed to absorb a deficit,
+   and it scrolls what it cannot show. See
+   `styles/__tests__/launchpad-connection-bounds.test.ts` and
+   `e2e/launchpad-composer-bounds.spec.ts`. */
+.thread-view__connections {
+  display: flex;
+  /* Never grows into space the composer wants; always shrinks before the
+     composer has to. */
+  flex: 0 1 auto;
+  flex-direction: column;
+  align-items: center;
+  /* Without this the flex item's `auto` min-height floor holds the list at
+     its content height and the shrink above never happens. */
+  min-height: 0;
+  /* A shrink with no scroller just moves the clip one level down. */
+  overflow-y: auto;
+  /* The list's outer air, paid once here rather than once per card. */
+  padding: clamp(16px, 5vh, 56px) 0 0;
+}
+
+/* Both cards return null against a remote launchpad the owner has not
+   configured. An empty list would still paint its first card's border as a
+   stray hairline above the composer. */
+.thread-view__connections:not(:has(.mcp-connection)) {
+  display: none;
+}
+
 .mcp-connection {
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr) auto;
-  gap: 18px;
+  grid-template-columns: 44px minmax(0, 1fr) auto;
+  gap: 14px;
   align-items: center;
-  align-self: center;
   width: calc(100% - 32px);
   max-width: var(--chat-column-max);
-  margin: clamp(28px, 7vh, 72px) 16px 0;
-  padding: 20px 0;
+  padding: 14px 0;
+  /* One rule per card plus the closing rule below reads as a single list:
+     between two cards the pair collapses to the one hairline that
+     separates them, rather than the doubled border two self-contained
+     cards used to stack. */
   border-top: 1px solid var(--border-subtle);
+}
+
+/* Shrinkable cards inside the scroller would squeeze instead of scroll —
+   the same unreachable-content trap one level down. */
+.thread-view__connections > .mcp-connection {
+  flex: 0 0 auto;
+}
+
+.thread-view__connections > .mcp-connection:last-child {
   border-bottom: 1px solid var(--border-subtle);
 }
 
 .mcp-connection__icon {
   display: block;
-  width: 72px;
-  height: 72px;
+  width: 44px;
+  height: 44px;
   border-radius: 8px;
 }
 
@@ -16074,19 +16125,19 @@ a.button {
 }
 
 .mcp-connection__copy h2 {
-  margin-top: 4px;
+  margin-top: 2px;
   color: var(--text-primary);
-  font-size: 20px;
-  line-height: 1.2;
-  letter-spacing: -0.025em;
+  font-size: 16px;
+  line-height: 1.25;
+  letter-spacing: -0.02em;
 }
 
 .mcp-connection__copy > p:not(.eyebrow) {
   max-width: 620px;
-  margin-top: 7px;
+  margin-top: 4px;
   color: var(--text-secondary);
   font-size: 13px;
-  line-height: 1.5;
+  line-height: 1.45;
 }
 
 .mcp-connection__copy .mcp-connection__detail {
@@ -16122,18 +16173,49 @@ a.button {
 
 @media (max-width: 760px) {
   .mcp-connection {
-    grid-template-columns: 56px minmax(0, 1fr);
-    gap: 14px;
+    grid-template-columns: 36px minmax(0, 1fr);
+    gap: 12px;
   }
 
   .mcp-connection__icon {
-    width: 56px;
-    height: 56px;
+    width: 36px;
+    height: 36px;
   }
 
   .mcp-connection__action {
     grid-column: 2;
     justify-content: flex-start;
+  }
+}
+
+/* Short windows: the list already scrolls, but a two-card list you have to
+   scroll to read is worse than two cards that fit. Buy the fit back out of
+   air and type scale rather than out of the copy — truncating the
+   description would hide the only thing that explains what the connection
+   is for. The app's own minimum window is 640px tall, so this is the size
+   the cards actually have to work at, not an edge case. */
+@media (max-height: 780px) {
+  .thread-view__connections {
+    padding-top: 12px;
+  }
+
+  .mcp-connection {
+    grid-template-columns: 32px minmax(0, 1fr) auto;
+    gap: 12px;
+    padding: 10px 0;
+  }
+
+  .mcp-connection__icon {
+    width: 32px;
+    height: 32px;
+  }
+
+  .mcp-connection__copy h2 {
+    font-size: 14px;
+  }
+
+  .mcp-connection__copy > p:not(.eyebrow) {
+    font-size: 12px;
   }
 }
 
@@ -26957,7 +27039,13 @@ button.pricing-token-miser__folded:focus-visible {
      floor lands entirely below the caret line and reads as lopsided
      padding (56px produced 12px above the text and ~19.6px below). */
   min-height: 48px;
-  max-height: 280px;
+  /* 280px is the design cap, but it is 44% of the pane at the app's own
+     640px minimum window height — tall enough that a full draft could
+     still push the send controls past the clipped bottom edge even with
+     everything above the composer collapsed. The `vh` half only ever binds
+     below ~825px of window, where the fixed cap is the thing that does not
+     fit; the editor scrolls inside the wrapper either way. */
+  max-height: min(280px, 34vh);
   overflow-y: auto;
   border: 1px solid var(--border-subtle);
   border-radius: 8px;
@@ -27798,6 +27886,22 @@ button.pricing-token-miser__folded:focus-visible {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  /* Pasted images wrap onto new rows, and the composer is `flex: 0 0 auto`
+     inside a pane that clips with no scrollbar — before this cap every
+     extra row pushed the send controls down by its full height until they
+     left the window. Roughly two rows are visible; the rest scroll here,
+     which is the one place in the composer where hidden content is
+     obviously recoverable (the thumbnails are their own affordance).
+     Window-relative so the cap shrinks with the pane it has to fit in. */
+  max-height: min(232px, 24vh);
+  overflow-y: auto;
+  /* Each thumbnail's remove cookie is pinned at `top: -6px; right: -6px`,
+     outside its own box, so a scroller would clip it. Pad the two edges it
+     overhangs; the negative top margin puts the strip back where it was,
+     and the right pad sits inside the row's own wrapping slack so the left
+     edge stays aligned with the rest of the composer column. */
+  padding: 8px 8px 0 0;
+  margin-top: -8px;
 }
 
 .composer__attachment {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16171,23 +16171,6 @@ a.button {
   font-size: 12px;
 }
 
-@media (max-width: 760px) {
-  .mcp-connection {
-    grid-template-columns: 36px minmax(0, 1fr);
-    gap: 12px;
-  }
-
-  .mcp-connection__icon {
-    width: 36px;
-    height: 36px;
-  }
-
-  .mcp-connection__action {
-    grid-column: 2;
-    justify-content: flex-start;
-  }
-}
-
 /* Short windows: the list already scrolls, but a two-card list you have to
    scroll to read is worse than two cards that fit. Buy the fit back out of
    air and type scale rather than out of the copy — truncating the
@@ -16216,6 +16199,27 @@ a.button {
 
   .mcp-connection__copy > p:not(.eyebrow) {
     font-size: 12px;
+  }
+}
+
+/* Placed after the short-window block on purpose: both rules touch
+   `grid-template-columns` and the icon size, and at a viewport that is both
+   narrow and short the stacked two-column layout is the one that has to
+   win — the short-window rule only wants the row smaller, not wider. */
+@media (max-width: 760px) {
+  .mcp-connection {
+    grid-template-columns: 36px minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .mcp-connection__icon {
+    width: 36px;
+    height: 36px;
+  }
+
+  .mcp-connection__action {
+    grid-column: 2;
+    justify-content: flex-start;
   }
 }
 

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16050,10 +16050,10 @@ a.button {
    `clamp(28px, 7vh, 72px)` top margin — two cards bought two lots of that
    air — and the composer was pinned under them at `flex: 0 0 auto`.
    Nothing could give, so a composer holding pasted images simply walked
-   off the clipped bottom edge with "Start thread" on it: measured in
-   headless Chromium at 56px past the clip in an 800px-tall window and
-   142px at 700px, with `elementFromPoint` at the button's centre
-   returning null.
+   off the clipped bottom edge with "Start thread" on it: 125px past the
+   clip in a 600px-tall window on the macOS CI lane, with the button's
+   centre hit-testing to nothing (56px past at 800px and 142px at 700px in
+   a headless-Chromium harness over this stylesheet).
 
    This list is now the one box in the column allowed to absorb a deficit,
    and it scrolls what it cannot show. See

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16071,13 +16071,23 @@ a.button {
   min-height: 0;
   /* A shrink with no scroller just moves the clip one level down. */
   overflow-y: auto;
-  /* The list's outer air, paid once here rather than once per card. */
-  padding: clamp(16px, 5vh, 56px) 0 0;
+  /* `align-items: center` and the cards' `calc(100% - 32px)` both resolve
+     against the content box, which a space-taking scrollbar narrows — so
+     without a symmetric gutter the card column would sit half a scrollbar
+     left of the composer column directly below it, on Windows and Linux
+     and on macOS set to "Show scroll bars: Always". `both-edges` keeps the
+     centring honest; it costs nothing where scrollbars are overlays. */
+  scrollbar-gutter: stable both-edges;
+  /* The list's outer air, paid once here rather than once per card. The
+     bottom pays too: scrolled to its end, the last card's border would
+     otherwise land straight on the composer's top edge. */
+  padding: clamp(16px, 5vh, 56px) 0 14px;
 }
 
-/* Both cards return null against a remote launchpad the owner has not
-   configured. An empty list would still paint its first card's border as a
-   stray hairline above the composer. */
+/* Both cards return `null` against a remote launchpad whose owner has not
+   configured PwrSnap or PwrGit, and the wrapper still renders. There is no
+   card and so no border to paint — what an empty list leaves behind is its
+   own `padding`, up to 56px of dead air directly above the composer. */
 .thread-view__connections:not(:has(.mcp-connection)) {
   display: none;
 }
@@ -27893,11 +27903,23 @@ button.pricing-token-miser__folded:focus-visible {
   /* Pasted images wrap onto new rows, and the composer is `flex: 0 0 auto`
      inside a pane that clips with no scrollbar — before this cap every
      extra row pushed the send controls down by its full height until they
-     left the window. Roughly two rows are visible; the rest scroll here,
-     which is the one place in the composer where hidden content is
-     obviously recoverable (the thumbnails are their own affordance).
-     Window-relative so the cap shrinks with the pane it has to fit in. */
-  max-height: min(232px, 24vh);
+     left the window. The rest scroll here, which is the one place in the
+     composer where hidden content is obviously recoverable (the thumbnails
+     are their own affordance).
+
+     240px is two rows measured through the border box, which is what
+     `max-height` bounds: a row is the 88px thumbnail + the 6px
+     `.composer__attachment` gap + an 18px chip line (the size chip always
+     renders), so 112 + 8 + 112 of content, plus the 8px top padding below.
+     Derived at 232px first, which silently clipped the second row by
+     exactly that padding.
+
+     The `vh` half is the one that usually binds — it wins below a 1000px
+     window, so at the app's own 640px minimum the strip is 154px and shows
+     one row and part of the next. That is the point: the cap has to shrink
+     with the pane it must fit inside, and the fixed half is only there to
+     stop the strip eating a tall display. */
+  max-height: min(240px, 24vh);
   overflow-y: auto;
   /* Each thumbnail's remove cookie is pinned at `top: -6px; right: -6px`,
      outside its own box, so a scroller would clip it. Pad the two edges it


### PR DESCRIPTION
## The bug

`.thread-view__primary` is a flex column and `.thread-view` clips with `overflow: hidden` and no scrollbar. On the launchpad, nothing in that column could shrink — the two PwrSuite connection cards were direct children sized to their own content, each carrying its own `clamp(28px, 7vh, 72px)` top margin, and the composer was pinned beneath them at `flex: 0 0 auto`. Put enough above the composer (both cards plus pasted images) and the composer walks off the bottom edge with "Start thread" on it, unreachable by any means.

Measured on the macOS CI lane against the shipped layout, in a 600px-tall window with three pasted images:

```
[bounds] {"cardHeights":[253,316],"clipHeight":600,"composerHeight":401,
          "startBottom":725,"startHitsItself":false}
Error: "Start thread" is 125px below the pane's clipped bottom edge
       — the operator cannot reach it by any means
```

970px of content in a 600px pane, and `document.elementFromPoint` at the button's centre hits nothing.

## Before / after

Rendered from a scratch harness that `<link>`s the real `app.css` (both revisions) around hand-written launchpad markup and a fixed-height composer stand-in, at 1280x700. Contrived data throughout.

### Before
![launchpad before, send controls off screen](./pr-before-700.png)

### After
![launchpad after, send controls in view](./pr-after-700.png)

| | measured | send row |
|---|---|---|
| before, 600px window (CI, real app) | 125px past the clip | hit test misses |
| before, 800px / 700px window (harness) | 56px / 142px past | hit test `null` |
| after (both) | 16px inside the pane | hits the button |

After the fix, swept 1600/1200/900px wide by 1300/1100/900/800/700/640px tall, and independently across composer heights of 200/360/460px at 900/800/720/640px tall: 16px inside the pane in every combination, hit-testing to itself.

## The fix

Give the column one box that can absorb a deficit. Both cards now render into a single `.thread-view__connections` list at `flex: 0 1 auto; min-height: 0; overflow-y: auto` — it never grows into space the composer wants, always shrinks before the composer has to, and scrolls what it cannot show. The composer stays `flex: 0 0 auto`, so the send row is the last thing to give rather than the first thing pushed out.

### Tightening, while they were being restructured

One list rather than two self-contained cards: the outer air is paid once on the list instead of once per card, and between two cards the borders collapse to the single hairline that separates them. Icons 72 → 44px, heading 20 → 16px, padding 20 → 14px. A new `max-height: 780px` breakpoint takes them smaller again (32px icons, 14px heading, 10px padding), because a two-card list you have to scroll to read is worse than two cards that fit — bought out of air and type scale, never out of the copy, since truncating the description would hide the only thing that says what the connection is for.

### The two other unbounded contributors

So the fix does not depend on the cards being the only thing above the composer:

- `.composer__attachments` wraps, so every extra row of pasted images added its full height to a composer that cannot shrink. Capped at `min(232px, 24vh)` and scrolls, padded on the two edges each thumbnail's remove cookie overhangs so the scroller does not clip it.
- `.composer-tiptap-input`'s 280px cap is 44% of the pane at the app's own 640px minimum window height. Now `min(280px, 34vh)`; the `vh` half binds only below ~825px of window, and the editor scrolls inside the wrapper either way. `composer-height-growth.spec.ts` now pins its window above that, so its expectations no longer depend on the runner's display.

## Tests

Written first and verified red on `main`'s stylesheet (first commit), green after (second):

- `e2e/launchpad-composer-bounds.spec.ts` — opens a launchpad in a 600px window, pastes three images, asserts the send row's bottom is inside the clipping ancestor and that its centre hit-tests to itself. Framed against the clip rather than against any box the broken layout produces, since an assertion derived from the geometry under test agrees with the bug by construction. Two preconditions guard a vacuous pass: both cards must render, and everything the pane holds must — at natural height — exceed the pane. Both held during the negative-control failure above, so that failure is the assertion under test rather than a scenario that never set itself up.
- `styles/__tests__/launchpad-connection-bounds.test.ts` — pins the declarations that produce it, jsdom having no layout engine.
- `thread-view.test.tsx` — pins the structural half: both cards render into one list that is a sibling of the composer.

`theme-contract.test.tsx` gains the `vh` half of the input cap alongside the fixed one, so neither can be dropped silently.

The fourth commit fixes an ordering bug found while re-reading the diff: the short-window and narrow-width media blocks both set `grid-template-columns` and the icon size, and the short one was written second, so a viewport that was both narrow and short lost the two-column stacking. The app's 960px minimum window width puts that out of reach today, which is exactly why it would have sat there unnoticed. Order is the whole fix.

### Verification

- Full CI green at head (`0c8c3f78`) — 17 checks, including all four macOS and both Linux Desktop E2E lanes. The new spec ran in macOS lane 2 and passed (1.1s).
- Negative control: a `TEMP:` commit reverting only the fix failed that lane with the numbers quoted above, on the run and on the retry, then was force-pushed away. (Branch pushes do not trigger this repo's CI, so the control had to ride on the PR.) The third commit folds those numbers into the doc comments.
- Local: `pnpm lint:eslint` (0 errors), `pnpm typecheck`, `pnpm lint:colors`, all 12 stylesheet-contract files (153 tests), and the composer + thread-detail renderer suites (71 files, 1409 tests).

## Design record

[Launchpad PwrSuite Connections — Shipped](https://claude.ai/design/p/019df437-879b-7ea9-89a7-aa689d28f06f?file=Launchpad+PwrSuite+Connections+Shipped.dc.html) in the PwrAgent Claude Design project.
