### PR TITLE
fix(desktop): keep remote selection counts in viewer directories

### DIFF
--- a/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
@@ -25,6 +25,63 @@ function api() {
     } satisfies DesktopApi };
 }
 
+it.each([
+  [false, "owner"], [false, "viewer"], [true, "owner"], [true, "viewer"],
+] as const)("keeps viewer directory counts during remote selection (same path=%s, first=%s)", async (samePath, first) => {
+  const fixture = api();
+  const local = { ...directory, key: "directory:/viewer/PwrSnap", label: "PwrSnap",
+    counts: { total: 10, active: 2, activeRemote: 2, unread: 1, review: 1 } };
+  const remote = { ...local, key: samePath ? local.key : "directory:/owner/PwrSnap",
+    counts: { total: 3, active: 2, unread: 1, review: 1 } };
+  const ref = { backend: "codex" as const, threadId: "remote-root", ownerInstanceId: "peer" };
+  const row: NavigationRow = { id: ref.threadId, source: "codex", ref, title: "Remote root", titleSource: "explicit",
+    rowRevision: "r", linkedDirectories: [{ id: "owner-project", label: "PwrSnap", path: "/owner/PwrSnap", kind: "local" }],
+    inbox: { inInbox: false }, ordinaryChildCount: 1,
+    nativeSubAgentGroupPresent: false, queueCount: 0, queueState: "unknown" };
+  let finish!: () => void;
+  const gate = new Promise<void>((resolve) => { finish = resolve; });
+  fixture.read.mockImplementation(async (request) => {
+    if (request.query.kind === "directory-index") return page({ directories: request.query.keys ? [] : [local] });
+    if (request.query.kind !== "exact") return page();
+    const owner = request.federationTarget?.scope === "remote";
+    if (owner !== (first === "owner")) await gate;
+    return page({ selectionDirectory: owner ? remote : local,
+      entries: [{ row, placement: { kind: "root" }, orderKey: "root" }] });
+  });
+  const { result, unmount } = renderHook(() => useBoundedNavigationWindow({ ...base,
+    desktopApi: fixture.desktopApi, selectedRef: ref, selectedDirectoryKeys: [remote.key],
+  }));
+  try {
+    const firstId = first === "owner" ? "selected-context" : "selected-viewer-mount";
+    await waitFor(() => expect(result.current.resources.get(firstId)?.state.page).toBeDefined());
+    expect(result.current.directories).toEqual([local]);
+    expect(result.current.selectedDirectoryKeys).toEqual(first === "owner" ? [] : [local.key]);
+    await act(async () => finish());
+    await waitFor(() => expect(result.current.resources.get("selected-context")?.loading).toBe(false));
+    await waitFor(() => expect(result.current.resources.get("selected-viewer-mount")?.loading).toBe(false));
+    expect(result.current.directories).toEqual([local]);
+    expect(result.current.selectedDirectoryKeys).toEqual([local.key]);
+    expect(result.current.resources.get("selected-context")?.state.page?.entries[0]?.row.ordinaryChildCount).toBe(1);
+    if (!samePath) expect(fixture.read.mock.calls.some(([request]) =>
+      request.query.kind === "directory" && request.query.directoryKey === remote.key)).toBe(false);
+  } finally {
+    finish();
+    unmount();
+  }
+});
+
+it("uses owner directory descriptors in a window browsing that owner", async () => {
+  const fixture = api();
+  fixture.read.mockImplementation(async (request) => page(request.query.kind === "exact"
+    ? { selectionDirectory: directory } : {}));
+  const { result, unmount } = renderHook(() => useBoundedNavigationWindow({ ...base, desktopApi: fixture.desktopApi,
+    target: { scope: "remote", instanceId: "peer" }, selectedRef: { backend: "codex", threadId: "root", ownerInstanceId: "peer" },
+  }));
+  await waitFor(() => expect(result.current.directories).toEqual([directory]));
+  expect(result.current.selectedDirectoryKeys).toEqual([directory.key]);
+  unmount();
+});
+
 it.each([5, 35])("restores selected root %s without discarding the first page when it already contains that root", async (index) => {
   const fixture = api();
   const selectedRef = { backend: "codex" as const, threadId: `thread-${index}` };

--- a/apps/desktop/src/renderer/src/lib/useBoundedNavigationWindow.ts
+++ b/apps/desktop/src/renderer/src/lib/useBoundedNavigationWindow.ts
@@ -30,14 +30,21 @@ export function useBoundedNavigationWindow(params: Demand & {
   const directories = useMemo(() => {
     const descriptors = new Map<string, NavigationDirectoryRow>();
     for (const id of ["directory-index", "selected-directories"]) {
-      for (const directory of state.resources.get(id)?.state.page?.directories ?? []) descriptors.set(directory.key, directory);
+      const resource = state.resources.get(id);
+      if (!federationTargetsEqual(resource?.state.request.federationTarget, params.target)) continue;
+      for (const directory of resource?.state.page?.directories ?? []) descriptors.set(directory.key, directory);
     }
     for (const id of ["selected-context", "selected-viewer-mount"]) {
-      const directory = state.resources.get(id)?.state.page?.selectionDirectory;
+      const resource = state.resources.get(id);
+      // Owner exact reads supply ancestry, not viewer project membership or
+      // counts. Importing their descriptor duplicates peer paths and turns
+      // owner-local activity into viewer-local activity.
+      if (!federationTargetsEqual(resource?.state.request.federationTarget, params.target)) continue;
+      const directory = resource?.state.page?.selectionDirectory;
       if (directory) descriptors.set(directory.key, directory);
     }
     return [...descriptors.values()];
-  }, [state.resources]);
+  }, [state.resources, params.target]);
   const selectedResource = state.resources.get("selected-context");
   const selectedQuery = selectedResource?.state.request.query;
   const selectedContext = params.selectedRef && selectedQuery?.kind === "exact"
@@ -45,10 +52,15 @@ export function useBoundedNavigationWindow(params: Demand & {
     && navigationIdentityKey(selectedQuery.identities[0]!) === navigationIdentityKey(params.selectedRef)
     ? selectedResource?.state.page : undefined;
   const selectedRoot = selectedContext?.entries.find((entry) => entry.placement.kind === "root");
-  const selectedHome = state.resources.get("selected-viewer-mount")?.state.page?.selectionDirectory
-    ?? selectedContext?.selectionDirectory;
-  const selectedDirectoryKeys = selectedHome ? [selectedHome.key] : selectedRoot?.row.linkedDirectories.length
-    ? selectedRoot.row.linkedDirectories.map((directory) => classifyDirectory(directory).key) : params.selectedDirectoryKeys;
+  const remoteViewerSelection = Boolean(params.selectedRef?.ownerInstanceId) && params.target?.scope !== "remote";
+  const selectedHome = remoteViewerSelection
+    ? state.resources.get("selected-viewer-mount")?.state.page?.selectionDirectory
+    : selectedContext?.selectionDirectory;
+  // While the viewer mount loads, neither owner-linked paths nor detail
+  // fallback paths can identify a directory in the viewer inventory.
+  const selectedDirectoryKeys = selectedHome ? [selectedHome.key] : remoteViewerSelection ? []
+    : selectedRoot?.row.linkedDirectories.length
+      ? selectedRoot.row.linkedDirectories.map((directory) => classifyDirectory(directory).key) : params.selectedDirectoryKeys;
   const demandParams = { ...params, directories, selectedDirectoryKeys,
     selectedRootRef: selectedRoot?.row.ref, selectedContextReady: Boolean(selectedContext),
     indexedDirectoryKeys: new Set((state.resources.get("directory-index")?.state.page?.directories ?? []).map((directory) => directory.key)),


### PR DESCRIPTION
## Summary

- I fixed remote thread selection importing the owner's directory descriptor into the local sidebar. Different checkout paths produced duplicate project headers; identical paths could overwrite viewer counts with owner counts and display remote busy threads as local.
- I keep directory descriptors, counts, and selection placement scoped to the window's inventory. While a remote selection's viewer mount loads, I wait for that membership instead of querying owner paths locally. Owner thread metadata and ancestry remain available, and dedicated remote windows retain their owner descriptors.

## Verification

- I reproduced the regression in hook tests before the fix: three cases failed, showing duplicate descriptors or loss of `activeRemote`.
- I verified all 55 tests across six navigation suites pass, including both owner/viewer response arrival orders, identical and different checkout paths, and dedicated remote windows.
- I ran workspace typechecking, `pnpm lint:eslint` (zero errors), and dependency-boundary checks successfully.

## Notes

- The reported PID was a development Electron process, but the reproduction does not require HMR. I could not establish that HMR occurred during the reported interval.
- This changes navigation data selection, with no new persistence or CSS changes. I did not run live Electron E2E.
