### PR TITLE
fix(desktop): preserve ACP identities in terminal and compatibility parsers

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -211,6 +211,48 @@ describe("integrated terminal IPC federation branch", () => {
     expect(mocks.localCreateOrAttach).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["acp:grok:remote-thread", "acp:grok", "remote-thread"],
+    ["acp:claude-code:remote-thread", "acp:claude-code", "remote-thread"],
+    ["acp%3Agrok:remote-thread", "acp:grok", "remote-thread"],
+    ["acp:grok:remote:thread", "acp:grok", "remote:thread"],
+  ])(
+    "routes the thread identity %s intact to the owner",
+    async (threadKey, backend, threadId) => {
+      const sender = fakeWebContents(7);
+      mocks.federationWindowIds.add(7);
+      mocks.federationTargets.set(7, { scope: "remote", instanceId: "peer-a" });
+
+      await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+        threadKey,
+        cols: 120,
+        rows: 32,
+      });
+
+      expect(mocks.remotePtyOpen).toHaveBeenCalledWith({
+        backend,
+        threadId,
+        cols: 120,
+        rows: 32,
+      });
+      expect(mocks.localCreateOrAttach).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["acp:grok", "acp:grok:", "codex:", "unknown:thread", "acp%ZZ:thread"])(
+    "rejects malformed remote thread identity %s before opening a shell",
+    async (threadKey) => {
+      await expect(invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, fakeWebContents(2), {
+        threadKey,
+        cols: 80,
+        rows: 24,
+        federationTarget: { scope: "remote", instanceId: "peer-a" },
+      })).rejects.toThrow("Remote terminal thread key is malformed.");
+      expect(mocks.remotePtyOpen).not.toHaveBeenCalled();
+      expect(mocks.localCreateOrAttach).not.toHaveBeenCalled();
+    },
+  );
+
   it("routes a MAIN window's create remotely when the request names an owning instance", async () => {
     const sender = fakeWebContents(2);
 

--- a/apps/desktop/src/main/__tests__/messaging-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/messaging-controller.test.ts
@@ -8288,6 +8288,22 @@ describe("MessagingController", () => {
     );
   });
 
+  it.each([
+    ["codex", "codex"],
+    ["acp:grok", "acp:grok"],
+    ["acp%3Agrok", "acp:grok"],
+  ] as const)("binds a legacy callback identity for %s without a structured value", async (keyBackend, backend) => {
+    const navigation = buildNavigationSnapshot();
+    navigation.threads[0] = { ...navigation.threads[0]!, source: backend };
+    const harness = await createHarness({ navigation });
+    await harness.controller.handleInboundEvent(buildCallbackEvent({
+      actionId: `bind:${keyBackend}:thread-1`,
+    }));
+    await expect(
+      harness.store.findActiveBindingForChannel(buildCommandEvent("/resume").channel),
+    ).resolves.toMatchObject({ backend, threadId: "thread-1" });
+  });
+
   it("binds a callback-selected thread to the channel", async () => {
     const harness = await createHarness();
 

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -1,11 +1,9 @@
 import type { WebContents } from "electron";
-import type {
-  AppServerBackendKind,
-  FederationRemoteTarget,
-} from "@pwragent/shared";
+import type { FederationRemoteTarget } from "@pwragent/shared";
 import {
   isFederationInstanceId,
   isRemoteFederationTarget,
+  parseThreadIdentityKey,
 } from "@pwragent/shared";
 import {
   INTEGRATED_TERMINAL_ERROR_CHANNEL,
@@ -109,12 +107,11 @@ export class FederationTerminalBridge {
     if (inFlight) {
       return await inFlight.promise;
     }
-    const separator = threadKey.indexOf(":");
-    if (separator <= 0 || separator === threadKey.length - 1) {
+    const identity = parseThreadIdentityKey(threadKey);
+    if (!identity?.threadId) {
       throw new Error("Remote terminal thread key is malformed.");
     }
-    const backend = threadKey.slice(0, separator) as AppServerBackendKind;
-    const threadId = threadKey.slice(separator + 1);
+    const { backend, threadId } = identity;
     const pending: PendingRemoteOpen = {
       closeRequested: false,
       promise: Promise.resolve() as unknown as Promise<IntegratedTerminalCreateResponse>,

--- a/apps/desktop/src/main/messaging/core/messaging-controller.ts
+++ b/apps/desktop/src/main/messaging/core/messaging-controller.ts
@@ -17,6 +17,7 @@ import {
   isMessagingBindingTargetKind,
   normalizeRenamedTitleSource,
   parseCodexTurnErrorMessage,
+  parseThreadIdentityKey,
   permissionForActionId,
   permissionForCommandVerb,
   permissionForDynamicTool,
@@ -22568,19 +22569,11 @@ function readBindingTarget(
   }
 
   const actionId = event.actionId ?? event.interaction.id;
-  const match = /^bind:([^:]+):(.+)$/.exec(actionId);
-  if (!match) {
+  if (!actionId.startsWith("bind:")) {
     return undefined;
   }
-  const backend = match[1]!;
-  if (!isAppServerBackendKind(backend)) {
-    return undefined;
-  }
-
-  return {
-    backend,
-    threadId: match[2]!,
-  };
+  const identity = parseThreadIdentityKey(actionId.slice("bind:".length));
+  return identity?.threadId ? identity : undefined;
 }
 
 function readBindingTargetFromValue(

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/useDurableComposerDraftStore.test.tsx
@@ -174,6 +174,28 @@ describe("useDurableComposerDraftStore", () => {
       return { ...rendered, saveComposerDraft };
     };
 
+    it.each(["acp:grok", "acp%3Agrok"])(
+      "preserves legacy %s draft metadata without adding writes",
+      (keyBackend) => {
+        const { result, saveComposerDraft } = setup();
+        const scopeKey = `thread:${keyBackend}:thread:1`;
+        act(() => {
+          result.current.set(scopeKey, buildSnapshot("Unsent draft"));
+          vi.advanceTimersByTime(5_000);
+        });
+        expect(saveComposerDraft).toHaveBeenCalledOnce();
+        expect(saveComposerDraft).toHaveBeenCalledWith(expect.objectContaining({
+          draft: expect.objectContaining({
+            scopeKey,
+            scopeKind: "thread",
+            backend: "acp:grok",
+            threadId: "thread:1",
+            text: "Unsent draft",
+          }),
+        }));
+      },
+    );
+
     it("coalesces a burst of typing into a single write", () => {
       // The point of the change: this used to be one sqlite commit per 200ms,
       // roughly five a second while typing, for a recovery feature that does

--- a/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useDurableComposerDraftStore.ts
@@ -1,5 +1,5 @@
 import { hydrateComposerDraft } from "./composer-draft-hydration";
-import { parseOwnedComposerScopeKey } from "@pwragent/shared";
+import { parseOwnedComposerScopeKey, parseThreadIdentityKey } from "@pwragent/shared";
 import {
   useCallback,
   useEffect,
@@ -403,15 +403,11 @@ function parseScope(scopeKey: string): {
   if (owned) return { backend: owned.backend, threadId: owned.threadId, scopeKind: "thread" };
   if (scopeKey.startsWith("thread:")) {
     const remainder = scopeKey.slice("thread:".length);
-    const separatorIndex = remainder.indexOf(":");
-    if (separatorIndex === -1) {
+    if (!remainder.includes(":")) {
       return { scopeKind: "thread", threadId: remainder };
     }
-    return {
-      backend: remainder.slice(0, separatorIndex) as AppServerBackendKind,
-      scopeKind: "thread",
-      threadId: remainder.slice(separatorIndex + 1),
-    };
+    const identity = parseThreadIdentityKey(remainder);
+    return { ...identity, scopeKind: "thread" };
   }
   if (scopeKey.startsWith("launchpad:")) {
     return {

--- a/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/TranscriptList.tsx
@@ -34,7 +34,6 @@ import type {
 import {
   buildPendingRequestActions,
   buildPendingRequestApprovalContext,
-  isAppServerBackendKind,
 } from "@pwragent/shared";
 import { injectMessagingBindingTransitions } from "./messaging-binding-transition-entries";
 import { injectPermissionTransitions } from "./permission-transition-entries";
@@ -169,11 +168,6 @@ const LOAD_OLDER_THRESHOLD_PX = 160;
 // transcript message on an unrelated live-turn render.
 const EMPTY_SKILLS: AppServerSkillSummary[] = [];
 
-type AutomationThreadTarget = {
-  backend: AppServerBackendKind;
-  threadId: string;
-};
-
 function isAssistantFinalMessage(entry: AppServerThreadEntry): boolean {
   return (
     entry.type === "message" &&
@@ -184,16 +178,6 @@ function isAssistantFinalMessage(entry: AppServerThreadEntry): boolean {
 
 function entryCreatedAt(entry: AppServerThreadEntry): number | undefined {
   return typeof entry.createdAt === "number" ? entry.createdAt : undefined;
-}
-
-function parseThreadIdentity(value: string | undefined): AutomationThreadTarget | undefined {
-  const separatorIndex = value?.indexOf(":") ?? -1;
-  if (!value || separatorIndex <= 0) return undefined;
-  const backend = value.slice(0, separatorIndex);
-  if (!isAppServerBackendKind(backend)) return undefined;
-  const threadId = value.slice(separatorIndex + 1);
-  if (!threadId) return undefined;
-  return { backend, threadId };
 }
 
 function pendingEntriesInEventOrder(


### PR DESCRIPTION
Opening an integrated terminal for a remote Grok thread split `acp:grok:<thread-id>` at the first colon, sending backend `acp` and thread ID `grok:<thread-id>` to the owner. Codex keys were unaffected because their backend contains no colon. Two compatibility paths had the same assumption: legacy composer draft metadata and messaging binding callbacks without structured values.

Use the shared thread identity parser in all three paths, preserving ACP backend IDs and accepting legacy percent-encoded keys. Remove the unused transcript identity parser and its unused type. Current ownership-aware draft scopes and structured messaging callback values retain their existing precedence; draft persistence frequency is unchanged. The remote terminal fix must be present on the viewer instance.

Validation:
- Reproduced failing ACP terminal, draft metadata, and messaging callback regressions before their fixes.
- All 51 terminal IPC/Federation PTY tests and all 470 messaging-controller/durable-draft tests pass.
- Typecheck, ESLint, and dependency-boundary checks pass.
- No live application restart or remote GUI verification was performed.
