### PR TITLE
fix(desktop): allow non-git folders in directory picker

### DIFF
--- a/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
@@ -1,4 +1,8 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { classifyDirectory } from "@pwragent/shared";
 import type {
   AppServerBackendKind,
   EnsureDirectoryLaunchpadResponse,
@@ -164,25 +168,73 @@ describe("registerDirectoryFromDisk", () => {
     );
   });
 
-  it("returns not-a-git-repo when `git rev-parse` fails", async () => {
+  it.each([
+    "/tmp/not-a-repo",
+    "C:\\Users\\fixture-user\\notes",
+    "/Users/fixture-user/Documents/Codex",
+    "/tmp/plain/.worktrees/abc123/notes",
+  ])("registers the selected non-git folder %s without repo normalization", async (candidate) => {
+    const directoryPath = candidate.replace(/\\/g, "/");
     const ensure = buildEnsureSpy();
     const runGit = vi.fn(async () => {
       throw new Error("fatal: not a git repository");
     });
 
     const result = await registerDirectoryFromDisk(
-      { path: "/tmp/not-a-repo" },
-      {
-        ensureDirectoryLaunchpad: ensure,
-        runGit,
-        statPath: statDir,
-      },
+      { path: candidate, preferredBackend: "acp:grok" },
+      { ensureDirectoryLaunchpad: ensure, runGit, statPath: statDir },
     );
 
-    assertFailed(result);
-    expect(result.reason).toBe("not-a-git-repo");
-    expect(result.message).toContain("/tmp/not-a-repo");
-    expect(ensure).not.toHaveBeenCalled();
+    assertOk(result);
+    expect(result.directoryPath).toBe(directoryPath);
+    expect(result.directoryKey).toBe(`directory:${directoryPath}`);
+    expect(result.currentBranch).toBeUndefined();
+    expect(ensure).toHaveBeenCalledExactlyOnceWith({
+      directoryKey: `directory:${directoryPath}`,
+      directoryKind: "directory",
+      directoryLabel: path.basename(directoryPath),
+      directoryPath,
+      currentBranch: undefined,
+      preferredBackend: "acp:grok",
+      registeredAt: expect.any(Number),
+    });
+    expect(runGit).toHaveBeenCalledExactlyOnceWith(candidate, [
+      "rev-parse", "--show-toplevel",
+    ]);
+  });
+
+  it("registers a folder when git reports an empty root", async () => {
+    const ensure = buildEnsureSpy();
+    const runGit = vi.fn(async () => "  ");
+    const result = await registerDirectoryFromDisk(
+      { path: "/tmp/notes" },
+      { ensureDirectoryLaunchpad: ensure, runGit, statPath: statDir },
+    );
+
+    assertOk(result);
+    expect(result.directoryPath).toBe("/tmp/notes");
+    expect(result.currentBranch).toBeUndefined();
+    expect(runGit).toHaveBeenCalledTimes(1);
+  });
+
+  it("registers a real plain folder with the same key as navigation classification", async () => {
+    const candidate = await mkdtemp(path.join(os.tmpdir(), "pwragent-plain-directory-"));
+    try {
+      const result = await registerDirectoryFromDisk(
+        { path: candidate },
+        { ensureDirectoryLaunchpad: buildEnsureSpy() },
+      );
+      assertOk(result);
+      const classified = classifyDirectory({
+        id: candidate, kind: "local", path: candidate, label: path.basename(candidate),
+      });
+      expect(result.directoryKey).toBe(classified.key);
+      expect(result.directoryPath).toBe(candidate.replace(/\\/g, "/"));
+      expect(result.currentBranch).toBeUndefined();
+      expect(result.launchpad.workMode).toBe("local");
+    } finally {
+      await rm(candidate, { recursive: true, force: true });
+    }
   });
 
   it("returns not-a-directory when the chosen path is a file", async () => {

--- a/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
+++ b/apps/desktop/src/main/__tests__/directory-registration-service.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { classifyDirectory } from "@pwragent/shared";
+import { buildDirectorySummaries, classifyDirectory } from "@pwragent/shared";
 import type {
   AppServerBackendKind,
   EnsureDirectoryLaunchpadResponse,
@@ -173,6 +173,7 @@ describe("registerDirectoryFromDisk", () => {
     "C:\\Users\\fixture-user\\notes",
     "/Users/fixture-user/Documents/Codex",
     "/tmp/plain/.worktrees/abc123/notes",
+    "C:\\plain\\.worktrees\\abc123\\notes",
   ])("registers the selected non-git folder %s without repo normalization", async (candidate) => {
     const directoryPath = candidate.replace(/\\/g, "/");
     const ensure = buildEnsureSpy();
@@ -189,6 +190,30 @@ describe("registerDirectoryFromDisk", () => {
     expect(result.directoryPath).toBe(directoryPath);
     expect(result.directoryKey).toBe(`directory:${directoryPath}`);
     expect(result.currentBranch).toBeUndefined();
+    const directory = {
+      id: directoryPath,
+      kind: "local" as const,
+      path: directoryPath,
+      label: result.directoryLabel,
+    };
+    expect(classifyDirectory(directory).key).toBe(result.directoryKey);
+    const summaries = buildDirectorySummaries({
+      threads: [{
+        id: "plain-folder-thread",
+        source: "codex",
+        title: "Plain folder",
+        titleSource: "explicit",
+        linkedDirectories: [directory],
+        inbox: { inInbox: false },
+      }],
+      launchpadsByKey: { [result.directoryKey]: result.launchpad },
+    });
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toMatchObject({
+      key: result.directoryKey,
+      path: directoryPath,
+      threadKeys: ["codex:plain-folder-thread"],
+    });
     expect(ensure).toHaveBeenCalledExactlyOnceWith({
       directoryKey: `directory:${directoryPath}`,
       directoryKind: "directory",
@@ -349,6 +374,12 @@ describe("registerDirectoryFromDisk", () => {
     expect(result.directoryPath).toBe("/Users/me/code/PwrAgent");
     expect(result.directoryKey).toBe("directory:/Users/me/code/PwrAgent");
     expect(result.directoryLabel).toBe("PwrAgent");
+    expect(classifyDirectory({
+      id: "/Users/me/code/PwrAgent/.worktrees/abc123/PwrAgent",
+      kind: "worktree",
+      path: "/Users/me/code/PwrAgent/.worktrees/abc123/PwrAgent",
+      label: "PwrAgent",
+    }).key).toBe(result.directoryKey);
   });
 
   it("propagates preferredBackend through to ensureDirectoryLaunchpad", async () => {

--- a/apps/desktop/src/main/app-server/directory-registration-service.ts
+++ b/apps/desktop/src/main/app-server/directory-registration-service.ts
@@ -23,14 +23,11 @@ import { runGitCommand } from "./git-executable";
  *      bookmark or a permissions-blocked folder).
  *   2. The path resolves to a directory, not a file. Failure →
  *      `not-a-directory`.
- *   3. `git rev-parse --show-toplevel` succeeds inside the path. Per
- *      issue #223 acceptance criteria the picker registers git repos
- *      only — a non-repo errors with `not-a-git-repo`.
  *
  * On success we call `ensureDirectoryLaunchpad` so the directory is
- * known to the launchpad layer immediately. The repo's canonical root
- * (rev-parse output) is what we persist — symlinked roots normalize so
- * the same repo accessed via two paths still maps to one launchpad.
+ * known to the launchpad layer immediately. Git detection is best effort:
+ * repositories persist their canonical root so symlinked roots normalize
+ * to one launchpad; other folders persist the selected path (issue #1750).
  */
 export type DirectoryRegistrationDeps = {
   ensureDirectoryLaunchpad: (request: {
@@ -118,56 +115,49 @@ export async function registerDirectoryFromDisk(
     );
   }
 
-  let repoRoot: string;
+  // Match navigation keys on Windows, where the native picker uses backslashes.
+  let directoryPath = candidate.replace(/\\/g, "/");
+  let repoRoot: string | undefined;
   try {
     const toplevel = (await runGit(candidate, [
       "rev-parse",
       "--show-toplevel",
     ])).trim();
-    if (!toplevel) {
-      return failed(
-        "not-a-git-repo",
-        `${candidate} is not inside a git repository.`,
-      );
+    if (toplevel) {
+      // Only Git roots use repository/worktree normalization. Plain folders
+      // keep their selected path, even when it contains `.worktrees`.
+      repoRoot = canonicalizeRepoWorktreePath(toplevel);
+      directoryPath = repoRoot;
     }
-    // If the toplevel is itself a pwragent-managed worktree, walk back
-    // to the parent repo so the directoryKey dedupes against the
-    // already-tracked directory entry. See `canonicalizeRepoWorktreePath`.
-    repoRoot = canonicalizeRepoWorktreePath(toplevel);
   } catch {
-    // `git rev-parse --show-toplevel` exits non-zero (with a message on
-    // stderr) for any path that isn't tracked. We treat all such
-    // failures as "not a git repo" rather than surfacing the raw stderr,
-    // which is implementation-y and not useful in the picker UI.
-    return failed(
-      "not-a-git-repo",
-      `${candidate} is not inside a git repository.`,
-    );
+    // Git metadata is optional: a plain folder (or unavailable Git) must
+    // not prevent registration after filesystem validation succeeds.
   }
 
-  // Resolve the current branch (best effort — detached HEADs return an
-  // empty string and we just leave `currentBranch` unset).
+  // Resolve the current branch only for detected repos (best effort).
   let currentBranch: string | undefined;
-  try {
-    const head = (await runGit(repoRoot, [
-      "rev-parse",
-      "--abbrev-ref",
-      "HEAD",
-    ])).trim();
-    if (head && head !== "HEAD") {
-      currentBranch = head;
+  if (repoRoot) {
+    try {
+      const head = (await runGit(repoRoot, [
+        "rev-parse",
+        "--abbrev-ref",
+        "HEAD",
+      ])).trim();
+      if (head && head !== "HEAD") {
+        currentBranch = head;
+      }
+    } catch {
+      // Brand-new repo with no commits — leave currentBranch undefined.
     }
-  } catch {
-    // Brand-new repo with no commits — leave currentBranch undefined.
   }
 
-  const directoryKey = `directory:${repoRoot}`;
-  const directoryLabel = path.basename(repoRoot) || repoRoot;
+  const directoryKey = `directory:${directoryPath}`;
+  const directoryLabel = path.basename(directoryPath) || directoryPath;
   const ensured = await deps.ensureDirectoryLaunchpad({
     directoryKey,
     directoryKind: "directory",
     directoryLabel,
-    directoryPath: repoRoot,
+    directoryPath,
     currentBranch,
     preferredBackend: request.preferredBackend,
     registeredAt: Date.now(),
@@ -175,7 +165,7 @@ export async function registerDirectoryFromDisk(
 
   return {
     ok: true,
-    directoryPath: repoRoot,
+    directoryPath,
     directoryKey,
     directoryLabel,
     currentBranch,

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -16381,8 +16381,8 @@ describe("Composer", () => {
       // the send-time attach re-registers.
       const registerDirectoryFromDisk = vi.fn(async () => ({
         ok: false as const,
-        reason: "not-a-git-repo" as const,
-        message: "That folder isn't a git repository.",
+        reason: "inaccessible" as const,
+        message: "That folder is no longer accessible.",
       }));
 
       render(

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx
@@ -9044,16 +9044,16 @@ describe("useThreadNavigation", () => {
   it("publishes a masthead add-directory rejection to the notice stack", async () => {
     // "Add project directory" lives in the sidebar / title-bar menu, and
     // `pickDirectoryError`'s only inline surface is the launchpad composer's
-    // project picker — not mounted behind that menu. Picking a folder that is
-    // not a git repository would otherwise fail silently.
+    // project picker — not mounted behind that menu. A rejected path
+    // would otherwise fail silently.
     const pickDirectoryFromDisk = vi.fn(async () => ({
       canceled: false as const,
-      path: "/Users/test/not-a-repo",
+      path: "/Users/test/file.txt",
     }));
     const registerDirectoryFromDisk = vi.fn(async () => ({
       ok: false as const,
-      reason: "not-a-git-repo" as const,
-      message: "/Users/test/not-a-repo is not a git repository.",
+      reason: "not-a-directory" as const,
+      message: "/Users/test/file.txt is not a folder.",
     }));
     const readPopulation = vi.fn(async () => ({
       backend: "all" as const,
@@ -9089,7 +9089,7 @@ describe("useThreadNavigation", () => {
     });
 
     expect(latestThreadActionError(onThreadActionError, "add-directory")).toBe(
-      "/Users/test/not-a-repo is not a git repository.",
+      "/Users/test/file.txt is not a folder.",
     );
 
     // A later cancel clears the slot, so the notice comes down on its own.
@@ -12653,15 +12653,15 @@ describe("useThreadNavigation", () => {
       expect(result.current.pickDirectoryError).toBeUndefined();
     });
 
-    it("surfaces an inline error when the chosen path is not a git repo", async () => {
+    it("surfaces an inline error when the chosen path is a file", async () => {
       const pickDirectoryFromDisk = vi.fn(async () => ({
         canceled: false as const,
-        path: "/tmp/not-a-repo",
+        path: "/tmp/file.txt",
       }));
       const registerDirectoryFromDisk = vi.fn(async () => ({
         ok: false as const,
-        reason: "not-a-git-repo" as const,
-        message: "/tmp/not-a-repo is not inside a git repository.",
+        reason: "not-a-directory" as const,
+        message: "/tmp/file.txt is not a folder.",
       }));
       const desktopApi = buildBaseDesktopApi({
         pickDirectoryFromDisk,
@@ -12675,7 +12675,7 @@ describe("useThreadNavigation", () => {
         await result.current.pickAndRegisterDirectory();
       });
 
-      expect(result.current.pickDirectoryError).toContain("not inside a git");
+      expect(result.current.pickDirectoryError).toContain("not a folder");
       expect(result.current.selectedItemKey).toBeUndefined();
 
       // clearPickDirectoryError resets the inline error state.
@@ -12775,12 +12775,12 @@ describe("useThreadNavigation", () => {
     it("pickDirectoryForReference surfaces validation failures and resolves undefined", async () => {
       const pickDirectoryFromDisk = vi.fn(async () => ({
         canceled: false as const,
-        path: "/tmp/not-a-repo",
+        path: "/tmp/file.txt",
       }));
       const registerDirectoryFromDisk = vi.fn(async () => ({
         ok: false as const,
-        reason: "not-a-git-repo" as const,
-        message: "/tmp/not-a-repo is not inside a git repository.",
+        reason: "not-a-directory" as const,
+        message: "/tmp/file.txt is not a folder.",
       }));
       const desktopApi = buildBaseDesktopApi({
         pickDirectoryFromDisk,
@@ -12796,7 +12796,7 @@ describe("useThreadNavigation", () => {
       });
 
       expect(picked).toBeUndefined();
-      expect(result.current.pickDirectoryError).toContain("not inside a git");
+      expect(result.current.pickDirectoryError).toContain("not a folder");
       expect(result.current.selectedItemKey).toBeUndefined();
     });
   });

--- a/packages/shared/src/contracts/agent.ts
+++ b/packages/shared/src/contracts/agent.ts
@@ -1221,16 +1221,14 @@ export type RegisterDirectoryFromDiskRequest = {
 /** Why a registration attempt failed — drives the inline error copy. */
 export type RegisterDirectoryFromDiskFailureReason =
   | "inaccessible"
-  | "not-a-directory"
-  | "not-a-git-repo";
+  | "not-a-directory";
 
 export type RegisterDirectoryFromDiskResponse =
   | {
       ok: true;
       /**
-       * Canonical filesystem path (resolved via `git rev-parse
-       * --show-toplevel` so symlinked roots normalize). The directoryKey
-       * is derived from this path with the `directory:` prefix.
+       * Canonical Git root when detected, otherwise the selected folder
+       * path. The directoryKey uses this path with the `directory:` prefix.
        */
       directoryPath: string;
       directoryKey: string;

--- a/packages/shared/src/contracts/navigation.ts
+++ b/packages/shared/src/contracts/navigation.ts
@@ -2279,8 +2279,7 @@ export type AttachDirectoryToThreadRequest = {
 
 export type AttachDirectoryToThreadFailureReason =
   | "inaccessible"
-  | "not-a-directory"
-  | "not-a-git-repo";
+  | "not-a-directory";
 
 export type AttachDirectoryToThreadResponse =
   | {

--- a/packages/shared/src/directory-navigation.ts
+++ b/packages/shared/src/directory-navigation.ts
@@ -158,7 +158,10 @@ export function classifyDirectory(
   const repoWorktreeMatch = path.match(
     /^(.*)[\\/]\.worktrees[\\/][^\\/]+(?:[\\/].*)?$/,
   );
-  if (repoWorktreeMatch) {
+  // A local folder can use this naming convention without being a Git
+  // worktree. Only fold entries identified as worktrees onto their repo;
+  // plain folders must keep the same key as their registered launchpad.
+  if (directory.kind === "worktree" && repoWorktreeMatch) {
     const canonicalPath = repoWorktreeMatch[1];
     return {
       key: `directory:${canonicalPath}`,


### PR DESCRIPTION
The directory picker rejected ordinary folders because registration required `git rev-parse` to succeed. Add project directory and Attach directory to thread now accept accessible non-Git folders, using the selected path with normalized Windows separators and no branch metadata. Git repositories retain their existing root and managed-worktree normalization; inaccessible paths and files still fail validation.

Removes the obsolete `not-a-git-repo` reason from both shared response contracts and updates error-surfacing fixtures to use remaining validation failures.

Validation:
- Five new regression cases failed before the fix, including a real temporary non-Git folder.
- 632 tests passed across registration, IPC, navigation, and composer suites; the final registration run passed all 14 tests after adding Windows separator coverage.
- `pnpm lint:eslint` passed (existing warnings only), `pnpm typecheck` passed, and `pnpm lint:boundaries` passed.

Fixes #1750.
