### PR TITLE
fix(desktop): reveal threads with unmounted group parents

### DIFF
--- a/apps/desktop/src/main/__tests__/navigation-query-projection.test.ts
+++ b/apps/desktop/src/main/__tests__/navigation-query-projection.test.ts
@@ -256,3 +256,44 @@ it("recovers a legacy handoff's omitted remote group owner from its recorded lau
   expect(project([launcher, child, thread("root")]).entries.map((entry) => entry.row.id)).toEqual(["launcher"]);
   expect(project([launcher, { ...child, parentThreadInstanceId: "other" }]).entries.map((entry) => entry.row.id)).toEqual(["launcher"]);
 });
+
+it.each([undefined, "199680"])("keeps a local handoff reachable when its remote group is not mounted (pin %s)", (pinnedRank) => {
+  const launcher = thread("launcher", { parentThreadId: "remote-root", parentThreadBackend: "codex", parentThreadInstanceId: "peer" });
+  const child = thread("handoff", { pinnedRank, parentThreadId: "remote-root", parentThreadBackend: "codex", handoffOrigin: {
+    sourceBackend: "codex", sourceThreadId: "launcher", seedMode: "clean", groupingMode: "subthread", createdAt: 1,
+    workspace: { mode: "none", git: { kind: "none", worktreeCreationAvailable: false, unavailableReason: "Fixture" } },
+  } });
+  const source = snapshot([launcher, child]);
+  const project = (query: NavigationQueryRequest["query"]) => projectNavigationQuery({ index: source, request: request(query) });
+  const roots = project({ kind: "directory", directoryKey: "directory:/repo", roots: pinnedRank ? "pinned" : "unpinned" });
+  expect(roots.entries.find((entry) => entry.row.id === child.id)).toMatchObject({
+    placement: { kind: "root" },
+    row: { parentThreadId: "remote-root", parentThreadInstanceId: "peer" },
+  });
+  const descriptors = project({ kind: "directory-index" });
+  expect(descriptors.directories?.[0]).toMatchObject({ pinnedRootCount: pinnedRank ? 1 : 0, unpinnedRootCount: pinnedRank ? 1 : 2 });
+  const exact = project({ kind: "exact", identities: [{ backend: "codex", threadId: child.id }], includeAncestry: true });
+  expect(exact.entries).toHaveLength(1);
+  expect(exact.entries[0]?.placement).toEqual({ kind: "root" });
+  expect(exact.selectionDirectory?.key).toBe("directory:/repo");
+  const checking = projectNavigationQuery({ index: { ...source, coverage: { state: "checking" } },
+    request: request({ kind: "exact", identities: [{ backend: "codex", threadId: child.id }], includeAncestry: true }) });
+  expect(checking.entries[0]?.placement.kind).toBe("child");
+  // Placement is a presentation decision; the remote grouping remains intact.
+  expect(project({ kind: "children", parent: { backend: "codex", threadId: "remote-root", ownerInstanceId: "peer" } }).entries
+    .map((entry) => entry.row.id).sort()).toEqual(["handoff", "launcher"]);
+  // A same-ID thread on a different peer cannot supply this group's parent.
+  const remoteRoot = thread("remote-root", { federation: {
+    ref: { backend: "codex", threadId: "remote-root", target: { scope: "remote", instanceId: "other-peer" } }, instanceLabel: "Other peer",
+  } });
+  source.threads.push(remoteRoot);
+  expect(project({ kind: "exact", identities: [{ backend: "codex", threadId: child.id }], includeAncestry: true }).entries[0]?.placement)
+    .toEqual({ kind: "root" });
+  // Restoring the actual mount restores nesting without rewriting the handoff.
+  remoteRoot.federation!.ref.target = { scope: "remote", instanceId: "peer" };
+  const mounted = project({ kind: "exact", identities: [{ backend: "codex", threadId: child.id }], includeAncestry: true });
+  expect(mounted.entries.map((entry) => entry.row.id)).toEqual(["remote-root", "handoff"]);
+  expect(mounted.entries[1]?.placement).toEqual({ kind: "child", parent: { backend: "codex", threadId: "remote-root", ownerInstanceId: "peer" } });
+  expect(project({ kind: "directory", directoryKey: "directory:/repo" }).entries).toEqual([]);
+  expect(child.parentThreadInstanceId).toBeUndefined();
+});

--- a/apps/desktop/src/main/app-server/navigation-query-projection.ts
+++ b/apps/desktop/src/main/app-server/navigation-query-projection.ts
@@ -120,6 +120,24 @@ function isOrdinaryThread(thread: NavigationThreadSummary): boolean {
   return thread.codexNativeSubAgent === undefined;
 }
 
+/** Resolve reachability against the complete inventory, never a loaded page.
+ * A local child can outlive a viewer mount of its remote parent. Keep the
+ * relationship on its row, but give directory/selection queries a root to
+ * render until that parent is mounted again.
+ */
+function availableParentIdentity(
+  thread: NavigationThreadSummary,
+  candidatesByOwner: ReadonlyMap<string, readonly NavigationThreadSummary[]>,
+  coverage: NavigationQueryCoverage | undefined,
+): NavigationIdentity | undefined {
+  const parent = parentIdentity(thread, candidatesByOwner);
+  if (!parent) return undefined;
+  // Discovery still in progress cannot establish that a parent is absent.
+  if (coverage && coverage.state !== "complete") return parent;
+  const candidates = candidatesByOwner.get(JSON.stringify([parent.ownerInstanceId ?? null, parent.threadId])) ?? [];
+  return candidates.some((candidate) => candidate.source === parent.backend) ? parent : undefined;
+}
+
 function isActive(thread: NavigationThreadSummary): boolean {
   return thread.threadStatus === "active";
 }
@@ -326,12 +344,13 @@ function projectDirectoryGitStatus(
 function buildDirectoryRows(params: {
   snapshot: NavigationQueryIndex;
   threadsByLegacyKey: Map<string, NavigationThreadSummary>;
+  parentCandidates: ReadonlyMap<string, readonly NavigationThreadSummary[]>;
 }): NavigationDirectoryRow[] {
   return params.snapshot.directories.map((directory) => {
     const memberThreads = directory.threadKeys
       .map((key) => params.threadsByLegacyKey.get(key))
       .filter((thread): thread is NavigationThreadSummary => Boolean(thread));
-    const rootThreads = memberThreads.filter((thread) => !thread.parentThreadId);
+    const rootThreads = memberThreads.filter((thread) => !availableParentIdentity(thread, params.parentCandidates, params.snapshot.coverage));
     const pinnedRootCount = rootThreads.filter((thread) => thread.pinnedRank).length;
     const gitStatus = projectDirectoryGitStatus(directory);
     return {
@@ -571,7 +590,7 @@ function selectQueryThreads(params: {
       .map((key) => params.threadsByLegacyKey.get(key))
       .filter((thread): thread is NavigationThreadSummary => Boolean(thread))
       .filter((thread) => {
-        const parent = parentIdentity(thread, params.parentCandidates);
+        const parent = availableParentIdentity(thread, params.parentCandidates, params.index.coverage);
         if (parent) return disclosedParents.has(buildThreadIdentityKey(parent.backend, parent.threadId));
         return query.roots === "pinned" ? thread.pinnedRank !== undefined
           : query.roots === "unpinned" ? thread.pinnedRank === undefined : true;
@@ -726,7 +745,7 @@ export function projectNavigationQuery(params: {
       }
     }
     const filter = query.filter?.trim().toLowerCase();
-    const directories = buildDirectoryRows({ snapshot: { ...params.index, directories: sourceDirectories }, threadsByLegacyKey: eligibleByLegacyKey })
+    const directories = buildDirectoryRows({ snapshot: { ...params.index, directories: sourceDirectories }, threadsByLegacyKey: eligibleByLegacyKey, parentCandidates })
       .filter((directory) => !filter || [directory.key, directory.label, directory.path,
         query.scratchpadFirst && directory.kind === "workspace" ? "Workspaces Scratchpad" : undefined]
         .some((value) => value?.toLowerCase().includes(filter)))
@@ -737,6 +756,8 @@ export function projectNavigationQuery(params: {
   }
   const entries = selectedThreads.map((thread, index): NavigationQueryEntry => {
     const parent = parentIdentity(thread, parentCandidates);
+    const placementParent = query.kind === "directory" || (query.kind === "exact" && query.includeAncestry)
+      ? availableParentIdentity(thread, parentCandidates, params.index.coverage) : parent;
     return {
       row: projectNavigationRow({
         childCount: childCountByParent.get(threadKey(thread)) ?? 0,
@@ -750,8 +771,8 @@ export function projectNavigationQuery(params: {
       ...(params.attentionOrder?.members.has(navigationAttentionIdentity(thread))
         ? { attentionRank: params.attentionOrder.members.get(navigationAttentionIdentity(thread))!.rank }
         : {}),
-      placement: parent
-        ? { kind: "child", parent }
+      placement: placementParent
+        ? { kind: "child", parent: placementParent }
         : { kind: "root" },
     };
   });
@@ -781,11 +802,11 @@ export function projectNavigationQuery(params: {
       // worktree path is not necessarily the directory key shown by the viewer.
       selectionDirectory: buildDirectoryRows({ snapshot: { ...params.index,
         directories: params.index.directories.filter((directory) => directory.threadKeys.some((key) =>
-          selectedThreads[0] === threadsByLegacyKey.get(key))) }, threadsByLegacyKey })[0],
+          selectedThreads[0] === threadsByLegacyKey.get(key))) }, threadsByLegacyKey, parentCandidates })[0],
     } : {}),
     ...(query.kind === "messaging-threads" ? { collectionSize: entries.length,
       ...(query.directoryKey ? { selectionDirectory: buildDirectoryRows({ snapshot: { ...params.index, directories: params.index.directories.filter((directory) =>
-          directory.key === query.directoryKey || directory.path === query.directoryKey) }, threadsByLegacyKey })
+          directory.key === query.directoryKey || directory.path === query.directoryKey) }, threadsByLegacyKey, parentCandidates })
         .find((directory) => directory.key === query.directoryKey || directory.path === query.directoryKey) } : {}) } : {}),
     ...(query.kind === "star-map" ? {
       facets: countNavigationStarMapFacets(
@@ -796,7 +817,7 @@ export function projectNavigationQuery(params: {
     } : {}),
     directories: includeDirectories
       ? (query.kind === "star-map-geometry" ? buildProjectGeometry(params.index)
-        : buildDirectoryRows({ snapshot: params.index, threadsByLegacyKey }))
+        : buildDirectoryRows({ snapshot: params.index, threadsByLegacyKey, parentCandidates }))
           .filter((directory) => query.kind !== "directory-index" || ((!query.keys && !query.paths)
             || query.keys?.includes(directory.key) || (directory.path !== undefined && query.paths?.includes(directory.path))))
           .filter((directory) => query.kind !== "directory-index"


### PR DESCRIPTION
## Problem

A local handoff can remain grouped under a remote parent that is no longer mounted in the viewer. Search opens the transcript, but directory queries exclude the thread as a child and exact selection returns no root for the reveal action. Even a saved pin disappears from its directory.

## Change

Resolve directory and exact-ancestry placement against the complete owner/viewer inventory. When the parent is absent, expose the thread as a directory root and include it in root counts. Preserve its parent metadata and child-query membership, so mounting the correct parent restores nesting. Incomplete discovery retains child placement; a parent absent only from a loaded page is still resolved from the full inventory.

## Validation

- Added pinned and unpinned legacy remote-handoff regressions; both failed before the fix because the directory entry was missing.
- Verified exact selection supplies a root and directory, different peer identities cannot capture the child, and mounting the correct peer restores nesting without mutating the saved relationship.
- 209 tests passed across navigation projection, viewer pins, query store, and sidebar suites; the final discovery guard also passed all 54 main-process tests.
- Workspace typecheck, ESLint (zero errors; existing warnings), dependency boundaries, and `git diff --check` passed.
- No persistence changes or additional SQLite writes.
