### PR TITLE
fix(desktop): backport August 21 Sol pricing to 1.0

### DIFF
--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -403,6 +403,60 @@ describe("token usage pricing", () => {
     expect(estimateOpenAiCodexCreditUsage(usage)).toBeUndefined();
   });
 
+  it("prices GPT-5.6 Sol at the reduced August 21 rates", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, 24_400_000, 4, 0.4, 20],
+      ["gpt-5.6-sol", true, 48_800_000, 8, 0.8, 40],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      totalCostMicros,
+      inputUsdPerMillion,
+      cachedInputUsdPerMillion,
+      outputUsdPerMillion,
+    ] of cases) {
+      const cost = estimateOpenAiTokenUsageCost({
+        at: Date.UTC(2026, 7, 21),
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(cost).toMatchObject({
+        catalogVersion: "2026-08-21",
+        cachedInputUsdPerMillion,
+        inputUsdPerMillion,
+        outputUsdPerMillion,
+        rateId: `openai:2026-08-21:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
+        totalCostMicros,
+      });
+    }
+  });
+
+  it("keeps GPT-5.6 Sol on the July 9 rates until August 21", () => {
+    const cost = estimateOpenAiTokenUsageCost({
+      at: Date.UTC(2026, 7, 20, 23, 59, 59),
+      cachedInputTokens: 1_000_000,
+      model: "gpt-5.6-sol",
+      outputTokens: 1_000_000,
+      uncachedInputTokens: 1_000_000,
+    });
+
+    expect(cost).toMatchObject({
+      catalogVersion: "2026-07-09",
+      inputUsdPerMillion: 5,
+      cachedInputUsdPerMillion: 0.5,
+      outputUsdPerMillion: 30,
+      rateId: "openai:2026-07-09:gpt-5.6-sol:standard",
+      totalCostMicros: 35_500_000,
+    });
+  });
+
   it("does not price GPT-5.6 usage before its catalog effective date", () => {
     expect(
       estimateOpenAiTokenUsageCost({
@@ -646,6 +700,21 @@ describe("token usage pricing", () => {
         serviceTier: "priority",
       }),
     );
+    expect(listOpenAiTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        catalogId: "openai-api",
+        catalogVersion: "2026-08-21",
+        currency: "USD",
+        displayName: "GPT-5.6 Sol Standard",
+        inputMicrosPerMillion: 4_000_000,
+        cachedInputMicrosPerMillion: 400_000,
+        outputMicrosPerMillion: 20_000_000,
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        rateId: "openai:2026-08-21:gpt-5.6-sol:standard",
+        serviceTier: "standard",
+      }),
+    );
     expect(listTokenUsagePricingRates()).toContainEqual(
       expect.objectContaining({
         cachedInputUsdPerMillion: 0.5,
@@ -817,6 +886,46 @@ describe("token usage pricing", () => {
         provider: "openai",
         rateId: `openai:2026-07-30:codex-credits:${model}:priority`,
         serviceTier: "priority",
+        totalCreditMicros,
+        totalCredits: totalCreditMicros / 1_000_000,
+      });
+    }
+  });
+
+  it("estimates reduced GPT-5.6 Sol Codex Credits from August 21", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, "GPT-5.6 Sol Standard", 100, 10, 500, 610_000_000],
+      ["gpt-5.6-sol", true, "GPT-5.6 Sol Fast", 250, 25, 1250, 1_525_000_000],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      displayName,
+      inputCreditsPerMillion,
+      cachedInputCreditsPerMillion,
+      outputCreditsPerMillion,
+      totalCreditMicros,
+    ] of cases) {
+      const credits = estimateOpenAiCodexCreditUsage({
+        at: Date.UTC(2026, 7, 21),
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(credits).toMatchObject({
+        catalogId: "openai-codex-credits",
+        catalogVersion: "2026-08-21",
+        displayName,
+        inputCreditsPerMillion,
+        cachedInputCreditsPerMillion,
+        outputCreditsPerMillion,
+        provider: "openai",
+        rateId: `openai:2026-08-21:codex-credits:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
         totalCreditMicros,
         totalCredits: totalCreditMicros / 1_000_000,
       });

--- a/packages/shared/src/__tests__/token-usage-pricing.test.ts
+++ b/packages/shared/src/__tests__/token-usage-pricing.test.ts
@@ -457,6 +457,45 @@ describe("token usage pricing", () => {
     });
   });
 
+  it("prices current GPT-5.6 Sol, Terra, and Luna at the published list rates", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, "2026-08-21", 24_400_000, 4, 0.4, 20],
+      ["gpt-5.6-sol", true, "2026-08-21", 48_800_000, 8, 0.8, 40],
+      ["gpt-5.6-terra", false, "2026-07-30", 14_200_000, 2, 0.2, 12],
+      ["gpt-5.6-terra", true, "2026-07-30", 28_400_000, 4, 0.4, 24],
+      ["gpt-5.6-luna", false, "2026-07-30", 1_420_000, 0.2, 0.02, 1.2],
+      ["gpt-5.6-luna", true, "2026-07-30", 2_840_000, 0.4, 0.04, 2.4],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      catalogVersion,
+      totalCostMicros,
+      inputUsdPerMillion,
+      cachedInputUsdPerMillion,
+      outputUsdPerMillion,
+    ] of cases) {
+      const cost = estimateOpenAiTokenUsageCost({
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(cost).toMatchObject({
+        catalogVersion,
+        cachedInputUsdPerMillion,
+        inputUsdPerMillion,
+        outputUsdPerMillion,
+        rateId: `openai:${catalogVersion}:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
+        totalCostMicros,
+      });
+    }
+  });
+
   it("does not price GPT-5.6 usage before its catalog effective date", () => {
     expect(
       estimateOpenAiTokenUsageCost({
@@ -703,6 +742,21 @@ describe("token usage pricing", () => {
     expect(listOpenAiTokenUsagePricingRates()).toContainEqual(
       expect.objectContaining({
         catalogId: "openai-api",
+        catalogVersion: "2026-07-30",
+        currency: "USD",
+        displayName: "GPT-5.6 Terra Standard",
+        inputMicrosPerMillion: 2_000_000,
+        cachedInputMicrosPerMillion: 200_000,
+        outputMicrosPerMillion: 12_000_000,
+        model: "gpt-5.6-terra",
+        provider: "openai",
+        rateId: "openai:2026-07-30:gpt-5.6-terra:standard",
+        serviceTier: "standard",
+      }),
+    );
+    expect(listOpenAiTokenUsagePricingRates()).toContainEqual(
+      expect.objectContaining({
+        catalogId: "openai-api",
         catalogVersion: "2026-08-21",
         currency: "USD",
         displayName: "GPT-5.6 Sol Standard",
@@ -925,6 +979,50 @@ describe("token usage pricing", () => {
         outputCreditsPerMillion,
         provider: "openai",
         rateId: `openai:2026-08-21:codex-credits:${model}:${fastMode ? "priority" : "standard"}`,
+        serviceTier: fastMode ? "priority" : "standard",
+        totalCreditMicros,
+        totalCredits: totalCreditMicros / 1_000_000,
+      });
+    }
+  });
+
+  it("estimates current GPT-5.6 Codex Credits at the published list rates", () => {
+    const cases = [
+      ["gpt-5.6-sol", false, "2026-08-21", "GPT-5.6 Sol Standard", 100, 10, 500, 610_000_000],
+      ["gpt-5.6-sol", true, "2026-08-21", "GPT-5.6 Sol Fast", 250, 25, 1250, 1_525_000_000],
+      ["gpt-5.6-terra", false, "2026-07-30", "GPT-5.6 Terra Standard", 50, 5, 300, 355_000_000],
+      ["gpt-5.6-terra", true, "2026-07-30", "GPT-5.6 Terra Fast", 125, 12.5, 750, 887_500_000],
+      ["gpt-5.6-luna", false, "2026-07-30", "GPT-5.6 Luna Standard", 5, 0.5, 30, 35_500_000],
+      ["gpt-5.6-luna", true, "2026-07-30", "GPT-5.6 Luna Fast", 12.5, 1.25, 75, 88_750_000],
+    ] as const;
+
+    for (const [
+      model,
+      fastMode,
+      catalogVersion,
+      displayName,
+      inputCreditsPerMillion,
+      cachedInputCreditsPerMillion,
+      outputCreditsPerMillion,
+      totalCreditMicros,
+    ] of cases) {
+      const credits = estimateOpenAiCodexCreditUsage({
+        cachedInputTokens: 1_000_000,
+        fastMode,
+        model,
+        outputTokens: 1_000_000,
+        uncachedInputTokens: 1_000_000,
+      });
+
+      expect(credits).toMatchObject({
+        catalogId: "openai-codex-credits",
+        catalogVersion,
+        displayName,
+        inputCreditsPerMillion,
+        cachedInputCreditsPerMillion,
+        outputCreditsPerMillion,
+        provider: "openai",
+        rateId: `openai:${catalogVersion}:codex-credits:${model}:${fastMode ? "priority" : "standard"}`,
         serviceTier: fastMode ? "priority" : "standard",
         totalCreditMicros,
         totalCredits: totalCreditMicros / 1_000_000,

--- a/packages/shared/src/token-usage-pricing.ts
+++ b/packages/shared/src/token-usage-pricing.ts
@@ -270,6 +270,9 @@ const OPENAI_GPT56_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 6, 30);
 // https://developers.openai.com/api/docs/models/gpt-6-astra
 const OPENAI_GPT6_ASTRA_PRICING_CATALOG_VERSION = "2026-09-04";
 const OPENAI_GPT6_ASTRA_PRICING_EFFECTIVE_FROM = Date.UTC(2026, 8, 4);
+// https://developers.openai.com/api/docs/models/gpt-5.6-sol
+const OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION = "2026-08-21";
+const OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM = Date.UTC(2026, 7, 21);
 const OPENAI_CODEX_CREDITS_CATALOG_ID = "openai-codex-credits";
 const OPENAI_CODEX_CREDITS_CATALOG_VERSION = "2026-06-16";
 const OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION = "2026-07-27";
@@ -369,6 +372,32 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
   },
   {
     catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
+    model: "gpt-5.6-sol",
+    displayModel: "GPT-5.6 Sol",
+    displayTier: "Standard",
+    effectiveFrom: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "standard",
+    inputUsdPerMillion: 4,
+    cachedInputUsdPerMillion: 0.4,
+    outputUsdPerMillion: 20,
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
+    catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
+    model: "gpt-5.6-sol",
+    displayModel: "GPT-5.6 Sol",
+    displayTier: "Fast",
+    effectiveFrom: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
+    provider: "openai",
+    serviceTier: "priority",
+    inputUsdPerMillion: 8,
+    cachedInputUsdPerMillion: 0.8,
+    outputUsdPerMillion: 40,
+  },
+  {
+    catalogId: OPENAI_PRICING_CATALOG_ID,
     catalogVersion: OPENAI_GPT56_REPRICING_CATALOG_VERSION,
     model: "gpt-5.6-terra",
     displayModel: "GPT-5.6 Terra",
@@ -426,6 +455,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.6 Sol",
     displayTier: "Standard",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
+    effectiveTo: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "standard",
     inputUsdPerMillion: 5,
@@ -439,6 +469,7 @@ const OPENAI_PRICING_CATALOG: readonly PricingCatalogEntry[] = [
     displayModel: "GPT-5.6 Sol",
     displayTier: "Fast (Priority)",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
+    effectiveTo: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
     provider: "openai",
     serviceTier: "priority",
     inputUsdPerMillion: 10,
@@ -702,10 +733,23 @@ function buildCodexCreditsCatalogEntries(params: {
 
 const OPENAI_CODEX_CREDITS_CATALOG: readonly CodexCreditsCatalogEntry[] = [
   ...buildCodexCreditsCatalogEntries({
+    catalogVersion: OPENAI_GPT56_SOL_REPRICING_CATALOG_VERSION,
+    model: "gpt-5.6-sol",
+    displayModel: "GPT-5.6 Sol",
+    effectiveFrom: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
+    fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
+    standardRates: {
+      inputCreditsPerMillion: 100,
+      cachedInputCreditsPerMillion: 10,
+      outputCreditsPerMillion: 500,
+    },
+  }),
+  ...buildCodexCreditsCatalogEntries({
     catalogVersion: OPENAI_GPT56_CODEX_CREDITS_CATALOG_VERSION,
     model: "gpt-5.6-sol",
     displayModel: "GPT-5.6 Sol",
     effectiveFrom: OPENAI_GPT56_PRICING_EFFECTIVE_FROM,
+    effectiveTo: OPENAI_GPT56_SOL_REPRICING_EFFECTIVE_FROM,
     fastRateMultiplier: OPENAI_CODEX_FAST_RATE_MULTIPLIERS["gpt-5.6"],
     standardRates: {
       inputCreditsPerMillion: 125,


### PR DESCRIPTION
## Summary

Backport #1868 to `releases/1.0` so GPT-5.6 Sol usage on or after August 21 uses the reduced API list rates and Codex credit rates. Earlier usage retains its previous rates.

- Standard API rates per 1M input/cached/output tokens: $4 / $0.40 / $20; Fast: $8 / $0.80 / $40.
- Standard Codex credits per 1M input/cached/output tokens: 100 / 10 / 500, with the source PR's existing Fast multiplier.
- Preserve Astra and the existing July 30 Terra/Luna pricing entries.

Cherry-picked `fcf2c7322` and `d2f3ddae1` with provenance. The final source commit, `d5753e4fe`, only changes an expectation in a later live-usage test absent from `releases/1.0`, so it is not applicable. Conflict resolutions retain both Astra and Sol additions; no pricing redesign is included.

## Validation

- 515 passing tests across shared pricing, backend registry, SQLite pricing ledger, and database suites.
- `pnpm lint`.
- `git diff --check origin/releases/1.0...HEAD`.
- `git range-diff` confirms the source changes differ only in placement around the existing Astra additions and cherry-pick provenance.
