### PR TITLE
feat(desktop): backport Astra support to releases/1.0

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15817,7 +15817,7 @@ command = "pnpm dev"
     await registry.close();
   });
 
-  it("leaves multi-request Astra turn aggregates above 272K unpriced", async () => {
+  it("prices each Astra request before aggregating a multi-request turn", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },
     });
@@ -15836,25 +15836,101 @@ command = "pnpm dev"
     const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
 
     for (const cumulativeInputTokens of [200_000, 400_000]) {
+      for (let emission = 0; emission < 2; emission += 1) {
+        await codexClient.emit({
+          method: "thread/tokenUsage/updated",
+          params: {
+            threadId: "thread-1",
+            turnId: "turn-1",
+            tokenUsage: {
+              last_token_usage: {
+                input_tokens: 200_000,
+                cache_write_input_tokens: 10_000,
+                cached_input_tokens: 100_000,
+                output_tokens: 10_000,
+                reasoning_output_tokens: 0,
+                total_tokens: 210_000,
+              },
+              total_token_usage: {
+                input_tokens: cumulativeInputTokens,
+                cache_write_input_tokens: cumulativeInputTokens / 20,
+                cached_input_tokens: cumulativeInputTokens / 2,
+                output_tokens: cumulativeInputTokens / 20,
+                reasoning_output_tokens: 0,
+                total_tokens: cumulativeInputTokens * 1.05,
+              },
+            },
+          },
+        });
+      }
+    }
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cacheWriteInputCostMicros: 250_000,
+      cacheWriteInputTokens: 20_000,
+      cachedInputTokens: 200_000,
+      cachedInputCostMicros: 200_000,
+      inputTokens: 400_000,
+      outputCostMicros: 1_000_000,
+      priceStatus: "priced",
+      pricingBasis: "request-components",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      totalCostMicros: 3_250_000,
+      uncachedInputCostMicros: 1_800_000,
+      uncachedInputTokens: 200_000,
+    });
+
+    await registry.close();
+  });
+
+  it("sums mixed Astra short- and long-context request rates exactly", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-6-astra",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+    const requests = [
+      { cached: 100_000, input: 200_000, totalInput: 200_000 },
+      { cached: 100_000, input: 300_000, totalInput: 500_000 },
+    ];
+
+    for (const request of requests) {
       await codexClient.emit({
         method: "thread/tokenUsage/updated",
         params: {
           threadId: "thread-1",
           turnId: "turn-1",
           tokenUsage: {
-            last_token_usage: {
-              input_tokens: 200_000,
-              cached_input_tokens: 100_000,
-              output_tokens: 10_000,
-              reasoning_output_tokens: 0,
-              total_tokens: 210_000,
+            last: {
+              cachedInputTokens: request.cached,
+              inputTokens: request.input,
+              outputTokens: 10_000,
+              reasoningOutputTokens: 0,
+              totalTokens: request.input + 10_000,
             },
-            total_token_usage: {
-              input_tokens: cumulativeInputTokens,
-              cached_input_tokens: cumulativeInputTokens / 2,
-              output_tokens: cumulativeInputTokens / 20,
-              reasoning_output_tokens: 0,
-              total_tokens: cumulativeInputTokens * 1.05,
+            total: {
+              cachedInputTokens: request.totalInput === 200_000 ? 100_000 : 200_000,
+              inputTokens: request.totalInput,
+              outputTokens: request.totalInput === 200_000 ? 10_000 : 20_000,
+              reasoningOutputTokens: 0,
+              totalTokens: request.totalInput === 200_000 ? 210_000 : 520_000,
             },
           },
         },
@@ -15868,12 +15944,17 @@ command = "pnpm dev"
 
     expect(pricing.lines).toHaveLength(1);
     expect(pricing.lines[0]).toMatchObject({
-      cachedInputTokens: 200_000,
-      inputTokens: 400_000,
-      priceStatus: "unpriced",
-      totalCostMicros: 0,
-      uncachedInputTokens: 200_000,
+      cachedInputCostMicros: 300_000,
+      inputTokens: 500_000,
+      outputCostMicros: 1_250_000,
+      priceStatus: "priced",
+      pricingBasis: "request-components",
+      pricingCatalogId: "openai-api",
+      pricingCatalogVersion: "2026-09-04",
+      totalCostMicros: 6_550_000,
+      uncachedInputCostMicros: 5_000_000,
     });
+    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
 
     await registry.close();
   });

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -2439,6 +2439,12 @@ describe("DesktopBackendRegistry", () => {
         launchpadOptions: {
           models: [
             {
+              id: "gpt-6-astra",
+              label: "GPT-6-Astra",
+              supportsReasoning: true,
+              supportsFast: true,
+            },
+            {
               id: "gpt-5.6-sol",
               label: "GPT-5.6-Sol",
               supportsReasoning: true,
@@ -8882,8 +8888,8 @@ script = "echo setup"
 
     expect(codexClient.listModelsCallCount).toBe(2);
     expect(response.backends[0]?.launchpadOptions?.models?.[0]).toMatchObject({
-      id: "gpt-5.6-sol",
-      label: "GPT-5.6-Sol",
+      id: "gpt-6-astra",
+      label: "GPT-6-Astra",
     });
     expect(codexClient.lastStartThreadParams?.model).toBe("gpt-5.4");
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -15817,6 +15817,68 @@ command = "pnpm dev"
     await registry.close();
   });
 
+  it("leaves multi-request Astra turn aggregates above 272K unpriced", async () => {
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/read"] },
+    });
+    const overlayStore = createOverlayStoreMock({
+      overlays: {
+        "codex:thread-1": {
+          backend: "codex",
+          threadId: "thread-1",
+          executionMode: "default",
+          extraLinkedDirectories: [],
+          model: "gpt-6-astra",
+          serviceTier: "standard",
+        },
+      },
+    });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore });
+
+    for (const cumulativeInputTokens of [200_000, 400_000]) {
+      await codexClient.emit({
+        method: "thread/tokenUsage/updated",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          tokenUsage: {
+            last_token_usage: {
+              input_tokens: 200_000,
+              cached_input_tokens: 100_000,
+              output_tokens: 10_000,
+              reasoning_output_tokens: 0,
+              total_tokens: 210_000,
+            },
+            total_token_usage: {
+              input_tokens: cumulativeInputTokens,
+              cached_input_tokens: cumulativeInputTokens / 2,
+              output_tokens: cumulativeInputTokens / 20,
+              reasoning_output_tokens: 0,
+              total_tokens: cumulativeInputTokens * 1.05,
+            },
+          },
+        },
+      });
+    }
+
+    const pricing = await overlayStore.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines).toHaveLength(1);
+    expect(pricing.lines[0]).toMatchObject({
+      cachedInputTokens: 200_000,
+      inputTokens: 400_000,
+      priceStatus: "unpriced",
+      totalCostMicros: 0,
+      uncachedInputTokens: 200_000,
+    });
+
+    await registry.close();
+  });
+
+
   it("persists Qwen turn usage as an unpriced card when no catalog rate exists", async () => {
     const codexClient = new MockBackendClient({
       initializeResult: { methods: ["thread/read"] },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3938,6 +3938,7 @@ describe("CodexAppServerClient", () => {
             info: {
               last_token_usage: {
                 input_tokens: 272_001,
+                cache_write_input_tokens: 20_000,
                 cached_input_tokens: 72_001,
                 output_tokens: 100_000,
                 reasoning_output_tokens: 0,
@@ -3962,12 +3963,22 @@ describe("CodexAppServerClient", () => {
     );
 
     expect(usage?.type === "activity" ? usage.usageLine : undefined).toMatchObject({
+      cacheWriteInputCostMicros: 500_000,
+      cacheWriteInputTokens: 20_000,
       cachedInputCostMicros: 144_002,
       priceStatus: "priced",
       pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-gt-272k",
-      totalCostMicros: 11_644_002,
-      uncachedInputCostMicros: 4_000_000,
+      totalCostMicros: 11_744_002,
+      uncachedInputCostMicros: 3_600_000,
     });
+    expect(usage?.type === "activity" ? usage.summary : undefined).toContain(
+      "20,000 cache writes",
+    );
+    expect(
+      usage?.type === "activity"
+        ? usage.details.map((detail) => detail.label)
+        : [],
+    ).toContain("Cache write cost: 20,000 tokens at $25.00/M = $0.50");
 
     await client.close();
   });

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1612,6 +1612,11 @@ describe("CodexAppServerClient", () => {
     MockTransport.modelListResult = {
       data: [
         {
+          id: "gpt-6-astra",
+          displayName: "GPT-6 Astra",
+          supportsReasoning: true,
+        },
+        {
           id: "gpt-5.6-terra",
           displayName: "GPT-5.6-Terra",
           defaultReasoningEffort: "medium",
@@ -1686,6 +1691,12 @@ describe("CodexAppServerClient", () => {
     });
 
     await expect(client.listModels()).resolves.toEqual([
+      {
+        id: "gpt-6-astra",
+        label: "GPT-6-Astra",
+        current: undefined,
+        supportsReasoning: true,
+      },
       {
         id: "gpt-5.6-sol",
         label: "GPT-5.6-Sol",
@@ -1768,6 +1779,16 @@ describe("CodexAppServerClient", () => {
   it("derives Fast support from Codex model service tiers", async () => {
     MockTransport.modelListResult = createModelListResponse([
       createCodexModel({
+        id: "gpt-6-astra",
+        supportedReasoningEfforts: [
+          { reasoningEffort: "low", description: "Fast responses" },
+          { reasoningEffort: "medium", description: "Balanced" },
+          { reasoningEffort: "high", description: "Deep reasoning" },
+          { reasoningEffort: "xhigh", description: "Extra high" },
+          { reasoningEffort: "max", description: "Maximum reasoning" },
+        ],
+      }),
+      createCodexModel({
         id: "gpt-5.6-sol",
         serviceTiers: [
           {
@@ -1823,6 +1844,7 @@ describe("CodexAppServerClient", () => {
         supportsFast: model.supportsFast,
       })),
     ).toEqual([
+      { id: "gpt-6-astra", supportsFast: false },
       { id: "gpt-5.6-sol", supportsFast: true },
       { id: "gpt-5.6-terra", supportsFast: true },
       { id: "gpt-5.6-luna", supportsFast: true },

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -3918,6 +3918,60 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("prices a single Astra request above 272K at the long-context rate", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.readThreadResultByThreadId.set("thread-astra-long-request", {
+      events: [
+        {
+          type: "turn_context",
+          timestamp: "2026-09-04T12:00:00.000Z",
+          payload: {
+            turn_id: "turn-1",
+            model: "gpt-6-astra",
+          },
+        },
+        {
+          type: "event_msg",
+          timestamp: "2026-09-04T12:00:10.000Z",
+          payload: {
+            type: "token_count",
+            info: {
+              last_token_usage: {
+                input_tokens: 272_001,
+                cached_input_tokens: 72_001,
+                output_tokens: 100_000,
+                reasoning_output_tokens: 0,
+                total_tokens: 372_001,
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+
+    const replay = await client.readThread({
+      threadId: "thread-astra-long-request",
+    });
+    const usage = replay.entries.find(
+      (entry) => entry.type === "activity" && entry.usageLine,
+    );
+
+    expect(usage?.type === "activity" ? usage.usageLine : undefined).toMatchObject({
+      cachedInputCostMicros: 144_002,
+      priceStatus: "priced",
+      pricingRateId: "openai:2026-09-04:gpt-6-astra:standard:input-gt-272k",
+      totalCostMicros: 11_644_002,
+      uncachedInputCostMicros: 4_000_000,
+    });
+
+    await client.close();
+  });
+
   it("prices token_count entries with each turn's own model metadata", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     MockTransport.readThreadResultByThreadId.set("thread-token-count-model-switch", {

--- a/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-store-usage-pricing.test.ts
@@ -52,6 +52,50 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
     ]);
   });
 
+  it("round-trips request-component pricing for a mixed-band Astra turn", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cacheWriteInputCostMicros: 375_000,
+        cacheWriteInputTokens: 20_000,
+        cachedInputCostMicros: 300_000,
+        cachedInputTokens: 200_000,
+        createdAt: Date.UTC(2026, 8, 5),
+        inputTokens: 500_000,
+        model: "gpt-6-astra",
+        outputCostMicros: 1_250_000,
+        outputTokens: 20_000,
+        pricingBasis: "request-components",
+        pricingCatalogVersion: "2026-09-04",
+        pricingRateId: undefined,
+        reasoningOutputTokens: 0,
+        totalCostMicros: 6_625_000,
+        totalTokens: 520_000,
+        uncachedInputCostMicros: 4_700_000,
+        uncachedInputTokens: 300_000,
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      cacheWriteInputCostMicros: 375_000,
+      cacheWriteInputTokens: 20_000,
+      cachedInputCostMicros: 300_000,
+      priceStatus: "priced",
+      pricingBasis: "request-components",
+      totalCostMicros: 6_625_000,
+      uncachedInputCostMicros: 4_700_000,
+    });
+    expect(pricing.lines[0]?.pricingRateId).toBeUndefined();
+    expect(pricing.summaries[0]).toMatchObject({
+      totalCostMicros: 6_625_000,
+      unpricedUsageLineCount: 0,
+    });
+  });
+
   it("does not rewrite a finalized usage line model when thread settings change later", async () => {
     await store.upsertThreadUsageLine({
       line: buildUsageLine({
@@ -703,6 +747,40 @@ describe("SqliteOverlayStore thread usage pricing ledger", () => {
       totalCostMicros: 0,
       unpricedUsageLineCount: 1,
       usageLineCount: 1,
+    });
+  });
+
+  it("labels aggregate Astra usage as missing a request breakdown", async () => {
+    await store.upsertThreadUsageLine({
+      line: buildUsageLine({
+        cachedInputCostMicros: 0,
+        cachedInputTokens: 100_000,
+        createdAt: Date.UTC(2026, 8, 5),
+        inputTokens: 300_000,
+        model: "gpt-6-astra",
+        outputCostMicros: 0,
+        outputTokens: 10_000,
+        priceStatus: "unpriced",
+        pricingCatalogId: undefined,
+        pricingCatalogVersion: undefined,
+        pricingRateId: undefined,
+        reasoningOutputTokens: 0,
+        scope: "turn",
+        totalCostMicros: 0,
+        totalTokens: 310_000,
+        uncachedInputCostMicros: 0,
+        uncachedInputTokens: 200_000,
+      }),
+    });
+
+    const pricing = await store.readThreadPricing({
+      backend: "codex",
+      threadId: "thread-1",
+    });
+
+    expect(pricing.lines[0]).toMatchObject({
+      priceStatus: "unpriced",
+      priceUnavailableReason: "insufficient-token-breakdown",
     });
   });
 

--- a/apps/desktop/src/main/__tests__/state-db.test.ts
+++ b/apps/desktop/src/main/__tests__/state-db.test.ts
@@ -84,6 +84,41 @@ describe("StateDb", () => {
       "thread_usage_lines",
       "thread_usage_turns",
     ]);
+    const usageLineColumns = stateDb.raw
+      .prepare("PRAGMA table_info(thread_usage_lines)")
+      .all() as Array<{ name: string }>;
+    expect(usageLineColumns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "cache_write_input_cost_micros",
+        "cache_write_input_tokens",
+        "cumulative_cache_write_input_tokens",
+        "pricing_basis",
+      ]),
+    );
+  });
+
+  it("upgrades the release v32 ledger with request-pricing columns", () => {
+    stateDb.raw.exec("ALTER TABLE thread_usage_lines DROP COLUMN cache_write_input_cost_micros");
+    stateDb.raw.exec("ALTER TABLE thread_usage_lines DROP COLUMN cache_write_input_tokens");
+    stateDb.raw.exec("ALTER TABLE thread_usage_lines DROP COLUMN cumulative_cache_write_input_tokens");
+    stateDb.raw.exec("ALTER TABLE thread_usage_lines DROP COLUMN pricing_basis");
+    stateDb.raw.pragma("user_version = 32");
+    stateDb.close();
+
+    stateDb = StateDb.open(path.join(tempDir, "state.db"));
+
+    const columns = stateDb.raw
+      .prepare("PRAGMA table_info(thread_usage_lines)")
+      .all() as Array<{ name: string }>;
+    expect(columns.map((column) => column.name)).toEqual(
+      expect.arrayContaining([
+        "cache_write_input_cost_micros",
+        "cache_write_input_tokens",
+        "cumulative_cache_write_input_tokens",
+        "pricing_basis",
+      ]),
+    );
+    expect(stateDb.raw.pragma("user_version", { simple: true })).toBe(33);
   });
 
   it("creates thread tool accounting tables", () => {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -1526,6 +1526,15 @@ const DEFAULT_REASONING_EFFORT = "medium";
 
 const OPENAI_FALLBACK_MODELS: BackendModelOption[] = [
   {
+    id: "gpt-6-astra",
+    label: "GPT-6-Astra",
+    defaultReasoningEffort: DEFAULT_REASONING_EFFORT,
+    reasoningEfforts: OPENAI_GPT56_REASONING_EFFORTS,
+    supportsReasoning: true,
+    supportsFast: true,
+    supportsSteering: true,
+  },
+  {
     id: "gpt-5.6-sol",
     label: "GPT-5.6-Sol",
     defaultReasoningEffort: DEFAULT_REASONING_EFFORT,
@@ -4023,7 +4032,11 @@ function inferSupportsReasoning(
     return id.includes("reasoning");
   }
 
-  return id.startsWith("gpt-5") || id.startsWith("o");
+  return (
+    id.startsWith("gpt-5")
+    || id.startsWith("gpt-6")
+    || id.startsWith("o")
+  );
 }
 
 function inferSupportsFast(

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -30,7 +30,7 @@ import {
   estimateTokenUsageCost,
   formatTokenUsageUsd,
   isToolManagedWorktreePath,
-  resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
   shortenDerivedThreadTitle,
   type AgentEvent,
   type ArchiveWorktreeRequest,
@@ -2989,6 +2989,7 @@ function buildTaskMonitorRecoveryPrompt(params: {
 }
 
 type TaskMonitorTokenUsageBreakdown = {
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   uncachedInputTokens?: number;
@@ -3170,6 +3171,10 @@ function buildTaskMonitorUsageSnapshot(params: {
   const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
   const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cacheWriteInputTokens = Math.min(
+    uncachedInputTokens,
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const totalTokens = Math.max(
@@ -3177,6 +3182,7 @@ function buildTaskMonitorUsageSnapshot(params: {
     tokens.totalTokens ?? inputTokens + outputTokens + reasoningOutputTokens,
   );
   const cost = estimateTaskMonitorUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,
@@ -3206,6 +3212,9 @@ function buildTaskMonitorUsageSnapshot(params: {
     ...(params.serviceTier ? { serviceTier: params.serviceTier } : {}),
     summary,
     tokenUsage: {
+      ...(tokens.cacheWriteInputTokens !== undefined
+        ? { cacheWriteInputTokens }
+        : {}),
       cachedInputTokens,
       inputTokens,
       outputTokens,
@@ -3287,6 +3296,91 @@ function readTaskMonitorTokenUsageRecords(
   return undefined;
 }
 
+function addTaskMonitorTokenUsage(
+  first: TaskMonitorTokenUsageBreakdown,
+  second: TaskMonitorTokenUsageBreakdown,
+): TaskMonitorTokenUsageBreakdown | undefined {
+  const result: TaskMonitorTokenUsageBreakdown = {};
+  for (const key of [
+    "cacheWriteInputTokens",
+    "cachedInputTokens",
+    "inputTokens",
+    "uncachedInputTokens",
+    "outputTokens",
+    "reasoningOutputTokens",
+    "totalTokens",
+  ] as const) {
+    const firstValue = first[key];
+    const secondValue = second[key];
+    if (typeof firstValue === "number" || typeof secondValue === "number") {
+      result[key] = (firstValue ?? 0) + (secondValue ?? 0);
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function taskMonitorTokenUsageEqual(
+  first: TaskMonitorTokenUsageBreakdown | undefined,
+  second: TaskMonitorTokenUsageBreakdown | undefined,
+): boolean {
+  if (!first || !second) {
+    return false;
+  }
+  return (
+    first.cacheWriteInputTokens === second.cacheWriteInputTokens
+    && first.cachedInputTokens === second.cachedInputTokens
+    && first.inputTokens === second.inputTokens
+    && first.uncachedInputTokens === second.uncachedInputTokens
+    && first.outputTokens === second.outputTokens
+    && first.reasoningOutputTokens === second.reasoningOutputTokens
+    && first.totalTokens === second.totalTokens
+  );
+}
+
+function foldLiveThreadRequestUsage(params: {
+  current: LiveThreadRequestUsage | undefined;
+  tokenUsage: unknown;
+}): LiveThreadRequestUsage | undefined {
+  const records = readTaskMonitorTokenUsageRecords(params.tokenUsage);
+  const latestUsage = records?.latestUsage;
+  const cumulativeInputTokens = records?.totalUsage?.inputTokens;
+  if (
+    !latestUsage
+    || typeof cumulativeInputTokens !== "number"
+    || !Number.isFinite(cumulativeInputTokens)
+  ) {
+    return params.current;
+  }
+
+  const normalizedCumulativeInputTokens = Math.max(0, cumulativeInputTokens);
+  if (
+    params.current
+    && normalizedCumulativeInputTokens < params.current.cumulativeInputTokens
+  ) {
+    return params.current;
+  }
+  if (
+    params.current
+    && normalizedCumulativeInputTokens === params.current.cumulativeInputTokens
+  ) {
+    const priorRequest = params.current.requests.at(-1);
+    if (taskMonitorTokenUsageEqual(priorRequest, latestUsage)) {
+      return params.current;
+    }
+    return {
+      cumulativeInputTokens: normalizedCumulativeInputTokens,
+      requests: [
+        ...params.current.requests.slice(0, -1),
+        latestUsage,
+      ],
+    };
+  }
+  return {
+    cumulativeInputTokens: normalizedCumulativeInputTokens,
+    requests: [...(params.current?.requests ?? []), latestUsage],
+  };
+}
+
 function readTaskMonitorTokenBreakdownFromUnknown(
   value: unknown,
 ): TaskMonitorTokenUsageBreakdown | undefined {
@@ -3299,6 +3393,12 @@ function readTaskMonitorTokenBreakdown(
 ): TaskMonitorTokenUsageBreakdown | undefined {
   const explicitTotal = readTaskMonitorNumber(record, "totalTokens", "total_tokens");
   const inputTokens = readTaskMonitorNumber(record, "inputTokens", "input_tokens");
+  const cacheWriteInputTokens = readTaskMonitorNumber(
+    record,
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cache_write_tokens",
+  );
   const cachedInputTokens = readTaskMonitorNumber(
     record,
     "cachedInputTokens",
@@ -3316,6 +3416,7 @@ function readTaskMonitorTokenBreakdown(
   if (
     totalTokens === undefined &&
     inputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     cachedInputTokens === undefined &&
     outputTokens === undefined &&
     reasoningOutputTokens === undefined
@@ -3323,6 +3424,7 @@ function readTaskMonitorTokenBreakdown(
     return undefined;
   }
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -3337,6 +3439,7 @@ function subtractTaskMonitorTokenUsage(
 ): TaskMonitorTokenUsageBreakdown | undefined {
   const result: TaskMonitorTokenUsageBreakdown = {};
   for (const key of [
+    "cacheWriteInputTokens",
     "cachedInputTokens",
     "inputTokens",
     "uncachedInputTokens",
@@ -3361,6 +3464,10 @@ function normalizeTaskMonitorPricingTokens(
     inputTokens,
     Math.max(0, tokens.cachedInputTokens ?? 0),
   );
+  const cacheWriteInputTokens = Math.min(
+    Math.max(0, inputTokens - cachedInputTokens),
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
   const uncachedInputTokens = Math.max(
     0,
     tokens.uncachedInputTokens ?? inputTokens - cachedInputTokens,
@@ -3372,12 +3479,110 @@ function normalizeTaskMonitorPricingTokens(
     tokens.totalTokens ?? inputTokens + outputTokens + reasoningOutputTokens,
   );
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
     reasoningOutputTokens,
     totalTokens,
     uncachedInputTokens,
+  };
+}
+
+function estimateRequestComponentsCost(params: {
+  at?: number;
+  fastMode?: boolean;
+  model?: string;
+  requests: readonly TaskMonitorTokenUsageBreakdown[];
+  serviceTier?: string;
+  turnTokenUsage: TaskMonitorTokenUsageBreakdown;
+}): RequestComponentsCost | undefined {
+  if (params.requests.length === 0) {
+    return undefined;
+  }
+  const requestTotal = params.requests.reduce<TaskMonitorTokenUsageBreakdown>(
+    (total, request) => addTaskMonitorTokenUsage(total, request) ?? total,
+    {},
+  );
+  const normalizedRequestTotal = normalizeTaskMonitorPricingTokens(requestTotal);
+  const normalizedTurnTotal = normalizeTaskMonitorPricingTokens(
+    params.turnTokenUsage,
+  );
+  if (
+    normalizedRequestTotal.cacheWriteInputTokens
+      !== normalizedTurnTotal.cacheWriteInputTokens
+    || normalizedRequestTotal.cachedInputTokens
+      !== normalizedTurnTotal.cachedInputTokens
+    || normalizedRequestTotal.inputTokens !== normalizedTurnTotal.inputTokens
+    || normalizedRequestTotal.outputTokens !== normalizedTurnTotal.outputTokens
+    || normalizedRequestTotal.reasoningOutputTokens
+      !== normalizedTurnTotal.reasoningOutputTokens
+  ) {
+    return undefined;
+  }
+
+  const costs = params.requests.map((request) => {
+    const tokens = normalizeTaskMonitorPricingTokens(request);
+    return estimateTokenUsageCost({
+      at: params.at,
+      cacheWriteInputTokens: tokens.cacheWriteInputTokens,
+      cachedInputTokens: tokens.cachedInputTokens,
+      fastMode: params.fastMode,
+      inputTokenScope: "request",
+      model: params.model,
+      outputTokens: tokens.outputTokens,
+      reasoningOutputTokens: tokens.reasoningOutputTokens,
+      serviceTier: params.serviceTier,
+      uncachedInputTokens: tokens.uncachedInputTokens,
+    });
+  });
+  if (costs.some((cost) => cost === undefined)) {
+    return undefined;
+  }
+  const priced = costs.filter(
+    (cost): cost is NonNullable<typeof cost> => cost !== undefined,
+  );
+  const first = priced[0]!;
+  if (
+    priced.some(
+      (cost) =>
+        cost.catalogId !== first.catalogId
+        || cost.catalogVersion !== first.catalogVersion
+        || cost.currency !== first.currency
+        || cost.provider !== first.provider
+        || cost.serviceTier !== first.serviceTier,
+    )
+  ) {
+    return undefined;
+  }
+  const rateIds = new Set(priced.map((cost) => cost.rateId));
+  return {
+    cacheWriteInputCostMicros: priced.reduce(
+      (total, cost) => total + cost.cacheWriteInputCostMicros,
+      0,
+    ),
+    cachedInputCostMicros: priced.reduce(
+      (total, cost) => total + cost.cachedInputCostMicros,
+      0,
+    ),
+    catalogId: first.catalogId,
+    catalogVersion: first.catalogVersion,
+    currency: first.currency,
+    outputCostMicros: priced.reduce(
+      (total, cost) => total + cost.outputCostMicros,
+      0,
+    ),
+    provider: first.provider,
+    ...(rateIds.size === 1 ? { rateId: first.rateId } : {}),
+    serviceTier: first.serviceTier,
+    totalCostMicros: priced.reduce(
+      (total, cost) => total + cost.totalCostMicros,
+      0,
+    ),
+    uncachedInputCostMicros: priced.reduce(
+      (total, cost) => total + cost.uncachedInputCostMicros,
+      0,
+    ),
   };
 }
 
@@ -3395,6 +3600,7 @@ function readTaskMonitorNumber(
 }
 
 function estimateTaskMonitorUsageCost(params: {
+  cacheWriteInputTokens?: number;
   cachedInputTokens: number;
   fastMode?: boolean;
   model?: string;
@@ -3448,6 +3654,10 @@ function buildTaskMonitorUsageLine(params: {
     inputTokens,
     Math.max(0, tokenUsage.cachedInputTokens ?? 0),
   );
+  const cacheWriteInputTokens = Math.min(
+    Math.max(0, inputTokens - cachedInputTokens),
+    Math.max(0, tokenUsage.cacheWriteInputTokens ?? 0),
+  );
   const uncachedInputTokens = Math.max(
     0,
     tokenUsage.uncachedInputTokens ?? inputTokens - cachedInputTokens,
@@ -3460,6 +3670,7 @@ function buildTaskMonitorUsageLine(params: {
   );
   const model = params.model ?? params.usage.model ?? params.usage.cost?.model;
   const cost = estimateTokenUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     model,
@@ -3468,21 +3679,21 @@ function buildTaskMonitorUsageLine(params: {
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
-  const pricingServiceTier = resolveOpenAiPricingServiceTier({
-    fastMode: params.fastMode,
-    serviceTier: params.serviceTier,
-  });
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          cachedInputTokens,
+          fastMode: params.fastMode,
+          model,
+          serviceTier: params.serviceTier,
+          uncachedInputTokens,
+        });
 
   return {
     backend: params.backend,
+    cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
+    cacheWriteInputTokens,
     cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
     cachedInputTokens,
     createdAt: Date.now(),
@@ -3656,6 +3867,7 @@ function buildLiveThreadUsageLine(params: {
   fastMode?: boolean;
   model?: string;
   observedReplays?: ObservedContextReplayTally;
+  requestTokenUsages?: readonly TaskMonitorTokenUsageBreakdown[];
   serviceTier?: string;
   startedAt?: number;
   threadId: string;
@@ -3668,6 +3880,7 @@ function buildLiveThreadUsageLine(params: {
   }
 
   const {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -3678,7 +3891,20 @@ function buildLiveThreadUsageLine(params: {
   const cumulativeTokens = params.cumulativeTokenUsage
     ? normalizeTaskMonitorPricingTokens(params.cumulativeTokenUsage)
     : undefined;
-  const cost = estimateTokenUsageCost({
+  const createdAt = params.createdAt ?? params.completedAt ?? Date.now();
+  const requestComponentsCost = params.requestTokenUsages
+    ? estimateRequestComponentsCost({
+        at: createdAt,
+        fastMode: params.fastMode,
+        model: params.model,
+        requests: params.requestTokenUsages,
+        serviceTier: params.serviceTier,
+        turnTokenUsage: tokens,
+      })
+    : undefined;
+  const cost = requestComponentsCost ?? estimateTokenUsageCost({
+    at: createdAt,
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     model: params.model,
@@ -3687,29 +3913,31 @@ function buildLiveThreadUsageLine(params: {
     serviceTier: params.serviceTier,
     uncachedInputTokens,
   });
-  const pricingServiceTier = resolveOpenAiPricingServiceTier({
-    fastMode: params.fastMode,
-    serviceTier: params.serviceTier,
-  });
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !params.model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          cachedInputTokens,
+          fastMode: params.fastMode,
+          model: params.model,
+          serviceTier: params.serviceTier,
+          uncachedInputTokens,
+        });
 
   return {
     backend: params.backend,
+    cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
+    cacheWriteInputTokens,
     cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
     cachedInputTokens,
     ...(typeof params.completedAt === "number" ? { completedAt: params.completedAt } : {}),
-    createdAt: params.createdAt ?? params.completedAt ?? Date.now(),
+    createdAt,
     currency: cost?.currency ?? "USD",
     ...(cumulativeTokens
       ? {
           cumulativeCachedInputTokens: cumulativeTokens.cachedInputTokens,
+          cumulativeCacheWriteInputTokens:
+            cumulativeTokens.cacheWriteInputTokens,
           cumulativeInputTokens: cumulativeTokens.inputTokens,
           cumulativeOutputTokens: cumulativeTokens.outputTokens,
           cumulativeReasoningOutputTokens: cumulativeTokens.reasoningOutputTokens,
@@ -3737,6 +3965,7 @@ function buildLiveThreadUsageLine(params: {
     provider: cost?.provider ?? fallbackUsageProvider(params.backend),
     ...(cost?.catalogId ? { pricingCatalogId: cost.catalogId } : {}),
     ...(cost?.catalogVersion ? { pricingCatalogVersion: cost.catalogVersion } : {}),
+    ...(requestComponentsCost ? { pricingBasis: "request-components" as const } : {}),
     ...(cost?.rateId ? { pricingRateId: cost.rateId } : {}),
     reasoningOutputTokens,
     scope: "turn",
@@ -3787,6 +4016,7 @@ function buildForkBaselineUsageLine(params: {
   usageTiming: { completedAt?: number; createdAt?: number; startedAt?: number };
 }): ThreadUsageLineRecord | undefined {
   const {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -3811,6 +4041,8 @@ function buildForkBaselineUsageLine(params: {
     Date.now();
   return {
     backend: params.backend,
+    cacheWriteInputCostMicros: 0,
+    cacheWriteInputTokens,
     cachedInputCostMicros: 0,
     cachedInputTokens,
     createdAt: Math.max(0, anchorAt - 1),
@@ -5587,6 +5819,25 @@ function buildCodexInvalidIdRecoveryCooldownMessage(
   );
 }
 
+type LiveThreadRequestUsage = {
+  cumulativeInputTokens: number;
+  requests: TaskMonitorTokenUsageBreakdown[];
+};
+
+type RequestComponentsCost = {
+  cacheWriteInputCostMicros: number;
+  cachedInputCostMicros: number;
+  catalogId: string;
+  catalogVersion: string;
+  currency: "USD";
+  outputCostMicros: number;
+  provider: string;
+  rateId?: string;
+  serviceTier: string;
+  totalCostMicros: number;
+  uncachedInputCostMicros: number;
+};
+
 export class DesktopBackendRegistry {
   private readonly codexClient: BackendClient;
   private readonly grokClient: BackendClient;
@@ -5690,6 +5941,7 @@ export class DesktopBackendRegistry {
   private readonly reservedCodexStartThreadIds = new Set<string>();
   private readonly reservedAcpStartThreadKeys = new Set<string>();
   private readonly activeTurnKeys = new Set<string>();
+  private readonly liveThreadRequestUsage = new Map<string, LiveThreadRequestUsage>();
   private readonly liveThreadUsageBaselines = new Map<
     string,
     TaskMonitorTokenUsageBreakdown
@@ -15846,6 +16098,33 @@ export class DesktopBackendRegistry {
     }
   }
 
+  private observeLiveThreadRequestUsage(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+    tokenUsage: unknown;
+    turnId?: string;
+  }): readonly TaskMonitorTokenUsageBreakdown[] | undefined {
+    if (!params.turnId) {
+      return undefined;
+    }
+    const key = [
+      params.backend,
+      params.threadId,
+      params.turnId,
+      "live-token-usage",
+    ].join(":");
+    const folded = foldLiveThreadRequestUsage({
+      current: this.liveThreadRequestUsage.get(key),
+      tokenUsage: params.tokenUsage,
+    });
+    if (!folded) {
+      return undefined;
+    }
+    this.liveThreadRequestUsage.set(key, folded);
+    return folded.requests;
+  }
+
+
   private deriveLiveThreadTokenUsage(params: {
     backend: AppServerBackendKind;
     threadId: string;
@@ -16153,6 +16432,12 @@ export class DesktopBackendRegistry {
     const fastMode =
       readUsageBoolean(tokenUsage, ["fastMode", "fast_mode"]) ??
       overlay?.fastMode;
+    const requestTokenUsages = this.observeLiveThreadRequestUsage({
+      backend: event.backend,
+      threadId,
+      tokenUsage,
+      turnId: notification.params.turnId ?? undefined,
+    });
     const derivedUsage = this.deriveLiveThreadTokenUsage({
       backend: event.backend,
       threadId,
@@ -16177,6 +16462,7 @@ export class DesktopBackendRegistry {
       fastMode,
       model,
       observedReplays,
+      requestTokenUsages,
       serviceTier,
       threadId,
       tokenUsage: derivedUsage.turnTokenUsage,
@@ -23510,6 +23796,13 @@ export class DesktopBackendRegistry {
         };
       };
       const turnId = turnIdFromStartedNotification(notification);
+      const requestUsagePrefix = [event.backend, notification.params.threadId, ""].join(":");
+      const currentRequestUsageKey = `${requestUsagePrefix}${turnId}:live-token-usage`;
+      for (const key of this.liveThreadRequestUsage.keys()) {
+        if (key.startsWith(requestUsagePrefix) && key !== currentRequestUsageKey) {
+          this.liveThreadRequestUsage.delete(key);
+        }
+      }
       if (!isAcpBackendId(event.backend)) {
         this.schedulePendingThreadTitleGenerationFromLifecycle({
           backend: event.backend,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -151,6 +151,7 @@ const LEGACY_CODEX_THREAD_TITLE_CONFIG: NonNullable<CodexThreadStartParams["conf
 const CODEX_DEFAULT_MODE_REQUEST_USER_INPUT_CONFIG_KEY =
   "features.default_mode_request_user_input";
 const SUPPORTED_CODEX_MODEL_ORDER = [
+  "gpt-6-astra",
   "gpt-5.6-sol",
   "gpt-5.6-terra",
   "gpt-5.6-luna",

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -11,6 +11,7 @@ import {
   isToolManagedWorktreePath,
   parseCodexTurnErrorMessage,
   resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
   shortenDerivedThreadTitle,
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
@@ -2724,6 +2725,7 @@ function formatElapsedMs(elapsedMs: number): string {
 }
 
 type TokenUsageBreakdown = {
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -2749,6 +2751,11 @@ function readTokenUsageBreakdown(
 ): TokenUsageBreakdown | undefined {
   const explicitTotal = pickNumber(record, ["totalTokens", "total_tokens"]);
   const inputTokens = pickNumber(record, ["inputTokens", "input_tokens"]);
+  const cacheWriteInputTokens = pickNumber(record, [
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cache_write_tokens",
+  ]);
   const cachedInputTokens = pickNumber(record, [
     "cachedInputTokens",
     "cached_input_tokens",
@@ -2765,6 +2772,7 @@ function readTokenUsageBreakdown(
   if (
     totalTokens === undefined &&
     inputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     cachedInputTokens === undefined &&
     outputTokens === undefined &&
     reasoningOutputTokens === undefined
@@ -2773,6 +2781,7 @@ function readTokenUsageBreakdown(
   }
 
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,
@@ -2921,6 +2930,11 @@ function summarizeTokenUsageActivity(
   const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
   const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cacheWriteInputTokens = Math.min(
+    uncachedInputTokens,
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
+  const regularInputTokens = uncachedInputTokens - cacheWriteInputTokens;
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const billedOutputTokens = outputTokens + reasoningOutputTokens;
@@ -2929,6 +2943,7 @@ function summarizeTokenUsageActivity(
     pricingContext
   );
   const cost = estimateTokenUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     at: createdAt,
     fastMode: resolvedPricingContext.fastMode,
@@ -2942,6 +2957,9 @@ function summarizeTokenUsageActivity(
   const idSuffix = typeof createdAt === "number" ? Math.round(createdAt) : "unknown";
   const summaryParts = [
     `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    cacheWriteInputTokens > 0
+      ? `${formatTokenCount(cacheWriteInputTokens)} cache writes`
+      : undefined,
     `${formatTokenCount(cachedInputTokens)} cached`,
     reasoningOutputTokens > 0
       ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(reasoningOutputTokens)} reasoning)`
@@ -2956,18 +2974,26 @@ function summarizeTokenUsageActivity(
   const sourceItemId =
     pickString(record, ["id", "itemId", "item_id", "callId", "call_id"]) ??
     `${idSuffix}`;
-  const pricingServiceTier = resolveOpenAiPricingServiceTier(resolvedPricingContext);
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !resolvedPricingContext.model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          at: createdAt,
+          cachedInputTokens,
+          fastMode: resolvedPricingContext.fastMode,
+          inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
+          model: resolvedPricingContext.model,
+          serviceTier: resolvedPricingContext.serviceTier,
+          uncachedInputTokens,
+        });
+  const pricingServiceTier = resolveOpenAiPricingServiceTier(
+    resolvedPricingContext,
+  );
   const usageLine: ThreadUsageLineRecord | undefined = threadId
     ? {
         backend: "codex",
+        cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
+        cacheWriteInputTokens,
         cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
         cachedInputTokens,
         ...(typeof turn?.completedAt === "number" ? { completedAt: turn.completedAt } : {}),
@@ -3040,7 +3066,7 @@ function summarizeTokenUsageActivity(
         id: `token-usage-${idSuffix}-uncached-input-cost`,
         kind: "read",
         label: `Uncached input cost: ${formatTokenCount(
-          uncachedInputTokens
+          regularInputTokens
         )} tokens at ${formatTokenUsageUsdPerMillion(
           cost.inputUsdPerMillion
         )}/M${formatTokenUsageStandardRateSuffix(
@@ -3073,14 +3099,29 @@ function summarizeTokenUsageActivity(
           cost.standardOutputRateMultiplier
         )} = ${formatTokenUsageUsd(cost.outputUsd)}`,
         status: "completed",
-      },
-      {
-        id: `token-usage-${idSuffix}-cost`,
-        kind: "read",
-        label: `Cost: ${formatTokenUsageUsd(cost.totalUsd)} list price for ${cost.displayName}`,
-        status: "completed",
       }
     );
+    if (
+      cacheWriteInputTokens > 0
+      && cost.cacheWriteInputUsdPerMillion !== undefined
+    ) {
+      details.push({
+        id: `token-usage-${idSuffix}-cache-write-input-cost`,
+        kind: "read",
+        label: `Cache write cost: ${formatTokenCount(
+          cacheWriteInputTokens
+        )} tokens at ${formatTokenUsageUsdPerMillion(
+          cost.cacheWriteInputUsdPerMillion
+        )}/M = ${formatTokenUsageUsd(cost.cacheWriteInputUsd)}`,
+        status: "completed",
+      });
+    }
+    details.push({
+      id: `token-usage-${idSuffix}-cost`,
+      kind: "read",
+      label: `Cost: ${formatTokenUsageUsd(cost.totalUsd)} list price for ${cost.displayName}`,
+      status: "completed",
+    });
   } else if (resolvedPricingContext.model) {
     details.push({
       id: `token-usage-${idSuffix}-cost-unavailable`,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -2932,6 +2932,7 @@ function summarizeTokenUsageActivity(
     cachedInputTokens,
     at: createdAt,
     fastMode: resolvedPricingContext.fastMode,
+    inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
     model: resolvedPricingContext.model,
     outputTokens,
     reasoningOutputTokens,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -3827,6 +3827,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     at: line.createdAt,
     cachedInputTokens: line.cachedInputTokens,
     fastMode: line.fastMode,
+    inputTokenScope: line.scope === "latest-request" ? "request" : "aggregate",
     model: line.model,
     outputTokens: line.outputTokens,
     reasoningOutputTokens: line.reasoningOutputTokens,

--- a/apps/desktop/src/main/state/overlay-store-sqlite.ts
+++ b/apps/desktop/src/main/state/overlay-store-sqlite.ts
@@ -48,7 +48,7 @@ import {
   isAcpBackendId,
   parseThreadIdentityKey,
   projectNavigationLaunchpadProviderSettings,
-  resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
 } from "@pwragent/shared";
 import type { StateDb } from "./state-db.js";
 
@@ -1025,12 +1025,14 @@ export class SqliteOverlayStore {
             settings_source,
             settings_confidence,
             input_tokens,
+            cache_write_input_tokens,
             cached_input_tokens,
             uncached_input_tokens,
             output_tokens,
             reasoning_output_tokens,
             total_tokens,
             cumulative_input_tokens,
+            cumulative_cache_write_input_tokens,
             cumulative_cached_input_tokens,
             cumulative_uncached_input_tokens,
             cumulative_output_tokens,
@@ -1041,8 +1043,10 @@ export class SqliteOverlayStore {
             currency,
             pricing_catalog_id,
             pricing_catalog_version,
+            pricing_basis,
             pricing_rate_id,
             uncached_input_cost_micros,
+            cache_write_input_cost_micros,
             cached_input_cost_micros,
             output_cost_micros,
             total_cost_micros,
@@ -1074,12 +1078,14 @@ export class SqliteOverlayStore {
             @settingsSource,
             @settingsConfidence,
             @inputTokens,
+            @cacheWriteInputTokens,
             @cachedInputTokens,
             @uncachedInputTokens,
             @outputTokens,
             @reasoningOutputTokens,
             @totalTokens,
             @cumulativeInputTokens,
+            @cumulativeCacheWriteInputTokens,
             @cumulativeCachedInputTokens,
             @cumulativeUncachedInputTokens,
             @cumulativeOutputTokens,
@@ -1090,8 +1096,10 @@ export class SqliteOverlayStore {
             @currency,
             @pricingCatalogId,
             @pricingCatalogVersion,
+            @pricingBasis,
             @pricingRateId,
             @uncachedInputCostMicros,
+            @cacheWriteInputCostMicros,
             @cachedInputCostMicros,
             @outputCostMicros,
             @totalCostMicros,
@@ -1123,12 +1131,14 @@ export class SqliteOverlayStore {
             settings_source = excluded.settings_source,
             settings_confidence = excluded.settings_confidence,
             input_tokens = excluded.input_tokens,
+            cache_write_input_tokens = excluded.cache_write_input_tokens,
             cached_input_tokens = excluded.cached_input_tokens,
             uncached_input_tokens = excluded.uncached_input_tokens,
             output_tokens = excluded.output_tokens,
             reasoning_output_tokens = excluded.reasoning_output_tokens,
             total_tokens = excluded.total_tokens,
             cumulative_input_tokens = excluded.cumulative_input_tokens,
+            cumulative_cache_write_input_tokens = excluded.cumulative_cache_write_input_tokens,
             cumulative_cached_input_tokens = excluded.cumulative_cached_input_tokens,
             cumulative_uncached_input_tokens = excluded.cumulative_uncached_input_tokens,
             cumulative_output_tokens = excluded.cumulative_output_tokens,
@@ -1139,8 +1149,10 @@ export class SqliteOverlayStore {
             currency = excluded.currency,
             pricing_catalog_id = excluded.pricing_catalog_id,
             pricing_catalog_version = excluded.pricing_catalog_version,
+            pricing_basis = excluded.pricing_basis,
             pricing_rate_id = excluded.pricing_rate_id,
             uncached_input_cost_micros = excluded.uncached_input_cost_micros,
+            cache_write_input_cost_micros = excluded.cache_write_input_cost_micros,
             cached_input_cost_micros = excluded.cached_input_cost_micros,
             output_cost_micros = excluded.output_cost_micros,
             total_cost_micros = excluded.total_cost_micros,
@@ -1305,6 +1317,7 @@ export class SqliteOverlayStore {
          pricing_catalog_version = @pricingCatalogVersion,
          pricing_rate_id = @pricingRateId,
          uncached_input_cost_micros = @uncachedInputCostMicros,
+         cache_write_input_cost_micros = @cacheWriteInputCostMicros,
          cached_input_cost_micros = @cachedInputCostMicros,
          output_cost_micros = @outputCostMicros,
          provider = @provider,
@@ -1344,6 +1357,8 @@ export class SqliteOverlayStore {
     this.stateDb.raw.transaction(() => {
       for (const { existing, repaired } of repairs) {
         updateLine.run({
+          cacheWriteInputCostMicros:
+            repaired.cacheWriteInputCostMicros ?? 0,
           cachedInputCostMicros: repaired.cachedInputCostMicros,
           currency: repaired.currency,
           outputCostMicros: repaired.outputCostMicros,
@@ -3433,12 +3448,14 @@ type ThreadUsageLineRow = {
   settings_source: ThreadUsageLineRecord["settingsSource"] | null;
   settings_confidence: ThreadUsageLineRecord["settingsConfidence"] | null;
   input_tokens: number;
+  cache_write_input_tokens: number;
   cached_input_tokens: number;
   uncached_input_tokens: number;
   output_tokens: number;
   reasoning_output_tokens: number;
   total_tokens: number;
   cumulative_input_tokens: number | null;
+  cumulative_cache_write_input_tokens: number | null;
   cumulative_cached_input_tokens: number | null;
   cumulative_uncached_input_tokens: number | null;
   cumulative_output_tokens: number | null;
@@ -3449,8 +3466,10 @@ type ThreadUsageLineRow = {
   currency: string;
   pricing_catalog_id: string | null;
   pricing_catalog_version: string | null;
+  pricing_basis: ThreadUsageLineRecord["pricingBasis"] | null;
   pricing_rate_id: string | null;
   uncached_input_cost_micros: number;
+  cache_write_input_cost_micros: number;
   cached_input_cost_micros: number;
   output_cost_micros: number;
   total_cost_micros: number;
@@ -3671,6 +3690,10 @@ function normalizeThreadUsageLine(
 ): ThreadUsageLineRecord {
   const inputTokens = clampTokenCount(line.inputTokens);
   const cachedInputTokens = Math.min(inputTokens, clampTokenCount(line.cachedInputTokens));
+  const cacheWriteInputTokens = Math.min(
+    Math.max(0, inputTokens - cachedInputTokens),
+    clampTokenCount(line.cacheWriteInputTokens),
+  );
   const uncachedInputTokens = Math.max(
     0,
     line.uncachedInputTokens ?? inputTokens - cachedInputTokens,
@@ -3683,12 +3706,20 @@ function normalizeThreadUsageLine(
       : inputTokens + outputTokens + reasoningOutputTokens;
   return {
     ...line,
+    cacheWriteInputTokens,
     cachedInputTokens,
     completedAt: line.completedAt,
     createdAt: line.createdAt || updatedAt,
     currency: line.currency || "USD",
     ...(line.cumulativeCachedInputTokens !== undefined
       ? { cumulativeCachedInputTokens: clampTokenCount(line.cumulativeCachedInputTokens) }
+      : {}),
+    ...(line.cumulativeCacheWriteInputTokens !== undefined
+      ? {
+          cumulativeCacheWriteInputTokens: clampTokenCount(
+            line.cumulativeCacheWriteInputTokens,
+          ),
+        }
       : {}),
     ...(line.cumulativeInputTokens !== undefined
       ? { cumulativeInputTokens: clampTokenCount(line.cumulativeInputTokens) }
@@ -3815,6 +3846,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     } = line;
     return {
       ...forkBaseLine,
+      cacheWriteInputCostMicros: 0,
       cachedInputCostMicros: 0,
       outputCostMicros: 0,
       priceStatus: "priced",
@@ -3822,9 +3854,16 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
       uncachedInputCostMicros: 0,
     };
   }
+  // This line already contains the sum of individually priced requests. Its
+  // aggregate token count may span multiple context bands, so applying one
+  // catalog entry to the whole row would destroy the exact cost.
+  if (line.pricingBasis === "request-components") {
+    return line;
+  }
 
   const cost = estimateTokenUsageCost({
     at: line.createdAt,
+    cacheWriteInputTokens: line.cacheWriteInputTokens,
     cachedInputTokens: line.cachedInputTokens,
     fastMode: line.fastMode,
     inputTokenScope: line.scope === "latest-request" ? "request" : "aggregate",
@@ -3834,18 +3873,19 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
     serviceTier: line.serviceTier,
     uncachedInputTokens: line.uncachedInputTokens,
   });
-  const pricingServiceTier = resolveOpenAiPricingServiceTier({
-    fastMode: line.fastMode,
-    serviceTier: line.serviceTier,
-  });
   const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | undefined =
     cost
       ? undefined
-      : !line.model
-        ? "missing-model"
-        : pricingServiceTier === undefined
-          ? "unsupported-service-tier"
-          : "missing-rate";
+      : resolveTokenUsagePriceUnavailableReason({
+          at: line.createdAt,
+          cachedInputTokens: line.cachedInputTokens,
+          fastMode: line.fastMode,
+          inputTokenScope:
+            line.scope === "latest-request" ? "request" : "aggregate",
+          model: line.model,
+          serviceTier: line.serviceTier,
+          uncachedInputTokens: line.uncachedInputTokens,
+        });
   const {
     priceUnavailableReason: _discardedPriceUnavailableReason,
     pricingCatalogId: _discardedPricingCatalogId,
@@ -3856,6 +3896,7 @@ function repriceTokenUsageLine(line: ThreadUsageLineRecord): ThreadUsageLineReco
 
   return {
     ...baseLine,
+    cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
     cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
     currency: cost?.currency ?? line.currency,
     outputCostMicros: cost?.outputCostMicros ?? 0,
@@ -3880,11 +3921,15 @@ function clampTokenCount(value: number | undefined): number {
 function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string, unknown> {
   return {
     backend: line.backend,
+    cacheWriteInputCostMicros: line.cacheWriteInputCostMicros ?? 0,
+    cacheWriteInputTokens: line.cacheWriteInputTokens ?? 0,
     cachedInputCostMicros: line.cachedInputCostMicros,
     cachedInputTokens: line.cachedInputTokens,
     completedAt: line.completedAt ?? null,
     createdAt: line.createdAt,
     cumulativeCachedInputTokens: line.cumulativeCachedInputTokens ?? null,
+    cumulativeCacheWriteInputTokens:
+      line.cumulativeCacheWriteInputTokens ?? null,
     cumulativeInputTokens: line.cumulativeInputTokens ?? null,
     cumulativeOutputTokens: line.cumulativeOutputTokens ?? null,
     cumulativeReasoningOutputTokens: line.cumulativeReasoningOutputTokens ?? null,
@@ -3913,6 +3958,7 @@ function toThreadUsageLineRowParams(line: ThreadUsageLineRecord): Record<string,
     provider: line.provider,
     pricingCatalogId: line.pricingCatalogId ?? null,
     pricingCatalogVersion: line.pricingCatalogVersion ?? null,
+    pricingBasis: line.pricingBasis ?? null,
     pricingRateId: line.pricingRateId ?? null,
     reasoningEffort: line.reasoningEffort ?? null,
     reasoningOutputTokens: line.reasoningOutputTokens,
@@ -3997,12 +4043,20 @@ function toThreadToolInvocationAlertRowParams(
 function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord {
   return {
     backend: row.backend,
+    cacheWriteInputCostMicros: row.cache_write_input_cost_micros,
+    cacheWriteInputTokens: row.cache_write_input_tokens,
     cachedInputCostMicros: row.cached_input_cost_micros,
     cachedInputTokens: row.cached_input_tokens,
     ...(row.completed_at !== null ? { completedAt: row.completed_at } : {}),
     createdAt: row.created_at,
     ...(row.cumulative_cached_input_tokens !== null
       ? { cumulativeCachedInputTokens: row.cumulative_cached_input_tokens }
+      : {}),
+    ...(row.cumulative_cache_write_input_tokens !== null
+      ? {
+          cumulativeCacheWriteInputTokens:
+            row.cumulative_cache_write_input_tokens,
+        }
       : {}),
     ...(row.cumulative_input_tokens !== null
       ? { cumulativeInputTokens: row.cumulative_input_tokens }
@@ -4044,6 +4098,7 @@ function threadUsageLineFromRow(row: ThreadUsageLineRow): ThreadUsageLineRecord 
     ...(row.pricing_catalog_version
       ? { pricingCatalogVersion: row.pricing_catalog_version }
       : {}),
+    ...(row.pricing_basis ? { pricingBasis: row.pricing_basis } : {}),
     ...(row.pricing_rate_id ? { pricingRateId: row.pricing_rate_id } : {}),
     ...(row.reasoning_effort ? { reasoningEffort: row.reasoning_effort } : {}),
     reasoningOutputTokens: row.reasoning_output_tokens,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -4,13 +4,13 @@ import Database from "better-sqlite3";
 import type BetterSqlite3 from "better-sqlite3";
 import {
   estimateTokenUsageCost,
-  resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
   type ComposerDraftSnapshotRecord,
   type ThreadUsageLineRecord,
 } from "@pwragent/shared";
 import { getNativeBinding } from "./native-binding.js";
 
-export const CURRENT_STATE_DB_USER_VERSION = 32;
+export const CURRENT_STATE_DB_USER_VERSION = 33;
 export const STATE_DB_WAL_AUTOCHECKPOINT_PAGES = 1000;
 export const STATE_DB_JOURNAL_SIZE_LIMIT_BYTES = 16 * 1024 * 1024;
 
@@ -570,12 +570,14 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   settings_source            TEXT,
   settings_confidence        TEXT,
   input_tokens               INTEGER NOT NULL,
+  cache_write_input_tokens   INTEGER NOT NULL DEFAULT 0,
   cached_input_tokens        INTEGER NOT NULL,
   uncached_input_tokens      INTEGER NOT NULL,
   output_tokens              INTEGER NOT NULL,
   reasoning_output_tokens    INTEGER NOT NULL,
   total_tokens               INTEGER NOT NULL,
   cumulative_input_tokens    INTEGER,
+  cumulative_cache_write_input_tokens INTEGER,
   cumulative_cached_input_tokens INTEGER,
   cumulative_uncached_input_tokens INTEGER,
   cumulative_output_tokens   INTEGER,
@@ -586,8 +588,10 @@ CREATE TABLE IF NOT EXISTS thread_usage_lines (
   currency                   TEXT NOT NULL,
   pricing_catalog_id         TEXT,
   pricing_catalog_version    TEXT,
+  pricing_basis              TEXT,
   pricing_rate_id            TEXT,
   uncached_input_cost_micros INTEGER NOT NULL,
+  cache_write_input_cost_micros INTEGER NOT NULL DEFAULT 0,
   cached_input_cost_micros   INTEGER NOT NULL,
   output_cost_micros         INTEGER NOT NULL,
   total_cost_micros          INTEGER NOT NULL,
@@ -971,6 +975,12 @@ export class StateDb {
     if ((db.pragma("user_version", { simple: true }) as number) < 32) {
       db.transaction(() => {
         repairTokenUsagePricing(db);
+        db.pragma("user_version = 32");
+      })();
+    }
+    if ((db.pragma("user_version", { simple: true }) as number) < 33) {
+      db.transaction(() => {
+        ensureThreadUsageRequestPricingColumns(db);
         db.pragma(`user_version = ${CURRENT_STATE_DB_USER_VERSION}`);
       })();
     }
@@ -1292,6 +1302,7 @@ function ensureCurrentSchema(db: BetterSqlite3.Database): void {
     ensurePullRequestProviderColumns(db);
     ensureThreadUsagePricingProviderScope(db);
     ensureThreadUsagePricingCumulativeColumns(db);
+    ensureThreadUsageRequestPricingColumns(db);
     db.exec(THREAD_TOOL_ACCOUNTING_SCHEMA);
     ensureThreadMessageOriginSchema(db);
     if ((db.pragma("user_version", { simple: true }) as number) < 4) {
@@ -1536,6 +1547,37 @@ function ensureThreadUsagePricingCumulativeColumns(db: BetterSqlite3.Database): 
     {
       name: "cumulative_total_cost_micros",
       sql: "ALTER TABLE thread_usage_lines ADD COLUMN cumulative_total_cost_micros INTEGER",
+    },
+  ];
+  for (const column of columns) {
+    if (!tableColumnExists(db, "thread_usage_lines", column.name)) {
+      db.exec(column.sql);
+    }
+  }
+}
+
+function ensureThreadUsageRequestPricingColumns(db: BetterSqlite3.Database): void {
+  if (!tableExists(db, "thread_usage_lines")) {
+    db.exec(THREAD_USAGE_PRICING_SCHEMA);
+    return;
+  }
+
+  const columns: Array<{ name: string; sql: string }> = [
+    {
+      name: "cache_write_input_tokens",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN cache_write_input_tokens INTEGER NOT NULL DEFAULT 0",
+    },
+    {
+      name: "cumulative_cache_write_input_tokens",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN cumulative_cache_write_input_tokens INTEGER",
+    },
+    {
+      name: "cache_write_input_cost_micros",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN cache_write_input_cost_micros INTEGER NOT NULL DEFAULT 0",
+    },
+    {
+      name: "pricing_basis",
+      sql: "ALTER TABLE thread_usage_lines ADD COLUMN pricing_basis TEXT",
     },
   ];
   for (const column of columns) {
@@ -1802,12 +1844,14 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   ) {
     return;
   }
+  ensureThreadUsageRequestPricingColumns(db);
 
   const now = Date.now();
   const rows = db
     .prepare(
       `SELECT
          usage_line_id,
+         cache_write_input_tokens,
          cached_input_tokens,
          created_at,
          currency,
@@ -1815,6 +1859,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          model,
          output_tokens,
          price_status,
+         pricing_basis,
          provider,
          reasoning_output_tokens,
          service_tier,
@@ -1825,6 +1870,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          AND scope != 'fork-baseline'`,
     )
     .all() as Array<{
+      cache_write_input_tokens: number;
       cached_input_tokens: number;
       created_at: number;
       currency: string;
@@ -1832,6 +1878,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       model: string | null;
       output_tokens: number;
       price_status: string;
+      pricing_basis: ThreadUsageLineRecord["pricingBasis"] | null;
       provider: string;
       reasoning_output_tokens: number;
       service_tier: string | null;
@@ -1849,6 +1896,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
        pricing_catalog_version = @pricingCatalogVersion,
        pricing_rate_id = @pricingRateId,
        uncached_input_cost_micros = @uncachedInputCostMicros,
+       cache_write_input_cost_micros = @cacheWriteInputCostMicros,
        cached_input_cost_micros = @cachedInputCostMicros,
        output_cost_micros = @outputCostMicros,
        provider = @provider,
@@ -1858,8 +1906,12 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
   );
 
   for (const row of rows) {
+    if (row.pricing_basis === "request-components") {
+      continue;
+    }
     const cost = estimateTokenUsageCost({
       at: row.created_at,
+      cacheWriteInputTokens: row.cache_write_input_tokens,
       cachedInputTokens: row.cached_input_tokens,
       fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
       inputTokenScope: row.scope === "latest-request" ? "request" : "aggregate",
@@ -1873,20 +1925,21 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       continue;
     }
 
-    const pricingServiceTier = resolveOpenAiPricingServiceTier({
-      fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
-      serviceTier: row.service_tier ?? undefined,
-    });
     const priceUnavailableReason: ThreadUsageLineRecord["priceUnavailableReason"] | null =
       cost
         ? null
-        : !row.model
-          ? "missing-model"
-          : pricingServiceTier === undefined
-            ? "unsupported-service-tier"
-            : "missing-rate";
+        : resolveTokenUsagePriceUnavailableReason({
+            at: row.created_at,
+            cachedInputTokens: row.cached_input_tokens,
+            fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+            inputTokenScope: row.scope === "latest-request" ? "request" : "aggregate",
+            model: row.model ?? undefined,
+            serviceTier: row.service_tier ?? undefined,
+            uncachedInputTokens: row.uncached_input_tokens,
+          });
 
     updateLine.run({
+      cacheWriteInputCostMicros: cost?.cacheWriteInputCostMicros ?? 0,
       cachedInputCostMicros: cost?.cachedInputCostMicros ?? 0,
       currency: cost?.currency ?? row.currency,
       outputCostMicros: cost?.outputCostMicros ?? 0,

--- a/apps/desktop/src/main/state/state-db.ts
+++ b/apps/desktop/src/main/state/state-db.ts
@@ -1818,6 +1818,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
          provider,
          reasoning_output_tokens,
          service_tier,
+         scope,
          uncached_input_tokens
        FROM thread_usage_lines
        WHERE provider IN ('openai', 'qwen', 'xai')
@@ -1834,6 +1835,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       provider: string;
       reasoning_output_tokens: number;
       service_tier: string | null;
+      scope: ThreadUsageLineRecord["scope"];
       uncached_input_tokens: number;
       usage_line_id: string;
     }>;
@@ -1860,6 +1862,7 @@ function repairTokenUsagePricing(db: BetterSqlite3.Database): void {
       at: row.created_at,
       cachedInputTokens: row.cached_input_tokens,
       fastMode: row.fast_mode === null ? undefined : Boolean(row.fast_mode),
+      inputTokenScope: row.scope === "latest-request" ? "request" : "aggregate",
       model: row.model ?? undefined,
       outputTokens: row.output_tokens,
       reasoningOutputTokens: row.reasoning_output_tokens,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/live-transcript-activity.test.ts
@@ -348,6 +348,29 @@ describe("buildTokenUsageActivityEntry", () => {
     ]);
   });
 
+  it("includes Astra cache-write costs in a request usage entry", () => {
+    const entry = buildTokenUsageActivityEntry({
+      id: "astra-request",
+      model: "gpt-6-astra",
+      tokenUsage: {
+        last: {
+          inputTokens: 200_000,
+          cacheWriteInputTokens: 10_000,
+          cachedInputTokens: 100_000,
+          outputTokens: 10_000,
+          reasoningOutputTokens: 0,
+          totalTokens: 210_000,
+        },
+      },
+    });
+
+    expect(entry?.summary).toContain("10,000 cache writes");
+    expect(entry?.summary).toContain("$1.63 list price");
+    expect(entry?.details.map((detail) => detail.label)).toContain(
+      "Cache write cost: 10,000 tokens at $12.50/M = $0.13",
+    );
+  });
+
   it("prices the Grok ACP build model alias without double-billing reasoning", () => {
     const entry = buildTokenUsageActivityEntry({
       id: "usage-grok-45",

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -250,6 +250,7 @@ function buildLiveCommandDetail(
 }
 
 type TokenUsageBreakdown = {
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -282,9 +283,15 @@ export function buildTokenUsageActivityEntry(params: {
   const cachedInputTokens = Math.max(0, tokens.cachedInputTokens ?? 0);
   const inputTokens = Math.max(0, tokens.inputTokens ?? 0);
   const uncachedInputTokens = Math.max(0, inputTokens - cachedInputTokens);
+  const cacheWriteInputTokens = Math.min(
+    uncachedInputTokens,
+    Math.max(0, tokens.cacheWriteInputTokens ?? 0),
+  );
+  const regularInputTokens = uncachedInputTokens - cacheWriteInputTokens;
   const outputTokens = Math.max(0, tokens.outputTokens ?? 0);
   const reasoningOutputTokens = Math.max(0, tokens.reasoningOutputTokens ?? 0);
   const cost = estimateTokenUsageCost({
+    cacheWriteInputTokens,
     cachedInputTokens,
     fastMode: params.fastMode,
     inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
@@ -299,6 +306,9 @@ export function buildTokenUsageActivityEntry(params: {
     : outputTokens + reasoningOutputTokens;
   const summaryParts = [
     `${formatTokenCount(uncachedInputTokens)} uncached in`,
+    cacheWriteInputTokens > 0
+      ? `${formatTokenCount(cacheWriteInputTokens)} cache writes`
+      : undefined,
     `${formatTokenCount(cachedInputTokens)} cached`,
     reasoningOutputTokens > 0
       ? `${formatTokenCount(outputTokens)} out (${formatTokenCount(reasoningOutputTokens)} reasoning)`
@@ -335,7 +345,7 @@ export function buildTokenUsageActivityEntry(params: {
         id: `${params.id}-uncached-input-cost`,
         kind: "read",
         label: `Uncached input cost: ${formatTokenCount(
-          uncachedInputTokens,
+          regularInputTokens,
         )} tokens at ${formatTokenUsageUsdPerMillion(
           cost.inputUsdPerMillion,
         )}/M${formatTokenUsageStandardRateSuffix(
@@ -370,6 +380,21 @@ export function buildTokenUsageActivityEntry(params: {
         status: "completed",
       },
     );
+    if (
+      cacheWriteInputTokens > 0
+      && cost.cacheWriteInputUsdPerMillion !== undefined
+    ) {
+      details.push({
+        id: `${params.id}-cache-write-input-cost`,
+        kind: "read",
+        label: `Cache write cost: ${formatTokenCount(
+          cacheWriteInputTokens,
+        )} tokens at ${formatTokenUsageUsdPerMillion(
+          cost.cacheWriteInputUsdPerMillion,
+        )}/M = ${formatTokenUsageUsd(cost.cacheWriteInputUsd)}`,
+        status: "completed",
+      });
+    }
     details.push({
       id: `${params.id}-cost`,
       kind: "read",
@@ -460,6 +485,11 @@ function normalizeTokenUsage(tokenUsage: unknown): NormalizedTokenUsage | undefi
 function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdown | undefined {
   const explicitTotal = readFiniteNumber(record, ["totalTokens", "total_tokens"]);
   const inputTokens = readFiniteNumber(record, ["inputTokens", "input_tokens"]);
+  const cacheWriteInputTokens = readFiniteNumber(record, [
+    "cacheWriteInputTokens",
+    "cache_write_input_tokens",
+    "cache_write_tokens",
+  ]);
   const cachedInputTokens = readFiniteNumber(record, [
     "cachedInputTokens",
     "cached_input_tokens",
@@ -476,6 +506,7 @@ function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdow
   if (
     totalTokens === undefined &&
     inputTokens === undefined &&
+    cacheWriteInputTokens === undefined &&
     cachedInputTokens === undefined &&
     outputTokens === undefined &&
     reasoningOutputTokens === undefined
@@ -484,6 +515,7 @@ function readTokenBreakdown(record: Record<string, unknown>): TokenUsageBreakdow
   }
 
   return {
+    cacheWriteInputTokens,
     cachedInputTokens,
     inputTokens,
     outputTokens,

--- a/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
+++ b/apps/desktop/src/renderer/src/features/thread-detail/live-transcript-activity.ts
@@ -287,6 +287,7 @@ export function buildTokenUsageActivityEntry(params: {
   const cost = estimateTokenUsageCost({
     cachedInputTokens,
     fastMode: params.fastMode,
+    inputTokenScope: scope === "latest-request" ? "request" : "aggregate",
     model: params.model,
     outputTokens,
     reasoningOutputTokens,

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -244,6 +244,71 @@ describe("token usage pricing", () => {
     }
   });
 
+  it("prices GPT-6 Astra at the short-context boundary", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_000,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+
+    expect(cost).toMatchObject({
+      catalogVersion: "2026-09-04",
+      displayName: "GPT-6 Astra Standard (<=272K input)",
+      inputUsdPerMillion: 10,
+      cachedInputUsdPerMillion: 1,
+      outputUsdPerMillion: 50,
+      rateId: "openai:2026-09-04:gpt-6-astra:standard:input-lte-272k",
+      serviceTier: "standard",
+      uncachedInputCostMicros: 2_000_000,
+      cachedInputCostMicros: 72_000,
+      outputCostMicros: 5_000_000,
+      totalCostMicros: 7_072_000,
+    });
+  });
+
+  it("prices GPT-6 Astra above 272K input at the long-context rates", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_001,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+
+    expect(cost).toMatchObject({
+      catalogVersion: "2026-09-04",
+      displayName: "GPT-6 Astra Standard (>272K input)",
+      inputUsdPerMillion: 20,
+      cachedInputUsdPerMillion: 2,
+      outputUsdPerMillion: 75,
+      rateId: "openai:2026-09-04:gpt-6-astra:standard:input-gt-272k",
+      serviceTier: "standard",
+      uncachedInputCostMicros: 4_000_000,
+      cachedInputCostMicros: 144_002,
+      outputCostMicros: 7_500_000,
+      totalCostMicros: 11_644_002,
+    });
+  });
+
+  it("keeps unsupported GPT-6 Astra pricing modes unpriced", () => {
+    const usage = {
+      cachedInputTokens: 1_000,
+      model: "gpt-6-astra",
+      outputTokens: 1_000,
+      uncachedInputTokens: 1_000,
+    };
+
+    expect(
+      estimateOpenAiTokenUsageCost({ ...usage, fastMode: true }),
+    ).toBeUndefined();
+    expect(
+      estimateOpenAiTokenUsageCost({ ...usage, serviceTier: "flex" }),
+    ).toBeUndefined();
+    expect(estimateOpenAiCodexCreditUsage(usage)).toBeUndefined();
+  });
+
   it("does not price GPT-5.6 usage before its catalog effective date", () => {
     expect(
       estimateOpenAiTokenUsageCost({

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -272,6 +272,7 @@ describe("token usage pricing", () => {
     const cost = estimateOpenAiTokenUsageCost({
       at: Date.UTC(2026, 8, 4),
       cachedInputTokens: 72_001,
+      inputTokenScope: "request",
       model: "gpt-6-astra",
       outputTokens: 100_000,
       uncachedInputTokens: 200_000,
@@ -292,7 +293,58 @@ describe("token usage pricing", () => {
     });
   });
 
-  it("keeps unsupported GPT-6 Astra pricing modes unpriced", () => {
+  it("prices GPT-6 Astra Fast usage in both context bands", () => {
+    const shortContext = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_000,
+      fastMode: true,
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+    const longContext = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cachedInputTokens: 72_001,
+      inputTokenScope: "request",
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      serviceTier: "priority",
+      uncachedInputTokens: 200_000,
+    });
+
+    expect(shortContext).toMatchObject({
+      displayName: "GPT-6 Astra Fast (<=272K input)",
+      inputUsdPerMillion: 20,
+      cachedInputUsdPerMillion: 2,
+      outputUsdPerMillion: 100,
+      rateId: "openai:2026-09-04:gpt-6-astra:priority:input-lte-272k",
+      serviceTier: "priority",
+      totalCostMicros: 14_144_000,
+    });
+    expect(longContext).toMatchObject({
+      displayName: "GPT-6 Astra Fast (>272K input)",
+      inputUsdPerMillion: 40,
+      cachedInputUsdPerMillion: 4,
+      outputUsdPerMillion: 150,
+      rateId: "openai:2026-09-04:gpt-6-astra:priority:input-gt-272k",
+      serviceTier: "priority",
+      totalCostMicros: 23_288_004,
+    });
+  });
+
+  it("leaves ambiguous multi-request Astra aggregates unpriced", () => {
+    expect(
+      estimateOpenAiTokenUsageCost({
+        at: Date.UTC(2026, 8, 4),
+        cachedInputTokens: 72_001,
+        model: "gpt-6-astra",
+        outputTokens: 100_000,
+        uncachedInputTokens: 200_000,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps unsupported GPT-6 Astra billing modes unpriced", () => {
     const usage = {
       cachedInputTokens: 1_000,
       model: "gpt-6-astra",
@@ -300,9 +352,6 @@ describe("token usage pricing", () => {
       uncachedInputTokens: 1_000,
     };
 
-    expect(
-      estimateOpenAiTokenUsageCost({ ...usage, fastMode: true }),
-    ).toBeUndefined();
     expect(
       estimateOpenAiTokenUsageCost({ ...usage, serviceTier: "flex" }),
     ).toBeUndefined();

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -6,6 +6,7 @@ import {
   listOpenAiTokenUsagePricingRates,
   listTokenUsagePricingRates,
   resolveOpenAiPricingServiceTier,
+  resolveTokenUsagePriceUnavailableReason,
 } from "../token-usage-pricing";
 
 describe("token usage pricing", () => {
@@ -293,6 +294,40 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("prices and lists GPT-6 Astra cache writes", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 8, 4),
+      cacheWriteInputTokens: 20_000,
+      cachedInputTokens: 72_001,
+      inputTokenScope: "request",
+      model: "gpt-6-astra",
+      outputTokens: 100_000,
+      uncachedInputTokens: 200_000,
+    });
+    const cacheWriteRates = listOpenAiTokenUsagePricingRates()
+      .filter((rate) => rate.model === "gpt-6-astra")
+      .map((rate) => [rate.serviceTier, rate.cacheWriteInputUsdPerMillion]);
+
+    expect(cost).toMatchObject({
+      cacheWriteInputCostMicros: 500_000,
+      cacheWriteInputUsd: 0.5,
+      cacheWriteInputUsdPerMillion: 25,
+      totalCostMicros: 11_744_002,
+      uncachedInputCostMicros: 3_600_000,
+    });
+    expect(cacheWriteRates).toEqual([
+      ["standard", 12.5],
+      ["standard", 25],
+      ["priority", 25],
+      ["priority", 50],
+    ]);
+    expect(
+      listOpenAiTokenUsagePricingRates().find(
+        (rate) => rate.rateId.endsWith(":standard:input-gt-272k"),
+      )?.cacheWriteInputMicrosPerMillion,
+    ).toBe(25_000_000);
+  });
+
   it("prices GPT-6 Astra Fast usage in both context bands", () => {
     const shortContext = estimateOpenAiTokenUsageCost({
       at: Date.UTC(2026, 8, 4),
@@ -342,6 +377,16 @@ describe("token usage pricing", () => {
         uncachedInputTokens: 200_000,
       }),
     ).toBeUndefined();
+    expect(
+      resolveTokenUsagePriceUnavailableReason({
+        at: Date.UTC(2026, 8, 4),
+        cachedInputTokens: 72_001,
+        inputTokenScope: "aggregate",
+        model: "gpt-6-astra",
+        serviceTier: "standard",
+        uncachedInputTokens: 200_000,
+      }),
+    ).toBe("insufficient-token-breakdown");
   });
 
   it("keeps unsupported GPT-6 Astra billing modes unpriced", () => {

--- a/packages/shared/src/contracts/task-monitor-tools.ts
+++ b/packages/shared/src/contracts/task-monitor-tools.ts
@@ -59,6 +59,7 @@ export type TaskMonitorUsageSnapshot = {
   serviceTier?: string;
   summary: string;
   tokenUsage: {
+    cacheWriteInputTokens?: number;
     cachedInputTokens?: number;
     inputTokens?: number;
     outputTokens?: number;

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -209,6 +209,7 @@ type PricingCatalogEntry = {
   effectiveTo?: number;
   inputUsdPerMillion: number;
   maximumInputTokens?: number;
+  minimumInputTokens?: number;
   model: string;
   outputUsdPerMillion: number;
   outputTokensIncludeReasoning?: boolean;
@@ -248,6 +249,9 @@ const OPENAI_GPT56_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 9);
 // https://openai.com/index/advancing-the-price-performance-frontier-with-gpt-5-6/
 const OPENAI_GPT56_REPRICING_CATALOG_VERSION = "2026-07-30";
 const OPENAI_GPT56_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 30);
+// https://developers.openai.com/api/docs/models/gpt-6-astra
+const OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION = "2026-09-04";
+const OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 8, 4);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
 const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-27";
@@ -275,6 +279,39 @@ const QWEN_PRICING_CATALOG_VERSION = "2026-07-15";
 const QWEN37_PLUS_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 4, 26);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
+  // The usage schema cannot distinguish cache writes from ordinary uncached
+  // input. Keep cache-write charges outside the estimate instead of applying
+  // the higher write rate to every uncached token.
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Standard (<=272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 10,
+    cachedInputUsdPerMillion: 1,
+    outputUsdPerMillion: 50,
+    maximumInputTokens: 272_000,
+    rateBandId: "input-lte-272k",
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Standard (>272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 20,
+    cachedInputUsdPerMillion: 2,
+    outputUsdPerMillion: 75,
+    minimumInputTokens: 272_001,
+    rateBandId: "input-gt-272k",
+  },
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT56_REPRICING_CATALOG_VERSION,
@@ -1076,8 +1113,14 @@ function pricingEntryMatchesInputTokens(
   inputTokens: number,
 ): boolean {
   return (
-    entry.maximumInputTokens === undefined
-    || inputTokens <= entry.maximumInputTokens
+    (
+      entry.minimumInputTokens === undefined
+      || inputTokens >= entry.minimumInputTokens
+    )
+    && (
+      entry.maximumInputTokens === undefined
+      || inputTokens <= entry.maximumInputTokens
+    )
   );
 }
 

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -13,6 +13,8 @@ export type TokenUsagePriceUnavailableReason =
   | "insufficient-token-breakdown";
 
 export type ThreadUsageTokenBreakdown = {
+  // Provider-reported subset of uncached input that populated a prompt cache.
+  cacheWriteInputTokens?: number;
   cachedInputTokens?: number;
   inputTokens?: number;
   outputTokens?: number;
@@ -47,12 +49,17 @@ export type ThreadUsageLineStatus = "pending" | "finalized" | "superseded";
 
 export type ThreadUsageLineRecord = {
   backend: string;
+  // Cache-write cost is separate from uncachedInputCostMicros; the tokens are
+  // still a subset of uncachedInputTokens.
+  cacheWriteInputCostMicros?: number;
+  cacheWriteInputTokens?: number;
   cachedInputCostMicros: number;
   cachedInputTokens: number;
   completedAt?: number;
   createdAt: number;
   currency: string;
   cumulativeCachedInputTokens?: number;
+  cumulativeCacheWriteInputTokens?: number;
   cumulativeInputTokens?: number;
   cumulativeOutputTokens?: number;
   cumulativeReasoningOutputTokens?: number;
@@ -80,6 +87,7 @@ export type ThreadUsageLineRecord = {
   provider: string;
   pricingCatalogId?: string;
   pricingCatalogVersion?: string;
+  pricingBasis?: "aggregate" | "request-components";
   pricingRateId?: string;
   reasoningEffort?: string;
   reasoningOutputTokens: number;
@@ -103,6 +111,7 @@ export type ThreadUsageLineRecord = {
   // persisted before this field existed). The renderer treats `false` as a
   // historical summary instead of guessing from raw token counts.
   turnUsageAttributed?: boolean;
+  // Cost of regular uncached input after removing cache-write tokens.
   uncachedInputCostMicros: number;
   uncachedInputTokens: number;
   usageLineId: string;
@@ -128,6 +137,8 @@ export type ThreadPricingSummary = {
 };
 
 export type TokenUsagePricingCatalogRate = {
+  cacheWriteInputMicrosPerMillion?: number;
+  cacheWriteInputUsdPerMillion?: number;
   cachedInputMicrosPerMillion: number;
   cachedInputUsdPerMillion: number;
   catalogId: string;
@@ -149,6 +160,9 @@ export type TokenUsagePricingCatalogRate = {
 };
 
 export type TokenUsageCostEstimate = {
+  cacheWriteInputCostMicros: number;
+  cacheWriteInputUsd: number;
+  cacheWriteInputUsdPerMillion?: number;
   cachedInputCostMicros: number;
   cachedInputUsd: number;
   cachedInputUsdPerMillion: number;
@@ -202,6 +216,7 @@ export type TokenUsageCreditEstimate = {
 
 type PricingCatalogEntry = {
   aliases?: readonly string[];
+  cacheWriteInputUsdPerMillion?: number;
   cachedInputUsdPerMillion: number;
   catalogId: string;
   catalogVersion: string;
@@ -282,9 +297,8 @@ const QWEN_PRICING_CATALOG_VERSION = "2026-07-15";
 const QWEN37_PLUS_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 4, 26);
 
 const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
-  // The usage schema cannot distinguish cache writes from ordinary uncached
-  // input. Keep cache-write charges outside the estimate instead of applying
-  // the higher write rate to every uncached token.
+  // Codex App Server reports cache-write tokens separately. They remain a
+  // subset of uncached input tokens and are charged at the write rate below.
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
@@ -294,6 +308,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "standard",
+    cacheWriteInputUsdPerMillion: 12.5,
     inputUsdPerMillion: 10,
     cachedInputUsdPerMillion: 1,
     outputUsdPerMillion: 50,
@@ -311,6 +326,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "standard",
+    cacheWriteInputUsdPerMillion: 25,
     inputUsdPerMillion: 20,
     cachedInputUsdPerMillion: 2,
     outputUsdPerMillion: 75,
@@ -327,6 +343,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "priority",
+    cacheWriteInputUsdPerMillion: 25,
     inputUsdPerMillion: 20,
     cachedInputUsdPerMillion: 2,
     outputUsdPerMillion: 100,
@@ -342,6 +359,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "priority",
+    cacheWriteInputUsdPerMillion: 50,
     inputUsdPerMillion: 40,
     cachedInputUsdPerMillion: 4,
     outputUsdPerMillion: 150,
@@ -791,6 +809,7 @@ export function listTokenUsagePricingRates(): TokenUsagePricingCatalogRate[] {
 }
 
 export function estimateOpenAiTokenUsageCost(params: {
+  cacheWriteInputTokens?: number;
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
@@ -806,6 +825,7 @@ export function estimateOpenAiTokenUsageCost(params: {
 }
 
 export function estimateTokenUsageCost(params: {
+  cacheWriteInputTokens?: number;
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
@@ -822,6 +842,7 @@ export function estimateTokenUsageCost(params: {
 
 function estimateTokenUsageCostFromCatalog(
   params: {
+    cacheWriteInputTokens?: number;
     cachedInputTokens: number;
     at?: number;
     fastMode?: boolean;
@@ -866,6 +887,17 @@ function estimateTokenUsageCostFromCatalog(
     return undefined;
   }
 
+  const cacheWriteInputTokens = Math.max(0, params.cacheWriteInputTokens ?? 0);
+  if (
+    cacheWriteInputTokens > params.uncachedInputTokens
+    || (
+      cacheWriteInputTokens > 0
+      && entry.cacheWriteInputUsdPerMillion === undefined
+    )
+  ) {
+    return undefined;
+  }
+
   const standardEntry = catalog.find(
     (candidate) =>
       candidate.model === entry.model
@@ -879,8 +911,12 @@ function estimateTokenUsageCostFromCatalog(
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
-    params.uncachedInputTokens,
+    params.uncachedInputTokens - cacheWriteInputTokens,
     entry.inputUsdPerMillion,
+  );
+  const cacheWriteInputCostMicros = calculateTokenCostMicros(
+    cacheWriteInputTokens,
+    entry.cacheWriteInputUsdPerMillion ?? 0,
   );
   const cachedInputCostMicros = calculateTokenCostMicros(
     params.cachedInputTokens,
@@ -898,12 +934,21 @@ function estimateTokenUsageCostFromCatalog(
     entry.outputUsdPerMillion,
   );
   const totalCostMicros =
-    uncachedInputCostMicros + cachedInputCostMicros + outputCostMicros;
+    uncachedInputCostMicros
+    + cacheWriteInputCostMicros
+    + cachedInputCostMicros
+    + outputCostMicros;
   const uncachedInputUsd = microsToCurrencyUnits(uncachedInputCostMicros);
+  const cacheWriteInputUsd = microsToCurrencyUnits(cacheWriteInputCostMicros);
   const cachedInputUsd = microsToCurrencyUnits(cachedInputCostMicros);
   const outputUsd = microsToCurrencyUnits(outputCostMicros);
 
   return {
+    cacheWriteInputCostMicros,
+    cacheWriteInputUsd,
+    ...(entry.cacheWriteInputUsdPerMillion !== undefined
+      ? { cacheWriteInputUsdPerMillion: entry.cacheWriteInputUsdPerMillion }
+      : {}),
     cachedInputCostMicros,
     cachedInputUsd,
     cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
@@ -1033,6 +1078,53 @@ export function resolveOpenAiPricingServiceTier(params: {
   return params.fastMode === true ? "priority" : "standard";
 }
 
+export function resolveTokenUsagePriceUnavailableReason(params: {
+  at?: number;
+  cachedInputTokens: number;
+  fastMode?: boolean;
+  inputTokenScope?: TokenUsagePricingInputScope;
+  model?: string;
+  serviceTier?: string;
+  uncachedInputTokens: number;
+}): TokenUsagePriceUnavailableReason {
+  const model = params.model?.trim();
+  if (!model) {
+    return "missing-model";
+  }
+
+  const inputTokens = params.cachedInputTokens + params.uncachedInputTokens;
+  const matchingEntries = TOKEN_USAGE_PRICING_CATALOG.filter(
+    (candidate) =>
+      pricingEntryMatchesModel(candidate, model)
+      && pricingEntryAppliesAt(candidate, params.at)
+      // A request scope answers only whether the token count belongs in this
+      // entry's numeric band. The caller's actual scope is checked below.
+      && pricingEntryMatchesInputTokens(candidate, inputTokens, "request"),
+  );
+  const provider = matchingEntries[0]?.provider;
+  const serviceTier =
+    provider === "xai" || provider === "qwen"
+      ? resolveStandardOnlyPricingServiceTier(params.serviceTier)
+      : resolveOpenAiPricingServiceTier({
+          fastMode: params.fastMode,
+          serviceTier: params.serviceTier,
+        });
+  if (serviceTier === undefined) {
+    return "unsupported-service-tier";
+  }
+
+  const entry = matchingEntries.find(
+    (candidate) => candidate.serviceTier === serviceTier,
+  );
+  if (
+    entry?.requiresRequestInputTokens
+    && params.inputTokenScope !== "request"
+  ) {
+    return "insufficient-token-breakdown";
+  }
+  return "missing-rate";
+}
+
 function resolveStandardOnlyPricingServiceTier(
   serviceTier: string | undefined,
 ): TokenUsagePricingServiceTier | undefined {
@@ -1112,6 +1204,14 @@ function tokenUsageRateMultiplier(
 
 function toPublicRate(entry: PricingCatalogEntry): TokenUsagePricingCatalogRate {
   return {
+    ...(entry.cacheWriteInputUsdPerMillion !== undefined
+      ? {
+          cacheWriteInputMicrosPerMillion: dollarsToMicros(
+            entry.cacheWriteInputUsdPerMillion,
+          ),
+          cacheWriteInputUsdPerMillion: entry.cacheWriteInputUsdPerMillion,
+        }
+      : {}),
     cachedInputMicrosPerMillion: dollarsToMicros(entry.cachedInputUsdPerMillion),
     cachedInputUsdPerMillion: entry.cachedInputUsdPerMillion,
     catalogId: entry.catalogId,

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -2,6 +2,8 @@ export type TokenUsagePricingServiceTier = "standard" | "priority";
 
 export type TokenUsagePricingProvider = "openai" | "qwen" | "xai";
 
+export type TokenUsagePricingInputScope = "aggregate" | "request";
+
 export type TokenUsagePriceStatus = "priced" | "unpriced";
 
 export type TokenUsagePriceUnavailableReason =
@@ -215,6 +217,7 @@ type PricingCatalogEntry = {
   outputTokensIncludeReasoning?: boolean;
   provider: TokenUsagePricingProvider;
   rateBandId?: string;
+  requiresRequestInputTokens?: boolean;
   serviceTier: TokenUsagePricingServiceTier;
 };
 
@@ -297,6 +300,8 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     maximumInputTokens: 272_000,
     rateBandId: "input-lte-272k",
   },
+  // OpenAI applies the higher band per request. Turn-wide totals above the
+  // boundary are ambiguous and must not select this rate.
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
@@ -311,6 +316,38 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     outputUsdPerMillion: 75,
     minimumInputTokens: 272_001,
     rateBandId: "input-gt-272k",
+    requiresRequestInputTokens: true,
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Fast (<=272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "priority",
+    inputUsdPerMillion: 20,
+    cachedInputUsdPerMillion: 2,
+    outputUsdPerMillion: 100,
+    maximumInputTokens: 272_000,
+    rateBandId: "input-lte-272k",
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION,
+    model: "gpt-6-astra",
+    displayModel: "GPT-6 Astra",
+    displayTier: "Fast (>272K input)",
+    effectiveFrom: OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "priority",
+    inputUsdPerMillion: 40,
+    cachedInputUsdPerMillion: 4,
+    outputUsdPerMillion: 150,
+    minimumInputTokens: 272_001,
+    rateBandId: "input-gt-272k",
+    requiresRequestInputTokens: true,
   },
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
@@ -757,6 +794,7 @@ export function estimateOpenAiTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
+  inputTokenScope?: TokenUsagePricingInputScope;
   outputTokensIncludeReasoning?: boolean;
   model?: string;
   outputTokens: number;
@@ -771,6 +809,7 @@ export function estimateTokenUsageCost(params: {
   cachedInputTokens: number;
   at?: number;
   fastMode?: boolean;
+  inputTokenScope?: TokenUsagePricingInputScope;
   outputTokensIncludeReasoning?: boolean;
   model?: string;
   outputTokens: number;
@@ -786,6 +825,7 @@ function estimateTokenUsageCostFromCatalog(
     cachedInputTokens: number;
     at?: number;
     fastMode?: boolean;
+    inputTokenScope?: TokenUsagePricingInputScope;
     outputTokensIncludeReasoning?: boolean;
     model?: string;
     outputTokens: number;
@@ -807,6 +847,7 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
+        params.inputTokenScope,
       ),
   );
   const provider = matchingEntries[0]?.provider;
@@ -834,6 +875,7 @@ function estimateTokenUsageCostFromCatalog(
       && pricingEntryMatchesInputTokens(
         candidate,
         params.cachedInputTokens + params.uncachedInputTokens,
+        params.inputTokenScope,
       ),
   );
   const uncachedInputCostMicros = calculateTokenCostMicros(
@@ -1111,9 +1153,11 @@ function pricingEntryMatchesModel(
 function pricingEntryMatchesInputTokens(
   entry: PricingCatalogEntry,
   inputTokens: number,
+  inputTokenScope: TokenUsagePricingInputScope | undefined,
 ): boolean {
   return (
-    (
+    (!entry.requiresRequestInputTokens || inputTokenScope === "request")
+    && (
       entry.minimumInputTokens === undefined
       || inputTokens >= entry.minimumInputTokens
     )


### PR DESCRIPTION
## Summary

Backport GPT-6 Astra support from #1983 to `releases/1.0`. Astra is available in generated and legacy Codex model lists and fallback metadata, with Standard/Fast pricing, the 272K per-request context boundary, and separately reported cache-write costs.

Live request observations are accumulated and deduplicated so turns spanning multiple pricing bands retain their exact cost. Ambiguous historical aggregates and unsupported pricing modes remain explicitly unpriced.

## Backport adaptations

- Cherry-picked all three source commits with `-x` provenance; resolved conflicts against the release implementation.
- Preserve the release branch's Grok reasoning behavior, preferred model default, and existing Sol pricing.
- Add the request-pricing columns in release schema migration **32 → 33**, with an upgrade regression test.
- Integrate request accounting with the release branch's existing usage lifecycle and clear previous-turn request observations when a new turn starts.
- Adapt cache-write display coverage to the existing usage-entry renderer. The newer `main` transcript projection is absent from this branch; the release Pricing panel already reads persisted line totals.
- Additional fields use existing ledger writes; no new per-event or timer-triggered SQLite commits are introduced.

## Validation

Rebased onto `releases/1.0` at `a10ca6a94` after #2051. The conflict resolution retains both Codex recovery and Astra accounting declarations; no pricing behavior changed during the rebase.

- 655 tests across shared pricing, Codex model lists/hydration, live request accounting, SQLite persistence/repricing/migrations, and renderer usage entries.
- `pnpm lint` (SQL, Codex storage boundary, colors, Electron version policy, licenses, ESLint, workspace typecheck, dependency boundaries).
- `git diff --check origin/releases/1.0...HEAD`.

