### PR TITLE
fix(desktop): prevent composer attachment tooltip clipping

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -10811,19 +10811,19 @@ export function Composer(props: ComposerProps) {
                     <span className="composer__attachment-chip">PDF</span>
                   )}
                 </div>
-                <span
-                  className="composer__pdf-preview-label tooltip-target"
-                  data-tooltip={buildFileReferenceTooltip(reference.path)}
+                <AttachmentTooltip
+                  className="composer__pdf-preview-label"
+                  path={reference.path}
                 >
                   {reference.label}
-                </span>
+                </AttachmentTooltip>
               </div>
             );
           })}
           {visibleFileAttachments.map((attachment) => (
-            <span
-              className="composer__file-attachment tooltip-target"
-              data-tooltip={buildFileReferenceTooltip(attachment.path)}
+            <AttachmentTooltip
+              className="composer__file-attachment"
+              path={attachment.path}
               key={attachment.id}
             >
               <FileCodeIcon size={13} aria-hidden="true" />
@@ -10840,7 +10840,7 @@ export function Composer(props: ComposerProps) {
               >
                 <CloseIcon size={12} aria-hidden="true" />
               </button>
-            </span>
+            </AttachmentTooltip>
           ))}
         </div>
       ) : null}
@@ -12517,6 +12517,37 @@ export function Composer(props: ComposerProps) {
       {imageLightbox}
       {pdfPreviewLightboxNode}
     </>
+  );
+}
+
+function AttachmentTooltip({
+  children,
+  className,
+  path,
+}: {
+  children: ReactNode;
+  className: string;
+  path: string;
+}) {
+  const { show, showAfterDelay, hide, visible, tooltipId, tooltipNode } =
+    useViewportTooltip({
+      className: "viewport-tooltip composer__attachment-tooltip",
+    });
+  const content = buildFileReferenceTooltip(path);
+
+  return (
+    <span
+      className={className}
+      tabIndex={0}
+      aria-describedby={visible ? tooltipId : undefined}
+      onMouseEnter={(event) => showAfterDelay(event.currentTarget, content)}
+      onMouseLeave={hide}
+      onFocus={(event) => show(event.currentTarget, content)}
+      onBlur={hide}
+    >
+      {children}
+      {tooltipNode}
+    </span>
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -20019,6 +20019,53 @@ describe("Composer", () => {
     }
   });
 
+  it("shows a pasted MP4 path outside the composer clipping boundary", async () => {
+    const path = "C:\\Users\\fixture-user\\AppData\\Roaming\\PwrSnap\\clipboard\\recording.mp4";
+    const video = new File(["video"], "recording.mp4", { type: "video/mp4" });
+    const { container } = render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          getPathForFile: () => path,
+        }}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Attachment tooltip fixture",
+          titleSource: "explicit",
+          source: "codex",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.paste(screen.getByLabelText("Reply"), {
+      clipboardData: {
+        files: [video],
+        items: [{ kind: "file", type: "video/mp4", getAsFile: () => video }],
+        getData: () => "",
+      },
+    });
+
+    const label = await screen.findByText("recording.mp4");
+    const chip = label.closest(".composer__file-attachment")!;
+    fireEvent.mouseEnter(chip);
+    const tooltip = await screen.findByRole("tooltip");
+    expect(tooltip).toHaveTextContent(path);
+    expect(tooltip.parentElement).toBe(document.body);
+    expect(container).not.toContainElement(tooltip);
+    expect(chip).toHaveAttribute("aria-describedby", tooltip.id);
+
+    fireEvent.mouseLeave(chip);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+    fireEvent.focus(chip);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(path);
+    fireEvent.blur(chip);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+  });
+
   it("removes a file attachment via its pill remove button", async () => {
     (window as unknown as { __pwragentHomeDir?: string }).__pwragentHomeDir =
       "/Users/fixture-user";

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -28969,6 +28969,10 @@ button.pricing-token-miser__folded:focus-visible {
    28px silhouette as the directory-reference pill, but a solid border:
    the file is an explicit attachment with its own remove control, not
    an informational echo of the draft text. */
+.composer__attachment-tooltip {
+  overflow-wrap: anywhere;
+}
+
 .composer__file-attachment {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
Pasting an MP4 into the composer showed its file-path tooltip underneath the thread list, cutting off the start of the path. File attachment chips and PDF filename labels now use the shared viewport tooltip portal, which escapes composer clipping and clamps to the window. Long paths wrap, and keyboard focus exposes the tooltip with an accessible description.

## Validation
- Composer and shared viewport-tooltip suites: 341 tests passed, including a pasted-MP4 regression covering portal placement, hover dismissal, and keyboard focus.
- `pnpm lint:eslint` passed.
- `pnpm typecheck` passed.
- `git diff --check` passed.

Native Windows visual verification was not run.
