### PR TITLE
fix(desktop): serialize Codex history recovery lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -83,6 +83,7 @@ function createModelListResponse(models: Model[]): ModelListResponse {
 class MockTransport implements JsonRpcTransport {
   static instances: MockTransport[] = [];
   static serverVersion = "1.0.0";
+  static requireLoadedThreads = false;
   static codexHome = "/Users/fixture-user/.codex";
   static readThreadErrorByThreadId = new Map<string, { code: number; message: string }>();
   static readThreadTransientErrorsByThreadId = new Map<
@@ -202,6 +203,7 @@ class MockTransport implements JsonRpcTransport {
   readonly sentMessages: string[] = [];
   readonly options?: unknown;
   closeCount = 0;
+  readonly loadedThreads = new Set<string>();
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
 
@@ -216,6 +218,7 @@ class MockTransport implements JsonRpcTransport {
 
   async close(): Promise<void> {
     this.closeCount += 1;
+    this.loadedThreads.clear();
     this.closeHandler();
   }
 
@@ -227,6 +230,18 @@ class MockTransport implements JsonRpcTransport {
       method?: string;
       params?: Record<string, unknown>;
     };
+
+    if (MockTransport.requireLoadedThreads
+      && ["review/start", "turn/start", "turn/steer", "turn/interrupt", "thread/compact/start", "thread/settings/update"]
+        .includes(payload.method ?? "")
+      && !this.loadedThreads.has(String(payload.params?.threadId))) {
+      this.messageHandler(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        error: { code: -32000, message: "thread not loaded" },
+      }));
+      return;
+    }
 
     if (payload.method === "initialize") {
       const result: InitializeResponse = {
@@ -1078,6 +1093,7 @@ class MockTransport implements JsonRpcTransport {
         );
         return;
       }
+      this.loadedThreads.add(String(payload.params?.threadId));
       this.messageHandler(
         JSON.stringify({
           jsonrpc: "2.0",
@@ -1171,6 +1187,15 @@ class MockTransport implements JsonRpcTransport {
           result: MockTransport.turnStartResult
         })
       );
+      return;
+    }
+
+    if (payload.method === "turn/steer" || payload.method === "thread/compact/start") {
+      this.messageHandler(JSON.stringify({
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: { turnId: "turn-1" },
+      }));
       return;
     }
 
@@ -1287,6 +1312,7 @@ describe("CodexAppServerClient", () => {
     codexClientLogWarn.mockClear();
     MockTransport.instances.length = 0;
     MockTransport.serverVersion = "1.0.0";
+    MockTransport.requireLoadedThreads = false;
     MockTransport.codexHome = "/Users/fixture-user/.codex";
     MockTransport.readThreadErrorByThreadId.clear();
     MockTransport.readThreadTransientErrorsByThreadId.clear();
@@ -3048,6 +3074,7 @@ describe("CodexAppServerClient", () => {
     async function fixture(options: ConstructorParameters<
       typeof import("../codex-app-server/client").CodexAppServerClient
     >[0] = {}) {
+      MockTransport.requireLoadedThreads = true;
       const recovery = await import("../codex-app-server/invalid-response-message-id-recovery");
       const repair = vi.spyOn(recovery, "repairCodexInvalidResponseMessageIds")
         .mockResolvedValue(repaired);
@@ -3124,41 +3151,138 @@ describe("CodexAppServerClient", () => {
       await client.close();
     });
 
-    it("drains an admitted RPC and gates the next RPC of an in-flight review", async () => {
-      const resumeSent = deferred();
-      const finishResume = deferred();
-      const repairing = deferred();
-      const finishRepair = deferred();
-      let firstResume = true;
-      const { client, transport, repair, methods } = await fixture({
+    it.each(["review", "turn", "steer", "compact", "interrupt"] as const)(
+      "restores loaded thread state for an in-flight %s after recovery",
+      async (action) => {
+        const resumeSent = deferred();
+        const finishResume = deferred();
+        const repairing = deferred();
+        const finishRepair = deferred();
+        let firstResume = true;
+        const { client, transport, repair, methods } = await fixture({
+          connectionObserver: {
+            onMessage: async (event) => {
+              if (firstResume && event.direction === "outbound" && event.envelope.method === "thread/resume") {
+                firstResume = false;
+                resumeSent.resolve();
+                await finishResume.promise;
+              }
+            },
+          },
+        });
+        repair.mockImplementationOnce(async () => {
+          repairing.resolve();
+          await finishRepair.promise;
+          return repaired;
+        });
+        const operation = action === "review"
+          ? client.startReview({ threadId: "thread-2", target: { type: "uncommittedChanges" } })
+          : action === "turn"
+            ? client.startTurn({ threadId: "thread-2", input: [] })
+            : action === "steer"
+              ? client.steerTurn({ threadId: "thread-2", input: [], expectedTurnId: "turn-1" })
+              : action === "compact"
+                ? client.compactThread({ threadId: "thread-2" })
+                : client.interruptTurn({ threadId: "thread-2", turnId: "turn-1" });
+        await resumeSent.promise;
+        const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+        await flush();
+        expect(transport.closeCount).toBe(0);
+        expect(repair).not.toHaveBeenCalled();
+        finishResume.resolve();
+        await repairing.promise;
+        await flush();
+        expect(methods()).not.toContain("review/start");
+        finishRepair.resolve();
+        await Promise.all([operation, recovery]);
+        const resumes = transport.sentMessages.map((message) => JSON.parse(message))
+          .filter((message) => message.method === "thread/resume" && message.params.threadId === "thread-2");
+        expect(resumes).toHaveLength(2);
+        expect(resumes[1].params).toEqual(resumes[0].params);
+        const actionMethod = {
+          review: "review/start", turn: "turn/start", steer: "turn/steer",
+          compact: "thread/compact/start", interrupt: "turn/interrupt",
+        }[action];
+        expect(methods().filter((method) => method === actionMethod)).toHaveLength(1);
+        await client.close();
+      },
+    );
+
+    it("replays review settings as well as resume after a restart", async () => {
+      const updating = deferred();
+      const finishUpdate = deferred();
+      let firstUpdate = true;
+      const { client, transport } = await fixture({
         connectionObserver: {
           onMessage: async (event) => {
-            if (firstResume && event.direction === "outbound" && event.envelope.method === "thread/resume") {
-              firstResume = false;
-              resumeSent.resolve();
-              await finishResume.promise;
+            if (firstUpdate && event.direction === "outbound" && event.envelope.method === "thread/settings/update") {
+              firstUpdate = false;
+              updating.resolve();
+              await finishUpdate.promise;
             }
           },
         },
       });
-      repair.mockImplementationOnce(async () => {
-        repairing.resolve();
-        await finishRepair.promise;
-        return repaired;
+      const review = client.startReview({
+        threadId: "thread-2",
+        target: { type: "uncommittedChanges" },
+        model: "gpt-5.4",
+        reasoningEffort: "high",
       });
-      const review = client.startReview({ threadId: "thread-2", target: { type: "uncommittedChanges" } });
-      await resumeSent.promise;
+      await updating.promise;
       const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
-      await flush();
-      expect(transport.closeCount).toBe(0);
-      expect(repair).not.toHaveBeenCalled();
-      finishResume.resolve();
-      await repairing.promise;
-      await flush();
-      expect(methods()).not.toContain("review/start");
-      finishRepair.resolve();
+      finishUpdate.resolve();
       await Promise.all([review, recovery]);
-      expect(methods().at(-1)).toBe("review/start");
+      const requests = transport.sentMessages.map((message) => JSON.parse(message));
+      const settings = requests.filter((message) => message.method === "thread/settings/update");
+      expect(settings).toHaveLength(2);
+      expect(settings[1].params).toEqual(settings[0].params);
+      expect(requests.slice(-3).map((message) => message.method))
+        .toEqual(["thread/resume", "thread/settings/update", "review/start"]);
+      await client.close();
+    });
+
+    it.each(["read", "initialize", "recovery"])("close cancels an unanswered RPC promptly (%s)", async (scenario) => {
+      const { client, transport, repair } = await fixture();
+      if (scenario !== "initialize") await client.getInitializeResult();
+      const blockedMethod = scenario === "initialize" ? "initialize" : "thread/read";
+      const sent = deferred();
+      let unanswered = "";
+      const send = transport.send.bind(transport);
+      vi.spyOn(transport, "send").mockImplementation((message) => {
+        if (JSON.parse(message).method === blockedMethod) {
+          unanswered = message;
+          sent.resolve();
+        } else {
+          send(message);
+        }
+      });
+      const read = client.readThread({ threadId: "thread-2", includeTurns: false })
+        .catch((error: unknown) => error);
+      await sent.promise;
+      const recovery = scenario === "recovery"
+        ? client.recoverInvalidPersistedResponseMessageIds(recoveryParams).catch((error: unknown) => error)
+        : Promise.resolve();
+      let closed = false;
+      const close = client.close().then(() => { closed = true; });
+      try {
+        await flush();
+        // No clock advancement or server response is necessary for shutdown.
+        expect(closed).toBe(true);
+        expect(await read).toBeInstanceOf(Error);
+        expect(repair).not.toHaveBeenCalled();
+      } finally {
+        send(unanswered);
+        await Promise.all([read, recovery, close]);
+      }
+    });
+
+    it("clears client state even when external transport shutdown fails", async () => {
+      const { client, transport } = await fixture();
+      await client.getInitializeResult();
+      vi.spyOn(transport, "close").mockRejectedValueOnce(new Error("stop failed"));
+      await expect(client.close()).rejects.toThrow("stop failed");
+      await client.readThread({ threadId: "thread-2", includeTurns: false });
       await client.close();
     });
 

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
 import gitBudgets from "./fixtures/git-subprocess-budgets.json";
@@ -3022,6 +3022,308 @@ describe("CodexAppServerClient", () => {
       await client.close();
       await fs.rm(tempRoot, { force: true, recursive: true });
     }
+  });
+
+  describe("persisted-message-ID recovery concurrency", () => {
+    const threadId = "019fb6c7-1545-77c1-be52-98f86cae3c11";
+    const failureMessage = "[invalid_id_prefix] Invalid 'input[1].id': 'bad'. "
+      + "Expected an ID that begins with 'msg'.";
+    const recoveryParams = { threadId, failureMessage };
+    const repaired = {
+      threadId,
+      rolloutPath: "/fixture/rollout.jsonl",
+      backupPath: "/fixture/rollout.jsonl.bak",
+      removedMessageIdCount: 1,
+    };
+
+    function deferred() {
+      let resolve!: () => void;
+      const promise = new Promise<void>((done) => { resolve = done; });
+      return { promise, resolve };
+    }
+
+    // Drain runnable continuations, without using elapsed time as readiness.
+    const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+    async function fixture(options: ConstructorParameters<
+      typeof import("../codex-app-server/client").CodexAppServerClient
+    >[0] = {}) {
+      const recovery = await import("../codex-app-server/invalid-response-message-id-recovery");
+      const repair = vi.spyOn(recovery, "repairCodexInvalidResponseMessageIds")
+        .mockResolvedValue(repaired);
+      MockTransport.unfilteredThreadListResult = [{
+        id: threadId,
+        path: repaired.rolloutPath,
+        updatedAt: 1_775_000_000,
+      }];
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+        ...options,
+      });
+      const transport = MockTransport.instances.at(-1)!;
+      const methods = () => transport.sentMessages.map((message) =>
+        (JSON.parse(message) as { method: string }).method,
+      );
+      return { client, transport, repair, methods };
+    }
+
+    afterEach(() => vi.restoreAllMocks());
+
+    it("blocks reads and reviews through shutdown, repair, and resume", async () => {
+      const stopped = deferred();
+      const finishClose = deferred();
+      const repairing = deferred();
+      const finishRepair = deferred();
+      const resuming = deferred();
+      const finishResume = deferred();
+      const { client, transport, repair, methods } = await fixture({
+        connectionObserver: {
+          onMessage: async (event) => {
+            if (event.direction === "outbound" && event.envelope.method === "thread/resume") {
+              resuming.resolve();
+              await finishResume.promise;
+            }
+          },
+        },
+      });
+      const close = transport.close.bind(transport);
+      vi.spyOn(transport, "close").mockImplementationOnce(async () => {
+        await close();
+        stopped.resolve();
+        await finishClose.promise;
+      });
+      repair.mockImplementationOnce(async () => {
+        repairing.resolve();
+        await finishRepair.promise;
+        return repaired;
+      });
+      const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+      await stopped.promise;
+      const read = client.readThread({ threadId: "thread-2", includeTurns: false });
+      const review = client.startReview({ threadId: "thread-2", target: { type: "uncommittedChanges" } });
+      await flush();
+      expect(repair).not.toHaveBeenCalled();
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(1);
+      finishClose.resolve();
+      await repairing.promise;
+      await flush();
+      expect(methods()).not.toContain("thread/read");
+      expect(methods()).not.toContain("review/start");
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(1);
+      finishRepair.resolve();
+      await resuming.promise;
+      await flush();
+      expect(methods()).not.toContain("thread/read");
+      expect(methods()).not.toContain("review/start");
+      finishResume.resolve();
+      await Promise.all([recovery, read, review]);
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(2);
+      expect(methods().indexOf("thread/read")).toBeGreaterThan(methods().indexOf("thread/resume"));
+      await client.close();
+    });
+
+    it("drains an admitted RPC and gates the next RPC of an in-flight review", async () => {
+      const resumeSent = deferred();
+      const finishResume = deferred();
+      const repairing = deferred();
+      const finishRepair = deferred();
+      let firstResume = true;
+      const { client, transport, repair, methods } = await fixture({
+        connectionObserver: {
+          onMessage: async (event) => {
+            if (firstResume && event.direction === "outbound" && event.envelope.method === "thread/resume") {
+              firstResume = false;
+              resumeSent.resolve();
+              await finishResume.promise;
+            }
+          },
+        },
+      });
+      repair.mockImplementationOnce(async () => {
+        repairing.resolve();
+        await finishRepair.promise;
+        return repaired;
+      });
+      const review = client.startReview({ threadId: "thread-2", target: { type: "uncommittedChanges" } });
+      await resumeSent.promise;
+      const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+      await flush();
+      expect(transport.closeCount).toBe(0);
+      expect(repair).not.toHaveBeenCalled();
+      finishResume.resolve();
+      await repairing.promise;
+      await flush();
+      expect(methods()).not.toContain("review/start");
+      finishRepair.resolve();
+      await Promise.all([review, recovery]);
+      expect(methods().at(-1)).toBe("review/start");
+      await client.close();
+    });
+
+    it("drains initialization without making its public waiter deadlock on recovery", async () => {
+      const initializing = deferred();
+      const finishInitialize = deferred();
+      let firstInitialize = true;
+      const { client, repair } = await fixture({
+        connectionObserver: {
+          onMessage: async (event) => {
+            if (firstInitialize && event.direction === "outbound" && event.envelope.method === "initialize") {
+              firstInitialize = false;
+              initializing.resolve();
+              await finishInitialize.promise;
+            }
+          },
+        },
+      });
+      const read = client.readThread({ threadId: "thread-2", includeTurns: false });
+      await initializing.promise;
+      const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+      await flush();
+      expect(repair).not.toHaveBeenCalled();
+      finishInitialize.resolve();
+      await Promise.all([read, recovery]);
+      expect(repair).toHaveBeenCalledOnce();
+      await client.close();
+    });
+
+    it("serializes two recoveries before releasing ordinary operations", async () => {
+      const repairing = deferred();
+      const finishRepair = deferred();
+      const { client, repair, methods } = await fixture();
+      repair.mockImplementationOnce(async () => {
+        repairing.resolve();
+        await finishRepair.promise;
+        return repaired;
+      });
+      const first = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+      await repairing.promise;
+      const second = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+      const read = client.readThread({ threadId: "thread-2", includeTurns: false });
+      await flush();
+      expect(repair).toHaveBeenCalledOnce();
+      finishRepair.resolve();
+      await Promise.all([first, second, read]);
+      expect(repair).toHaveBeenCalledTimes(2);
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(3);
+      expect(methods().indexOf("thread/read")).toBeGreaterThan(methods().lastIndexOf("thread/resume"));
+      await client.close();
+    });
+
+    it.each(["repair", "restart", "both", "resume", "lookup", "shutdown"])(
+      "releases admission after %s failure and permits a later operation",
+      async (failure) => {
+        let initializeCount = 0;
+        const { client, transport, repair } = await fixture();
+        if (failure === "repair" || failure === "both") repair.mockRejectedValueOnce(new Error("repair failed"));
+        if (failure === "restart" || failure === "both") {
+          vi.spyOn(transport, "connect").mockImplementation(async () => {
+            if (++initializeCount === 2) throw new Error("restart failed");
+          });
+        }
+        if (failure === "resume") MockTransport.threadResumeError = { message: "resume failed" };
+        if (failure === "lookup") MockTransport.unfilteredThreadListResult = [];
+        if (failure === "shutdown") vi.spyOn(transport, "close").mockRejectedValueOnce(new Error("shutdown failed"));
+        const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams);
+        const queuedRead = client.readThread({ threadId: "thread-2", includeTurns: false });
+        const error = await recovery.catch((caught: unknown) => caught);
+        expect(error).toBeInstanceOf(Error);
+        if (failure === "both") {
+          expect(error).toBeInstanceOf(AggregateError);
+          expect((error as AggregateError).errors.map((entry: Error) => entry.message))
+            .toEqual(["repair failed", "restart failed"]);
+        }
+        MockTransport.threadResumeError = undefined;
+        await queuedRead;
+        await client.readThread({ threadId: "thread-2", includeTurns: false });
+        await client.close();
+      },
+    );
+
+    it("external close during restart waits for initialization and prevents resume", async () => {
+      const restarting = deferred();
+      const finishRestart = deferred();
+      let initializeCount = 0;
+      const { client, methods } = await fixture({
+        connectionObserver: {
+          onMessage: async (event) => {
+            if (event.direction === "outbound" && event.envelope.method === "initialize"
+              && ++initializeCount === 2) {
+              restarting.resolve();
+              await finishRestart.promise;
+            }
+          },
+        },
+      });
+      const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams)
+        .catch((error: unknown) => error);
+      await restarting.promise;
+      const close = client.close();
+      finishRestart.resolve();
+      expect(await recovery).toBeInstanceOf(Error);
+      await close;
+      expect(methods()).not.toContain("thread/resume");
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(2);
+    });
+
+    it("external close during shutdown cancels repair before it starts", async () => {
+      const stopping = deferred();
+      const finishStop = deferred();
+      const { client, transport, repair, methods } = await fixture();
+      const stop = transport.close.bind(transport);
+      vi.spyOn(transport, "close").mockImplementationOnce(async () => {
+        await stop();
+        stopping.resolve();
+        await finishStop.promise;
+      });
+      const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams)
+        .catch((error: unknown) => error);
+      await stopping.promise;
+      const close = client.close();
+      finishStop.resolve();
+      expect(await recovery).toBeInstanceOf(Error);
+      await close;
+      expect(repair).not.toHaveBeenCalled();
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(1);
+    });
+
+    it("external close waits for atomic repair and cancels restart plus queued callers", async () => {
+      const repairing = deferred();
+      const finishRepair = deferred();
+      const { client, repair, methods } = await fixture();
+      repair.mockImplementationOnce(async () => {
+        repairing.resolve();
+        await finishRepair.promise;
+        return repaired;
+      });
+      const recovery = client.recoverInvalidPersistedResponseMessageIds(recoveryParams)
+        .catch((error: unknown) => error);
+      await repairing.promise;
+      const read = client.readThread({ threadId: "thread-2", includeTurns: false })
+        .catch((error: unknown) => error);
+      const second = client.recoverInvalidPersistedResponseMessageIds(recoveryParams)
+        .catch((error: unknown) => error);
+      let closed = false;
+      const close = client.close().then(() => { closed = true; });
+      await flush();
+      expect(closed).toBe(false);
+      await expect(client.readThread({ threadId: "thread-2", includeTurns: false }))
+        .rejects.toThrow("client closed");
+      await expect(client.recoverInvalidPersistedResponseMessageIds(recoveryParams))
+        .rejects.toThrow("client closed");
+      finishRepair.resolve();
+      const [recoveryError, readError, secondError] = await Promise.all([recovery, read, second, close]);
+      expect(recoveryError).toBeInstanceOf(Error);
+      expect(readError).toBeInstanceOf(Error);
+      expect(secondError).toBeInstanceOf(Error);
+      expect(repair).toHaveBeenCalledOnce();
+      expect(methods().filter((method) => method === "initialize")).toHaveLength(1);
+      expect(methods()).not.toContain("thread/resume");
+      // close remains reusable, but only a new call can initialize it again.
+      await client.readThread({ threadId: "thread-2", includeTurns: false });
+      await client.close();
+    });
   });
 
   it("stops owner search pagination at its absolute deadline", async () => {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7375,6 +7375,8 @@ export class CodexAppServerClient {
   private readonly activeRequests = new Set<Promise<unknown>>();
   private closeGeneration = 0;
   private pendingCloses = 0;
+  private serverGeneration = 0;
+  private transportClosePromise: Promise<void> | null = null;
   private readonly threadDirectoryEnricher: (
     projectKey?: string,
     caller?: DirectoryEnrichmentCaller,
@@ -7567,8 +7569,18 @@ export class CodexAppServerClient {
     // interrupted. It must finish the atomic write, but must not restart Codex.
     this.closeGeneration += 1;
     this.pendingCloses += 1;
+    // Stop the transport now: pending RPC responses must not hold shutdown
+    // (or a recovery waiting to drain those RPCs) until their timeouts expire.
+    const stopped = this.stopTransport();
+    void stopped.catch(() => undefined);
     try {
-      await this.runLifecycle(() => this.closeConnection());
+      await this.runLifecycle(async () => {
+        try {
+          await stopped;
+        } finally {
+          await this.closeConnection();
+        }
+      });
     } finally {
       this.pendingCloses -= 1;
     }
@@ -7588,7 +7600,17 @@ export class CodexAppServerClient {
     this.helperTurnTitleObjects.clear();
     this.helperTurnTokenUsage.clear();
     this.helperThreadPredicates.clear();
-    await this.rawConnection.close();
+    await this.stopTransport();
+  }
+
+  private stopTransport(): Promise<void> {
+    if (this.transportClosePromise) return this.transportClosePromise;
+    const stopped = this.rawConnection.close();
+    this.transportClosePromise = stopped;
+    void stopped.finally(() => {
+      if (this.transportClosePromise === stopped) this.transportClosePromise = null;
+    }).catch(() => undefined);
+    return stopped;
   }
 
   async recoverInvalidPersistedResponseMessageIds(params: {
@@ -8853,6 +8875,7 @@ export class CodexAppServerClient {
     turnId: string;
   }> {
     await this.ensureInitialized();
+    const connection = this.createThreadOperationConnection();
 
     const pendingFirstTurnResult = this.pendingFirstTurnThreadResults.get(params.threadId);
     // thread/resume primes the per-thread permission profile in codex
@@ -8867,7 +8890,7 @@ export class CodexAppServerClient {
     let resumeResult = pendingFirstTurnResult;
     if (!pendingFirstTurnResult || refreshPendingFirstTurn) {
       const resume = requestWithFallbacks({
-        client: this.connection,
+        client: connection,
         methods: ["thread/resume"],
         payloads: buildThreadResumePayloads(
           {
@@ -8914,7 +8937,7 @@ export class CodexAppServerClient {
       input: params.input,
     });
     const result = await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["turn/start"],
       payloads: [
         buildTurnStartPayload(
@@ -9274,13 +9297,14 @@ export class CodexAppServerClient {
     dynamicTools?: CodexDynamicToolSpec[];
   }): Promise<{ threadId: string; reviewThreadId: string; turnId: string }> {
     await this.ensureInitialized();
+    const connection = this.createThreadOperationConnection();
 
     const pendingFirstTurn = this.pendingFirstTurnThreadResults.has(
       params.threadId,
     );
     if (!pendingFirstTurn || params.dynamicTools !== undefined) {
       const resume = requestWithFallbacks({
-        client: this.connection,
+        client: connection,
         methods: ["thread/resume"],
         payloads: buildThreadResumePayloads(
           {
@@ -9315,7 +9339,7 @@ export class CodexAppServerClient {
     });
     if (settingsPayload) {
       await requestWithFallbacks({
-        client: this.connection,
+        client: connection,
         methods: ["thread/settings/update"],
         payloads: [settingsPayload],
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -9323,7 +9347,7 @@ export class CodexAppServerClient {
     }
 
     const result = await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["review/start"],
       payloads: [buildReviewStartPayload(params)],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -9472,9 +9496,10 @@ export class CodexAppServerClient {
     turnId: string;
   }): Promise<{ threadId: string; turnId: string }> {
     await this.ensureInitialized();
+    const connection = this.createThreadOperationConnection();
 
     await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["thread/resume"],
       payloads: buildThreadResumePayloads(
         {
@@ -9491,7 +9516,7 @@ export class CodexAppServerClient {
         turnId: params.turnId,
       };
       await requestWithFallbacks({
-        client: this.connection,
+        client: connection,
         methods: ["turn/interrupt"],
         payloads: [payload],
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -9525,9 +9550,10 @@ export class CodexAppServerClient {
     threadId: string;
   }): Promise<{ threadId: string; turnId: string; itemId?: string }> {
     await this.ensureInitialized();
+    const connection = this.createThreadOperationConnection();
 
     await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["thread/resume"],
       payloads: buildThreadResumePayloads(
         {
@@ -9539,7 +9565,7 @@ export class CodexAppServerClient {
     }).catch(() => undefined);
 
     await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["thread/compact/start"],
       payloads: [
         {
@@ -9561,9 +9587,10 @@ export class CodexAppServerClient {
     expectedTurnId: string;
   }): Promise<{ threadId: string; turnId: string }> {
     await this.ensureInitialized();
+    const connection = this.createThreadOperationConnection();
 
     await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["thread/resume"],
       payloads: buildThreadResumePayloads(
         {
@@ -9583,7 +9610,7 @@ export class CodexAppServerClient {
       expectedTurnId: params.expectedTurnId,
     };
     const result = await requestWithFallbacks({
-      client: this.connection,
+      client: connection,
       methods: ["turn/steer"],
       payloads: [payload],
       timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -9595,9 +9622,41 @@ export class CodexAppServerClient {
     };
   }
 
-  private async requestWhenAvailable(
+  private requestWhenAvailable(
     ...args: Parameters<JsonRpcConnection["request"]>
   ): Promise<unknown> {
+    return this.runAdmittedRequest(() => this.rawConnection.request(...args));
+  }
+
+  private createThreadOperationConnection(): Pick<JsonRpcConnection, "request"> {
+    let generation = this.serverGeneration;
+    const setup: Array<Parameters<JsonRpcConnection["request"]>> = [];
+    return {
+      request: (...args) => this.runAdmittedRequest(async () => {
+        const closeGeneration = this.closeGeneration;
+        const request = (...requestArgs: Parameters<JsonRpcConnection["request"]>) => {
+          if (this.pendingCloses > 0 || closeGeneration !== this.closeGeneration) {
+            throw new Error("codex app server client closed");
+          }
+          return this.rawConnection.request(...requestArgs);
+        };
+        // Resume and settings belong to a process. Reapply successful setup
+        // after recovery, with setup plus the next RPC admitted as one unit.
+        // Never replay the action itself (turn/start, review/start, etc.).
+        if (generation !== this.serverGeneration) {
+          for (const previous of setup) await request(...previous);
+          generation = this.serverGeneration;
+        }
+        const result = await request(...args);
+        if (args[0] === "thread/resume" || args[0] === "thread/settings/update") {
+          setup.push(args);
+        }
+        return result;
+      }),
+    };
+  }
+
+  private async runAdmittedRequest(work: () => Promise<unknown>): Promise<unknown> {
     if (this.pendingCloses > 0) throw new Error("codex app server client closed");
     const generation = this.closeGeneration;
     while (this.lifecycleBarrier) {
@@ -9608,7 +9667,7 @@ export class CodexAppServerClient {
     if (generation !== this.closeGeneration || !this.initialized) {
       throw new Error("codex app server client closed");
     }
-    const request = this.rawConnection.request(...args);
+    const request = work();
     this.activeRequests.add(request);
     try {
       return await request;
@@ -9675,8 +9734,16 @@ export class CodexAppServerClient {
       return;
     }
 
+    const closeGeneration = this.closeGeneration;
+    const assertNotClosed = () => {
+      if (closeGeneration !== this.closeGeneration || this.pendingCloses > 0) {
+        throw new Error("codex app server client closed");
+      }
+    };
+    this.serverGeneration += 1;
     this.initializationPromise = (async () => {
       await this.rawConnection.connect();
+      assertNotClosed();
 
       try {
         const activationNonce =
@@ -9715,7 +9782,9 @@ export class CodexAppServerClient {
         }
       }
 
+      assertNotClosed();
       await this.rawConnection.notify("initialized", {});
+      assertNotClosed();
       this.initialized = true;
     })();
 

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7069,7 +7069,7 @@ function threadReadResultIncludesTurns(value: unknown): boolean {
 }
 
 async function requestCodexThreadItemsPage(params: {
-  client: JsonRpcConnection;
+  client: Pick<JsonRpcConnection, "request">;
   payload: CodexThreadItemsListParams;
   timeoutMs: number;
 }): Promise<CodexThreadItemsListResponse> {
@@ -7099,7 +7099,7 @@ async function requestCodexThreadItemsPage(params: {
 }
 
 async function listCodexThreadItems(params: {
-  client: JsonRpcConnection;
+  client: Pick<JsonRpcConnection, "request">;
   threadId: string;
   timeoutMs: number;
   turnId: string;
@@ -7135,7 +7135,7 @@ async function listCodexThreadItems(params: {
 
 async function hydrateCodexThreadHistory(params: {
   before?: string;
-  client: JsonRpcConnection;
+  client: Pick<JsonRpcConnection, "request">;
   limit?: number;
   readResult: unknown;
   threadId: string;
@@ -7225,7 +7225,7 @@ async function hydrateCodexThreadHistory(params: {
 }
 
 async function requestWithFallbacks(params: {
-  client: JsonRpcConnection;
+  client: Pick<JsonRpcConnection, "request">;
   diagnostics?: JsonRpcObserverDiagnostics;
   methods: Array<CodexClientRequestMethod | (string & {})>;
   payloads: unknown[];
@@ -7261,7 +7261,7 @@ async function requestWithFallbacks(params: {
 
 async function requestThreadListPages(params: {
   archived?: boolean;
-  client: JsonRpcConnection;
+  client: Pick<JsonRpcConnection, "request">;
   diagnostics?: JsonRpcObserverDiagnostics;
   filter?: string;
   limit?: number;
@@ -7367,7 +7367,14 @@ async function ensureCodexThreadTitleWorkspace(): Promise<string> {
 }
 
 export class CodexAppServerClient {
-  private readonly connection: JsonRpcConnection;
+  private readonly rawConnection: JsonRpcConnection;
+  // All ordinary RPCs, including continuations of multi-request operations,
+  // pass through admission. Only lifecycle work uses the raw connection.
+  private readonly connection: Pick<JsonRpcConnection, "request">;
+  private lifecycleBarrier: Promise<void> | null = null;
+  private readonly activeRequests = new Set<Promise<unknown>>();
+  private closeGeneration = 0;
+  private pendingCloses = 0;
   private readonly threadDirectoryEnricher: (
     projectKey?: string,
     caller?: DirectoryEnrichmentCaller,
@@ -7427,7 +7434,7 @@ export class CodexAppServerClient {
   private readonly reportedUnknownNotificationMethods = new Set<string>();
 
   constructor(private readonly options: CodexClientOptions = {}) {
-    this.connection = new JsonRpcConnection(
+    this.rawConnection = new JsonRpcConnection(
       new StdioJsonRpcTransport({
         command: options.command?.trim() || "codex",
         args: options.args ?? [],
@@ -7441,6 +7448,9 @@ export class CodexAppServerClient {
       createCodexObserverWithConfigReadRedaction(options.connectionObserver),
       { logContext: { backend: "codex" }, logger: getMainLogger("pwragent:json-rpc") },
     );
+    this.connection = {
+      request: (...args) => this.requestWhenAvailable(...args),
+    };
     const directoryResolver = options.directoryResolver;
     this.threadDirectoryEnricher =
       options.threadDirectoryEnricher ??
@@ -7449,7 +7459,7 @@ export class CodexAppServerClient {
             linkedDirectories: await directoryResolver(projectKey),
           })
         : createThreadDirectoryEnricher());
-    this.connection.setNotificationHandler(async (method, params) => {
+    this.rawConnection.setNotificationHandler(async (method, params) => {
       if (navigationQueryEventRequiresRefresh(method)) this.pendingThreadListings.clear();
       const isKnownCodexMethod = isKnownCodexNotificationMethod(method);
       if (!isKnownCodexMethod) {
@@ -7510,7 +7520,7 @@ export class CodexAppServerClient {
         await listener(normalized);
       }
     });
-    this.connection.setRequestHandler(async (method, params, rpcId) => {
+    this.rawConnection.setRequestHandler(async (method, params, rpcId) => {
       const wireRequest = isKnownCodexServerRequestMethod(method)
         ? ({
             method,
@@ -7553,6 +7563,18 @@ export class CodexAppServerClient {
   }
 
   async close(): Promise<void> {
+    // Invalidate a recovery immediately, even when its disk repair cannot be
+    // interrupted. It must finish the atomic write, but must not restart Codex.
+    this.closeGeneration += 1;
+    this.pendingCloses += 1;
+    try {
+      await this.runLifecycle(() => this.closeConnection());
+    } finally {
+      this.pendingCloses -= 1;
+    }
+  }
+
+  private async closeConnection(): Promise<void> {
     this.initialized = false;
     this.initializationPromise = null;
     this.initializeResult = null;
@@ -7566,7 +7588,7 @@ export class CodexAppServerClient {
     this.helperTurnTitleObjects.clear();
     this.helperTurnTokenUsage.clear();
     this.helperThreadPredicates.clear();
-    await this.connection.close();
+    await this.rawConnection.close();
   }
 
   async recoverInvalidPersistedResponseMessageIds(params: {
@@ -7579,80 +7601,94 @@ export class CodexAppServerClient {
         "Codex persisted-message-ID recovery requires the exact invalid ID prefix failure",
       );
     }
-    await this.ensureInitialized();
-    // Codex thread/list searchTerm is title/content search, not an ID lookup.
-    // Walk this profile-scoped app-server's protocol listing and select the
-    // exact ID locally so legacy threads in alternate CODEX_HOME profiles are
-    // resolved without guessing at Codex-owned storage paths.
-    const matchingThreads = (
-      await requestThreadListPages({
-        archived: false,
-        client: this.connection,
-        requestTimeoutMs:
-          this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
-      })
-    ).filter((thread) => thread.id === params.threadId);
-    if (matchingThreads.length !== 1) {
-      throw new Error(
-        `Codex recovery expected one protocol path for thread ${params.threadId}; found ${matchingThreads.length}`,
-      );
-    }
-    const rolloutPath = matchingThreads[0]!.path?.trim();
-    if (!rolloutPath) {
-      throw new Error(
-        `Codex App Server did not provide a persisted session path for thread ${params.threadId}`,
-      );
-    }
-
-    const env = this.options.resolveEnv
-      ? await this.options.resolveEnv()
-      : this.options.env ?? process.env;
-    const codexHome = path.resolve(
-      extractStringProperty(this.initializeResult, "codexHome", "codex_home")
-      || env.CODEX_HOME?.trim()
-      || path.join(homedir(), ".codex"),
-    );
-
-    // The Codex app-server process is the only writer for this profile. Stop
-    // it and wait for process exit before the narrowly authorized repair so
-    // no in-memory writer can race the atomic replacement.
-    await this.close();
-    let recoveryResult: CodexInvalidResponseMessageIdRecoveryResult | undefined;
-    let recoveryError: unknown;
-    try {
-      recoveryResult = await repairCodexInvalidResponseMessageIds({
-        codexHome,
-        forkLineageThreadIds: params.forkLineageThreadIds,
-        rolloutPath,
-        threadId: params.threadId,
-      });
-    } catch (error) {
-      recoveryError = error;
-    }
-
-    try {
-      await this.ensureInitialized();
-    } catch (restartError) {
-      if (recoveryError) {
-        throw new AggregateError(
-          [recoveryError, restartError],
-          `Codex history recovery and app-server restart both failed for thread ${params.threadId}`,
-          { cause: restartError },
+    if (this.pendingCloses > 0) throw new Error("codex app server client closed");
+    const generation = this.closeGeneration;
+    const assertNotClosed = () => {
+      if (generation !== this.closeGeneration) {
+        throw new Error("Codex history recovery cancelled because the client was closed");
+      }
+    };
+    return await this.runLifecycle(async () => {
+      assertNotClosed();
+      await this.initializeConnection();
+      // Codex thread/list searchTerm is title/content search, not an ID lookup.
+      // Walk this profile-scoped app-server's protocol listing and select the
+      // exact ID locally so legacy threads in alternate CODEX_HOME profiles are
+      // resolved without guessing at Codex-owned storage paths.
+      const matchingThreads = (
+        await requestThreadListPages({
+          archived: false,
+          client: this.rawConnection,
+          requestTimeoutMs:
+            this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+        })
+      ).filter((thread) => thread.id === params.threadId);
+      if (matchingThreads.length !== 1) {
+        throw new Error(
+          `Codex recovery expected one protocol path for thread ${params.threadId}; found ${matchingThreads.length}`,
         );
       }
-      throw restartError;
-    }
-    if (recoveryError) {
-      throw recoveryError;
-    }
+      const rolloutPath = matchingThreads[0]!.path?.trim();
+      if (!rolloutPath) {
+        throw new Error(
+          `Codex App Server did not provide a persisted session path for thread ${params.threadId}`,
+        );
+      }
 
-    await requestWithFallbacks({
-      client: this.connection,
-      methods: ["thread/resume"],
-      payloads: [{ threadId: params.threadId }],
-      timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      const env = this.options.resolveEnv
+        ? await this.options.resolveEnv()
+        : this.options.env ?? process.env;
+      const codexHome = path.resolve(
+        extractStringProperty(this.initializeResult, "codexHome", "codex_home")
+        || env.CODEX_HOME?.trim()
+        || path.join(homedir(), ".codex"),
+      );
+
+      // The Codex app-server process is the only writer for this profile. Stop
+      // it and wait for process exit before the narrowly authorized repair so
+      // no in-memory writer can race the atomic replacement.
+      assertNotClosed();
+      await this.closeConnection();
+      assertNotClosed();
+      let recoveryResult: CodexInvalidResponseMessageIdRecoveryResult | undefined;
+      let recoveryError: unknown;
+      try {
+        recoveryResult = await repairCodexInvalidResponseMessageIds({
+          codexHome,
+          forkLineageThreadIds: params.forkLineageThreadIds,
+          rolloutPath,
+          threadId: params.threadId,
+        });
+      } catch (error) {
+        recoveryError = error;
+      }
+
+      assertNotClosed();
+      try {
+        await this.initializeConnection();
+      } catch (restartError) {
+        if (recoveryError) {
+          throw new AggregateError(
+            [recoveryError, restartError],
+            `Codex history recovery and app-server restart both failed for thread ${params.threadId}`,
+            { cause: restartError },
+          );
+        }
+        throw restartError;
+      }
+      if (recoveryError) {
+        throw recoveryError;
+      }
+
+      assertNotClosed();
+      await requestWithFallbacks({
+        client: this.rawConnection,
+        methods: ["thread/resume"],
+        payloads: [{ threadId: params.threadId }],
+        timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+      });
+      return recoveryResult!;
     });
-    return recoveryResult!;
   }
 
   onNotification(
@@ -9559,7 +9595,66 @@ export class CodexAppServerClient {
     };
   }
 
+  private async requestWhenAvailable(
+    ...args: Parameters<JsonRpcConnection["request"]>
+  ): Promise<unknown> {
+    if (this.pendingCloses > 0) throw new Error("codex app server client closed");
+    const generation = this.closeGeneration;
+    while (this.lifecycleBarrier) {
+      await this.lifecycleBarrier;
+    }
+    // No await between the final admission check and registering the RPC.
+    // A close must not let a previously admitted continuation revive a writer.
+    if (generation !== this.closeGeneration || !this.initialized) {
+      throw new Error("codex app server client closed");
+    }
+    const request = this.rawConnection.request(...args);
+    this.activeRequests.add(request);
+    try {
+      return await request;
+    } finally {
+      this.activeRequests.delete(request);
+    }
+  }
+
+  private async runLifecycle<T>(work: () => Promise<T>): Promise<T> {
+    const previous = this.lifecycleBarrier;
+    let release!: () => void;
+    const barrier = new Promise<void>((resolve) => { release = resolve; });
+    // Reserve synchronously, before awaiting initialization or in-flight RPCs.
+    this.lifecycleBarrier = barrier;
+    try {
+      await previous;
+      // Drain RPCs, not whole public operations: helper turns can wait for
+      // notifications until close rejects their waiters. Their later RPCs
+      // must return through admission instead of holding this lifecycle open.
+      await Promise.allSettled([
+        ...this.activeRequests,
+        ...(this.initializationPromise ? [this.initializationPromise] : []),
+      ]);
+      return await work();
+    } finally {
+      if (this.lifecycleBarrier === barrier) this.lifecycleBarrier = null;
+      release();
+    }
+  }
+
   private async ensureInitialized(): Promise<void> {
+    if (this.pendingCloses > 0) throw new Error("codex app server client closed");
+    const generation = this.closeGeneration;
+    do {
+      while (this.lifecycleBarrier) {
+        await this.lifecycleBarrier;
+      }
+      if (generation !== this.closeGeneration) {
+        throw new Error("codex app server client closed");
+      }
+      await this.initializeConnection();
+      // A reservation may have arrived while initialization was in flight.
+    } while (this.lifecycleBarrier);
+  }
+
+  private async initializeConnection(): Promise<void> {
     if (this.initialized) {
       return;
     }
@@ -9581,7 +9676,7 @@ export class CodexAppServerClient {
     }
 
     this.initializationPromise = (async () => {
-      await this.connection.connect();
+      await this.rawConnection.connect();
 
       try {
         const activationNonce =
@@ -9612,7 +9707,7 @@ export class CodexAppServerClient {
               : {}),
           },
         };
-        const result = await this.connection.request("initialize", initializeParams);
+        const result = await this.rawConnection.request("initialize", initializeParams);
         this.initializeResult = parseInitializeResponse(result);
       } catch (error) {
         if (!isAlreadyInitializedError(error)) {
@@ -9620,7 +9715,7 @@ export class CodexAppServerClient {
         }
       }
 
-      await this.connection.notify("initialized", {});
+      await this.rawConnection.notify("initialized", {});
       this.initialized = true;
     })();
 


### PR DESCRIPTION
Concurrent Codex reads, reviews, or continuations of an in-flight operation could restart the app server after invalid-message-ID recovery stopped it but before the rollout repair finished. This violated the repair's stopped-writer requirement.

Reserve a client lifecycle barrier synchronously and gate every ordinary RPC as well as initialization. Drain admitted RPCs and initialization, then keep exclusive access through shutdown, repair, restart, and thread resume. Recovery uses private lifecycle methods so it cannot wait on its own barrier.

External close immediately stops the transport and cancels unanswered RPCs, including those blocking a recovery reservation. It cancels recovery's restart and waits for an active atomic repair to finish. Initialization cannot publish readiness after close; failure paths release admission and allow a fresh call to reuse the client.

Stateful review, turn, steer, interrupt, and compact operations retain successful resume/settings setup. If recovery restarts Codex between their RPCs, they reapply that setup before sending the next action. Setup replay and the next RPC share admission so another recovery cannot split them. Actions themselves are not replayed.

Validation:
- 876 tests passed across the Codex client, disk repair, and backend registry suites, including 22 deterministic concurrency cases.
- Coverage includes unanswered reads/initialization and recovery blocked on an unanswered RPC; transport-close failure cleanup; overlapping recoveries; external close during shutdown/repair/restart; loaded-thread state cleared on restart; settings replay; and single action delivery for all five stateful operation types.
- Verified the original restart/shutdown regressions fail against unchanged main. Also verified four review regression cases fail against the prior PR commit: unanswered-RPC shutdown with/without waiting recovery, unloaded review state, and missing review settings replay.
- `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:codex-storage`, and `pnpm lint:boundaries` passed.

Targets `main`. Inspected terminal-notification ordering: notification emit still precedes recovery handling, but main's failed-turn queue path holds the queue. This PR changes only the shared client lifecycle and its tests; it does not modify PR #2051 or `releases/1.0`.
