### PR TITLE
perf(desktop): retain transcript resize subscriptions

### DIFF
--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -1355,6 +1355,23 @@ export function TranscriptList(props: TranscriptListProps) {
     transcriptEntries,
   ]);
 
+  // Content updates change these callbacks. Keep the native subscription tied
+  // to the DOM lifetime: reconnecting ResizeObserver requests another initial
+  // notification even when the observed elements have not changed size.
+  const resizeActionsRef = useRef({
+    requestOlderPageIfUnderflowing,
+    scrollToBottom,
+    syncScrollState,
+  });
+  useLayoutEffect(() => {
+    resizeActionsRef.current = {
+      requestOlderPageIfUnderflowing,
+      scrollToBottom,
+      syncScrollState,
+    };
+  }, [requestOlderPageIfUnderflowing, scrollToBottom, syncScrollState]);
+  const hasScrollContainer = hasTranscriptContent || hasPendingContent;
+
   useEffect(() => {
     const content = scrollContentRef.current;
     const container = scrollContainerRef.current;
@@ -1370,6 +1387,7 @@ export function TranscriptList(props: TranscriptListProps) {
       if (isSidebarResizing()) {
         return;
       }
+      const { scrollToBottom, syncScrollState, requestOlderPageIfUnderflowing } = resizeActionsRef.current;
       if (isGluedToBottomRef.current) {
         scrollToBottom();
       } else {
@@ -1382,7 +1400,7 @@ export function TranscriptList(props: TranscriptListProps) {
     return () => {
       observer.disconnect();
     };
-  }, [requestOlderPageIfUnderflowing, scrollToBottom, syncScrollState]);
+  }, [hasScrollContainer]);
 
   // When a sidebar drag ends, the pane has settled at its final width but the
   // ResizeObserver/onScroll handlers were paused throughout — re-sync the

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/transcript-list.test.tsx
@@ -4215,6 +4215,75 @@ Implementation notes remain in a readable bubble.`;
     expect(list.scrollTop).toBe(120);
   });
 
+  it("retains the resize subscription across streamed updates and uses current callbacks", () => {
+    const callbacks: ResizeObserverCallback[] = [];
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const original = globalThis.ResizeObserver;
+    class ResizeObserverMock {
+      constructor(callback: ResizeObserverCallback) {
+        callbacks.push(callback);
+      }
+      observe = observe;
+      disconnect = disconnect;
+      unobserve = vi.fn();
+    }
+    Object.defineProperty(globalThis, "ResizeObserver", {
+      configurable: true,
+      value: ResizeObserverMock,
+    });
+    try {
+      const onLoadOlder = vi.fn(async () => undefined);
+      const entries = [{ type: "message" as const, id: "prompt", role: "user" as const, text: "Hello" }];
+      const view = render(
+        <TranscriptList entries={[]} loading={false} loadingMore={false}
+          threadId="stream" onLoadOlder={onLoadOlder} />,
+      );
+      expect(callbacks).toHaveLength(0);
+      view.rerender(
+        <TranscriptList entries={entries} loading={false} loadingMore={false}
+          threadId="stream" onLoadOlder={onLoadOlder} />,
+      );
+      for (let index = 0; index < 50; index += 1) {
+        view.rerender(
+          <TranscriptList entries={entries} loading={false} loadingMore={false}
+            threadId="stream" onLoadOlder={onLoadOlder}
+            pendingAssistantMessage={{ type: "message", id: "reply", role: "assistant", text: `Reply ${index}` }} />,
+        );
+      }
+      expect(callbacks).toHaveLength(1);
+      expect(observe).toHaveBeenCalledTimes(2);
+      expect(disconnect).not.toHaveBeenCalled();
+
+      // The retained subscription must use the latest pagination and thread,
+      // not the props captured when it was first installed.
+      view.rerender(
+        <TranscriptList entries={entries} loading={false} loadingMore={false}
+          threadId="next" onLoadOlder={onLoadOlder}
+          pagination={{ supportsPagination: true, hasPreviousPage: true }} />,
+      );
+      scrollHeight = 100;
+      act(() => callbacks[0]([], {} as ResizeObserver));
+      expect(onLoadOlder).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("list").scrollTop).toBe(100);
+      view.rerender(
+        <TranscriptList entries={[]} loading={false} loadingMore={false}
+          threadId="empty" onLoadOlder={onLoadOlder} />,
+      );
+      expect(disconnect).toHaveBeenCalledTimes(1);
+      view.rerender(
+        <TranscriptList entries={[]} loading={false} loadingMore={false}
+          pendingStatusText="Thinking" threadId="empty" onLoadOlder={onLoadOlder} />,
+      );
+      expect(callbacks).toHaveLength(2);
+      expect(observe).toHaveBeenCalledTimes(4);
+      view.unmount();
+      expect(disconnect).toHaveBeenCalledTimes(2);
+    } finally {
+      Object.defineProperty(globalThis, "ResizeObserver", { configurable: true, value: original });
+    }
+  });
+
   it("keeps the bottom pinned when rendered content grows after layout", () => {
     let resizeCallback: ResizeObserverCallback | undefined;
     const OriginalResizeObserver = globalThis.ResizeObserver;


### PR DESCRIPTION
Streamed transcript updates recreated scroll callbacks and disconnected/recreated ResizeObserver on the same content and container elements. Each fresh observation can deliver another initial notification, repeating viewport measurements and bottom-follow work already performed by the layout effect.

Keep the observer attached for the scroll container lifetime and refresh its callbacks after each relevant commit. Empty/content transitions still attach and disconnect the observer, and retained callbacks use current pagination and thread state.

Validation:
- Regression failed before the fix: 50 streamed updates created 51 observers. It now creates one observer, with two observed elements and no reconnects during streaming.
- Regression also checks current pagination callbacks after a thread switch, empty-to-pending-content attachment, and unmount cleanup.
- All 104 transcript tests pass; ESLint, desktop TypeScript, and diff checks pass.

This addresses a verified amplification path in the viewport-measurement stacks from the September 9 renderer captures. The reduction in total live CPU/GC remains to be measured; this does not claim to resolve all navigation rendering work.
