### PR TITLE
fix(desktop): handle federated navigation contention quietly

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -2374,6 +2374,20 @@ describe("app server ipc", () => {
     await expect(handler(event, request)).rejects.toThrow("Unexpected projection failure");
   });
 
+  it("returns a Federation-wrapped owner read race without rejecting the Electron handler", async () => {
+    const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
+    const { NAVIGATION_QUERY_PAGE_CHANNEL } = await import("../../shared/ipc");
+    registerAppServerIpcHandlers();
+    const error = Object.assign(new Error("handler_failed: [navigation_busy] Navigation changed during its owner read. Refresh the retained range."), {
+      code: "handler_failed",
+    });
+    federationMock.runtime.remoteNavigationQueryPage.mockRejectedValueOnce(error);
+    await expect(handlers.get(NAVIGATION_QUERY_PAGE_CHANNEL)!({ sender: { id: 90010, once: vi.fn() } }, {
+      protocol: 2, consumer: "main-sidebar", federationTarget: { scope: "remote", instanceId: "busy-peer" },
+      query: { kind: "directory-index" },
+    })).resolves.toEqual({ navigationReadFailure: true, code: "navigation_busy", message: error.message });
+  });
+
   it("overlays only a bounded remote page's viewer directory preferences without accepting owner-only unchanged proof", async () => {
     const { registerAppServerIpcHandlers } = await import("../ipc/app-server");
     const { NAVIGATION_QUERY_PAGE_CHANNEL } = await import("../../shared/ipc");

--- a/apps/desktop/src/shared/__tests__/navigation-ipc-result.test.ts
+++ b/apps/desktop/src/shared/__tests__/navigation-ipc-result.test.ts
@@ -26,3 +26,23 @@ it("carries normal navigation cancellation without an Electron handler exception
   expect(result).toEqual({ navigationReadFailure: true, code: "navigation_busy", message: error.message });
   expect(() => unwrapNavigationRead(result)).toThrow(expect.objectContaining({ name: "NavigationQueryError", code: "navigation_busy" }));
 });
+
+it("restores expected busy state wrapped by a remote Federation handler", () => {
+  const error = Object.assign(new Error("handler_failed: [navigation_busy] Navigation changed during its owner read. Refresh the retained range."), {
+    code: "handler_failed",
+  });
+  const result = expectedNavigationReadFailure(error);
+  expect(result).toEqual({ navigationReadFailure: true, code: "navigation_busy", message: error.message });
+  expect(() => unwrapNavigationRead(structuredClone(result))).toThrow(expect.objectContaining({
+    name: "NavigationQueryError", code: "navigation_busy", message: error.message,
+  }));
+});
+
+it.each([
+  ["handler_failed", "handler_failed: Unexpected projection failure"],
+  ["handler_failed", "handler_failed: [navigation_invalid_request] Invalid query"],
+  ["handler_failed", "handler_failed: Unexpected failure mentioning [navigation_busy]"],
+  ["transport_failed", "handler_failed: [navigation_busy] Busy"],
+])("keeps unexpected wrapped failures actionable: %s / %s", (code, message) => {
+  expect(expectedNavigationReadFailure(Object.assign(new Error(message), { code }))).toBeUndefined();
+});

--- a/apps/desktop/src/shared/navigation-ipc-result.ts
+++ b/apps/desktop/src/shared/navigation-ipc-result.ts
@@ -7,8 +7,14 @@ export type NavigationReadFailure = {
 };
 
 export function expectedNavigationReadFailure(error: unknown): NavigationReadFailure | undefined {
-  if (!(error instanceof Error) || !("code" in error) || (error.code !== "FEDERATION_PEER_UNAVAILABLE" && error.code !== "navigation_busy")) return undefined;
-  return { navigationReadFailure: true, code: error.code, message: error.message,
+  if (!(error instanceof Error) || !("code" in error)) return undefined;
+  // Federation wraps owner exceptions as handler_failed. NavigationQueryError
+  // preserves its code in the message; recognize only its exact busy prefix so
+  // expected owner contention takes the same quiet IPC path as local contention.
+  const code = error.code === "handler_failed" && error.message.startsWith("handler_failed: [navigation_busy] ")
+    ? "navigation_busy" : error.code;
+  if (code !== "FEDERATION_PEER_UNAVAILABLE" && code !== "navigation_busy") return undefined;
+  return { navigationReadFailure: true, code, message: error.message,
     ...("instanceId" in error && typeof error.instanceId === "string" ? { instanceId: error.instanceId } : {}) };
 }
 


### PR DESCRIPTION
## Summary

- I fixed repeated Electron `navigation:get-query-page` handler stack traces when a remote owner rejects a changing navigation read with `navigation_busy`. Federation wraps that expected exception as `handler_failed`, which previously bypassed the quiet navigation IPC result path.
- I recognize the exact Federation busy prefix and restore the `navigation_busy` result code. The preload still rejects for the renderer to handle; unexpected failures remain actionable.

## Verification

- I reproduced the bug with failing helper and IPC-handler regression tests before applying the fix (2 failures, 159 passes).
- I verified all 206 tests across the navigation IPC result, app-server IPC, navigation query store, and Federation RPC suites pass after the fix.
- I ran `pnpm lint:eslint` (0 errors), `pnpm typecheck`, `pnpm lint:boundaries`, and `git diff --check` successfully.

## Notes

- I started from freshly fetched `origin/main` at `b2d6bd1d3` and kept separate signed regression-test and fix commits.
- This corrects error transport and logging. It preserves the owner consistency guard and does not reduce navigation contention or alter retry behavior.
- The accompanying large-frame messages are separate information-level diagnostics for Federation frames over 200,000 bytes. They are unchanged.
