### PR TITLE
feat(release): add Apple Silicon macOS packages and updates

### DIFF
--- a/.agents/skills/release/SKILL.md
+++ b/.agents/skills/release/SKILL.md
@@ -6,7 +6,7 @@ description: Prepare, validate, tag, publish, and monitor guarded PwrAgent deskt
 # Release
 
 Use this skill for PwrAgent desktop releases published by the
-`.github/workflows/release.yml` Universal macOS workflow.
+`.github/workflows/release.yml` Universal + Apple Silicon macOS workflow.
 
 ## Read First
 
@@ -263,7 +263,7 @@ Push the tag after the release metadata is already on `RELEASE_BRANCH`:
 git push origin v<version>
 ```
 
-The tag push triggers `Release Desktop (macOS universal)`. The workflow must
+The tag push triggers `Release Desktop (macOS universal + arm64 + Windows + Linux DEB)`. The workflow must
 pass `Check release metadata` in the no-secret `Test and prepare signing input`
 job before the environment-gated `Sign, notarize, publish` job can request
 approval and access Apple signing secrets.
@@ -314,8 +314,10 @@ Expect signed/notarized Universal macOS assets:
 - A versioned Universal DMG, such as `PwrAgent-<version>-universal.dmg`.
 - A stable `PwrAgent.dmg` alias uploaded by the workflow for
   `https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg`.
-- A Universal updater ZIP and `.blockmap`.
-- `latest-mac.yml`.
+- Universal and arm64 updater ZIPs, each with its own `.blockmap`.
+- An Apple Silicon DMG and stable `PwrAgent-arm64.dmg` alias.
+- `PwrAgent-macos-SHA256SUMS` covering both targets and aliases.
+- One merged `latest-mac.yml`, universal legacy path/hash and both ZIP entries.
 
 The stable `PwrAgent.dmg` alias is intentionally unversioned so the website can
 link to the latest release without knowing the current version. Do not remove

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,7 +323,9 @@ jobs:
 
       - name: Test
         timeout-minutes: 20
-        run: pnpm exec vitest run --config vitest.workspace.ts --project desktop-main
+        # The deploy-isolation test launches pnpm's JS entry directly to avoid
+        # Windows .cmd handoffs. pnpm run supplies npm_execpath; exec does not.
+        run: pnpm test --project desktop-main
 
   windows-renderer-packages:
     name: Windows renderer + packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Desktop (macOS universal + Windows + Linux DEB)
+name: Release Desktop (macOS universal + arm64 + Windows + Linux DEB)
 
 on:
   push:
@@ -78,6 +78,16 @@ jobs:
           PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
         run: node apps/desktop/scripts/release.mjs --prepare-only
 
+      - name: Stage pinned Grok ACP runtime for Apple Silicon
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: node apps/desktop/scripts/stage-grok-bundle.mjs --platform macos-aarch64
+
+      - name: Prepare Apple Silicon release stage
+        env:
+          PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
+        run: node apps/desktop/scripts/release.mjs --prepare-only --mac-arch=arm64
+
       - name: Archive signing input
         id: archive
         run: |
@@ -88,8 +98,10 @@ jobs:
             pnpm-lock.yaml \
             pnpm-workspace.yaml \
             apps/desktop/release-stage \
+            apps/desktop/release-stage-arm64 \
             .github/actions/select-xcode-for-actool \
             apps/desktop/scripts/release.mjs \
+            apps/desktop/scripts/assemble-mac-release.mjs \
             apps/desktop/scripts/release-signing-environment.mjs \
             apps/desktop/scripts/update-channel-files.mjs \
             apps/desktop/scripts/verify-asar-contents.mjs \
@@ -166,14 +178,15 @@ jobs:
           APPLE_TEAM_ID: T44CNHC4UH
 
           PWRAGENT_REQUIRE_GROK_BUNDLE: "1"
-        run: node apps/desktop/scripts/release.mjs --sign-stage-only --no-publish
-
-      - name: Prepare stable-name DMG alias
         run: |
-          set -euo pipefail
-          cd apps/desktop/release-stage/dist
-          versioned=$(ls PwrAgent-*-universal.dmg | head -n 1)
-          cp "$versioned" PwrAgent.dmg
+          node apps/desktop/scripts/release.mjs --sign-stage-only --no-publish
+          node apps/desktop/scripts/release.mjs --sign-stage-only --no-publish --mac-arch=arm64
+
+      - name: Assemble macOS updater metadata and stable-name DMG aliases
+        run: |
+          node apps/desktop/scripts/assemble-mac-release.mjs \
+            apps/desktop/release-stage/dist \
+            apps/desktop/release-stage-arm64/dist
 
       # This is the macOS release payload consumed by publish-release-assets.
       # It is intentionally not a best-effort debug upload: publishing must
@@ -187,6 +200,7 @@ jobs:
             apps/desktop/release-stage/dist/*.zip
             apps/desktop/release-stage/dist/*.blockmap
             apps/desktop/release-stage/dist/latest-mac.yml
+            apps/desktop/release-stage/dist/PwrAgent-macos-SHA256SUMS
             apps/desktop/release-stage/dist/builder-debug.yml
           retention-days: 30
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ apps/desktop/e2e/fixtures/**/raw.capture.jsonl
 apps/desktop/dist/
 # pnpm deploy stage (release.mjs materializes a flat node_modules tree here)
 apps/desktop/release-stage/
+apps/desktop/release-stage-arm64/
 apps/desktop/build/bundled-agents/grok/
 apps/desktop/build/bundled-tools/ripgrep/
 apps/desktop/build/native/

--- a/README.md
+++ b/README.md
@@ -4,15 +4,11 @@
 
 An open-source desktop coding agent. Pair it once with Telegram, Discord, Slack, Mattermost, Feishu / Lark, or LINE — then start, resume, steer, and approve from wherever you happen to be reading.
 
-<p>
-  <a href="https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg">
-    <img src="docs/assets/buttons/download-macos.png" alt="Download for macOS" width="440">
-  </a>
-  &nbsp;
-  <a href="https://docs.pwragent.ai">
-    <img src="docs/assets/buttons/read-the-docs.png" alt="Read the docs" width="440">
-  </a>
-</p>
+**[Download for Mac — Apple Silicon](https://github.com/pwrdrvr/PwrAgent/releases/latest)**
+
+Choose the `arm64.dmg` asset when available. Not sure which Mac? Choose Universal.
+
+[macOS Universal (Apple Silicon + Intel)](https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg) · [Windows (x64)](https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-windows-x64-setup.exe) · [Debian/Ubuntu installation](https://docs.pwragent.ai/linux/) · [Read the docs](https://docs.pwragent.ai)
 
 ![PwrAgent desktop in use — Directories lens grouping threads across two repos, a thread mid-conversation, four messenger status icons in the title bar, per-thread model / access / fast-mode / worktree controls above the composer.](https://docs.pwragent.ai/assets/screenshots/desktop-hero.png)
 
@@ -40,7 +36,7 @@ Screenshots are produced by a Playwright spec that drives the real UI surfaces a
 
 ### Just want to use it
 
-1. **Download** [PwrAgent.dmg](https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg). Universal binary — runs natively on Apple Silicon (M1+) and Intel Macs. Developer ID-signed and Apple-notarized, so first launch is a single Gatekeeper prompt (no right-click-open dance).
+1. **Download** the Apple Silicon (`arm64.dmg`) build from the [latest release](https://github.com/pwrdrvr/PwrAgent/releases/latest) when available, or [PwrAgent.dmg](https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent.dmg), the Universal build that runs natively on both Apple Silicon (M1+) and Intel Macs. Developer ID-signed and Apple-notarized, so first launch is a single Gatekeeper prompt (no right-click-open dance).
 2. **Install** by opening the DMG and dragging PwrAgent into Applications.
 3. **(Optional) Pair a messenger** from **Settings → Messaging → \<your platform\>**. End-to-end walkthroughs at **[docs.pwragent.ai/providers/](https://docs.pwragent.ai/providers/)**; the usage guide (bound threads, slash commands, queue/steer, monitor cards, detach) lives at **[docs.pwragent.ai/using-codex/](https://docs.pwragent.ai/using-codex/)**.
 

--- a/apps/desktop/.npmignore
+++ b/apps/desktop/.npmignore
@@ -1,0 +1,4 @@
+# pnpm deploy reads package-local packing rules. Neither the destination nor
+# a previously prepared sibling may become input to another release stage.
+/release-stage/
+/release-stage-arm64/

--- a/apps/desktop/grok-bundle.json
+++ b/apps/desktop/grok-bundle.json
@@ -1,10 +1,11 @@
 {
   "repository": "pwrdrvr/grok-build",
-  "tag": "pwragent-v1.0.0-pwragent.2",
+  "tag": "pwragent-v1.0.24-pwragent.2",
   "assets": {
-    "macos-universal": "pwragent-grok-1.0.0-pwragent.2-macos-universal.tar.gz",
-    "linux-x86_64": "pwragent-grok-1.0.0-pwragent.2-linux-x86_64.tar.gz",
-    "linux-aarch64": "pwragent-grok-1.0.0-pwragent.2-linux-aarch64.tar.gz",
-    "windows-x86_64": "pwragent-grok-1.0.0-pwragent.2-windows-x86_64.zip"
+    "macos-universal": "pwragent-grok-1.0.24-pwragent.2-macos-universal.tar.gz",
+    "linux-x86_64": "pwragent-grok-1.0.24-pwragent.2-linux-x86_64.tar.gz",
+    "linux-aarch64": "pwragent-grok-1.0.24-pwragent.2-linux-aarch64.tar.gz",
+    "windows-x86_64": "pwragent-grok-1.0.24-pwragent.2-windows-x86_64.zip",
+    "macos-aarch64": "pwragent-grok-1.0.24-pwragent.2-macos-aarch64.tar.gz"
   }
 }

--- a/apps/desktop/scripts/assemble-mac-release.mjs
+++ b/apps/desktop/scripts/assemble-mac-release.mjs
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { closeSync, copyFileSync, existsSync, openSync, readFileSync, readSync, statSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { basename, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Use the prepared builder's YAML dependency, including in the signing job
+// where dependency installation is forbidden.
+const require = createRequire(import.meta.url);
+const builderRequire = createRequire(require.resolve("electron-builder/package.json"));
+const libraryRequire = createRequire(builderRequire.resolve("app-builder-lib/package.json"));
+const yaml = libraryRequire("js-yaml");
+
+function digest(path, algorithm, encoding) {
+  const hash = createHash(algorithm);
+  const buffer = Buffer.alloc(1024 * 1024);
+  const descriptor = openSync(path, "r");
+  try {
+    let count;
+    while ((count = readSync(descriptor, buffer)) > 0) {
+      hash.update(buffer.subarray(0, count));
+    }
+    return hash.digest(encoding);
+  } finally {
+    closeSync(descriptor);
+  }
+}
+
+function readTarget(directory, arch) {
+  const info = yaml.load(readFileSync(join(directory, "latest-mac.yml"), "utf8"));
+  if (typeof info?.version !== "string" || !Array.isArray(info.files) || info.files.length !== 1) {
+    throw new Error(`Expected one updater ZIP in ${directory}`);
+  }
+  const file = info.files[0];
+  const expected = `PwrAgent-${info.version}-${arch}-mac.zip`;
+  if (file.url !== expected || basename(file.url) !== file.url) {
+    throw new Error(`Expected ${expected} in ${directory}`);
+  }
+  const zip = join(directory, file.url);
+  if (file.sha512 !== digest(zip, "sha512", "base64") || file.size !== statSync(zip).size) {
+    throw new Error(`Updater hash or size does not match ${zip}`);
+  }
+  for (const name of [`${expected}.blockmap`, `PwrAgent-${info.version}-${arch}.dmg`]) {
+    if (!existsSync(join(directory, name))) throw new Error(`Missing ${name}`);
+  }
+  return info;
+}
+
+export function assembleMacRelease(universalDir, arm64Dir) {
+  const universal = readTarget(universalDir, "universal");
+  const arm64 = readTarget(arm64Dir, "arm64");
+  if (universal.version !== arm64.version) throw new Error("macOS target versions differ");
+  const version = universal.version;
+  const armZip = arm64.files[0].url;
+  for (const name of [armZip, `${armZip}.blockmap`, `PwrAgent-${version}-arm64.dmg`]) {
+    copyFileSync(join(arm64Dir, name), join(universalDir, name));
+  }
+  const aliases = [
+    [`PwrAgent-${version}-universal.dmg`, "PwrAgent.dmg"],
+    [`PwrAgent-${version}-arm64.dmg`, "PwrAgent-arm64.dmg"],
+  ];
+  for (const [source, alias] of aliases) {
+    copyFileSync(join(universalDir, source), join(universalDir, alias));
+  }
+  // Preserve the universal legacy path/hash for older clients. Modern
+  // MacUpdater selects arm64 by URL on Apple Silicon, including Rosetta.
+  const merged = {
+    ...universal,
+    files: [universal.files[0], arm64.files[0]],
+    path: universal.files[0].url,
+    sha512: universal.files[0].sha512,
+  };
+  writeFileSync(join(universalDir, "latest-mac.yml"), yaml.dump(merged));
+  const names = [
+    "latest-mac.yml",
+    ...merged.files.flatMap(({ url }) => [url, `${url}.blockmap`]),
+    ...aliases.flat(),
+  ];
+  writeFileSync(join(universalDir, "PwrAgent-macos-SHA256SUMS"), names.map(
+    (name) => `${digest(join(universalDir, name), "sha256", "hex")}  ${name}\n`,
+  ).join(""));
+  return merged;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [universalDir, arm64Dir] = process.argv.slice(2);
+  if (!universalDir || !arm64Dir) throw new Error("Usage: assemble-mac-release.mjs <universal-dist> <arm64-dist>");
+  assembleMacRelease(universalDir, arm64Dir);
+  console.log("Verified and assembled universal + arm64 macOS release payload");
+}

--- a/apps/desktop/scripts/assemble-mac-release.test.mjs
+++ b/apps/desktop/scripts/assemble-mac-release.test.mjs
@@ -1,0 +1,69 @@
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createRequire } from "node:module";
+import { afterEach, describe, expect, it } from "vitest";
+import { assembleMacRelease } from "./assemble-mac-release.mjs";
+
+const require = createRequire(import.meta.url);
+const { MacUpdater } = require("electron-updater/out/MacUpdater.js");
+const roots = [];
+
+function fixture() {
+  const root = mkdtempSync(join(tmpdir(), "pwragent-mac-release-"));
+  roots.push(root);
+  const directories = ["universal", "arm64"].map((arch) => {
+    const directory = join(root, arch);
+    mkdirSync(directory);
+    const url = `PwrAgent-1.2.0-${arch}-mac.zip`;
+    const bytes = Buffer.from(`ZIP fixture ${arch}`);
+    writeFileSync(join(directory, url), bytes);
+    writeFileSync(join(directory, `${url}.blockmap`), "blockmap fixture");
+    writeFileSync(join(directory, `PwrAgent-1.2.0-${arch}.dmg`), `DMG ${arch}`);
+    writeFileSync(join(directory, "latest-mac.yml"), JSON.stringify({
+      version: "1.2.0",
+      files: [{ url, size: bytes.length, sha512: createHash("sha512").update(bytes).digest("base64") }],
+    }));
+    return directory;
+  });
+  return directories;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("paired macOS release assembly", () => {
+  it("preserves legacy universal routing and selects arm64 only on Apple Silicon", () => {
+    const dirs = fixture();
+    const info = assembleMacRelease(...dirs);
+    expect(info.path).toBe("PwrAgent-1.2.0-universal-mac.zip");
+    expect(info.sha512).toBe(info.files[0].sha512);
+    const resolved = info.files.map((file) => ({ info: file, url: new URL(file.url, "https://example.test/") }));
+    expect(MacUpdater.filterFilesForArch(resolved, true)).toEqual([resolved[1]]);
+    expect(MacUpdater.filterFilesForArch(resolved, false)).toEqual([resolved[0]]);
+    expect(MacUpdater.filterFilesForArch([resolved[0]], true)).toEqual([resolved[0]]);
+    expect(readFileSync(join(dirs[0], "PwrAgent.dmg"), "utf8")).toBe("DMG universal");
+    expect(readFileSync(join(dirs[0], "PwrAgent-arm64.dmg"), "utf8")).toBe("DMG arm64");
+    expect(readFileSync(join(dirs[0], "PwrAgent-macos-SHA256SUMS"), "utf8").trim().split("\n")).toHaveLength(9);
+  });
+
+  it("rejects a corrupted ZIP before merging or publishing metadata", () => {
+    const dirs = fixture();
+    writeFileSync(join(dirs[1], "PwrAgent-1.2.0-arm64-mac.zip"), "corrupt");
+    expect(() => assembleMacRelease(...dirs)).toThrow("hash or size");
+  });
+
+  it("rejects missing blockmaps", () => {
+    const dirs = fixture();
+    rmSync(join(dirs[1], "PwrAgent-1.2.0-arm64-mac.zip.blockmap"));
+    expect(() => assembleMacRelease(...dirs)).toThrow("Missing");
+  });
+
+  it("rejects cross-architecture file names", () => {
+    const dirs = fixture();
+    writeFileSync(join(dirs[1], "latest-mac.yml"), readFileSync(join(dirs[0], "latest-mac.yml")));
+    expect(() => assembleMacRelease(...dirs)).toThrow("Expected PwrAgent-1.2.0-arm64-mac.zip");
+  });
+});

--- a/apps/desktop/scripts/build-dock-tile-plugin.mjs
+++ b/apps/desktop/scripts/build-dock-tile-plugin.mjs
@@ -32,6 +32,10 @@ rmSync(outputBundle, { force: true, recursive: true });
 mkdirSync(executableDir, { recursive: true });
 copyFileSync(join(sourceRoot, "Info.plist"), join(contentsDir, "Info.plist"));
 
+const macArch = process.env.PWRAGENT_MAC_ARCH ?? "universal";
+if (!["universal", "arm64"].includes(macArch)) {
+  throw new Error("PWRAGENT_MAC_ARCH must be universal or arm64");
+}
 const compile = spawnSync(
   "xcrun",
   [
@@ -41,8 +45,7 @@ const compile = spawnSync(
     "-bundle",
     "-arch",
     "arm64",
-    "-arch",
-    "x86_64",
+    ...(macArch === "universal" ? ["-arch", "x86_64"] : []),
     "-mmacosx-version-min=12.0",
     "-framework",
     "AppKit",
@@ -72,5 +75,5 @@ if (sign.status !== 0) {
 }
 
 console.log(
-  `[build-dock-tile-plugin] universal bundle → ${outputBundle}`,
+  `[build-dock-tile-plugin] ${macArch} bundle → ${outputBundle}`,
 );

--- a/apps/desktop/scripts/release-deploy-isolation.test.mjs
+++ b/apps/desktop/scripts/release-deploy-isolation.test.mjs
@@ -1,0 +1,57 @@
+import { spawnSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "vitest";
+
+it("keeps both release stages out of repeated paired pnpm deployments", () => {
+  const pnpmCli = process.env.npm_execpath;
+  if (!pnpmCli || !/pnpm\.(?:c?js|mjs)$/.test(pnpmCli)) {
+    throw new Error("Run deployment isolation tests through pnpm test");
+  }
+  const root = mkdtempSync(join(tmpdir(), "pwragent-deploy-isolation-"));
+  try {
+    const desktop = join(root, "desktop");
+    mkdirSync(desktop);
+    writeFileSync(join(root, "package.json"), JSON.stringify({ private: true }));
+    writeFileSync(join(root, "pnpm-workspace.yaml"), "packages:\n  - desktop\n");
+    writeFileSync(join(desktop, "package.json"), JSON.stringify({
+      name: "deploy-isolation-fixture",
+      version: "1.0.0",
+      private: true,
+    }));
+    cpSync(fileURLToPath(new URL("../.npmignore", import.meta.url)), join(desktop, ".npmignore"));
+    writeFileSync(join(desktop, "runtime.js"), "export const ready = true;\n");
+    const stages = ["release-stage", "release-stage-arm64"];
+    for (const stage of stages) {
+      mkdirSync(join(desktop, stage));
+      writeFileSync(join(desktop, stage, "previous-build.txt"), "must not be deployed");
+    }
+
+    // Both preparation orders matter: the universal stage exists before the
+    // arm64 stage in CI, and the arm64 stage survives into the next build.
+    for (const stage of [...stages, ...stages]) {
+      const target = join(desktop, stage);
+      rmSync(target, { recursive: true, force: true });
+      // Run the pinned pnpm JS entry directly; no Windows .cmd shell handoff.
+      const result = spawnSync(process.execPath, [
+        pnpmCli,
+        "--filter", "deploy-isolation-fixture", "deploy", "--legacy",
+        "--prod", "--offline", "--ignore-scripts", target,
+      ], {
+        cwd: root,
+        encoding: "utf8",
+        timeout: 30_000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(join(target, "runtime.js"), "utf8")).toContain("ready = true");
+      for (const sibling of stages) {
+        expect(existsSync(join(target, sibling))).toBe(false);
+      }
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/apps/desktop/scripts/release.mjs
+++ b/apps/desktop/scripts/release.mjs
@@ -18,6 +18,7 @@
  *                       package/sign an already prepared release-stage without
  *                       reinstalling dependencies or rerunning tests. Defaults
  *                       to macOS; combine with --win for Windows NSIS.
+ *       --mac-arch=arm64: use an isolated Apple Silicon stage (default: universal)
  *       --linux       : build/package a Linux .deb for the current native
  *                       architecture (or PWRAGENT_LINUX_ARCH=x64|arm64)
  *       --win         : build/package a Windows x64 NSIS installer (unsigned
@@ -60,7 +61,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const desktopRoot = resolve(__dirname, "..");
 const repoRoot = resolve(desktopRoot, "..", "..");
-const stageDir = join(desktopRoot, "release-stage");
 let codesignKeychainCleanup = null;
 const MAC_CANVAS_BINDINGS = [
   {
@@ -82,6 +82,25 @@ const prepareOnly = args.includes("--prepare-only");
 const signStageOnly = args.includes("--sign-stage-only");
 const linux = args.includes("--linux");
 const win = args.includes("--win");
+const macArch = args.find((arg) => arg.startsWith("--mac-arch="))?.split("=")[1] ?? "universal";
+if (!["universal", "arm64"].includes(macArch) || ((linux || win) && macArch !== "universal")) {
+  throw new Error("--mac-arch must be universal or arm64 and is only valid for macOS");
+}
+const stageDir = join(desktopRoot, macArch === "arm64" ? "release-stage-arm64" : "release-stage");
+const macCanvasBindings = MAC_CANVAS_BINDINGS.filter(
+  ({ lipoArch }) => macArch === "universal" || lipoArch === "arm64",
+);
+const macSlices = macArch === "universal" ? ["x86_64", "arm64"] : ["arm64"];
+
+function verifyMacSlices(file, allowUniversal = false) {
+  const actual = runQuiet("lipo", ["-archs", file]).trim().split(/\s+/).sort();
+  const expected = [...macSlices].sort();
+  const universalFallback = allowUniversal && actual.join(",") === "arm64,x86_64";
+  if (actual.join(",") !== expected.join(",") && !universalFallback) {
+    throw new Error(`Unexpected architectures in ${file}: ${actual.join(", ")}; expected ${expected.join(", ")}`);
+  }
+}
+
 // Release builds pass this so an unsigned Windows installer can never ship
 // unnoticed; local/sandbox/PR builds omit it and stay unsigned. See the `win`
 // branch below and docs/desktop-windows-signing.md.
@@ -464,7 +483,7 @@ function verifyWindowsCanvasBindingInStage() {
 }
 
 function verifyMacCanvasBindingsInStage() {
-  for (const { binding, packageName } of MAC_CANVAS_BINDINGS) {
+  for (const { binding, packageName } of macCanvasBindings) {
     const bindingPath = join(
       stageDir,
       "node_modules",
@@ -479,7 +498,13 @@ function verifyMacCanvasBindingsInStage() {
       );
     }
   }
-  console.log("  verified arm64 and x64 canvas native bindings in release-stage");
+  if (macArch === "arm64") {
+    const unwanted = join(stageDir, "node_modules", "@napi-rs", "canvas-darwin-x64");
+    if (existsSync(unwanted)) {
+      throw new Error("arm64 release stage unexpectedly contains Intel canvas");
+    }
+  }
+  console.log(`  verified ${macArch} canvas native bindings in release-stage`);
 }
 
 function stageDesktopVersion() {
@@ -540,7 +565,7 @@ function ripgrepBundlePlatform() {
       ? "linux-aarch64"
       : "linux-x86_64";
   }
-  return "macos-universal";
+  return macArch === "arm64" ? "macos-arm64" : "macos-universal";
 }
 
 function assertRequiredRipgrepBundle() {
@@ -844,7 +869,7 @@ if (!signStageOnly) {
     runChecked(
       "pnpm",
       ["--filter", "@pwragent/desktop", "build:native:dock"],
-      { cwd: repoRoot },
+      { cwd: repoRoot, env: { PWRAGENT_MAC_ARCH: macArch } },
     );
   }
 
@@ -856,7 +881,7 @@ if (!signStageOnly) {
   // boundary.
   const deployArgs = [
     ...(!linux && !win
-      ? ["--cpu=x64", "--cpu=arm64", "--os=darwin"]
+      ? [...(macArch === "universal" ? ["--cpu=x64"] : []), "--cpu=arm64", "--os=darwin"]
       : []),
     "deploy",
     "--filter",
@@ -953,7 +978,7 @@ if (win) {
   step(`electron-builder --linux deb --${linuxArch} (no builder publish)`);
   builderArgs.push("--linux", "deb", `--${linuxArch}`, "--publish=never");
 } else {
-  step(`electron-builder --mac --universal (${publish ? "publish" : "no publish"}, ${dryrun ? "ad-hoc signed" : "signed"})`);
+  step(`electron-builder --mac --${macArch} (${publish ? "publish" : "no publish"}, ${dryrun ? "ad-hoc signed" : "signed"})`);
   maybeDecodeAppleApiKey();
   if (!dryrun) {
     maybeDecodeCscLink();
@@ -962,7 +987,7 @@ if (win) {
       console.log("  using preloaded Developer ID keychain for electron-builder signing");
     }
   }
-  builderArgs.push("--mac", "--universal");
+  builderArgs.push("--mac", "dmg", "zip", `--${macArch}`);
   if (dryrun) {
     // Use ad-hoc signing (identity=-) instead of no signing (identity=null).
     // electron-builder modifies the Electron binary to set fuses, which
@@ -1059,7 +1084,7 @@ if (linux) {
   process.exit(0);
 }
 
-const builtApp = join(dist, "mac-universal", "PwrAgent.app");
+const builtApp = join(dist, `mac-${macArch}`, "PwrAgent.app");
 const dockTilePlugin = join(
   builtApp,
   "Contents",
@@ -1073,19 +1098,9 @@ const dockTilePluginExecutable = join(
   "PwrAgentDockTilePlugin",
 );
 
-step("verify universal binary slices");
-runChecked("lipo", [
-  join(builtApp, "Contents", "MacOS", "PwrAgent"),
-  "-verify_arch",
-  "x86_64",
-  "arm64",
-]);
-runChecked("lipo", [
-  dockTilePluginExecutable,
-  "-verify_arch",
-  "x86_64",
-  "arm64",
-]);
+step(`verify ${macArch} binary slices`);
+verifyMacSlices(join(builtApp, "Contents", "MacOS", "PwrAgent"));
+verifyMacSlices(dockTilePluginExecutable);
 runChecked("plutil", [
   "-lint",
   join(dockTilePlugin, "Contents", "Info.plist"),
@@ -1096,23 +1111,11 @@ runChecked("codesign", [
   "--verbose=2",
   dockTilePlugin,
 ]);
-runChecked("lipo", [
-  join(
-    builtApp,
-    "Contents",
-    "Resources",
-    "app.asar.unpacked",
-    "node_modules",
-    "better-sqlite3",
-    "build",
-    "Release",
-    "better_sqlite3.node",
-  ),
-  "-verify_arch",
-  "x86_64",
-  "arm64",
-]);
-for (const { binding, lipoArch, packageName } of MAC_CANVAS_BINDINGS) {
+verifyMacSlices(join(
+  builtApp, "Contents", "Resources", "app.asar.unpacked", "node_modules",
+  "better-sqlite3", "build", "Release", "better_sqlite3.node",
+));
+for (const { binding, lipoArch, packageName } of macCanvasBindings) {
   runChecked("lipo", [
     join(
       builtApp,
@@ -1133,23 +1136,21 @@ const bundledGrokExecutable = verifyPackagedGrok(
   join(builtApp, "Contents", "Resources"),
 );
 if (bundledGrokExecutable) {
-  runChecked("lipo", [
-    bundledGrokExecutable,
-    "-verify_arch",
-    "x86_64",
-    "arm64",
-  ]);
+  // Until the pinned Grok release supplies arm64, its verified universal
+  // runtime remains a compatible fallback inside the Apple Silicon app.
+  verifyMacSlices(bundledGrokExecutable, macArch === "arm64");
 }
 
 const bundledRipgrepExecutable = verifyPackagedRipgrep(
   join(builtApp, "Contents", "Resources"),
 );
-runChecked("lipo", [
-  bundledRipgrepExecutable,
-  "-verify_arch",
-  "x86_64",
-  "arm64",
-]);
+verifyMacSlices(bundledRipgrepExecutable);
+if (macArch === "arm64" && existsSync(join(
+  builtApp, "Contents", "Resources", "app.asar.unpacked", "node_modules",
+  "@napi-rs", "canvas-darwin-x64",
+))) {
+  throw new Error("Apple Silicon app contains Intel canvas");
+}
 
 step("verify packaged asar contents");
 runChecked("node", [join(desktopRoot, "scripts", "verify-asar-contents.mjs"), builtApp]);

--- a/apps/desktop/scripts/stage-grok-bundle.mjs
+++ b/apps/desktop/scripts/stage-grok-bundle.mjs
@@ -110,6 +110,42 @@ function validateExtractedBundle(directory) {
   }
 }
 
+// Asset absence is compatible with old pinned releases. A published asset
+// with missing/bad checksum metadata is an incomplete release, never fallback.
+export function selectGrokBundleAsset(manifest, platform, checksumText, assetNames = []) {
+  const preferred = manifest.assets[platform];
+  let selected = preferred;
+  if (platform === "macos-aarch64") {
+    const candidate = preferred ?? manifest.assets["macos-universal"]?.replace(
+      "-macos-universal.tar.gz", "-macos-aarch64.tar.gz",
+    );
+    selected = assetNames.includes(candidate) ? candidate : manifest.assets["macos-universal"];
+  }
+  if (typeof selected !== "string" || !selected) {
+    throw new Error(`No Grok bundle asset is configured for ${platform}`);
+  }
+  expectedChecksum(checksumText, selected);
+  return selected;
+}
+
+async function publishedAssetNames(manifest) {
+  const token = process.env.GH_TOKEN || process.env.GITHUB_TOKEN;
+  const response = await fetch(
+    `https://api.github.com/repos/${manifest.repository}/releases/tags/${encodeURIComponent(manifest.tag)}`,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "PwrAgent-release-packager",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    },
+  );
+  if (!response.ok) throw new Error(`Cannot inspect pinned Grok release (${response.status})`);
+  const release = await response.json();
+  if (!Array.isArray(release.assets)) throw new Error("Pinned Grok release has no asset list");
+  return release.assets.filter((asset) => asset.state !== "deleted").map((asset) => asset.name);
+}
+
 async function main() {
   const platform = readArgument("--platform");
   if (!platform) {
@@ -117,21 +153,20 @@ async function main() {
   }
 
   const manifest = readManifest();
-  const assetName = manifest.assets[platform];
-  if (typeof assetName !== "string" || !assetName) {
-    throw new Error(`No Grok bundle asset is configured for ${platform}`);
-  }
-
   const releaseBase =
     `https://github.com/${manifest.repository}/releases/download/${manifest.tag}`;
   const tempRoot = mkdtempSync(join(tmpdir(), "pwragent-grok-bundle-"));
   try {
     const checksumPath = join(tempRoot, "SHA256SUMS");
+    await download(`${releaseBase}/SHA256SUMS`, checksumPath);
+    const checksumText = readFileSync(checksumPath, "utf8");
+    const assetNames = platform === "macos-aarch64" ? await publishedAssetNames(manifest) : [];
+    const assetName = selectGrokBundleAsset(manifest, platform, checksumText, assetNames);
+    if (platform === "macos-aarch64" && assetName === manifest.assets["macos-universal"]) {
+      console.log("Pinned Grok release has no arm64 asset; using verified universal runtime");
+    }
     const archivePath = join(tempRoot, assetName);
-    await Promise.all([
-      download(`${releaseBase}/SHA256SUMS`, checksumPath),
-      download(`${releaseBase}/${assetName}`, archivePath),
-    ]);
+    await download(`${releaseBase}/${assetName}`, archivePath);
 
     const expected = expectedChecksum(
       readFileSync(checksumPath, "utf8"),
@@ -147,6 +182,14 @@ async function main() {
     const extractedRoot = join(tempRoot, "extracted");
     extractArchive(archivePath, extractedRoot);
     validateExtractedBundle(extractedRoot);
+    if (platform.startsWith("macos-")) {
+      const expectedArchs = assetName.endsWith("-macos-aarch64.tar.gz")
+        ? "arm64" : "arm64,x86_64";
+      const probe = spawnSync("lipo", ["-archs", join(extractedRoot, "grok")], { encoding: "utf8" });
+      if (probe.status !== 0 || probe.stdout.trim().split(/\s+/).sort().join(",") !== expectedArchs) {
+        throw new Error(`Grok asset ${assetName} must contain ${expectedArchs}`);
+      }
+    }
 
     rmSync(outputRoot, { recursive: true, force: true });
     cpSync(extractedRoot, outputRoot, { recursive: true });
@@ -169,4 +212,6 @@ async function main() {
   }
 }
 
-await main();
+if (process.argv[1] && resolve(process.argv[1]) === scriptPath) {
+  await main();
+}

--- a/apps/desktop/scripts/stage-grok-bundle.test.mjs
+++ b/apps/desktop/scripts/stage-grok-bundle.test.mjs
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { selectGrokBundleAsset } from "./stage-grok-bundle.mjs";
+
+const universal = "pwragent-grok-1.0.0-pwragent.2-macos-universal.tar.gz";
+const arm64 = universal.replace("macos-universal", "macos-aarch64");
+const manifest = { assets: { "macos-universal": universal } };
+const checksum = (name) => `${"a".repeat(64)}  ${name}\n`;
+
+describe("Grok arm64 availability", () => {
+  it("keeps old pinned releases usable with universal Grok", () => {
+    expect(selectGrokBundleAsset(manifest, "macos-aarch64", checksum(universal))).toBe(universal);
+  });
+  it("selects arm64 only when the exact pinned release asset exists", () => {
+    expect(selectGrokBundleAsset(manifest, "macos-aarch64", checksum(universal) + checksum(arm64), [universal, arm64])).toBe(arm64);
+    expect(selectGrokBundleAsset(manifest, "macos-aarch64", checksum(universal) + checksum(arm64), [universal])).toBe(universal);
+  });
+  it("fails when an existing arm64 asset has missing or malformed checksum metadata", () => {
+    expect(() => selectGrokBundleAsset(manifest, "macos-aarch64", checksum(universal), [universal, arm64])).toThrow("SHA256SUMS does not contain");
+    expect(() => selectGrokBundleAsset(manifest, "macos-aarch64", checksum(universal) + `bad  ${arm64}\n`, [universal, arm64])).toThrow("SHA256SUMS does not contain");
+  });
+  it("does not mistake another version's asset for the pinned one", () => {
+    expect(selectGrokBundleAsset(manifest, "macos-aarch64", checksum(universal), [arm64.replace(".2-", ".3-")])).toBe(universal);
+  });
+  it("preserves universal selection even when arm64 is available", () => {
+    expect(selectGrokBundleAsset(manifest, "macos-universal", checksum(universal) + checksum(arm64), [universal, arm64])).toBe(universal);
+  });
+});

--- a/apps/desktop/scripts/stage-ripgrep-bundle.mjs
+++ b/apps/desktop/scripts/stage-ripgrep-bundle.mjs
@@ -158,19 +158,10 @@ function cachedBundleMatches(manifest, requestedPlatform, assetPlatforms) {
   if (!existsSync(metadataPath)) return false;
   try {
     const metadata = JSON.parse(readFileSync(metadataPath, "utf8"));
-    const platformMatches = metadata.platform === requestedPlatform
-      || (
-        requestedPlatform.startsWith("macos-")
-        && requestedPlatform !== "macos-universal"
-        && metadata.platform === "macos-universal"
-      );
+    const platformMatches = metadata.platform === requestedPlatform;
     const expectedAssets = assetPlatforms.map((platform) => manifest.assets[platform]);
     const cachedAssets = metadata.assets?.map(({ asset }) => asset);
-    const assetsMatch = metadata.platform === "macos-universal"
-      && requestedPlatform.startsWith("macos-")
-      && requestedPlatform !== "macos-universal"
-      ? expectedAssets.every((asset) => cachedAssets?.includes(asset))
-      : JSON.stringify(cachedAssets) === JSON.stringify(expectedAssets);
+    const assetsMatch = JSON.stringify(cachedAssets) === JSON.stringify(expectedAssets);
     if (
       metadata.repository !== manifest.repository
       || metadata.tag !== manifest.tag

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -79,8 +79,28 @@ This build retained universal Grok from the existing pin. The arm64 package
 contained only the arm64 canvas binding. Both dry-run packages, archive
 assembly, and merged updater metadata passed. The new upstream arm64 Grok
 package is tracked in [grok-build PR #13](https://github.com/pwrdrvr/grok-build/pull/13);
-its signed release must exist before updating the pin to realize further
-savings. These are unsigned rehearsal sizes, not signed-release measurements.
+the signed `pwragent-v1.0.24-pwragent.2` release now supplies that asset and
+`grok-bundle.json` pins it for all platforms. Its arm64 archive is 70,436,351
+bytes versus 145,538,128 bytes for universal. The checksum, arm64-only Mach-O
+and PwrDrvr Developer ID signature were verified before packaging. The table
+above records the earlier universal-Grok fallback rehearsal, not this new pin
+or signed-release measurements.
+
+With the new Grok pin, a second paired dry-run build measured:
+
+| Output | Universal bytes | Apple Silicon bytes | Reduction |
+|---|---:|---:|---:|
+| Installed regular files, excluding symlinks | 1,042,140,897 | 588,902,297 | 43.49% |
+| Updater ZIP | 389,852,650 | 210,232,734 | 46.07% |
+| DMG | 402,947,119 | 217,516,484 | 46.02% |
+
+Packaged Grok reports `1.0.24-pwragent.2` in both targets. Its arm64 executable
+is 182,241,968 bytes and arm64-only; the universal executable is 377,047,728
+bytes with both slices. Both embedded provenance manifests reference the new
+pin and expected asset hashes. Upstream Developer ID verification, both
+package commands, merged updater assembly, and all assembled SHA256SUMS
+entries passed. These app builds used ad-hoc dry-run signing; protected app
+signing/notarization and real update/relaunch smoke tests remain required.
 
 ## One-time setup
 

--- a/docs/desktop-release-runbook.md
+++ b/docs/desktop-release-runbook.md
@@ -3,12 +3,84 @@
 > MIT-licensed desktop release pipeline.
 
 This runbook covers cutting v1.x desktop releases. macOS releases ship as
-universal Apple Silicon + Intel binaries; distribution is outside the Mac App
+Apple Silicon (arm64) and universal Apple Silicon + Intel binaries; distribution is outside the Mac App
 Store via signed/notarized DMG with auto-update through `electron-updater`
 against GitHub Releases on `pwrdrvr/PwrAgent`. Linux releases ship as manual
 Debian packages for x64/amd64 and arm64.
 
 ---
+
+## macOS architecture contract
+
+`release.mjs` defaults to universal, preserving local and preview workflows.
+Pass `--mac-arch=arm64` to prepare/package the Apple Silicon build. Its stage
+is `apps/desktop/release-stage-arm64/`; universal remains `release-stage/`.
+CI prepares both before the protected signing job and signs/notarizes each.
+The Dock plug-in, Electron, SQLite, node-pty, canvas and ripgrep use the target
+architecture. Universal keeps both canvas platform packages; arm64 omits Intel.
+
+Stage Grok with `stage-grok-bundle.mjs --platform macos-aarch64` before preparing
+arm64. If the pinned release's asset list includes the corresponding
+`-macos-aarch64.tar.gz`, staging requires its SHA256SUMS entry, downloads and
+verifies it. An absent asset uses that same pinned release's universal asset.
+A present asset with a missing/bad checksum fails. API, download, checksum or
+architecture failures do not trigger fallback. No runtime version floats to latest: a newly
+published Grok release becomes available by updating `grok-bundle.json`'s pin.
+This fallback intentionally leaves universal Grok inside an arm64 app until
+upstream supplies the smaller signed artifact. Managed Grok updates remain
+universal for now; this change only selects the runtime bundled in the app.
+
+After both package commands, run:
+
+```bash
+node apps/desktop/scripts/assemble-mac-release.mjs \
+  apps/desktop/release-stage/dist apps/desktop/release-stage-arm64/dist
+```
+
+Assembly checks each ZIP's SHA-512, size, version and architecture-specific
+name, requires both blockmaps and DMGs, and writes one `latest-mac.yml` into
+the universal dist. Its `files` contains universal then arm64; legacy `path`
+and `sha512` still describe universal. Do not upload the arm64 stage's manifest
+separately. Both ZIPs retain their own `.blockmap`. The macOS checksum manifest
+is `PwrAgent-macos-SHA256SUMS`, including both stable DMG aliases.
+
+Keep existing versioned universal names and the `PwrAgent.dmg` alias forever.
+New names are `PwrAgent-${version}-arm64.dmg`,
+`PwrAgent-${version}-arm64-mac.zip`, and `PwrAgent-arm64.dmg`.
+The pinned electron-updater 6.8.9 chooses arm64 ZIPs on Apple Silicon (including
+Rosetta) and universal ZIPs on Intel from the existing `latest-mac.yml` URL.
+Older universal-only release feeds remain usable. Allow a full ZIP download
+on the first architecture transition because an older arm64 blockmap may not
+exist. Verify signed upgrade/relaunch on Apple Silicon, Rosetta and Intel
+before promoting the first paired release; unit routing checks do not prove
+Squirrel installation or notarization succeeds.
+
+Before promotion, confirm both targets and aliases are attached. The README's
+Apple Silicon link uses the latest release page during rollout so it does not
+point at an absent stable alias. Once the first paired stable release is
+promoted, it can link directly to `releases/latest/download/PwrAgent-arm64.dmg`.
+The website change belongs in `pwrdrvr/pwragent.ai`: add both choices and use
+high-entropy architecture hints only when available, with universal as the
+unknown/no-JavaScript fallback. Do not infer architecture from “Intel Mac OS X”
+in the UA string. Keep separate size badges for each artifact.
+
+### Paired build size baseline
+
+The 2026-09-11 unsigned alpha.5 build rehearsal (same source for both targets,
+including PR #2069's SQLite source exclusion) measured:
+
+| Output | Universal bytes | Apple Silicon bytes | Reduction |
+|---|---:|---:|---:|
+| Installed regular files, excluding symlinks | 1,011,399,701 | 752,966,865 | 25.55% |
+| Updater ZIP | 377,064,050 | 269,880,597 | 28.43% |
+| DMG | 389,834,137 | 279,235,131 | 28.37% |
+
+This build retained universal Grok from the existing pin. The arm64 package
+contained only the arm64 canvas binding. Both dry-run packages, archive
+assembly, and merged updater metadata passed. The new upstream arm64 Grok
+package is tracked in [grok-build PR #13](https://github.com/pwrdrvr/grok-build/pull/13);
+its signed release must exist before updating the pin to realize further
+savings. These are unsigned rehearsal sizes, not signed-release measurements.
 
 ## One-time setup
 
@@ -147,7 +219,7 @@ git tag -s v1.0.0-alpha.7 -m "v1.0.0-alpha.7"
 git push origin v1.0.0-alpha.7
 ```
 
-The `Release Desktop (macOS universal + Windows + Linux DEB)` workflow contains
+The `Release Desktop (macOS universal + arm64 + Windows + Linux DEB)` workflow contains
 seven job definitions (the Linux package job fans out across two architectures):
 
 1. `Test and prepare signing input`, with `contents: read`, explicit
@@ -233,8 +305,9 @@ The macOS environment-gated signing job:
    notarization service via `notarytool`, staples the ticket, builds the DMG
    and universal updater ZIP, and generates `latest-mac.yml` without creating
    a GitHub Release.
-6. Prepares the stable-name `PwrAgent.dmg` alias and transfers the signed
-   macOS assets to the all-platform publishing job.
+6. Repeats packaging for the separately prepared arm64 stage, merges updater
+   metadata, prepares `PwrAgent.dmg` (universal) and `PwrAgent-arm64.dmg`,
+   and transfers both signed targets to the all-platform publishing job.
 
 The all-platform publishing job creates the GitHub Release only after the
 signed macOS, Windows, and Linux payloads are all available. It uploads the

--- a/docs/plans/2026-09-11-apple-silicon-distribution-evidence.json
+++ b/docs/plans/2026-09-11-apple-silicon-distribution-evidence.json
@@ -1,0 +1,465 @@
+{
+  "measured_date": "2026-09-11",
+  "repository_commit": "592efcd90557dd6ad02149e117a38ab90e9a214a",
+  "installed_application": "/Applications/PwrAgent.app",
+  "installed_version": "1.1.0-alpha.4",
+  "installed_electron_updater": "6.8.9",
+  "units": "bytes (decimal MB = bytes / 1000000)",
+  "method": {
+    "files": "Regular files only; do not follow symlinks. All other files retained unchanged.",
+    "arm64_projection": "Parse big-endian FAT_MAGIC/FAT_MAGIC_64 architecture records; use CPU_TYPE_ARM64 slice offset and length. Omit paths containing canvas-darwin-x64/.",
+    "compression": "Independent raw DEFLATE streams per file, level 6; compare whole file and projected slice. Sum compressed stream lengths, excluding archive headers and symlinks.",
+    "zlib_version": "1.2.12",
+    "python_version": "3.14.7",
+    "limitation": "Projection only. No signed app or actual release archive generated; no credit for SQLite source removal."
+  },
+  "totals": {
+    "bytes": 1021285004,
+    "arm64_bytes": 584778028,
+    "deflate_bytes": 393003210,
+    "arm64_deflate_bytes": 214139310
+  },
+  "published_alpha4": {
+    "universal_zip": 379597882,
+    "zip_blockmap": 398775,
+    "universal_dmg": 393047867
+  },
+  "changed_files": [
+    {
+      "path": "Contents/MacOS/PwrAgent",
+      "bytes": 118768,
+      "arm64_bytes": 53232,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 32800
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 65536,
+          "bytes": 53232
+        }
+      ],
+      "arm64_offset": 65536,
+      "deflate_bytes": 14513,
+      "arm64_deflate_bytes": 7222
+    },
+    {
+      "path": "Contents/PlugIns/PwrAgentDockTilePlugin.plugin/Contents/MacOS/PwrAgentDockTilePlugin",
+      "bytes": 141168,
+      "arm64_bytes": 75632,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 44608
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 65536,
+          "bytes": 75632
+        }
+      ],
+      "arm64_offset": 65536,
+      "deflate_bytes": 26139,
+      "arm64_deflate_bytes": 13391
+    },
+    {
+      "path": "Contents/Resources/tools/rg",
+      "bytes": 8483520,
+      "arm64_bytes": 4010688,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 4440864
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 4472832,
+          "bytes": 4010688
+        }
+      ],
+      "arm64_offset": 4472832,
+      "deflate_bytes": 3469061,
+      "arm64_deflate_bytes": 1652875
+    },
+    {
+      "path": "Contents/Resources/agents/grok/grok",
+      "bytes": 346308896,
+      "arm64_bytes": 167526688,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 178764096
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 178782208,
+          "bytes": 167526688
+        }
+      ],
+      "arm64_offset": 178782208,
+      "deflate_bytes": 131262907,
+      "arm64_deflate_bytes": 63050708
+    },
+    {
+      "path": "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/pty.node",
+      "bytes": 224400,
+      "arm64_bytes": 109712,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 87136
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 114688,
+          "bytes": 109712
+        }
+      ],
+      "arm64_offset": 114688,
+      "deflate_bytes": 55831,
+      "arm64_deflate_bytes": 26392
+    },
+    {
+      "path": "Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper",
+      "bytes": 119344,
+      "arm64_bytes": 70192,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 29440
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 49152,
+          "bytes": 70192
+        }
+      ],
+      "arm64_offset": 49152,
+      "deflate_bytes": 15203,
+      "arm64_deflate_bytes": 7567
+    },
+    {
+      "path": "Contents/Resources/app.asar.unpacked/node_modules/@napi-rs/canvas-darwin-x64/skia.darwin-x64.node",
+      "bytes": 32558848,
+      "arm64_bytes": 0,
+      "slices": [],
+      "deflate_bytes": 13525331,
+      "arm64_deflate_bytes": 0
+    },
+    {
+      "path": "Contents/Resources/app.asar.unpacked/node_modules/@napi-rs/canvas-darwin-x64/package.json",
+      "bytes": 608,
+      "arm64_bytes": 0,
+      "slices": [],
+      "deflate_bytes": 301,
+      "arm64_deflate_bytes": 0
+    },
+    {
+      "path": "Contents/Resources/app.asar.unpacked/node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+      "bytes": 3941088,
+      "arm64_bytes": 1942240,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 1973088
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 1998848,
+          "bytes": 1942240
+        }
+      ],
+      "arm64_offset": 1998848,
+      "deflate_bytes": 1989091,
+      "arm64_deflate_bytes": 947137
+    },
+    {
+      "path": "Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework",
+      "bytes": 377834256,
+      "arm64_bytes": 178129680,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 199675008
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 199704576,
+          "bytes": 178129680
+        }
+      ],
+      "arm64_offset": 199704576,
+      "deflate_bytes": 160683934,
+      "arm64_deflate_bytes": 73914795
+    },
+    {
+      "path": "Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libEGL.dylib",
+      "bytes": 207968,
+      "arm64_bytes": 109664,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 77200
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 98304,
+          "bytes": 109664
+        }
+      ],
+      "arm64_offset": 98304,
+      "deflate_bytes": 50418,
+      "arm64_deflate_bytes": 23887
+    },
+    {
+      "path": "Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libvk_swiftshader.dylib",
+      "bytes": 21329648,
+      "arm64_bytes": 16611056,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 4687776
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 4718592,
+          "bytes": 16611056
+        }
+      ],
+      "arm64_offset": 4718592,
+      "deflate_bytes": 8376358,
+      "arm64_deflate_bytes": 6522698
+    },
+    {
+      "path": "Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libGLESv2.dylib",
+      "bytes": 14699088,
+      "arm64_bytes": 6834768,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 7836672
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 7864320,
+          "bytes": 6834768
+        }
+      ],
+      "arm64_offset": 7864320,
+      "deflate_bytes": 5807484,
+      "arm64_deflate_bytes": 2692689
+    },
+    {
+      "path": "Contents/Frameworks/Electron Framework.framework/Versions/A/Libraries/libffmpeg.dylib",
+      "bytes": 4758000,
+      "arm64_bytes": 2218480,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 2514000
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 2539520,
+          "bytes": 2218480
+        }
+      ],
+      "arm64_offset": 2539520,
+      "deflate_bytes": 2063723,
+      "arm64_deflate_bytes": 976771
+    },
+    {
+      "path": "Contents/Frameworks/Electron Framework.framework/Versions/A/Helpers/chrome_crashpad_handler",
+      "bytes": 3091824,
+      "arm64_bytes": 1502576,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 1556880
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 1589248,
+          "bytes": 1502576
+        }
+      ],
+      "arm64_offset": 1589248,
+      "deflate_bytes": 1356510,
+      "arm64_deflate_bytes": 650504
+    },
+    {
+      "path": "Contents/Frameworks/ReactiveObjC.framework/Versions/A/ReactiveObjC",
+      "bytes": 794832,
+      "arm64_bytes": 385232,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 379120
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 409600,
+          "bytes": 385232
+        }
+      ],
+      "arm64_offset": 409600,
+      "deflate_bytes": 281686,
+      "arm64_deflate_bytes": 135758
+    },
+    {
+      "path": "Contents/Frameworks/Squirrel.framework/Versions/A/Squirrel",
+      "bytes": 326368,
+      "arm64_bytes": 162528,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 142768
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 163840,
+          "bytes": 162528
+        }
+      ],
+      "arm64_offset": 163840,
+      "deflate_bytes": 101654,
+      "arm64_deflate_bytes": 48945
+    },
+    {
+      "path": "Contents/Frameworks/Squirrel.framework/Versions/A/Resources/ShipIt",
+      "bytes": 291728,
+      "arm64_bytes": 144272,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 116112
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 147456,
+          "bytes": 144272
+        }
+      ],
+      "arm64_offset": 147456,
+      "deflate_bytes": 82394,
+      "arm64_deflate_bytes": 39948
+    },
+    {
+      "path": "Contents/Frameworks/Mantle.framework/Versions/A/Mantle",
+      "bytes": 221760,
+      "arm64_bytes": 107072,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 82800
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 114688,
+          "bytes": 107072
+        }
+      ],
+      "arm64_offset": 114688,
+      "deflate_bytes": 58735,
+      "arm64_deflate_bytes": 28432
+    },
+    {
+      "path": "Contents/Frameworks/PwrAgent Helper (GPU).app/Contents/MacOS/PwrAgent Helper (GPU)",
+      "bytes": 484016,
+      "arm64_bytes": 221872,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 239584
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 262144,
+          "bytes": 221872
+        }
+      ],
+      "arm64_offset": 262144,
+      "deflate_bytes": 172829,
+      "arm64_deflate_bytes": 77240
+    },
+    {
+      "path": "Contents/Frameworks/PwrAgent Helper (Renderer).app/Contents/MacOS/PwrAgent Helper (Renderer)",
+      "bytes": 484032,
+      "arm64_bytes": 221888,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 239600
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 262144,
+          "bytes": 221888
+        }
+      ],
+      "arm64_offset": 262144,
+      "deflate_bytes": 172822,
+      "arm64_deflate_bytes": 77242
+    },
+    {
+      "path": "Contents/Frameworks/PwrAgent Helper.app/Contents/MacOS/PwrAgent Helper",
+      "bytes": 484016,
+      "arm64_bytes": 221872,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 239584
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 262144,
+          "bytes": 221872
+        }
+      ],
+      "arm64_offset": 262144,
+      "deflate_bytes": 172830,
+      "arm64_deflate_bytes": 77241
+    },
+    {
+      "path": "Contents/Frameworks/PwrAgent Helper (Plugin).app/Contents/MacOS/PwrAgent Helper (Plugin)",
+      "bytes": 484032,
+      "arm64_bytes": 221888,
+      "slices": [
+        {
+          "cpu": "0x1000007",
+          "offset": 16384,
+          "bytes": 239600
+        },
+        {
+          "cpu": "0x100000c",
+          "offset": 262144,
+          "bytes": 221888
+        }
+      ],
+      "arm64_offset": 262144,
+      "deflate_bytes": 172835,
+      "arm64_deflate_bytes": 77247
+    }
+  ]
+}

--- a/docs/plans/2026-09-11-apple-silicon-distribution.md
+++ b/docs/plans/2026-09-11-apple-silicon-distribution.md
@@ -1,0 +1,327 @@
+# Apple Silicon macOS distribution exploration
+
+Exploration only, 2026-09-11. No release, feed, website, README, or packaging
+behavior was changed. Repository inspected at
+`592efcd90557dd6ad02149e117a38ab90e9a214a` (desktop `1.1.0-alpha.5`).
+
+## Recommendation
+
+Ship an arm64 DMG and updater ZIP alongside the existing universal pair.
+Keep universal for Intel, uncertain browser detection, portable installations,
+and older updater compatibility. Do not add an Intel-only product initially.
+Use one merged `latest-mac.yml` containing architecture-specific ZIP entries;
+the installed updater already performs architecture selection. Preserve the
+universal legacy `path` and `sha512` fields and all existing universal names.
+
+Make the arm64 build genuinely architecture-specific: Electron, Grok, native
+modules, canvas, ripgrep, and the Dock plug-in. The expected installed saving
+is approximately **436.5 MB (42.74%)**, not 50%. Grok's separate signed arm64
+distribution is a prerequisite for the recommended complete implementation.
+
+## Measured evidence
+
+Read `/Applications/PwrAgent.app` without modifying it. Its Info.plist reports
+`1.1.0-alpha.4`. Counts below are decimal MB, logical regular-file lengths,
+excluding symlinks to avoid counting framework contents twice. These are not
+APFS allocated blocks or Finder's potentially rounded size display.
+
+For each fat Mach-O, read its fat architecture table and substitute the arm64
+slice length. Omit the `canvas-darwin-x64` unpacked package. Retain all other
+files, including shared ASAR resources and existing signatures. This estimates
+an arm64 payload; it does not produce a runnable, signed app.
+
+| Component | Installed universal MB | Projected arm64 MB | Saving MB |
+|---|---:|---:|---:|
+| Frameworks | 493.343 | 274.945 | 218.399 |
+| Bundled Grok including notices | 347.083 | 168.301 | 178.782 |
+| app.asar | 95.562 | 95.562 | 0 |
+| app.asar.unpacked | 74.263 | 39.541 | 34.722 |
+| Other resources | 10.728 | 6.255 | 4.473 |
+| Executable, plug-in, metadata | 0.305 | 0.174 | 0.131 |
+| **Total** | **1,021.285** | **584.778** | **436.507** |
+
+Specific measurements:
+
+- Grok executable: 346,308,896 bytes; arm64 slice 167,526,688 bytes;
+  x86_64 slice 178,764,096 bytes. The arm64 slice is 48.4% of the fat file.
+- Canvas: arm64 binding 26,968,624 bytes; x64 binding 32,558,848 bytes.
+  These are separate platform packages, not two slices of one canvas file.
+- Electron Framework main binary: 377,834,256 bytes → 178,129,680 bytes.
+  Framework resources and other libraries prevent assuming that the entire
+  Frameworks directory halves.
+- Keeping universal Grok alone would raise the projection to **763.560 MB**,
+  reducing the total saving to about **25.24%**.
+
+Compression probe: stream each regular file through independent raw DEFLATE
+level 6, then repeat using only each arm64 slice and excluding Intel canvas.
+The sums were **393,003,210 → 214,139,310 bytes**, a **45.51%** reduction.
+Grok alone was 131,262,907 → 63,050,708 compressed bytes. ZIP headers, symlinks,
+archive metadata, signing changes, and builder compression choices are outside
+this probe. It is a comparison of compressed payloads, not a generated ZIP.
+
+The published alpha.4 assets, read through GitHub's release API, are:
+
+| Asset | Bytes |
+|---|---:|
+| PwrAgent-1.1.0-alpha.4-universal-mac.zip | 379,597,882 |
+| ZIP blockmap | 398,775 |
+| PwrAgent-1.1.0-alpha.4-universal.dmg | 393,047,867 |
+
+Applying the measured compression ratio to that published ZIP gives roughly
+**207 MB**, saving about **173 MB**. Treat **~207–214 MB** as a planning
+estimate, not a confidence interval or acceptance result. DMG compression
+must be measured separately; do not apply a ZIP ratio as a measured DMG size.
+The first unsigned paired build must record actual ZIP, DMG, app logical size,
+and allocated size, and the signed candidate must repeat the archive checks.
+
+The SQLite source exclusion from PR #2069 is already present in the inspected
+builder config. The installed alpha.4 measurement still includes those files.
+This projection leaves them in both columns, assigning **no savings** to that
+separate change. Compare arm64 and universal from the same commit during
+implementation so that saving is not counted twice.
+
+Local raw evidence is in `.local/arm64-exploration/files.json` and
+`files-compressed.json`; a compact durable summary accompanies this plan.
+No Codex-owned storage was inspected.
+
+## Current packaging and publication contracts
+
+- `apps/desktop/electron-builder.yml`: mac DMG/ZIP targets are universal;
+  identity is `com.pwrdrvr.pwragent`; app name is PwrAgent. Keep those stable.
+  Preserve Developer ID identity, entitlements, hardened runtime, fuses,
+  minimum OS, Icon Composer package, and Xcode 26/actool requirements.
+- `apps/desktop/scripts/release.mjs`: a fixed `release-stage` is populated by
+  `pnpm deploy --cpu=x64 --cpu=arm64 --os=darwin`; both canvas bindings are
+  required. Builder arguments force `--mac --universal`. Post-build paths and
+  lipo assertions assume `dist/mac-universal/PwrAgent.app` and both slices for
+  the app, SQLite, Dock plug-in, Grok, and ripgrep.
+- `build-dock-tile-plugin.mjs` always compiles both architectures.
+  `afterpack-sign-dock-tile-plugin.mjs` signs nested code before app sealing.
+- `stage-ripgrep-bundle.mjs` already supports `macos-arm64`, but its cache
+  deliberately accepts a universal bundle for a single-architecture request.
+  That cache policy must not silently defeat the smaller package.
+- `.github/workflows/release.yml`: no-secret prepare installs/tests/stages;
+  protected `apple-signing` job verifies the digest of its input archive,
+  receives no checkout and performs no dependency install; final assembly
+  waits for signed macOS, signed Windows, and both Linux packages. Keep this
+  separation. Mac jobs run on `macos-26` and use the selected actool 26.
+- The signing job copies `PwrAgent-*-universal.dmg` to `PwrAgent.dmg` and
+  explicitly uploads `latest-mac.yml`. Assembly verifies updater metadata,
+  publishes every tag initially as a prerelease, and checks uploaded assets.
+  Promotion remains a separate operator step after all artifacts pass.
+- `update-channel-files.mjs`, `check-desktop-release-metadata.mjs`, release
+  workflow tests, preview workflow, release skill, and release runbook encode
+  these assumptions and need matching changes, not weakened checks.
+- The phase-2 runbook was read as required by the release skill. Its migration
+  options are historical; current source already uses the public PwrAgent repo.
+  Do not introduce the removed environment variables shown in that record.
+
+## Artifact and updater contract
+
+| Purpose | Name |
+|---|---|
+| Universal DMG, unchanged | `PwrAgent-${version}-universal.dmg` |
+| Universal stable alias, unchanged | `PwrAgent.dmg` |
+| Universal updater ZIP, unchanged | `PwrAgent-${version}-universal-mac.zip` |
+| Apple Silicon DMG, new | `PwrAgent-${version}-arm64.dmg` |
+| Apple Silicon stable alias, new | `PwrAgent-arm64.dmg` |
+| Apple Silicon updater ZIP, new | `PwrAgent-${version}-arm64-mac.zip` |
+| Blockmaps | Each versioned ZIP's name plus `.blockmap` |
+| macOS updater manifest, unchanged | `latest-mac.yml` |
+
+`latest-mac.yml` should have universal ZIP first in `files`, arm64 ZIP second,
+each with its own SHA-512, size, and generated blockmap-related properties.
+Top-level `path` and `sha512` must continue to describe the universal ZIP.
+Use versioned ZIP URLs only. Aliases are for human downloads.
+
+Evidence from pinned dependencies:
+
+- `electron-updater` **6.8.9**, `out/providers/Provider.js`, uses `-mac` on
+  Darwin regardless of architecture. Creating `latest-mac-arm64.yml` alone
+  does nothing for existing clients. A custom channel named `latest-arm64`
+  would instead resolve `latest-arm64-mac.yml`, and would require client
+  changes. Separate manifests are unnecessary for this rollout.
+- `out/MacUpdater.js` detects arm64 via `process.arch`, Rosetta's
+  `sysctl.proc_translated`, and an additional uname check. When arm64 files
+  exist, it selects only those; on Intel it excludes them. Classification
+  looks for the literal `arm64` in file URLs, so use exactly that spelling.
+- Installed alpha.4 contains updater 6.8.9 and this selection code, verified
+  by reading the application's ASAR. Four assertions against the local pinned
+  implementation passed: arm64 preference, Intel exclusion, universal-only
+  fallback, and order independence for Intel.
+- `app-builder-lib` **26.15.7**, `out/publish/updateInfoBuilder.js`, merges
+  update tasks within one invocation and sorts universal ahead of per-arch
+  artifacts for backward-compatible legacy fields. Separate builder runs
+  do **not** share that merge state: never let their manifests overwrite each
+  other or upload whichever finishes last.
+
+| Existing installation | Next release with merged metadata |
+|---|---|
+| alpha.4 universal on native Apple Silicon | Select arm64 ZIP |
+| alpha.4 universal running under Rosetta | Select arm64 ZIP; verify relaunch natively |
+| Universal on Intel | Select universal ZIP |
+| New arm64 installation | Select subsequent arm64 ZIP |
+| Apple Silicon targeting an older universal-only release | Universal fallback |
+| Legacy path-only updater | Universal through preserved legacy fields |
+| Other historical file-list updaters | Audit shipped version before claiming compatibility |
+
+Keep the current four channel/track slots and release selection semantics.
+`auto-updater.ts` points a generic feed at one selected release's download
+directory; no change to feed roots is required. Its current eligibility test
+only asks for `latest-mac.yml` and any `.zip`; tighten this to recognize the
+macOS universal fallback ZIP rather than allowing an unrelated ZIP to qualify.
+Do not demand an arm64 ZIP when selecting historical releases.
+
+For the initial universal → arm64 transition, budget a **full ZIP download**.
+Differential updating has a full-download fallback, and the previous arm64
+blockmap may not exist. Test cache and missing-blockmap behavior explicitly.
+Replacing the entire signed `.app` must remove the old Intel payload. Test
+bundle identity, signature acceptance, permissions, retained profile state,
+launch, and subsequent updates using Squirrel's real install path. Reading
+the file selector is not proof that installation/relaunch works.
+
+## Grok cross-repository prerequisite
+
+Inspected [pwrdrvr/grok-build release workflow](https://github.com/pwrdrvr/grok-build/blob/be713136d2a69080743a3f6b3c72077057e5948f/.github/workflows/pwragent-release.yml).
+It already builds raw `macos-aarch64` and `macos-x86_64` executables, merges
+them with lipo, and signs/publishes only the universal macOS distribution.
+The pinned `pwragent-v1.0.0-pwragent.2` release contains only a universal macOS
+tarball, **130,915,946 bytes**, plus Linux/Windows assets and SHA256SUMS.
+
+Add a separately signed `pwragent-grok-${version}-macos-aarch64.tar.gz` from
+the existing raw arm64 output. Preserve universal. Extend protected signing,
+input digest verification, expected-architecture assertions, notices,
+SOURCE_REV/build metadata, SHA256SUMS, assembly gates, and release checks.
+Do not merely rename the universal tarball. The inspected Grok workflow signs
+the executable; it does not show a standalone notarization step. Preserve
+that contract and verify the final containing PwrAgent app notarizes.
+
+In PwrAgent add `macos-aarch64` to `grok-bundle.json` at a new pinned release;
+select it for arm64 preparation and verify its actual Mach-O architecture.
+Keep `PWRAGENT-BUNDLE.json` provenance and all runtime signature checks.
+Although local lipo extraction could avoid a new upstream asset in principle,
+it changes the distributed bytes/provenance and complicates verification.
+A separately signed upstream asset is the recommended supported contract.
+
+Also handle `grok-managed-runtime.ts`: `managedGrokAssetPlatform` maps both
+Mac architectures to universal, and cached metadata requires an exact asset
+name. Changing that function alone would reject existing cached universals.
+Plan arm64 preference with compatible universal fallback for older releases
+and valid cached installs. The cache uses `versions/<tag>` without architecture;
+do not overwrite an active universal executable at that path with a same-tag
+arm64 asset. Either defer same-tag replacement until a new tag, or design
+architecture-qualified storage with backward-compatible reads. Include concurrent
+native/Rosetta processes and pinned runtimes in that decision. This concerns
+disk use outside the app and is separate from the 584.8 MB app estimate.
+
+## Implementation sequence
+
+1. **Upstream runtime.** Land Grok arm64 signed asset support, validate it,
+   then pin its new immutable release in PwrAgent. Do not alter existing tags.
+2. **Explicit isolated targets.** Add a validated mac architecture parameter
+   defaulting to universal. Give arm64/universal separate stage and output
+   roots. Deploy only arm64 for that stage; keep both CPUs for universal.
+   Ensure x64 canvas is absent from both ASAR and unpacked output in arm64,
+   while preserving both for universal and all license notices. Target native
+   rebuilds for SQLite/node-pty correctly. Parameterize Dock compilation,
+   Grok/ripgrep staging, builder arguments, output paths, and assertions.
+   Require exact slice sets, not just presence of arm64. Fix ripgrep cache
+   reuse for strict arm64 staging. Keep ASAR integrity generation in builder;
+   do not prune an already sealed app.
+3. **Paired preparation/signing.** Prefer two prepared target trees in one
+   digest-verified input archive and sequential package commands in the
+   existing protected mac signing job initially. This preserves the security
+   boundary and avoids duplicate full test runs. Measure signing duration
+   against the existing 60-minute budget. If parallel signing is needed,
+   use independent archives/digests and jobs, not shared mutable stages.
+   Include any new script imports in the signing archive allowlist (and the
+   Windows allowlist if release.mjs imports them unconditionally).
+4. **Deterministic assembly.** Retain each target's generated manifest under
+   a temporary distinct name, parse with a real YAML parser in no-secret
+   assembly, and produce one merged latest-mac.yml. Validate equal versions,
+   one ZIP per intended architecture, universal legacy fields, file sizes,
+   SHA-512 values, and referenced artifacts. Validate blockmaps and aliases.
+   Upload metadata only after all artifacts are assembled; retain existing
+   release prerelease/promotion gates. Add both aliases to checksum coverage.
+5. **Updater tests.** Cover the table above, malformed/partial releases,
+   universal-only history, missing arm64 blockmaps, interrupted downloads,
+   failed verification, cache reuse, and explicit downgrade across slots.
+   Perform signed private-candidate upgrade/relaunch tests on Apple Silicon,
+   Rosetta, and Intel before production rollout. Use managed lab procedures
+   for headed testing. Compare same-commit installed and archive sizes.
+6. **Documentation/discovery.** Update release scripts' contract tests,
+   `release:check`, release runbook/skill, and relevant preview packaging
+   coverage. Land website and README download links only once the new alias
+   exists in the promoted stable release. An alpha asset does not make a
+   `/releases/latest/download/` URL available.
+
+## Website and README proposal
+
+Read-only inspection identified concrete work in
+[pwrdrvr/pwragent.ai](https://github.com/pwrdrvr/pwragent.ai):
+`_config.yml`, `_layouts/default.html`, `index.md`, and `assets/js/site.js`.
+The site currently has a universal `mac_dmg` setting, `data-mac-dmg` and a
+universal asset suffix, an OS-selecting primary CTA, and one macOS size badge.
+Add separate arm64/universal URLs, suffix matching, labels, and size badges.
+Update the hero, Other platforms, and installation card consistently.
+
+For browsers that expose it, request `getHighEntropyValues(["architecture",
+"bitness"])`, feature-detect the API, and handle rejection/missing fields.
+Only a macOS result with `architecture: "arm"` and `bitness: "64"` should
+automatically select Apple Silicon. Retain mobile/iPad detection first.
+Intel results can use universal; unknown results use universal with visible
+Apple Silicon/Universal choices. Never infer CPU from the UA string's
+`Intel Mac OS X`, WebGL renderer, or CPU core count. Do not delay or break a
+click while an asynchronous hint lookup is pending, and never override an
+explicit choice. Keep Windows/Linux paths and no-JS links usable. Test
+missing hints, mobile, rejected hints, API failure, and asset absence.
+
+The browser API can withhold these values and is not available everywhere;
+see [MDN's API documentation](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues).
+Use feature detection rather than a fixed browser-version assumption.
+
+In this project's README, replace the universal-only primary button with a
+large **Download for Mac — Apple Silicon** link to
+`https://github.com/pwrdrvr/PwrAgent/releases/latest/download/PwrAgent-arm64.dmg`.
+Directly beside/below it provide equally readable text links:
+
+- **macOS Universal (Apple Silicon + Intel)** → existing `PwrAgent.dmg` URL.
+- **Windows (x64)** → existing `PwrAgent-windows-x64-setup.exe` alias.
+- **Debian/Ubuntu installation** → `https://docs.pwragent.ai/linux/`.
+
+Retain a docs link and explain “Not sure which Mac? Choose Universal.” README
+cannot run architecture detection. Update its “Get it” section to match these
+choices and use text or accurately labeled artwork; do not reuse the current
+generic macOS button image with a misleading arm64-only destination.
+
+In [pwrdrvr/docs.pwragent.ai](https://github.com/pwrdrvr/docs.pwragent.ai),
+update macOS setup/download references with both variants and update behavior.
+`linux.md` already exposes `/linux/`, the correct Debian instructions link.
+These are cross-repository follow-ups; no other checkout was edited.
+
+## Open decisions and release prerequisites
+
+- Approve automatic universal → arm64 migration after signed smoke tests, or
+  initially publish the arm64 DMG while leaving updater metadata universal-only.
+  Recommendation: merged metadata after tests; no mandatory bridge for alpha.4.
+- Inventory updater versions in all supported stable installations. Unknown
+  historical versions may warrant a universal bridge in their release train.
+- Decide Grok's same-tag cache migration policy; prefer leaving valid cached
+  universal runtimes until the next tag for the first implementation.
+- Confirm whether preserving a universal install intentionally on Apple Silicon
+  needs an opt-out. The pinned updater will otherwise select arm64 regardless
+  of which DMG the user originally installed.
+- Confirm dual notarization runtime/cost with a paired candidate. Do not solve
+  a measured slow job by weakening signing or skipping verification.
+- Intel-only artifacts are deferred: Intel remains natively supported by
+  universal, with fewer artifacts and fewer routing branches to maintain.
+
+Validation performed: source and release asset inspection, installed Mach-O
+and canvas sizing, paired compression probe, installed updater inspection,
+and four assertions against its pinned architecture filter. No full app build,
+signature/notarization operation, or actual update installation was performed.
+
+`git fetch origin --tags` encountered conflicting local alpha.1, alpha.3,
+and alpha.4 tags and returned exit 1. No tags were overwritten. The evidence
+uses the explicit worktree commit, installed Info.plist, and GitHub release
+API rather than treating those local tag refs as authoritative.

--- a/scripts/check-desktop-release-metadata.mjs
+++ b/scripts/check-desktop-release-metadata.mjs
@@ -452,6 +452,9 @@ assertWorkflowJobOrdersText(
 );
 for (const expected of [
   "--sign-stage-only --no-publish",
+  "--sign-stage-only --no-publish --mac-arch=arm64",
+  "node apps/desktop/scripts/assemble-mac-release.mjs",
+  "apps/desktop/release-stage/dist/PwrAgent-macos-SHA256SUMS",
   "Upload macOS release assets",
 ]) {
   assertWorkflowJobContainsText(
@@ -461,6 +464,28 @@ for (const expected of [
     expected,
   );
 }
+for (const expected of [
+  "stage-grok-bundle.mjs --platform macos-aarch64",
+  "--prepare-only --mac-arch=arm64",
+  "apps/desktop/release-stage-arm64 \\",
+  "apps/desktop/scripts/assemble-mac-release.mjs \\",
+]) {
+  assertWorkflowJobContainsText(releaseWorkflow, ".github/workflows/release.yml", "prepare", expected);
+}
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "sign",
+  "--sign-stage-only --no-publish --mac-arch=arm64",
+  "node apps/desktop/scripts/assemble-mac-release.mjs",
+);
+assertWorkflowJobOrdersText(
+  releaseWorkflow,
+  ".github/workflows/release.yml",
+  "sign",
+  "node apps/desktop/scripts/assemble-mac-release.mjs",
+  "Upload macOS release assets",
+);
 for (const unexpected of [
   "gh release upload",
   "continue-on-error: true",


### PR DESCRIPTION
## Change

Add Apple Silicon macOS DMG and updater ZIP artifacts alongside universal. Intel keeps the universal app and existing download URLs. Isolated arm64 staging targets Electron, native rebuilds, the Dock plug-in, canvas and ripgrep to arm64.

Pin signed Grok `1.0.24-pwragent.2` across platforms, including its new arm64 asset. The exact arm64 asset is selected from the pinned release when present; absence falls back to that tag's universal runtime. An existing asset with a missing/bad checksum fails. Both upstream Mac runtimes passed PwrDrvr Developer ID signature verification. Managed Grok updates remain unchanged.

The protected signing job packages both prepared targets. Assembly verifies ZIP hashes/sizes and required artifacts, then emits one `latest-mac.yml` with both ZIPs and universal legacy fields. The pinned updater selects arm64 on Apple Silicon/Rosetta and universal on Intel. README leads with Apple Silicon via the release chooser until its stable alias exists, alongside Universal, Windows and Debian instructions. The runbook records website follow-ups and rollout checks. SQLite source removal from #2069 is already on main and is not duplicated.

## Validation

- 29 focused tests passed, including pinned MacUpdater routing, corrupt archive rejection, and Grok availability/checksum cases.
- `pnpm lint:eslint` passed (existing warnings); release metadata check passed for v1.1.0-beta.1.
- Both dry-run packages with the new Grok pin and paired assembly passed. All assembled SHA256SUMS entries verified.
- Arm64 Grok is 182,241,968 bytes, arm64-only; universal is 377,047,728 bytes with both slices. Both report `1.0.24-pwragent.2` and carry matching pinned provenance.

| Output | Universal | Apple Silicon | Reduction |
|---|---:|---:|---:|
| Installed regular files, excluding symlinks | 1,042,140,897 bytes | 588,902,297 bytes | 43.49% |
| Updater ZIP | 389,852,650 bytes | 210,232,734 bytes | 46.07% |
| DMG | 402,947,119 bytes | 217,516,484 bytes | 46.02% |

Draft pending protected app signing/notarization and real upgrade/relaunch validation on Apple Silicon, Rosetta and Intel. Local app builds used ad-hoc dry-run signing. No release or production feed was changed. First architecture migration may require a full ZIP download.
