### PR TITLE
fix(desktop): match PwrGit and PwrSnap connection icon sizes

### DIFF
--- a/apps/desktop/scripts/app-icon.test.mjs
+++ b/apps/desktop/scripts/app-icon.test.mjs
@@ -2,7 +2,6 @@
 // authored build/icon.png and, on a Mac with Xcode 26, compiles the Icon
 // Composer package through electron-builder's own helper so a package that
 // passes here is what packages at release time. See AGENTS.md "macOS app icon".
-import { createCanvas, loadImage } from "@napi-rs/canvas";
 import { execFileSync } from "node:child_process";
 import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
@@ -10,6 +9,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { opaqueBounds, pixelAt, readPixels } from "./lib/icon-pixels.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const buildDir = resolve(here, "../build");
@@ -26,42 +26,6 @@ const ACCENT = [232, 116, 58];
  */
 function readManifest() {
   return JSON.parse(readFileSync(join(iconPackage, "icon.json"), "utf8"));
-}
-
-async function readPixels(source) {
-  const image = await loadImage(source);
-  const canvas = createCanvas(image.width, image.height);
-  const context = canvas.getContext("2d");
-  context.drawImage(image, 0, 0);
-  return {
-    width: image.width,
-    height: image.height,
-    data: context.getImageData(0, 0, image.width, image.height).data,
-  };
-}
-
-function pixelAt(pixels, x, y) {
-  const offset = (y * pixels.width + x) * 4;
-  return Array.from(pixels.data.subarray(offset, offset + 4));
-}
-
-/** Bounding box of pixels at or above the alpha threshold, or null when none is. */
-function opaqueBounds(pixels, threshold = 128) {
-  let left = pixels.width;
-  let top = pixels.height;
-  let right = -1;
-  let bottom = -1;
-  for (let y = 0; y < pixels.height; y += 1) {
-    for (let x = 0; x < pixels.width; x += 1) {
-      if (pixels.data[(y * pixels.width + x) * 4 + 3] < threshold) continue;
-      left = Math.min(left, x);
-      top = Math.min(top, y);
-      right = Math.max(right, x);
-      bottom = Math.max(bottom, y);
-    }
-  }
-  if (right < 0) return null;
-  return { x: left, y: top, width: right - left + 1, height: bottom - top + 1 };
 }
 
 /**

--- a/apps/desktop/scripts/lib/icon-pixels.mjs
+++ b/apps/desktop/scripts/lib/icon-pixels.mjs
@@ -1,0 +1,49 @@
+// Pixel measurement shared by the icon tests in this directory: app-icon.test.mjs
+// measures the macOS icon inputs, pwrsuite-brand-icons.test.mjs the sister apps'
+// brand marks. Both need to decode a PNG and find what part of it is drawn on,
+// and a second copy of an alpha-bbox scanner is a copy that can disagree with
+// the first about what "opaque" means.
+import { createCanvas, loadImage } from "@napi-rs/canvas";
+
+/** Decoded RGBA pixels plus the canvas they cover. */
+export async function readPixels(source) {
+  const image = await loadImage(source);
+  const canvas = createCanvas(image.width, image.height);
+  const context = canvas.getContext("2d");
+  context.drawImage(image, 0, 0);
+  return {
+    width: image.width,
+    height: image.height,
+    data: context.getImageData(0, 0, image.width, image.height).data,
+  };
+}
+
+/** The RGBA channels at one pixel, as a plain array. */
+export function pixelAt(pixels, x, y) {
+  const offset = (y * pixels.width + x) * 4;
+  return Array.from(pixels.data.subarray(offset, offset + 4));
+}
+
+/**
+ * Bounding box of pixels at or above the alpha threshold, or null when none is.
+ * The null matters: a caller that treats "nothing is drawn" as a box gets
+ * negative dimensions that compare equal to each other and can satisfy a
+ * symmetry assertion, so a blank image reads as a healthy one.
+ */
+export function opaqueBounds(pixels, threshold = 128) {
+  let left = pixels.width;
+  let top = pixels.height;
+  let right = -1;
+  let bottom = -1;
+  for (let y = 0; y < pixels.height; y += 1) {
+    for (let x = 0; x < pixels.width; x += 1) {
+      if (pixels.data[(y * pixels.width + x) * 4 + 3] < threshold) continue;
+      left = Math.min(left, x);
+      top = Math.min(top, y);
+      right = Math.max(right, x);
+      bottom = Math.max(bottom, y);
+    }
+  }
+  if (right < 0) return null;
+  return { x: left, y: top, width: right - left + 1, height: bottom - top + 1 };
+}

--- a/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
+++ b/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
@@ -1,0 +1,151 @@
+// The PwrSuite connection cards in the New Thread view each draw the sister
+// app's own application icon, copied verbatim from its repository — see the
+// README beside each asset. The two were authored on different canvases, so
+// `.mcp-connection__icon--inset-plate` in app.css scales one of them back up
+// to the size the other paints at. Nothing about that ratio is visible from
+// either file alone, so this measures the assets and the rule together: a
+// refreshed asset whose margin differs fails here rather than shipping a
+// mismatched pair of icons.
+import { createCanvas, loadImage } from "@napi-rs/canvas";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const rendererSrc = resolve(here, "../src/renderer/src");
+const appCss = readFileSync(resolve(rendererSrc, "styles/app.css"), "utf8");
+
+const ASSETS = {
+  PwrSnap: resolve(rendererSrc, "assets/pwrsnap/pwrsnap-app-icon.png"),
+  PwrGit: resolve(rendererSrc, "assets/pwrgit/pwrgit-app-icon.png"),
+};
+
+/** The asset that carries Apple's legacy margin, and so wears the modifier. */
+const INSET = "PwrGit";
+
+async function readPixels(source) {
+  const image = await loadImage(source);
+  const canvas = createCanvas(image.width, image.height);
+  canvas.getContext("2d").drawImage(image, 0, 0);
+  return {
+    width: image.width,
+    height: image.height,
+    data: canvas.getContext("2d").getImageData(0, 0, image.width, image.height).data,
+  };
+}
+
+/** Bounding box of the pixels at or above the alpha threshold. */
+function opaqueBounds(pixels, threshold = 128) {
+  let left = pixels.width;
+  let top = pixels.height;
+  let right = -1;
+  let bottom = -1;
+  for (let y = 0; y < pixels.height; y += 1) {
+    for (let x = 0; x < pixels.width; x += 1) {
+      if (pixels.data[(y * pixels.width + x) * 4 + 3] < threshold) continue;
+      left = Math.min(left, x);
+      top = Math.min(top, y);
+      right = Math.max(right, x);
+      bottom = Math.max(bottom, y);
+    }
+  }
+  return { x: left, y: top, width: right - left + 1, height: bottom - top + 1 };
+}
+
+/**
+ * The share of its own canvas each asset's opaque plate covers — the only
+ * property of the artwork the card's sizing depends on.
+ */
+async function plateFractions() {
+  const fractions = {};
+  for (const [name, file] of Object.entries(ASSETS)) {
+    const pixels = await readPixels(file);
+    const plate = opaqueBounds(pixels);
+    fractions[name] = { plate, canvas: pixels.width, fraction: plate.width / pixels.width };
+  }
+  return fractions;
+}
+
+/** Reports the rule that went missing, rather than throwing on a null match. */
+function matchCss(pattern, what, css = appCss) {
+  const match = pattern.exec(css);
+  expect(match, `app.css no longer states ${what}`).not.toBeNull();
+  return match;
+}
+
+/** The `width` of the shared `.mcp-connection__icon` box, in CSS pixels. */
+function iconBoxWidth() {
+  const rule = matchCss(
+    /\.mcp-connection__icon\s*\{([^}]*)\}/,
+    "the .mcp-connection__icon box",
+  );
+  return Number(matchCss(/width:\s*(\d+)px/, "that box's width", rule[1])[1]);
+}
+
+/** The compensating `scale()`, read as the canvas-over-plate ratio it states. */
+function insetPlateScale() {
+  const match = matchCss(
+    /\.mcp-connection__icon--inset-plate\s*\{[^}]*transform:\s*scale\(calc\((\d+)\s*\/\s*(\d+)\)\)/,
+    "the inset-plate scale as a canvas-over-plate ratio",
+  );
+  return Number(match[1]) / Number(match[2]);
+}
+
+describe("PwrSuite brand icon assets", () => {
+  it("holds a square plate centred on a square canvas", async () => {
+    for (const [name, { plate, canvas }] of Object.entries(await plateFractions())) {
+      expect(plate.width, `${name} plate is square`).toBe(plate.height);
+      expect(canvas, `${name} canvas is 256px`).toBe(256);
+      // Equal margins: a plate drawn off-centre would still measure the right
+      // size and land off-centre in the card.
+      expect(plate.x, `${name} plate is centred`).toBe(canvas - plate.x - plate.width);
+      expect(plate.y, `${name} plate is centred`).toBe(canvas - plate.y - plate.height);
+    }
+  });
+
+  it("leaves exactly one asset inset inside its canvas", async () => {
+    const fractions = await plateFractions();
+    for (const [name, { fraction }] of Object.entries(fractions)) {
+      if (name === INSET) {
+        expect(fraction, `${name} sits on Apple's legacy 824-in-1024 template`)
+          .toBeCloseTo(824 / 1024, 3);
+      } else {
+        expect(fraction, `${name} plate fills its canvas`).toBe(1);
+      }
+    }
+  });
+});
+
+describe("PwrSuite connection card icon sizing", () => {
+  it("paints both plates at the same size", async () => {
+    const box = iconBoxWidth();
+    const scale = insetPlateScale();
+    const painted = Object.entries(await plateFractions()).map(
+      ([name, { fraction }]) => [name, box * fraction * (name === INSET ? scale : 1)],
+    );
+    const [[, first], ...rest] = painted;
+    for (const [name, size] of rest) {
+      // Half a CSS pixel: closer than the display can resolve the difference.
+      expect(Math.abs(size - first), `${name} plate against ${painted[0][0]}`)
+        .toBeLessThan(0.5);
+    }
+    expect(first).toBeCloseTo(box, 5);
+  });
+
+  it("compensates only the inset asset", () => {
+    const modifier = "mcp-connection__icon--inset-plate";
+    for (const name of Object.keys(ASSETS)) {
+      const component = readFileSync(
+        resolve(rendererSrc, `features/thread-detail/${name}ConnectionPrompt.tsx`),
+        "utf8",
+      );
+      const icons = component.match(/className="mcp-connection__icon[^"]*"/g) ?? [];
+      // Both the local card and the remote-owner card draw one.
+      expect(icons.length, `${name} card icons`).toBe(2);
+      for (const icon of icons) {
+        expect(icon.includes(modifier), `${name}: ${icon}`).toBe(name === INSET);
+      }
+    }
+  });
+});

--- a/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
+++ b/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
@@ -6,15 +6,15 @@
 // either file alone, so this measures the assets and the rule together: a
 // refreshed asset whose margin differs fails here rather than shipping a
 // mismatched pair of icons.
-import { createCanvas, loadImage } from "@napi-rs/canvas";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
+import { opaqueBounds, readPixels } from "./lib/icon-pixels.mjs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const rendererSrc = resolve(here, "../src/renderer/src");
-const appCss = readFileSync(resolve(rendererSrc, "styles/app.css"), "utf8");
+const appCssPath = resolve(rendererSrc, "styles/app.css");
 
 const ASSETS = {
   PwrSnap: resolve(rendererSrc, "assets/pwrsnap/pwrsnap-app-icon.png"),
@@ -24,68 +24,70 @@ const ASSETS = {
 /** The asset that carries Apple's legacy margin, and so wears the modifier. */
 const INSET = "PwrGit";
 
-async function readPixels(source) {
-  const image = await loadImage(source);
-  const canvas = createCanvas(image.width, image.height);
-  canvas.getContext("2d").drawImage(image, 0, 0);
-  return {
-    width: image.width,
-    height: image.height,
-    data: canvas.getContext("2d").getImageData(0, 0, image.width, image.height).data,
-  };
-}
-
-/** Bounding box of the pixels at or above the alpha threshold. */
-function opaqueBounds(pixels, threshold = 128) {
-  let left = pixels.width;
-  let top = pixels.height;
-  let right = -1;
-  let bottom = -1;
-  for (let y = 0; y < pixels.height; y += 1) {
-    for (let x = 0; x < pixels.width; x += 1) {
-      if (pixels.data[(y * pixels.width + x) * 4 + 3] < threshold) continue;
-      left = Math.min(left, x);
-      top = Math.min(top, y);
-      right = Math.max(right, x);
-      bottom = Math.max(bottom, y);
-    }
-  }
-  return { x: left, y: top, width: right - left + 1, height: bottom - top + 1 };
-}
+/**
+ * Measured once: the assets are committed files that cannot change mid-run, and
+ * each measurement decodes a PNG and scans every pixel in it.
+ */
+let measured;
 
 /**
- * The share of its own canvas each asset's opaque plate covers — the only
- * property of the artwork the card's sizing depends on.
+ * What share of its own canvas each asset's opaque plate covers — the only
+ * property of the artwork the card's sizing depends on — plus the plate box
+ * and canvas the fraction came from, for the shape assertions.
  */
-async function plateFractions() {
-  const fractions = {};
+async function plates() {
+  if (measured) return measured;
+  measured = {};
   for (const [name, file] of Object.entries(ASSETS)) {
     const pixels = await readPixels(file);
     const plate = opaqueBounds(pixels);
-    fractions[name] = { plate, canvas: pixels.width, fraction: plate.width / pixels.width };
+    expect(plate, `${name} icon has no opaque pixels at all`).not.toBeNull();
+    measured[name] = {
+      plate,
+      canvas: { width: pixels.width, height: pixels.height },
+      fraction: plate.width / pixels.width,
+    };
   }
-  return fractions;
+  return measured;
+}
+
+/**
+ * Read inside each test, not at module scope: a moved or unreadable app.css
+ * should fail the tests written to report it, not turn the whole file into a
+ * collection error that registers no tests at all.
+ */
+function readAppCss() {
+  return readFileSync(appCssPath, "utf8");
 }
 
 /** Reports the rule that went missing, rather than throwing on a null match. */
-function matchCss(pattern, what, css = appCss) {
+function matchCss(css, pattern, what) {
   const match = pattern.exec(css);
   expect(match, `app.css no longer states ${what}`).not.toBeNull();
   return match;
 }
 
-/** The `width` of the shared `.mcp-connection__icon` box, in CSS pixels. */
-function iconBoxWidth() {
+/**
+ * The `width` of the shared `.mcp-connection__icon` box, in CSS pixels. Read
+ * from the unconditional rule: app.css states the same selector again inside
+ * two media queries, and a match that silently landed on one of those would
+ * measure a breakpoint while reporting the base size.
+ */
+function iconBoxWidth(css) {
+  // Anchored to column 0: the overrides are indented inside their `@media`
+  // block, so only the top-level rule can match.
   const rule = matchCss(
-    /\.mcp-connection__icon\s*\{([^}]*)\}/,
-    "the .mcp-connection__icon box",
+    css,
+    /^\.mcp-connection__icon\s*\{([^}]*)\}/m,
+    "an unconditional .mcp-connection__icon box",
   );
-  return Number(matchCss(/width:\s*(\d+)px/, "that box's width", rule[1])[1]);
+  return Number(matchCss(rule[1], /width:\s*(\d+)px/, "that box's width")[1]);
 }
 
 /** The compensating `scale()`, read as the canvas-over-plate ratio it states. */
-function insetPlateScale() {
+function insetPlateScale(css) {
   const match = matchCss(
+    css,
     /\.mcp-connection__icon--inset-plate\s*\{[^}]*transform:\s*scale\(calc\((\d+)\s*\/\s*(\d+)\)\)/,
     "the inset-plate scale as a canvas-over-plate ratio",
   );
@@ -94,19 +96,20 @@ function insetPlateScale() {
 
 describe("PwrSuite brand icon assets", () => {
   it("holds a square plate centred on a square canvas", async () => {
-    for (const [name, { plate, canvas }] of Object.entries(await plateFractions())) {
+    for (const [name, { plate, canvas }] of Object.entries(await plates())) {
+      expect(canvas.width, `${name} canvas is square`).toBe(canvas.height);
       expect(plate.width, `${name} plate is square`).toBe(plate.height);
-      expect(canvas, `${name} canvas is 256px`).toBe(256);
       // Equal margins: a plate drawn off-centre would still measure the right
       // size and land off-centre in the card.
-      expect(plate.x, `${name} plate is centred`).toBe(canvas - plate.x - plate.width);
-      expect(plate.y, `${name} plate is centred`).toBe(canvas - plate.y - plate.height);
+      expect(plate.x, `${name} plate is centred`).toBe(canvas.width - plate.x - plate.width);
+      expect(plate.y, `${name} plate is centred`).toBe(canvas.height - plate.y - plate.height);
     }
   });
 
   it("leaves exactly one asset inset inside its canvas", async () => {
-    const fractions = await plateFractions();
-    for (const [name, { fraction }] of Object.entries(fractions)) {
+    // Fractions, not pixel counts: a vendor shipping the same artwork off a
+    // larger canvas member changes nothing about how the card paints it.
+    for (const [name, { fraction }] of Object.entries(await plates())) {
       if (name === INSET) {
         expect(fraction, `${name} sits on Apple's legacy 824-in-1024 template`)
           .toBeCloseTo(824 / 1024, 3);
@@ -119,33 +122,19 @@ describe("PwrSuite brand icon assets", () => {
 
 describe("PwrSuite connection card icon sizing", () => {
   it("paints both plates at the same size", async () => {
-    const box = iconBoxWidth();
-    const scale = insetPlateScale();
-    const painted = Object.entries(await plateFractions()).map(
+    const css = readAppCss();
+    const box = iconBoxWidth(css);
+    const scale = insetPlateScale(css);
+    const painted = Object.entries(await plates()).map(
       ([name, { fraction }]) => [name, box * fraction * (name === INSET ? scale : 1)],
     );
-    const [[, first], ...rest] = painted;
+    const [[firstName, first], ...rest] = painted;
     for (const [name, size] of rest) {
       // Half a CSS pixel: closer than the display can resolve the difference.
-      expect(Math.abs(size - first), `${name} plate against ${painted[0][0]}`)
+      expect(Math.abs(size - first), `${name} plate against ${firstName}`)
         .toBeLessThan(0.5);
     }
+    // Not merely equal to each other: both fill the box the card reserves.
     expect(first).toBeCloseTo(box, 5);
-  });
-
-  it("compensates only the inset asset", () => {
-    const modifier = "mcp-connection__icon--inset-plate";
-    for (const name of Object.keys(ASSETS)) {
-      const component = readFileSync(
-        resolve(rendererSrc, `features/thread-detail/${name}ConnectionPrompt.tsx`),
-        "utf8",
-      );
-      const icons = component.match(/className="mcp-connection__icon[^"]*"/g) ?? [];
-      // Both the local card and the remote-owner card draw one.
-      expect(icons.length, `${name} card icons`).toBe(2);
-      for (const icon of icons) {
-        expect(icon.includes(modifier), `${name}: ${icon}`).toBe(name === INSET);
-      }
-    }
   });
 });

--- a/apps/desktop/src/renderer/src/assets/pwrgit/README.md
+++ b/apps/desktop/src/renderer/src/assets/pwrgit/README.md
@@ -14,3 +14,11 @@ To refresh it, take `Contents/Resources/icon.icns` from a packaged PwrGit.app
 (or compile PwrGit's `build/icon.icon` the way its `branding-assets.test.ts`
 does), run `iconutil -c iconset` on it, and copy `icon_128x128@2x.png` here
 unchanged. Do not resample, redraw, recolor, or inline the mark in PwrAgent.
+
+The plate in this copy covers 206 of its 256px — Apple's legacy 824-in-1024
+template — where the PwrSnap icon beside it on the same card is full-bleed.
+The card compensates in CSS rather than in the file, so the two marks paint at
+the same size: see `.mcp-connection__icon--inset-plate` in `styles/app.css`.
+A refreshed copy with a different margin fails
+`apps/desktop/scripts/pwrsuite-brand-icons.test.mjs`; correct the ratio there
+rather than editing the asset.

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrGitConnectionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrGitConnectionPrompt.test.tsx
@@ -252,4 +252,25 @@ describe("PwrGitConnectionPrompt", () => {
       screen.queryByRole("button", { name: /Connect to PwrGit/i }),
     ).toBeNull();
   });
+
+  // PwrGit's brand asset sits on Apple's legacy 824-in-1024 template while
+  // PwrSnap's is full-bleed, so this card's icon carries the compensating
+  // modifier and PwrSnap's must not. The ratio itself is measured against
+  // both assets in scripts/pwrsuite-brand-icons.test.mjs.
+  it("marks its icon as the inset-plate asset", async () => {
+    const { container } = render(
+      <PwrGitConnectionPrompt
+        backend="codex"
+        desktopApi={{
+          readPwrGitConnectionStatus: async () => status({ configured: true }),
+        }}
+        enabled={false}
+        onEnabledChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("switch");
+    const icon = container.querySelector(".mcp-connection__icon");
+    expect(icon?.classList.contains("mcp-connection__icon--inset-plate")).toBe(true);
+  });
 });

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrGitConnectionPrompt.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrGitConnectionPrompt.tsx
@@ -104,7 +104,7 @@ export function PwrGitConnectionPrompt(props: {
         <img
           alt=""
           aria-hidden="true"
-          className="mcp-connection__icon"
+          className="mcp-connection__icon mcp-connection__icon--inset-plate"
           src={pwrGitIcon}
         />
         <div className="mcp-connection__copy">
@@ -145,7 +145,7 @@ export function PwrGitConnectionPrompt(props: {
       <img
         alt=""
         aria-hidden="true"
-        className="mcp-connection__icon"
+        className="mcp-connection__icon mcp-connection__icon--inset-plate"
         src={pwrGitIcon}
       />
       <div className="mcp-connection__copy">

--- a/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/PwrSnapConnectionPrompt.test.tsx
@@ -146,4 +146,28 @@ describe("PwrSnapConnectionPrompt", () => {
     expect(screen.getByText(detail)).toBeTruthy();
     expect(screen.queryByRole("switch")).toBeNull();
   });
+
+  // The mirror of PwrGit's inset-plate assertion: this asset is full-bleed, so
+  // scaling it would overshoot the box the card reserves.
+  it("leaves its icon unscaled", async () => {
+    const { container } = render(
+      <PwrSnapConnectionPrompt
+        backend="codex"
+        desktopApi={{
+          readPwrSnapConnectionStatus: async () => ({
+            connectionId: "pwrsnap" as const,
+            displayName: "PwrSnap" as const,
+            availability: "running" as const,
+            configured: true,
+          }),
+        }}
+        enabled={false}
+        onEnabledChange={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole("switch");
+    const icon = container.querySelector(".mcp-connection__icon");
+    expect(icon?.classList.contains("mcp-connection__icon--inset-plate")).toBe(false);
+  });
 });

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16179,6 +16179,21 @@ a.button {
   border-radius: 8px;
 }
 
+/* Each mark is the sister app's own 256px icon, copied verbatim, but the two
+   were authored on different canvases: PwrSnap's rounded plate fills its
+   256px, while PwrGit's sits on Apple's legacy 824-in-1024 template, so a
+   fifth of that canvas is transparent margin. Drawn into the same box, the
+   inset plate lands 24% smaller than the full-bleed one beside it. Scale it
+   back by the canvas over the plate it holds. The grid column is a fixed
+   44px and the only thing this paints outside the box is the asset's own
+   transparent margin, so neither the layout nor the smaller widths below
+   need to know. `scripts/pwrsuite-brand-icons.test.mjs` measures both assets
+   against this ratio, so refreshing either one from its sister repo fails
+   there rather than silently painting at the wrong size. */
+.mcp-connection__icon--inset-plate {
+  transform: scale(calc(256 / 206));
+}
+
 .mcp-connection__copy {
   min-width: 0;
 }

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -16183,13 +16183,13 @@ a.button {
    were authored on different canvases: PwrSnap's rounded plate fills its
    256px, while PwrGit's sits on Apple's legacy 824-in-1024 template, so a
    fifth of that canvas is transparent margin. Drawn into the same box, the
-   inset plate lands 24% smaller than the full-bleed one beside it. Scale it
-   back by the canvas over the plate it holds. The grid column is a fixed
-   44px and the only thing this paints outside the box is the asset's own
-   transparent margin, so neither the layout nor the smaller widths below
-   need to know. `scripts/pwrsuite-brand-icons.test.mjs` measures both assets
-   against this ratio, so refreshing either one from its sister repo fails
-   there rather than silently painting at the wrong size. */
+   inset plate paints at 80% of the full-bleed one beside it — 35.4px against
+   44px. Scale it back by the canvas over the plate it holds. The grid column
+   is a fixed 44px and the only thing this paints outside the box is the
+   asset's own transparent margin, so neither the layout nor the smaller
+   widths below need to know. `scripts/pwrsuite-brand-icons.test.mjs` measures
+   both assets against this ratio, so refreshing either one from its sister
+   repo fails there rather than silently painting at the wrong size. */
 .mcp-connection__icon--inset-plate {
   transform: scale(calc(256 / 206));
 }


### PR DESCRIPTION
The two PwrSuite connection cards in the New Thread view drew their icons at
visibly different sizes.

## Before

![PwrGit tile smaller than PwrSnap's](https://github.com/user-attachments/assets/d90be657-ac85-43dd-9034-b73be1a155df)

## After

![both tiles the same size](https://github.com/user-attachments/assets/44a1c17e-870e-4b8f-98c6-46b1aef77ff1)

## Cause

Each card draws the sister app's own 256px application icon, copied verbatim
from its repository. The two assets do not share a canvas convention:

| Asset | Canvas | Opaque plate |
|---|---|---|
| `pwrsnap-app-icon.png` | 256x256 | 256x256 — full-bleed |
| `pwrgit-app-icon.png` | 256x256 | 206x206 at +25+25 |

206/256 is exactly Apple's legacy 824-in-1024 template. Both were painted into
the same 44px `.mcp-connection__icon` box, so the PwrGit plate landed at
35.4px — 24% smaller than the card above it.

## Fix

These are verbatim vendor assets (`apps/desktop/AGENTS.md` — "Third-Party
Brand Assets"), so the compensation goes in CSS, not in the file.
`.mcp-connection__icon--inset-plate` scales the inset asset back by the canvas
over the plate it holds. The grid column stays a fixed 44px and the only thing
the transform paints outside the box is the asset's own transparent margin, so
the copy column does not move and the two narrower breakpoints (36px, 32px)
follow the ratio for free.

## Guard

`apps/desktop/scripts/pwrsuite-brand-icons.test.mjs` measures both assets and
reads the ratio back out of `app.css`, so the arithmetic cannot rot: a
refreshed asset with a different margin, a changed ratio, or a dropped modifier
class fails there instead of silently painting at the wrong size. All three
failure modes were confirmed by reverting each in turn.

## Verification

Painted plate measured off a headless Chromium render of the real `app.css`
(not the element box — the opaque plate inside the image):

| Breakpoint | PwrSnap | PwrGit before | PwrGit after |
|---|---|---|---|
| default | 44px | 35.4px | 44px |
| `max-width: 760px` | 36px | 29.0px | 36px |
| short window | 32px | 25.8px | 32px |

The copy column's left edge is identical before and after (164px in both), so
nothing moved in the layout.

`pnpm lint:colors`, `pnpm lint:eslint` (0 errors), and `pnpm typecheck` pass;
the two connection-prompt suites, the new test, and `app-icon.test.mjs` pass
(30 passed, 1 skipped — the actool compile test, which needs Xcode 26 selected).

Screenshots are from a standalone harness over the real `app.css` with static
product copy — no user data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
