### PR TITLE
fix(release): exclude SQLite build sources from app bundle

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -64,6 +64,9 @@ files:
   # Keep those out of app.asar.unpacked so macOS universal merging only sees
   # electron-builder's rebuilt current-arch binary under build/Release.
   - "!**/node_modules/node-pty/prebuilds/**"
+  # SQLite's amalgamated C source and header are build inputs only. Keep the
+  # compiled better_sqlite3.node binding; omit roughly 10 MB of unused sources.
+  - "!**/node_modules/better-sqlite3/deps/sqlite3/*.{c,h}"
   # Our own workspace package metadata is unused at runtime — vite inlines.
   - "!**/node_modules/@pwragent/*/AGENTS.md"
   - "!**/node_modules/@pwragent/*/src/**"

--- a/apps/desktop/scripts/verify-asar-contents.mjs
+++ b/apps/desktop/scripts/verify-asar-contents.mjs
@@ -96,6 +96,7 @@ if (missingRuntimeFiles.length > 0) {
 }
 // Each rule: [label, regex]. Anything matching → fail.
 const forbidden = [
+  ["SQLite build source", /\/node_modules\/better-sqlite3\/deps\/sqlite3\/[^/]+\.[ch]$/],
   ["TypeScript source", /\.tsx?$/],
   ["TypeScript declaration", /\.d\.ts$/],
   ["Sourcemap", /\.map$/],


### PR DESCRIPTION
PwrAgent ships SQLite’s amalgamated C source and headers from `better-sqlite3` even though the packaged app uses the compiled native binding. Exclude those build inputs, removing 10,237,880 bytes (10.24 MB) measured in the installed macOS bundle, and add a rule to the existing ASAR verifier to reject future leaks.

The exclusion is limited to `better-sqlite3/deps/sqlite3/*.{c,h}`; the compiled binding and license disclosures remain included.

Validation:
- Electron-builder’s actual FileMatcher excludes all three installed source/header files and retains `build/Release/better_sqlite3.node`.
- Updated ASAR verifier rejects the installed pre-fix bundle with exactly the three SQLite source/header violations.
- `pnpm lint:eslint` passed.
- `git diff --check` passed.

A full signed application package was not rebuilt locally.
