### PR TITLE
fix(desktop): suppress Grok update notices when disabled

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -1157,6 +1157,17 @@ describe("settings ipc", () => {
         "grok",
         "qwen",
       ]);
+      for (const enabled of [true, false]) {
+        await service.writeConfigPatchTargeted({ acpAgents: { grok: { enabled } } });
+        const response = (await handlers.get(ACP_AGENTS_LIST_CHANNEL)?.(
+          {},
+          { refresh: false },
+        )) as { entries?: unknown[] } | undefined;
+        expect(response?.entries).toContainEqual(expect.objectContaining({
+          registryId: "grok",
+          enabled,
+        }));
+      }
       expect(
         cached?.entries?.every(
           (entry) =>

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -461,10 +461,11 @@ async function listAcpAgentSettingsImpl(
     })
     .map(({ entry }) => entry);
 
-  await decorateManagedGrokBuild(
-    orderedEntries,
-    settingsService.readProvidersConfig(),
-  );
+  const providers = settingsService.readProvidersConfig();
+  for (const entry of orderedEntries) {
+    entry.enabled = acpProviderEnabledFromSnapshot(providers, entry.registryId);
+  }
+  await decorateManagedGrokBuild(orderedEntries, providers);
 
   return {
     fetchedAt: snapshot?.fetchedAt ?? Date.now(),

--- a/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/GrokCliUpdateNotice.tsx
@@ -159,6 +159,7 @@ export function buildManagedGrokBuildNotice(params: {
   const activeTag = managed?.activeTag;
   if (
     params.entry?.registryId !== "grok"
+    || params.entry.enabled !== true
     || params.entry.pwrAgentManagedRuntime !== true
     || managed?.pinnedBehind !== true
     || !installedTag
@@ -208,6 +209,7 @@ export function buildXaiGrokCliUpdateNotice(params: {
   const update = params.entry?.update;
   if (
     params.entry?.registryId !== "grok"
+    || params.entry.enabled !== true
     || update?.status !== "available"
     || !update.latestVersion
     || update.dismissedAt !== undefined

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/grok-cli-update-notice.test.ts
@@ -19,6 +19,7 @@ function grokEntry(
     distributionSource: "grok agent stdio",
     installable: false,
     installed: true,
+    enabled: true,
     installStatus: "installed",
     authStatus: "not-required",
     verificationStatus: "not-applicable",
@@ -28,6 +29,21 @@ function grokEntry(
 }
 
 describe("buildXaiGrokCliUpdateNotice", () => {
+  it.each([false, undefined])("hides vendor updates when enabled is %s", (enabled) => {
+    expect(buildXaiGrokCliUpdateNotice({
+      entry: grokEntry({
+        status: "available",
+        checkedAt: 100,
+        currentVersion: "1.0.5",
+        latestVersion: "1.0.25",
+      }, { enabled }),
+      now: 200,
+      onOpenUpdatePage: vi.fn(),
+      onDismiss: vi.fn(),
+      onSnooze: vi.fn(),
+    })).toBeUndefined();
+  });
+
   it("builds a version-keyed durable update notice", () => {
     const onOpenUpdatePage = vi.fn();
     const onDismiss = vi.fn();
@@ -144,6 +160,18 @@ describe("buildManagedGrokBuildNotice", () => {
     installedAt: 100,
     pinnedBehind: true,
   };
+
+  it.each([false, undefined])("hides managed build notices when enabled is %s", (enabled) => {
+    expect(buildManagedGrokBuildNotice({
+      entry: grokEntry(undefined, {
+        enabled,
+        managedBuild: managed,
+        pwrAgentManagedRuntime: true,
+      }),
+      onDismiss: vi.fn(),
+      onOpenReleasePage: vi.fn(),
+    })).toBeUndefined();
+  });
 
   it("names the PwrAgent channel and links its own release page", () => {
     const onOpenReleasePage = vi.fn();


### PR DESCRIPTION
Grok update notifications appeared even when the provider was disabled in the active profile. Return the current profile enablement in ACP settings entries and require `enabled: true` before producing either the xAI CLI update notice or the PwrAgent managed-build notice.

Regression coverage checks disabled and unset enablement in both channels, preserves enabled-provider notices, and verifies cache-only settings reads reflect the profile toggle changing on and off.

Validation: four new notification cases failed before the fix; all 38 notification and settings IPC tests now pass. `pnpm lint:eslint` passed (0 errors; existing warnings), `pnpm typecheck` passed, and `git diff --check` passed.
