### PR TITLE
fix(desktop): distinguish selected unpinned directory threads

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -207,6 +207,7 @@ const POINTER_DRAG_ACTIVATION_PX = 4;
 
 const EMPTY_EXPANDED_DIRECTORY_THREAD_MODEL: PagedDirectoryPresentation = {
   unpinnedThreads: [],
+  selectedUnpinnedThreads: [],
   childThreadsByParentKey: new Map(),
   directoryPinnedThreads: [],
   directoryThreadsCollapsed: false,
@@ -1115,6 +1116,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     // direct children would silently drop it from the lens.
     const trays = createSubthreadTrays(childThreadsByParentKey);
     for (const thread of expandedThreadModel.directoryPinnedThreads) trays.addTrayOwner(thread);
+    for (const thread of expandedThreadModel.selectedUnpinnedThreads) trays.addTrayOwner(thread);
     for (const thread of expandedThreadModel.unpinnedThreads) trays.addTrayOwner(thread);
     const renderStaticSubthreads = (parent: NavigationPresentedThread): ReactElement | null => {
       const parentKey = threadSummaryIdentityKey(parent);
@@ -1294,6 +1296,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
     };
     const {
       unpinnedThreads,
+      selectedUnpinnedThreads,
       directoryPinnedThreads,
       directoryThreadsCollapsed,
       directoryUnpinnedThreadCount,
@@ -1335,6 +1338,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
             thinkingThreadKeys={props.thinkingThreadKeys}
             thread={thread}
             threadPinState="unpinned"
+            retainedForSelection={selectedUnpinnedThreads.includes(thread)}
             onToggleSubthreads={
               subthreadCount > 0
                 && threadSupportsFederationCapability(thread, "thread_grouping")
@@ -1852,6 +1856,7 @@ export function DirectoriesList(props: DirectoriesListProps) {
                       </div>
                     ) : null}
 
+                    {selectedUnpinnedThreads.map(renderUnpinnedRow)}
                     {(directory.pinnedRootCount ?? 0) > 0 &&
                     directoryUnpinnedThreadCount > 0 ? (
                       <div className="directory-row__threads-slot" role="listitem">

--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRow.tsx
@@ -83,6 +83,7 @@ type ThreadRowProps = {
   subthreadsCollapsed?: boolean;
   thinkingThreadKeys?: Record<string, boolean>;
   threadPinState?: "pinned" | "unpinned";
+  retainedForSelection?: boolean;
   thread: NavigationThreadSummary;
   onOpenContextMenu: (
     thread: NavigationThreadSummary,
@@ -163,15 +164,17 @@ export function ThreadRow(props: ThreadRowProps) {
     && props.thread.federation.peerStatus !== "connected",
   );
   const status = getThreadRowStatus(props.thread, props.thinkingThreadKeys);
-  // One expression for "this row carries the in-title pin": the row's
-  // `--pinned` modifier class, the ", pinned" accessible-name suffix,
-  // and the in-title pin render all derive from it, so the CSS class
-  // can never disagree with the control it stands for. The modifier
-  // exists so the hover-reserve rule in app.css matches a plain class
-  // instead of a per-hover `:has()` subtree scan (same optimization the
-  // DirectoriesList header modifiers document).
+  // Saved pins and selection-retained rows share the heading control's
+  // space, but only a saved pin offers Unpin or reports itself as pinned.
   const isPinnedRow =
     Boolean(props.thread.pinnedRank) && !props.nested;
+  const isRetainedRow = Boolean(props.retainedForSelection) && !isPinnedRow && !props.nested;
+  const hasHeadingPin = isPinnedRow || isRetainedRow;
+  const pinAction = isPinnedRow ? "Unpin thread" : "Pin thread";
+  const pinTooltip = isRetainedRow
+    ? "Shown for the open transcript. Pin thread to keep it here."
+    : pinAction;
+  const pinTooltipController = useViewportTooltip({ className: "viewport-tooltip" });
   const [pickerOpen, setPickerOpen] = useState(false);
   const rowRef = useRef<HTMLDivElement>(null);
   const openButtonRef = useRef<HTMLButtonElement>(null);
@@ -321,7 +324,7 @@ export function ThreadRow(props: ThreadRowProps) {
       <div
         ref={rowRef}
         className={`thread-row${props.compact ? " thread-row--compact" : ""}${
-          isPinnedRow ? " thread-row--pinned" : ""
+          isPinnedRow ? " thread-row--pinned" : isRetainedRow ? " thread-row--retained" : ""
         }${selected ? " is-selected" : ""}${
           isComposerSource ? " is-composer-source" : ""
         }${isLinkTarget ? " is-link-target" : ""}${
@@ -364,7 +367,8 @@ export function ThreadRow(props: ThreadRowProps) {
           // (same pattern as the chip flow) so the in-title pin can be a
           // real unpin button without nesting a control inside this one.
           aria-label={
-            isPinnedRow ? `${props.thread.title}, pinned` : props.thread.title
+            isPinnedRow ? `${props.thread.title}, pinned`
+              : isRetainedRow ? `${props.thread.title}, shown while open` : props.thread.title
           }
           aria-pressed={selected}
           className="thread-row__open"
@@ -410,12 +414,16 @@ export function ThreadRow(props: ThreadRowProps) {
               status={status}
             />
             <span className="thread-row__title">{props.thread.title}</span>
-            {isPinnedRow ? (
+            {hasHeadingPin ? (
               onSetThreadPin ? (
                 <button
-                  aria-label="Unpin thread"
+                  aria-label={pinAction}
+                  aria-describedby={pinTooltipController.visible ? pinTooltipController.tooltipId : undefined}
                   className="thread-row__heading-pin"
-                  title="Unpin thread"
+                  onMouseEnter={(event) => pinTooltipController.show(event.currentTarget, pinTooltip)}
+                  onMouseLeave={pinTooltipController.hide}
+                  onFocus={(event) => pinTooltipController.show(event.currentTarget, pinTooltip)}
+                  onBlur={pinTooltipController.hide}
                   type="button"
                   onClick={(event) => {
                     event.stopPropagation();
@@ -428,20 +436,22 @@ export function ThreadRow(props: ThreadRowProps) {
                     if (event.detail === 0) {
                       openButtonRef.current?.focus();
                     }
-                    void onSetThreadPin(props.thread, false);
+                    pinTooltipController.hide();
+                    void onSetThreadPin(props.thread, !isPinnedRow);
                   }}
                 >
-                  <PinIcon size={11} aria-hidden="true" />
+                  <PinIcon size={11} strokeDasharray={isRetainedRow ? "3 3" : undefined} aria-hidden="true" />
                 </button>
               ) : (
                 <span
                   aria-hidden="true"
                   className="thread-row__heading-pin thread-row__heading-pin--static"
                 >
-                  <PinIcon size={11} />
+                  <PinIcon size={11} strokeDasharray={isRetainedRow ? "3 3" : undefined} />
                 </span>
               )
             ) : null}
+            {pinTooltipController.tooltipNode}
           </span>
           <span className="thread-row__time">
             {formatRelativeTime(props.thread.updatedAt)}
@@ -537,15 +547,15 @@ export function ThreadRow(props: ThreadRowProps) {
       </div>
 
       <div className="thread-row__actions">
-        {/* Hover-revealed pin affordance for UNPINNED rows only — a
-            pinned row's always-visible in-title pin IS the unpin
-            control, so a second pin here would be a double affordance.
+        {/* Rows with an in-title pin already have a pin/unpin control,
+            including the dashed pin on a selection-retained row.
+            Other unpinned rows reveal this control on hover.
             Visibly nested sub-threads cannot be pinned. A remote child
             whose parent is absent from a full remote-viewer snapshot is
             rendered as a top-level row and remains pinnable. */}
         {onSetThreadPin
           && !props.nested
-          && !props.thread.pinnedRank ? (
+          && !hasHeadingPin ? (
           <button
             aria-label="Pin thread"
             className="thread-row__pin-button"

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/hover-stable-sidebar.test.tsx
@@ -579,7 +579,7 @@ describe("Sidebar hover-stable thread ordering", () => {
     expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
   });
 
-  it("removes a user-unpinned row from collapsed Directory threads immediately", () => {
+  it("shows an unpinned selected row with a pin action in collapsed Directory threads", () => {
     const onSetThreadPin = vi.fn(async () => undefined);
     const pinnedAlpha = { ...alpha, pinnedRank: "1024" };
     const pinnedBravo = { ...bravo, pinnedRank: "2048" };
@@ -609,7 +609,11 @@ describe("Sidebar hover-stable thread ordering", () => {
       onSetThreadPin,
     }));
 
-    expect(threadTitles()).toEqual(["Bravo thread"]);
+    expect(threadTitles()).toEqual(["Bravo thread", "Alpha thread"]);
+    const retained = threadRow("Alpha thread");
+    expect(within(retained).queryByRole("button", { name: "Unpin thread" })).toBeNull();
+    fireEvent.click(within(retained).getByRole("button", { name: "Pin thread" }));
+    expect(onSetThreadPin).toHaveBeenLastCalledWith({ ...alpha, pinnedRank: undefined }, true);
   });
 
   it("applies a pointer drag pin reorder immediately while hovered", async () => {

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/selected-thread-pin.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/selected-thread-pin.test.tsx
@@ -1,0 +1,64 @@
+import "@testing-library/jest-dom/vitest";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildThreadIdentityKey } from "@pwragent/shared";
+import { FixtureDirectoriesList as DirectoriesList } from "../../../test/navigation-presentation-fixture";
+import { buildLargeDirectoryFixture } from "./fixtures/directory-performance";
+
+afterEach(cleanup);
+
+describe("Selected thread in a collapsed directory", () => {
+  it("offers pin, switches to unpin after saving, and returns to a temporary row after unpinning", () => {
+    const fixture = buildLargeDirectoryFixture({ pinnedThreadsPerDirectory: 1,
+      unpinnedThreadsPerDirectory: 2, directoryThreadsCollapsed: true });
+    const thread = fixture.threads[1]!;
+    const selectedItemKey = buildThreadIdentityKey(thread.source, thread.id);
+    const onSetThreadPin = vi.fn(async () => undefined);
+    const onSelectThread = vi.fn();
+    const props = { directories: fixture.directories, threads: fixture.threads,
+      selectedItemKey, onSetThreadPin, onSelectThread,
+      onOpenLaunchpad: async () => undefined, onOpenThreadContextMenu: () => undefined };
+    const { rerender } = render(<DirectoriesList {...props} />);
+    const retainedRow = () => screen.getByRole("button", { name: `${thread.title}, shown while open` }).closest('[role="listitem"]') as HTMLElement;
+    expect(within(retainedRow()).queryByRole("button", { name: "Unpin thread" })).toBeNull();
+    expect(within(retainedRow()).getByRole("button", { name: "Pin thread" }).querySelector("svg"))
+      .toHaveAttribute("stroke-dasharray", "3 3");
+    expect(retainedRow()).toHaveAttribute("data-thread-pin-state", "unpinned");
+    fireEvent.click(within(retainedRow()).getByRole("button", { name: "Pin thread" }));
+    expect(onSetThreadPin).toHaveBeenLastCalledWith(thread, true);
+    expect(onSelectThread).not.toHaveBeenCalled();
+
+    const pinned = { ...thread, pinnedRank: "4096" };
+    rerender(<DirectoriesList {...props} threads={[fixture.threads[0]!, pinned, fixture.threads[2]!]} />);
+    const pinnedRow = screen.getByRole("button", { name: `${thread.title}, pinned` }).closest('[role="listitem"]') as HTMLElement;
+    expect(pinnedRow).toHaveAttribute("data-thread-pin-state", "pinned");
+    fireEvent.click(within(pinnedRow).getByRole("button", { name: "Unpin thread" }));
+    expect(onSetThreadPin).toHaveBeenLastCalledWith(pinned, false);
+    rerender(<DirectoriesList {...props} />);
+    expect(within(retainedRow()).getByRole("button", { name: "Pin thread" })).toBeInTheDocument();
+
+    // Moving to another transcript removes the temporary row; returning restores it.
+    rerender(<DirectoriesList {...props} selectedItemKey={buildThreadIdentityKey(fixture.threads[0]!.source, fixture.threads[0]!.id)} />);
+    expect(screen.queryByRole("button", { name: `${thread.title}, shown while open` })).toBeNull();
+    rerender(<DirectoriesList {...props} />);
+    expect(retainedRow()).toBeInTheDocument();
+
+    rerender(<DirectoriesList {...props} directories={fixture.directories.map((directory) => ({ ...directory, directoryThreadsCollapsed: false }))} />);
+    const ordinaryRow = screen.getByRole("button", { name: thread.title }).closest('[role="listitem"]') as HTMLElement;
+    expect(ordinaryRow.querySelector(".thread-row__heading-pin")).toBeNull();
+  });
+  it("retains the root and selected child without giving the child a pin action", () => {
+    const fixture = buildLargeDirectoryFixture({ pinnedThreadsPerDirectory: 1,
+      unpinnedThreadsPerDirectory: 2, directoryThreadsCollapsed: true });
+    const parent = fixture.threads[1]!;
+    const child = fixture.threads[2]!;
+    child.parentThreadId = parent.id;
+    render(<DirectoriesList directories={fixture.directories} threads={fixture.threads}
+      selectedItemKey={buildThreadIdentityKey(child.source, child.id)}
+      onSetThreadPin={async () => undefined} onSelectThread={() => undefined}
+      onOpenLaunchpad={async () => undefined} onOpenThreadContextMenu={() => undefined} />);
+    expect(screen.getByRole("button", { name: `${parent.title}, shown while open` })).toBeInTheDocument();
+    const childRow = screen.getByRole("button", { name: child.title }).closest('[role="listitem"]') as HTMLElement;
+    expect(within(childRow).queryByRole("button", { name: "Pin thread" })).toBeNull();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/navigation/paged-directory-presentation.ts
+++ b/apps/desktop/src/renderer/src/features/navigation/paged-directory-presentation.ts
@@ -8,6 +8,7 @@ import { navigationThreadSelectionKey } from "../../lib/navigation-query-state";
 export type PagedDirectoryPresentation = {
   directoryPinnedThreads: NavigationThreadSummary[];
   unpinnedThreads: NavigationThreadSummary[];
+  selectedUnpinnedThreads: NavigationThreadSummary[];
   childThreadsByParentKey: Map<string, NavigationThreadSummary[]>;
   directoryThreadsCollapsed: boolean;
   directoryUnpinnedThreadCount: number;
@@ -61,11 +62,17 @@ export function buildPagedDirectoryPresentation(params: {
   }
   const directoryThreadsCollapsed = params.directory.directoryThreadsCollapsed === true;
   const unpinnedThreads = directoryThreadsCollapsed ? [] : roots.filter((thread) => !isPinnedThread(thread));
+  // Keep the open transcript (or its root ancestor) above the collapsed
+  // disclosure without claiming that it has a saved pin.
+  const selectedUnpinnedThreads = directoryThreadsCollapsed
+    && selected?.selectionDirectory?.key === params.directory.key
+    && selectedThread && !isPinnedThread(selectedThread)
+    ? [selectedThread] : [];
   // Exact ancestry also admits the selected child while its independently
   // paged siblings are loading (or the child lies beyond their loaded range).
   // Do not change that range's membership or continuation cursor.
   if (selected?.selectionDirectory?.key === params.directory.key) {
-    const visibleParents = new Set([...directoryPinnedThreads, ...unpinnedThreads].map(threadSummaryIdentityKey));
+    const visibleParents = new Set([...directoryPinnedThreads, ...selectedUnpinnedThreads, ...unpinnedThreads].map(threadSummaryIdentityKey));
     for (const entry of selected.entries) {
       if (entry.placement.kind !== "child") continue;
       const parentKey = navigationThreadSelectionKey(entry.placement.parent);
@@ -79,9 +86,9 @@ export function buildPagedDirectoryPresentation(params: {
     }
   }
   return {
-    directoryPinnedThreads, unpinnedThreads, childThreadsByParentKey, directoryThreadsCollapsed,
+    directoryPinnedThreads, unpinnedThreads, selectedUnpinnedThreads, childThreadsByParentKey, directoryThreadsCollapsed,
     directoryUnpinnedThreadCount: params.directory.unpinnedRootCount ?? 0,
-    selectionOrder: [...directoryPinnedThreads, ...unpinnedThreads].flatMap((thread) => {
+    selectionOrder: [...directoryPinnedThreads, ...selectedUnpinnedThreads, ...unpinnedThreads].flatMap((thread) => {
       const key = threadSummaryIdentityKey(thread);
       return [key, ...(thread.subthreadsCollapsed ? [] : (childThreadsByParentKey.get(key) ?? []).map((child) =>
         threadSummaryIdentityKey(child)))];

--- a/apps/desktop/src/renderer/src/lib/__tests__/navigation-window-demand.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/navigation-window-demand.test.ts
@@ -85,6 +85,16 @@ it("does not demand children of off-page selections, collapsed ancestors, or ina
   expect(visibleDisclosedNavigationParents({ collectionIds: ["lens"], pages,
     disclosedParents: disclosedParents.filter((item) => item.threadId !== "child") })).toEqual([ref("visible")]);
   expect(visibleDisclosedNavigationParents({ collectionIds: ["directory:other", "selected-context"], pages, disclosedParents })).toEqual([]);
+  // Exact selection alone does not expose an off-page unpinned root while
+  // the ordinary directory collection is open. Only the collapsed-list
+  // presentation retains it outside that collection.
+  pages.get("selected-context")!.selectionDirectory = directories[42]!;
+  expect(visibleDisclosedNavigationParents({
+    collectionIds: ["directory-pins:directory:42", "directory:directory:42"], pages, disclosedParents,
+  })).toEqual([]);
+  expect(visibleDisclosedNavigationParents({
+    collectionIds: ["directory-pins:directory:42"], pages, disclosedParents,
+  })).toEqual([ref("off-page")]);
 });
 
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
@@ -251,3 +251,49 @@ it("bounds React renders for separately delivered navigation events before the r
     vi.useRealTimers();
   }
 });
+
+
+it("loads and releases child pages for an unpinned selection retained above collapsed directory threads", async () => {
+  const fixture = api();
+  const home = { ...directory, directoryThreadsCollapsed: true };
+  const root: NavigationRow = { id: "retained", source: "codex", title: "Retained root", titleSource: "explicit",
+    ref: { backend: "codex", threadId: "retained" }, rowRevision: "r", linkedDirectories: [],
+    inbox: { inInbox: false }, ordinaryChildCount: 2, nativeSubAgentGroupPresent: false, queueCount: 0, queueState: "unknown" };
+  fixture.read.mockImplementation(async (request) => {
+    if (request.query.kind === "directory-index") return page({ directories: [home] });
+    if (request.query.kind === "exact") return page({ selectionDirectory: home,
+      entries: [{ row: root, placement: { kind: "root" }, orderKey: "root" }] });
+    if (request.query.kind === "children") {
+      const id = request.cursor ? "child-2" : "child-1";
+      return page({ complete: Boolean(request.cursor), nextCursor: request.cursor ? undefined : "next-child",
+        entries: [{ row: { ...root, id, ref: { backend: "codex", threadId: id }, ordinaryChildCount: 0 },
+          placement: { kind: "child", parent: root.ref }, orderKey: id }] });
+    }
+    // Neither directory collection contains the selected root.
+    return page();
+  });
+  const { result, rerender, unmount } = renderHook(({ disclosed, expanded, selected }) => useBoundedNavigationWindow({
+    ...base, desktopApi: fixture.desktopApi, expandedByKey: { [home.key]: expanded },
+    selectedRef: selected ? root.ref : undefined, disclosedParents: disclosed ? [root.ref] : [],
+  }), { initialProps: { disclosed: false, expanded: true, selected: true } });
+  const childId = 'children:[null,"codex","retained"]';
+  await waitFor(() => expect(result.current.resources.get(`directory-pins:${home.key}`)?.state.page).toBeDefined());
+  expect(result.current.resources.has(childId)).toBe(false);
+  rerender({ disclosed: true, expanded: true, selected: true });
+  await waitFor(() => expect(result.current.resources.get(childId)?.state.page?.entries[0]?.row.id).toBe("child-1"));
+  await act(() => result.current.loadMore(childId));
+  expect(result.current.resources.get(childId)?.state.page?.entries.map((entry) => entry.row.id)).toEqual(["child-1", "child-2"]);
+  expect(fixture.read.mock.calls.filter(([request]) => request.query.kind === "directory" && request.query.roots === "unpinned")).toHaveLength(0);
+
+  rerender({ disclosed: false, expanded: true, selected: true });
+  await waitFor(() => expect(result.current.resources.has(childId)).toBe(false));
+  rerender({ disclosed: true, expanded: true, selected: true });
+  await waitFor(() => expect(result.current.resources.get(childId)?.state.page).toBeDefined());
+  rerender({ disclosed: true, expanded: false, selected: true });
+  await waitFor(() => expect(result.current.resources.has(childId)).toBe(false));
+  rerender({ disclosed: true, expanded: true, selected: true });
+  await waitFor(() => expect(result.current.resources.get(childId)?.state.page).toBeDefined());
+  rerender({ disclosed: true, expanded: true, selected: false });
+  await waitFor(() => expect(result.current.resources.has(childId)).toBe(false));
+  unmount();
+});

--- a/apps/desktop/src/renderer/src/lib/navigation-window-demand.ts
+++ b/apps/desktop/src/renderer/src/lib/navigation-window-demand.ts
@@ -103,13 +103,16 @@ export function visibleDisclosedNavigationParents(params: {
   const candidates = new Map(params.disclosedParents.map((ref) => [navigationIdentityKey(ref), ref]));
   const visible = new Map<string, NavigationIdentity>();
   const pending = [...params.collectionIds].filter((id) => id === "lens" || (id.startsWith("directory:") || id.startsWith("directory-pins:")) || id.startsWith("drafts:"));
-  // Directory presentation admits the exact selected pin independently of
-  // its retained pin range. Its disclosed children need the same demand as
-  // a parent which happened to arrive in the first page.
+  // Directory presentation admits an exact selected pin outside its page,
+  // and retains an unpinned selected root while Directory threads is closed.
+  // Both roots need child demand even though no collection page contains them.
+  // An open unpinned collection still owns its visible membership.
   const selected = params.pages.get("selected-viewer-mount") ?? params.pages.get("selected-context");
   const selectedRoot = selected?.entries.find((entry) => entry.placement.kind === "root");
-  if (selectedRoot?.row.pinnedRank !== undefined && selected?.selectionDirectory
-    && pending.includes(`directory-pins:${selected.selectionDirectory.key}`)) {
+  if (selectedRoot && selected?.selectionDirectory
+    && pending.includes(`directory-pins:${selected.selectionDirectory.key}`)
+    && (selectedRoot.row.pinnedRank !== undefined
+      || !pending.includes(`directory:${selected.selectionDirectory.key}`))) {
     const key = navigationIdentityKey(selectedRoot.row.ref);
     const parent = candidates.get(key);
     if (parent) {

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -4632,8 +4632,8 @@ a.button {
    are pinned by theme-contract next to this rule's own pin, so a
    cluster resize fails a test instead of silently re-covering the pin.
 
-   Scoped by the row's `--pinned` modifier (set by ThreadRow from the
-   same expression that renders the pin — a plain class match instead
+   Scoped by the row's `--pinned` or `--retained` modifier (set by
+   ThreadRow when it renders an in-title pin — a plain class match instead
    of a per-hover `:has()` subtree scan, same optimization as the
    directory-row header modifiers). The selector list mirrors the
    cluster's reveal states in the fade/reveal rules above (the cluster
@@ -4643,6 +4643,10 @@ a.button {
    already clears it, so the reserve protects nothing there — accepted,
    since every production surface wires reactions and a narrower
    conditional would re-add the `:has()` scan this class avoids. */
+.thread-row-shell:hover .thread-row--retained .thread-row__heading,
+.thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row--retained .thread-row__heading,
+.thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--retained .thread-row__heading,
+.thread-row-shell:has(.thread-row__chip--add-reaction.is-open) .thread-row--retained .thread-row__heading,
 .thread-row-shell:hover .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__overflow-button:focus-visible) .thread-row--pinned .thread-row__heading,
 .thread-row-shell:has(.thread-row__chip--add-reaction:focus-visible) .thread-row--pinned .thread-row__heading,

--- a/apps/desktop/src/renderer/src/test/navigation-presentation-fixture.tsx
+++ b/apps/desktop/src/renderer/src/test/navigation-presentation-fixture.tsx
@@ -49,6 +49,9 @@ function usePresentationOwner(props: FixtureProps) {
         ownerInstanceId: selectedThread.federation?.ref.target.scope === "remote" ? selectedThread.federation.ref.target.instanceId : undefined } };
       page = navigationQueryFixture(request, { directories: props.directories, threads });
     }
+    if (id === "selected-context") {
+      page.selectionDirectory = (index.directories ?? []).find((directory) => selectedThreadDirectoryKeys.includes(directory.key));
+    }
     resources.set(id, { id, loading: false, state: { ...createNavigationPageState(request), page, stale: false } });
     return page;
   };


### PR DESCRIPTION
## Summary

- I added a dashed pin for an unpinned thread kept visible because its transcript is open while Directory threads is collapsed. It sits below saved pins and offers **Pin thread**, with a tooltip explaining why it is there.
- I kept the solid pin and **Unpin thread** action for saved pins. Unpinning the open thread returns it to the dashed state; navigating away removes the temporary row. A selected child retains its root ancestor without making the child pinnable.

## Verification

- I verified the production navigation hook requests and paginates children of retained roots, releases them on collapse or selection change, and never requests the collapsed unpinned directory collection. All 31 targeted demand, hook, and pin tests pass; the new hook regression failed before the fix.

- I ran all 316 navigation tests, including pin/unpin transitions, navigation away and back, expanded directories, and selected children.
- I ran all 80 theme contract tests and workspace typechecking.
- I ran `pnpm lint:eslint` with no errors (existing warnings remain).
- I visually checked the actual rendered row markup with the application stylesheet in Chromium. These screenshots use entirely contrived fixture data.

## Notes

I included retained roots in visible child-page demand, so their subthread disclosure loads children through the production query controller.

I kept owner pin ranks, page membership, pagination cursors, and directory counts unchanged. The temporary row is presentation state and adds no persistence.

### Saved pin

![Selected thread with a saved pin](https://github.com/user-attachments/assets/efc621f6-bca3-4d9b-8e8d-1825b49c60ad)

### Unpinned, shown for the open transcript

![Selected thread with a dashed pin above collapsed Directory threads](https://github.com/user-attachments/assets/b436b402-b6bf-40b4-91ec-3cd976eb684e)

