### PR TITLE
fix(desktop): load visible navigation without window focus

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.bounded.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.bounded.test.tsx
@@ -259,6 +259,11 @@ it("reconciles visible pages every five minutes without a sixty-second poll, and
     expect(lensReads()).toBe(2);
     vi.mocked(document.hasFocus).mockReturnValue(false);
     act(() => { window.dispatchEvent(new Event("blur")); });
+    await act(async () => { await vi.advanceTimersByTimeAsync(300_000); });
+    expect(lensReads()).toBe(3);
+    expect(result.current.selectedThreadConfigurationReady).toBe(true);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("hidden");
+    act(() => { document.dispatchEvent(new Event("visibilitychange")); });
     const hiddenReads = f.read.mock.calls.length;
     const hiddenDetails = f.detail.mock.calls.length;
     await act(async () => { await vi.advanceTimersByTimeAsync(15 * 60_000); });

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -171,6 +171,38 @@ describe("useThreadNavigation", () => {
     expect(removeItem).not.toHaveBeenCalled();
   });
 
+  it.each(["inbox", "directories"] as const)("loads navigation before a visible window gains focus (%s)", async (browseMode) => {
+    vi.mocked(document.hasFocus).mockReturnValue(false);
+    (window as unknown as { __pwragentNavigationPreferences: { browseMode: string } })
+      .__pwragentNavigationPreferences = { browseMode };
+    const snapshot = acpTitleSnapshot("Background startup", "explicit", 1);
+    snapshot.directories = [{
+      key: "directory:/fixture/project", kind: "directory", label: "Fixture project",
+      path: "/fixture/project", threadKeys: [], needsAttentionCount: 0,
+    }];
+    const getNavigationLaunchpadConfig = vi.fn<NonNullable<DesktopApi["getNavigationLaunchpadConfig"]>>(async () => ({
+      protocol: 2, revision: "startup-config", defaults: snapshot.launchpadDefaults,
+    }));
+    const desktopApi: DesktopApi = {
+      readPopulation: vi.fn(async () => snapshot),
+      getNavigationLaunchpadConfig,
+      ...actionDetailApi({ ...snapshot.threads[0]!, model: "owner-model" }),
+    };
+    const { result } = renderHook(() => useThreadNavigation(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+      expect(result.current.directories[0]?.label).toBe("Fixture project");
+      if (browseMode === "inbox") {
+        expect(result.current.threads[0]?.title).toBe("Background startup");
+        expect(result.current.selectedThreadConfigurationReady).toBe(true);
+        expect(result.current.selectedThread?.model).toBe("owner-model");
+      }
+    });
+    expect(getNavigationLaunchpadConfig).toHaveBeenCalled();
+    expect(document.hasFocus()).toBe(false);
+  });
+
   function createDeferred<T>(): {
     promise: Promise<T>;
     resolve: (value: T) => void;
@@ -1616,7 +1648,7 @@ describe("useThreadNavigation", () => {
     });
   });
 
-  it("retains stale rows without marking unseen activity read while the window is backgrounded", async () => {
+  it.each(["visible", "hidden"] as const)("refreshes only visible rows without marking unseen activity read while unfocused (%s)", async (visibility) => {
     const listeners = new Set<(event: AgentEvent) => void>();
     const markThreadSeen = vi.fn(
       async (
@@ -1704,8 +1736,10 @@ describe("useThreadNavigation", () => {
     });
 
     vi.mocked(document.hasFocus).mockReturnValue(false);
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue(visibility);
     act(() => {
       window.dispatchEvent(new Event("blur"));
+      document.dispatchEvent(new Event("visibilitychange"));
     });
 
     const readsBeforeBackgroundEvent = readPopulation.mock.calls.length;
@@ -1731,8 +1765,13 @@ describe("useThreadNavigation", () => {
     });
 
     await act(() => result.current.refresh());
-    expect(readPopulation).toHaveBeenCalledTimes(readsBeforeBackgroundEvent);
-    expect(result.current.threads[0]?.inbox.inInbox).toBe(false);
+    if (visibility === "visible") {
+      expect(readPopulation.mock.calls.length).toBeGreaterThan(readsBeforeBackgroundEvent);
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(true);
+    } else {
+      expect(readPopulation).toHaveBeenCalledTimes(readsBeforeBackgroundEvent);
+      expect(result.current.threads[0]?.inbox.inInbox).toBe(false);
+    }
     expect(markThreadSeen).not.toHaveBeenCalledWith({
       backend: "codex",
       threadId: "thread-read",

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -136,6 +136,10 @@ function readBridgedBrowseMode(): BrowseMode {
   return normalizeBrowseMode(bridged?.browseMode);
 }
 
+function isRendererViewVisible(): boolean {
+  return typeof document === "undefined" || document.visibilityState === "visible";
+}
+
 function isRendererViewForeground(): boolean {
   if (typeof document === "undefined") {
     return true;
@@ -2982,6 +2986,9 @@ export function useThreadNavigation(
     refreshing: false,
   });
   const [viewForeground, setViewForeground] = useState(isRendererViewForeground);
+  // A visible sidebar must load and refresh even when another app has focus.
+  // Keep foreground state separate: background updates must not mark rows read.
+  const [viewVisible, setViewVisible] = useState(isRendererViewVisible);
   const prChipLocationIndexRef = useRef<PrChipLocationIndex | undefined>(undefined);
 
   const optimisticThreadRef = useRef<NavigationThreadSummary | undefined>(undefined);
@@ -3086,13 +3093,13 @@ export function useThreadNavigation(
     ? navigationIdentityFromThreadKey(selectedItemKey, rendererFederationTarget)
     : undefined;
   const selectedDetail = useNavigationSelectedDetail({
-    desktopApi, enabled: enabled && viewForeground,
+    desktopApi, enabled: enabled && viewVisible,
     ref: selectedIdentity,
     federationTarget: selectedIdentity?.ownerInstanceId
       ? { scope: "remote", instanceId: selectedIdentity.ownerInstanceId }
       : undefined,
   });
-  const launchpadConfiguration = useNavigationLaunchpadConfiguration({ desktopApi, enabled: enabled && viewForeground,
+  const launchpadConfiguration = useNavigationLaunchpadConfiguration({ desktopApi, enabled: enabled && viewVisible,
     directoryKey: getDirectoryKeyFromLaunchpadSelection(selectedItemKey), federationTarget: rendererFederationTarget,
   });
   const draftStore = options.composerDraftStore;
@@ -3109,7 +3116,7 @@ export function useThreadNavigation(
   const selectedConfiguration = selectedDetail.state?.detail?.thread;
   const selectedDirectoryKeys = selectedConfiguration ? directoryKeysForThread(selectedConfiguration)
     : (getDirectoryKeyFromLaunchpadSelection(selectedItemKey) ? [getDirectoryKeyFromLaunchpadSelection(selectedItemKey)!] : []);
-  const boundedNavigation = useBoundedNavigationWindow({ desktopApi, enabled, visible: viewForeground, observeEvents: false,
+  const boundedNavigation = useBoundedNavigationWindow({ desktopApi, enabled, visible: viewVisible, observeEvents: false,
     browseMode, target: rendererFederationTarget, attentionView: { id: attentionViewId, promoteOnTurnEnd: options.attentionPromoteOnTurnEnd ?? true },
     expandedByKey: directoryDisclosure.expandedByKey, unpinnedExpandedByKey: directoryDisclosure.unpinnedExpandedByKey,
     selectedRef: selectedIdentity, selectedDirectoryKeys, removedDirectoryKeys: [...removedDirectoryKeysRef.current],
@@ -3386,7 +3393,7 @@ export function useThreadNavigation(
       if (
         !enabled ||
         !desktopApi?.getNavigationQueryPage ||
-        !isRendererViewForeground()
+        !isRendererViewVisible()
       ) {
         return;
       }
@@ -3422,6 +3429,7 @@ export function useThreadNavigation(
 
     const updateForegroundState = () => {
       setViewForeground(isRendererViewForeground());
+      setViewVisible(isRendererViewVisible());
     };
 
     updateForegroundState();
@@ -3462,7 +3470,7 @@ export function useThreadNavigation(
     if (
       !enabled ||
       !desktopApi?.getNavigationQueryPage ||
-      !viewForeground
+      !viewVisible
     ) {
       return;
     }
@@ -3488,7 +3496,7 @@ export function useThreadNavigation(
     enabled,
     lightweightNavigationRefresh,
     scheduleRefresh,
-    viewForeground,
+    viewVisible,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- I fixed navigation staying on “Loading threads…” when PwrAgent starts visible behind another application. The bounded-navigation wiring introduced in #2001 used `document.hasFocus()` as query visibility, so clicking the window was required to start navigation reads.
- I separated document visibility from foreground focus for navigation pages, selected-thread configuration, launchpad configuration, and periodic reconciliation. Visible windows now load and refresh without activation; automatic unread clearing still requires focus.

## Verification

- I reproduced the bug with a failing renderer hook test: a visible, unfocused window remained `loading: true` until the assertion timed out.
- I verified 177 tests across `useThreadNavigation`, `useThreadNavigation.bounded`, and `useBoundedNavigationWindow`. Coverage includes Inbox and Directories startup without focus, selected configuration and launchpad loading, refreshing unread rows without marking them read, and periodic reconciliation continuing while unfocused and stopping when hidden.
- I ran `pnpm lint:eslint`, `pnpm typecheck`, and `git diff --check` successfully. These are automated renderer tests; native macOS repainting was not exercised.

## Notes

- I preserved Star Map’s separate focus gate and Electron’s default background throttling. Electron also considers fully occluded macOS windows hidden; this fix addresses the application’s additional focus gate on windows that remain visible.
- Electron reference: https://www.electronjs.org/docs/latest/api/browser-window#page-visibility
