### PR TITLE
fix(desktop): truncate network stats to whole bytes

### DIFF
--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivity.test.tsx
@@ -292,18 +292,27 @@ describe("Activity report controls", () => {
     const data = fixture();
     data.activity.peers[0].series = structuredClone(data.activity.physical);
     data.activity.peers[0].series.lifetime.sent.requests = 987;
+    data.activity.peers[0].series.sizes.sent.requests = {
+      count: 33, averageBytes: 543.6363636363636, p50Bytes: 540.4903313206053,
+      minBytes: 403, maxBytes: 655,
+    };
     const copyText = vi.fn(async (_text: string) => {});
     render(<FederationActivityScreen desktopApi={{ readFederationActivity: async () => data, copyText }} />);
     await screen.findByText("Running · connected");
     expect(screen.getByRole("switch")).toHaveClass("settings-switch", "is-on");
     expect(screen.getByRole("switch").querySelector(".settings-switch__thumb")).not.toBeNull();
     fireEvent.change(screen.getByRole("combobox", { name: "Peer" }), { target: { value: "gateway" } });
+    const sizes = within(screen.getByRole("table", { name: "Lifetime request/response sizes · uncompressed" }));
+    const requestCells = within(sizes.getByRole("row", { name: /Sent requests/ })).getAllByRole("cell");
+    expect(requestCells[1]).toHaveAttribute("title", "543 bytes");
+    expect(requestCells[2]).toHaveAttribute("title", "540 bytes");
     fireEvent.click(screen.getByRole("button", { name: "Copy Federation activity" }));
     await waitFor(() => expect(copyText).toHaveBeenCalledTimes(1));
     const text = copyText.mock.calls[0][0];
     expect(text).toContain("Physical connections: gateway");
     expect(text).toContain("Requests\t12\t12\t12\t987");
     expect(text).toContain("2 KB (2000 bytes)");
+    expect(text).toContain("sent requests\t33\t0.54 KB (543 bytes)\t0.54 KB (540 bytes)\t0.4 KB (403 bytes)\t0.66 KB (655 bytes)");
     expect(text).toContain("Samples\tAvg\tp50 (approx.)\tMin\tMax");
     expect(text).toContain("Since: 1970-01-01T00:00:00.000Z");
     expect(text).toContain("excludes WebSocket framing");

--- a/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/federation-activity/FederationActivityWindow.tsx
@@ -10,7 +10,7 @@ import { federationRuntimeLabel, useFederationActivity } from "./useFederationAc
 
 type Period = "1m" | "10m" | "1h";
 const PERIODS: Period[] = ["1m", "10m", "1h"];
-const number = (value: number) => value.toLocaleString(undefined, { maximumFractionDigits: 2 });
+const number = (value: number) => Math.trunc(value).toLocaleString();
 const fields = [
   ["requests", "Requests"], ["responses", "Responses (including errors)"],
   ["notifications", "Notifications"], ["other", "Other envelopes (including blobs)"],

--- a/apps/desktop/src/renderer/src/features/federation-activity/format-activity-report.ts
+++ b/apps/desktop/src/renderer/src/features/federation-activity/format-activity-report.ts
@@ -13,7 +13,7 @@ export function formatActivityReport(series: FederationActivitySeries, view: str
     ] as const) {
       lines.push([label, ...[series.windows["1m"], series.windows["10m"], series.windows["1h"], series.lifetime]
         .map((totals) => key === "dataBytes" || key === "wireBytes"
-          ? `${formatTrafficBytes(totals[direction][key])} (${totals[direction][key]} bytes)`
+          ? `${formatTrafficBytes(totals[direction][key])} (${Math.trunc(totals[direction][key])} bytes)`
           : String(totals[direction][key]))].join("\t"));
     }
     lines.push("");
@@ -24,7 +24,7 @@ export function formatActivityReport(series: FederationActivitySeries, view: str
       const stats = series.sizes[direction][kind];
       lines.push([`${direction} ${kind}`, stats.count,
         ...[stats.averageBytes, stats.p50Bytes, stats.minBytes, stats.maxBytes]
-          .map((value) => value === undefined ? "—" : `${formatTrafficBytes(value)} (${value} bytes)`)].join("\t"));
+          .map((value) => value === undefined ? "—" : `${formatTrafficBytes(value)} (${Math.trunc(value)} bytes)`)].join("\t"));
     }
   }
   lines.push("", "p50 is estimated within about 1.1%. Responses include errors.",


### PR DESCRIPTION
Federation activity reports copied fractional averages and approximate medians with excessive precision, such as `0.54 KB (543.6363636363636 bytes)`. Truncate byte counts in copied reports and window tooltips to whole bytes, producing `0.54 KB (543 bytes)`. Keep the compact KB/MB formatting and underlying measurements unchanged.

Validation: all 28 focused federation activity and byte formatting tests pass, including the reported fractional values in clipboard output and tooltips. `pnpm lint:eslint` and `git diff --check` pass.
