### PR TITLE
fix(desktop): use primary project for thread breadcrumb

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -12815,6 +12815,45 @@ describe("main selected detail authority", () => {
     vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
   });
   afterEach(() => vi.restoreAllMocks());
+  it.each(["secondary-first", "primary-first", "primary-missing"])(
+    "selects the primary project for a multi-directory thread (%s)",
+    async (order) => {
+      const primary = {
+        id: "primary", label: "PwrGit", path: "/repo/PwrGit",
+        worktreePath: "/Users/test/.codex/worktrees/example/PwrGit",
+        kind: "worktree" as const,
+      };
+      const secondary = {
+        id: "secondary", label: "PwrAgnt", path: "/repo/PwrAgnt", kind: "local" as const,
+      };
+      const thread: NavigationThreadSummary = {
+        id: "multi-project", source: "codex", title: "Multi-project thread",
+        titleSource: "explicit", linkedDirectories: [primary, secondary],
+        inbox: { inInbox: true }, updatedAt: 1,
+      };
+      const links = order === "primary-missing" ? [secondary]
+        : order === "primary-first" ? [primary, secondary] : [secondary, primary];
+      const api: DesktopApi = {
+        ...actionDetailApi(thread),
+        readPopulation: vi.fn(async () => ({
+          backend: "all" as const, fetchedAt: 1, unchanged: false,
+          inboxThreadKeys: ["codex:multi-project"], threads: [thread],
+          launchpadDefaults: { backend: "codex" as const, executionMode: "default" as const },
+          directories: links.map((directory) => ({
+            key: `directory:${directory.path}`, kind: "directory" as const,
+            label: directory.label, path: directory.path,
+            threadKeys: ["codex:multi-project"], needsAttentionCount: 0,
+          })),
+        })),
+      };
+      const { result } = renderHook(() => useThreadNavigation(api));
+      await waitFor(() => expect(result.current.selectedThreadConfigurationReady).toBe(true));
+      expect(result.current.selectedDirectory?.label).toBe(
+        order === "primary-missing" ? undefined : "PwrGit",
+      );
+    },
+  );
+
   it("keeps an off-page peer selection and hydrates configuration independently of row refresh", async () => {
     const snapshot = acpTitleSnapshot("Loaded row", "explicit", 1);
     const thread = { ...snapshot.threads[0]!, id: "off-page", model: "owner-model" };

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -4652,9 +4652,10 @@ export function useThreadNavigation(
       return undefined;
     }
 
-    const directory = directories.find((directory) =>
-      directoryKeysForThread(selectedDetail.state?.detail?.thread).includes(directory.key)
-    );
+    // Match the primary workspace, as project grouping does. Directory-list
+    // ordering must not let a secondary link become the selected project.
+    const primaryDirectoryKey = directoryKeysForThread(selectedDetail.state?.detail?.thread)[0];
+    const directory = directories.find((directory) => directory.key === primaryDirectoryKey);
     const workspace = selectedDetail.state?.detail?.workspaceDirectories?.find((candidate) =>
       candidate.path === directory?.path,
     );


### PR DESCRIPTION
A PwrGit thread with PwrAgnt attached as a secondary directory could show PwrAgnt in its breadcrumb. The selected-directory lookup picked the first matching project in the directory list, allowing list ordering to override the thread's primary workspace.

Resolve the selected directory from the first linked workspace, matching project grouping. If the primary project is unavailable, do not substitute a secondary project. This also keeps actions consuming the selected directory aligned with the primary workspace.

Validation: reproduced the bug with three failing regression cases (both project input orders and an unavailable primary project). After the fix, all 166 navigation tests pass; the three regression cases also pass after completing the fixture's required defaults. `pnpm typecheck` and `pnpm lint:eslint` pass (existing ESLint warnings only).
