### PR TITLE
fix(desktop): omit startup feature warning from work summary

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -99,6 +99,53 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it.each([1, 2])("omits the startup feature warning from a heading with %i tool updates but retains its entry", (toolCount) => {
+    const turn = completedTurn("turn-1", 82_000);
+    const warning: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-warning-thread-1",
+      tone: "warning",
+      summary: "Warning: Under-development features enabled: default_mode_request_user_input. "
+        + "Under-development features are incomplete and may behave unpredictably. "
+        + "To suppress this warning, set `suppress_unstable_features_warning = true` in /Users/dev/.codex/config.toml.",
+      details: [],
+      turn,
+    };
+    const activities: AppServerThreadActivityEntry[] = Array.from({ length: toolCount }, (_, index) => ({
+      type: "activity",
+      id: `tool-${index}`,
+      summary: "Read config.toml",
+      details: [],
+      turn,
+    }));
+    const entries = [warning, ...activities];
+
+    expect(buildTranscriptRenderItems({ entries })).toEqual([
+      expect.objectContaining({
+        type: "workPhaseGroup",
+        entries,
+        label: toolCount === 1
+          ? "Worked for 1m 22s"
+          : "Worked for 1m 22s · 2 tool updates: 2 × Read config.toml",
+      }),
+    ]);
+  });
+
+  it("keeps other warnings and failed activities in the work heading", () => {
+    const turn = completedTurn("turn-1", 82_000);
+    const entries: AppServerThreadActivityEntry[] = [
+      { type: "activity", id: "live-warning-thread-1", summary: "Warning: connection interrupted", details: [], turn },
+      { type: "activity", id: "tool-1", summary: "Command failed", status: "failed", details: [], turn },
+    ];
+
+    expect(buildTranscriptRenderItems({ entries })).toEqual([
+      expect.objectContaining({
+        entries,
+        label: "Worked for 1m 22s · 2 tool updates: Warning: connection interrupted, Command failed",
+      }),
+    ]);
+  });
+
   it("relativizes absolute paths in a collapsed work phase label", () => {
     const turn = completedTurn("turn-1", 70_000);
     const root = "/Users/dev/.pwragent/worktrees/ab12/PwrAgnt";

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-render-items.test.ts
@@ -501,6 +501,43 @@ describe("buildTranscriptRenderItems", () => {
     ]);
   });
 
+  it("keeps the feature warning out of completed work between review cards", () => {
+    const turn = completedTurn("turn-review", 82_000);
+    const startedReview = review("review-start", "Review changes against origin/main", turn);
+    const completedReview = review("review-complete", "Code review", turn);
+    const warning: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "live-warning-thread-1",
+      tone: "warning",
+      summary: "Warning: Under-development features enabled: default_mode_request_user_input. "
+        + "Under-development features are incomplete and may behave unpredictably. "
+        + "To suppress this warning, set `suppress_unstable_features_warning = true` in /Users/dev/.codex/config.toml.",
+      details: [],
+      turn,
+    };
+    const activity: AppServerThreadActivityEntry = {
+      type: "activity",
+      id: "review-tools",
+      summary: "Explored 7 items · Used 5 tools",
+      details: [],
+      turn,
+    };
+
+    expect(buildTranscriptRenderItems({
+      entries: [startedReview, warning, activity, completedReview],
+    })).toEqual([
+      { type: "entry", entry: startedReview },
+      {
+        type: "workPhaseGroup",
+        id: "work:turn-review:live-warning-thread-1:complete",
+        collapsible: true,
+        entries: [warning, activity],
+        label: "Worked for 1m 22s",
+      },
+      { type: "entry", entry: completedReview },
+    ]);
+  });
+
   it("does not repeat elapsed labels for review-bounded work in one turn", () => {
     const turn = completedTurn("turn-review", 74_000);
     const startedReview = review(

--- a/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/transcript-render-items.ts
@@ -418,7 +418,13 @@ function workGroupLabel(
       ? `Worked for ${formatElapsedMs(turn.completedAt - turn.startedAt)}`
       : "Previous work";
   const toolEntries = entries.filter(
-    (entry): entry is AppServerThreadActivityEntry => entry.type === "activity",
+    (entry): entry is AppServerThreadActivityEntry =>
+      entry.type === "activity"
+      // Keep the startup notice available when expanded without counting it
+      // as tool work or copying its configuration instructions into the heading.
+      && !(entry.tone === "warning"
+        && entry.status !== "failed"
+        && entry.summary.startsWith("Warning: Under-development features enabled:")),
   );
   if (toolEntries.length < 2) {
     return base;


### PR DESCRIPTION
The completed “Worked for” heading treated Codex’s under-development feature notice as a tool update, copying its lengthy warning and config path into the collapsed summary.

Exclude that specific warning from the heading’s tool count and preview. Preserve the original activity in the expanded transcript. Other warnings and failed activities remain eligible for the heading; no Codex configuration or protocol data changes.

Validation: reproduced two failing regression cases before the fix (one and two actual tool updates); a review-specific case with the warning and aggregate tool activity between review-start and review-result cards also fails without the fix. All 30 transcript grouping tests now pass, including preservation of other warnings and failed activities. `pnpm lint:eslint`, `pnpm typecheck`, and `git diff --check` pass. No live UI screenshot captured.
