### PR TITLE
fix(desktop): apply environments to existing threads

### DIFF
--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3648,6 +3648,82 @@ describe("AcpBackendAdapter", () => {
     await adapter.close();
   });
 
+  it("isolates changed session environments and restores defaults when cleared", async () => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    const agent = {
+      ...buildInstalledAgent(),
+      launchDescriptor: {
+        backendId,
+        registryId: "gemini",
+        distributionKind: "local" as const,
+        command: "/fixture/gemini",
+        args: [],
+        env: { ORIGINAL: "yes" },
+      },
+    };
+    const session = { backendId, sessionId: "session-1", status: "idle", cwd: "/fixture" } as AcpSessionMetadata;
+    const makeClient = () => ({
+      initialize: vi.fn(async () => undefined),
+      ensureSession: vi.fn(async () => undefined),
+      dispose: vi.fn(async () => undefined),
+      ownsSession: () => true,
+      supportsSessionLoad: vi.fn(() => true),
+    });
+    const original = makeClient();
+    const failed = makeClient();
+    failed.ensureSession.mockRejectedValueOnce(new Error("load failed"));
+    const changed = makeClient();
+    const cleared = makeClient();
+    const createAcpClient = vi.fn()
+      .mockReturnValueOnce(original)
+      .mockReturnValueOnce(failed)
+      .mockReturnValueOnce(changed)
+      .mockReturnValueOnce(cleared);
+    const adapter = createTestAcpBackendAdapter({
+      acpAgentStore: null,
+      acpSessionStore: {
+        listSessions: () => [session],
+        getSession: () => session,
+        upsertSession: vi.fn(),
+      },
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [agent],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+    try {
+      await adapter.discoverAvailableAgents(issueProviderDiscoveryPermit("startup"));
+      original.supportsSessionLoad.mockReturnValue(false);
+      await expect(adapter.prepareSessionEnvironment(backendId, session.sessionId, { PATH: "/fixture/node/bin" }))
+        .rejects.toThrow("cannot reload");
+      expect(createAcpClient).toHaveBeenCalledOnce();
+      original.supportsSessionLoad.mockReturnValue(true);
+      await expect(adapter.prepareSessionEnvironment(backendId, session.sessionId, { PATH: "/fixture/node/bin" }))
+        .rejects.toThrow("load failed");
+      expect(failed.dispose).toHaveBeenCalledOnce();
+      await expect(adapter.getClientForSession(backendId, session.sessionId)).resolves.toBe(original);
+      await adapter.prepareSessionEnvironment(backendId, session.sessionId, { PATH: "/fixture/node/bin" });
+      expect(createAcpClient.mock.calls[2][0].launchDescriptor.env).toEqual({
+        ORIGINAL: "yes", PATH: "/fixture/node/bin",
+      });
+      expect(changed.ensureSession).toHaveBeenCalledWith(session);
+      await expect(adapter.getClientForSession(backendId, session.sessionId)).resolves.toBe(changed);
+      await expect(adapter.getClientForSession(backendId, "other-session")).resolves.toBe(original);
+      await adapter.prepareSessionEnvironment(backendId, session.sessionId, { PATH: "/fixture/node/bin" });
+      expect(createAcpClient).toHaveBeenCalledTimes(3);
+      await adapter.prepareSessionEnvironment(backendId, session.sessionId);
+      expect(createAcpClient.mock.calls[3][0].launchDescriptor.env).toEqual({ ORIGINAL: "yes" });
+      expect(changed.dispose).toHaveBeenCalledOnce();
+      expect(original.dispose).not.toHaveBeenCalled();
+      await expect(adapter.getClientForSession(backendId, session.sessionId)).resolves.toBe(cleared);
+    } finally {
+      await adapter.close();
+    }
+    expect(original.dispose).toHaveBeenCalledOnce();
+    expect(cleared.dispose).toHaveBeenCalledOnce();
+  });
+
   it("replaces the owner of a loadable session after launch identity changes", async () => {
     const backendId = "acp:gemini" as AcpBackendId;
     const firstAgent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
+++ b/apps/desktop/src/main/__tests__/acp-backend-adapter.test.ts
@@ -3724,6 +3724,94 @@ describe("AcpBackendAdapter", () => {
     expect(cleared.dispose).toHaveBeenCalledOnce();
   });
 
+  it.each([false, true])("reconciles provider changes for idle environment clients (selection cleared: %s)", async (cleared) => {
+    const backendId = "acp:gemini" as AcpBackendId;
+    let agent: AcpInstalledAgentRecord = {
+      ...buildInstalledAgent(),
+      launchDescriptor: {
+        backendId, registryId: "gemini", distributionKind: "local",
+        command: "/fixture/gemini", args: [], env: { PROVIDER: "original" },
+      },
+    };
+    const session = { backendId, sessionId: "session-1", status: "idle", cwd: "/fixture" } as AcpSessionMetadata;
+    const makeClient = () => ({
+      initialize: vi.fn(async () => undefined),
+      ensureSession: vi.fn(async () => undefined),
+      dispose: vi.fn(async () => undefined),
+      ownsSession: () => true,
+      hasActiveTurns: vi.fn(() => false),
+      hasActiveOperations: vi.fn(() => false),
+      supportsSessionLoad: () => true,
+    });
+    const clients: ReturnType<typeof makeClient>[] = [];
+    const createAcpClient = vi.fn(() => {
+      const client = makeClient();
+      clients.push(client);
+      return client;
+    });
+    const adapter = createTestAcpBackendAdapter({
+      acpAgentStore: null,
+      acpSessionStore: { listSessions: () => [session], getSession: () => session, upsertSession: vi.fn() },
+      captureStores: [],
+      createAcpClient: createAcpClient as never,
+      discoverLocalAcpAgents: async () => [agent],
+      emit: vi.fn(async () => undefined),
+      handleServerRequest: vi.fn(async () => ({ decision: "accept" })),
+    });
+    try {
+      await adapter.discoverAvailableAgents(issueProviderDiscoveryPermit("startup"));
+      await adapter.prepareSessionEnvironment(backendId, session.sessionId, { PATH: "/fixture/node/bin" });
+      if (cleared) await adapter.prepareSessionEnvironment(backendId, session.sessionId);
+      const previous = clients.at(-1)!;
+      const previousCount = clients.length;
+      previous.hasActiveTurns.mockReturnValue(true);
+      agent = {
+        ...agent,
+        activeCommand: "/replacement/gemini",
+        launchDescriptor: {
+          ...agent.launchDescriptor!, command: "/replacement/gemini", args: ["--new-option"], env: { PROVIDER: "updated" },
+        },
+      };
+      adapter.invalidateLocalAgentDiscovery();
+      await adapter.discoverAvailableAgents(issueProviderDiscoveryPermit("settings-user-action"));
+      await expect(adapter.getClientForSession(backendId, session.sessionId)).resolves.toBe(previous);
+      previous.hasActiveTurns.mockReturnValue(false);
+      previous.hasActiveOperations.mockReturnValue(true);
+      await expect(adapter.getClientForSession(backendId, session.sessionId)).resolves.toBe(previous);
+      expect(previous.dispose).not.toHaveBeenCalled();
+      expect(clients).toHaveLength(previousCount);
+      previous.hasActiveOperations.mockReturnValue(false);
+      const failed = makeClient();
+      failed.ensureSession.mockRejectedValueOnce(new Error("replacement could not load session"));
+      createAcpClient.mockImplementationOnce(() => {
+        clients.push(failed);
+        return failed;
+      });
+      await expect(adapter.getClientForSession(backendId, session.sessionId)).resolves.toBe(previous);
+      expect(failed.dispose).toHaveBeenCalledOnce();
+      expect(previous.dispose).not.toHaveBeenCalled();
+      // Concurrent lookups and turn preparation must load exactly one replacement.
+      const [first, second] = await Promise.all([
+        adapter.getClientForSession(backendId, session.sessionId),
+        adapter.getClientForSession(backendId, session.sessionId),
+        adapter.prepareSessionEnvironment(backendId, session.sessionId, cleared ? undefined : { PATH: "/fixture/node/bin" }),
+      ]);
+      expect(clients).toHaveLength(previousCount + 2);
+      expect(first).toBe(clients.at(-1));
+      expect(second).toBe(first);
+      expect(clients.at(-1)!.ensureSession).toHaveBeenCalledWith(session);
+      expect(previous.dispose).toHaveBeenCalledOnce();
+      expect(createAcpClient).toHaveBeenLastCalledWith(expect.objectContaining({
+        launchDescriptor: expect.objectContaining({
+          command: "/replacement/gemini", args: ["--new-option"],
+          env: cleared ? { PROVIDER: "updated" } : { PROVIDER: "updated", PATH: "/fixture/node/bin" },
+        }),
+      }));
+    } finally {
+      await adapter.close();
+    }
+  });
+
   it("replaces the owner of a loadable session after launch identity changes", async () => {
     const backendId = "acp:gemini" as AcpBackendId;
     const firstAgent: AcpInstalledAgentRecord = {

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -32844,7 +32844,7 @@ script = "printf setup"
     } as AppServerPendingRequestNotification);
 
     try {
-      await setupStarted;
+      await setupStarted.promise;
       expect(codexClient.lastStartThreadParams).toBeUndefined();
 
       const searchResponse = await codexClient.emitRequest({

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -18524,30 +18524,46 @@ command = "pnpm dev:messaging"
       "utf8",
     );
 
+    let finishSetup!: () => void;
+    let markSetupStarted!: () => void;
+    const setupGate = new Promise<void>((resolve) => { finishSetup = resolve; });
+    const setupStarted = new Promise<void>((resolve) => { markSetupStarted = resolve; });
+    const commandRunner = vi.fn(async () => {
+      markSetupStarted();
+      await setupGate;
+      return {
+        output: "installed",
+        exitCode: 0,
+        durationMs: 10,
+        shellEnvironment: { PATH: "/fixture/node/bin:/usr/bin", NVM_BIN: "/fixture/node/bin" },
+      };
+    });
     const overlayStore = createOverlayStoreMock();
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list"] },
+      threads: [
+        {
+          id: "thread-1",
+          title: "Thread",
+          titleSource: "explicit",
+          source: "codex",
+          updatedAt: 1,
+          projectKey: root,
+          linkedDirectories: [
+            {
+              id: root,
+              kind: "local",
+              label: "repo",
+              path: root,
+            },
+          ],
+        },
+      ],
+    });
     const registry = new DesktopBackendRegistry({
-      codexClient: new MockBackendClient({
-        initializeResult: { methods: ["thread/list"] },
-        threads: [
-          {
-            id: "thread-1",
-            title: "Thread",
-            titleSource: "explicit",
-            source: "codex",
-            updatedAt: 1,
-            projectKey: root,
-            linkedDirectories: [
-              {
-                id: root,
-                kind: "local",
-                label: "repo",
-                path: root,
-              },
-            ],
-          },
-        ],
-      }),
+      codexClient,
       overlayStore,
+      codexEnvironmentCommandRunner: commandRunner,
     });
     const events: AgentEvent[] = [];
     registry.onEvent((event) => {
@@ -18555,13 +18571,16 @@ command = "pnpm dev:messaging"
     });
 
     try {
-      await expect(
-        registry.setCodexThreadEnvironment({
-          backend: "codex",
-          threadId: "thread-1",
-          environmentId: "environment",
-        }),
-      ).resolves.toMatchObject({
+      const selection = registry.setCodexThreadEnvironment({
+        backend: "codex", threadId: "thread-1", environmentId: "environment",
+      });
+      await setupStarted;
+      const turn = registry.startTurn({
+        backend: "codex", threadId: "thread-1", input: [{ type: "text", text: "Use node" }],
+      });
+      expect(codexClient.startTurnCalls).toHaveLength(0);
+      finishSetup();
+      await expect(selection).resolves.toMatchObject({
         backend: "codex",
         threadId: "thread-1",
         codexEnvironmentRuntime: {
@@ -18570,6 +18589,8 @@ command = "pnpm dev:messaging"
           executionTarget: "local",
           cwd: root,
           setupCommand: "pnpm install",
+          setupStatus: "completed",
+          shellEnvironment: { PATH: "/fixture/node/bin:/usr/bin" },
           actions: [
             {
               id: "dev-messaging",
@@ -18579,6 +18600,20 @@ command = "pnpm dev:messaging"
           ],
         },
       });
+
+      expect(commandRunner).toHaveBeenCalledWith(expect.objectContaining({
+        cwd: root,
+        command: "pnpm install",
+        captureShellEnvironment: true,
+        mode: "wait",
+      }));
+      await registry.setCodexThreadEnvironment({
+        backend: "codex",
+        threadId: "thread-1",
+        environmentId: "environment",
+        actionId: "dev-messaging",
+      });
+      expect(commandRunner).toHaveBeenCalledOnce();
 
       await expect(
         overlayStore.getThreadOverlayState({
@@ -18614,6 +18649,21 @@ command = "pnpm dev:messaging"
           },
         },
       });
+      await turn;
+      expect(codexClient.lastStartTurnParams?.codexEnvironmentRuntime?.shellEnvironment)
+        .toEqual({ PATH: "/fixture/node/bin:/usr/bin", NVM_BIN: "/fixture/node/bin" });
+
+      await registry.setCodexThreadEnvironment({ backend: "codex", threadId: "thread-1" });
+      commandRunner.mockRejectedValueOnce(new Error("setup failed"));
+      await expect(registry.setCodexThreadEnvironment({
+        backend: "codex", threadId: "thread-1", environmentId: "environment",
+      })).rejects.toThrow("setup failed");
+      expect((await overlayStore.getThreadOverlayState({ backend: "codex", threadId: "thread-1" }))
+        ?.codexEnvironmentRuntime).toMatchObject({ setupStatus: "failed", setupOutput: "setup failed" });
+      await registry.setCodexThreadEnvironment({
+        backend: "codex", threadId: "thread-1", environmentId: "environment",
+      });
+      expect(commandRunner).toHaveBeenCalledTimes(3);
     } finally {
       await registry.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
@@ -32794,7 +32844,7 @@ script = "printf setup"
     } as AppServerPendingRequestNotification);
 
     try {
-      await setupStarted.promise;
+      await setupStarted;
       expect(codexClient.lastStartThreadParams).toBeUndefined();
 
       const searchResponse = await codexClient.emitRequest({

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -11758,6 +11758,50 @@ describe("CodexAppServerClient", () => {
     }
   });
 
+  it("refreshes an environment selected after creation but before the first turn", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
+    try {
+      const { threadId } = await client.startThread({ cwd: "/fixture" });
+      await client.startTurn({
+        threadId,
+        input: [{ type: "text", text: "Use selected environment" }],
+        codexEnvironmentRuntime: {
+          environmentId: "env", environmentName: "Env", executionTarget: "local",
+          shellEnvironment: { PATH: "/fixture/node/bin" },
+        },
+      });
+      const requests = MockTransport.instances.flatMap((transport) => transport.sentMessages)
+        .map((message) => JSON.parse(message));
+      expect(requests.find((request) => request.method === "thread/resume")?.params.config)
+        .toMatchObject({ "shell_environment_policy.set.PATH": "/fixture/node/bin" });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("does not start a turn when resuming its shell environment fails", async () => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadResumeError = { message: "resume failed" };
+    const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
+    try {
+      await expect(client.startTurn({
+        threadId: "thread-2",
+        input: [{ type: "text", text: "Use selected environment" }],
+        codexEnvironmentRuntime: {
+          environmentId: "env",
+          environmentName: "Env",
+          executionTarget: "local",
+          shellEnvironment: { PATH: "/fixture/node/bin" },
+        },
+      })).rejects.toThrow("resume failed");
+      expect(MockTransport.instances.flatMap((transport) => transport.sentMessages)
+        .map((message) => JSON.parse(message).method)).not.toContain("turn/start");
+    } finally {
+      await client.close();
+    }
+  });
+
   it("still emits the per-turn permission overrides on turn/start when thread/resume fails", async () => {
     // The defense-in-depth behavior: thread/resume primes codex's
     // per-thread profile, but if it fails (rare race or transient

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppServerThreadSummary } from "@pwragent/shared";
+import type { AppServerNotification, AppServerThreadSummary } from "@pwragent/shared";
 import type { JsonRpcTransport } from "@pwrdrvr/agent-transport";
 import gitBudgets from "./fixtures/git-subprocess-budgets.json";
 import type { InitializeResponse } from "@pwrdrvr/codex-app-server-protocol";
@@ -11760,6 +11760,9 @@ describe("CodexAppServerClient", () => {
 
   it("refreshes an environment selected after creation but before the first turn", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.serverCapabilitiesResult = {
+      codeModeOutputReducer: { protocolVersion: 1, dynamicToolsResumeField: "dynamicTools" },
+    };
     const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
     try {
       const { threadId } = await client.startThread({ cwd: "/fixture" });
@@ -11770,6 +11773,47 @@ describe("CodexAppServerClient", () => {
           environmentId: "env", environmentName: "Env", executionTarget: "local",
           shellEnvironment: { PATH: "/fixture/node/bin" },
         },
+      });
+      const requests = MockTransport.instances.flatMap((transport) => transport.sentMessages)
+        .map((message) => JSON.parse(message));
+      expect(requests.find((request) => request.method === "thread/resume")?.params.config)
+        .toMatchObject({ "shell_environment_policy.set.PATH": "/fixture/node/bin" });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it.each([false, true])("defers first-turn environment changes on stock Codex (capability RPC unavailable: %s)", async (unavailable) => {
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const client = new CodexAppServerClient({ command: "codex", directoryResolver: async () => [] });
+    if (unavailable) {
+      vi.spyOn(client, "readServerCapabilities").mockRejectedValue(new Error("Method not found"));
+    }
+    const notifications: AppServerNotification[] = [];
+    client.onNotification((notification) => { notifications.push(notification); });
+    try {
+      const { threadId } = await client.startThread({ cwd: "/fixture" });
+      const runtime = {
+        environmentId: "env", environmentName: "Env", executionTarget: "local" as const,
+        shellEnvironment: { PATH: "/fixture/node/bin" },
+      };
+      MockTransport.threadResumeError = { message: "no rollout before the first turn" };
+      await expect(client.startTurn({
+        threadId, input: [{ type: "text", text: "First turn" }], codexEnvironmentRuntime: runtime,
+      })).resolves.toMatchObject({ turnId: "turn-1" });
+      const firstRequests = MockTransport.instances.flatMap((transport) => transport.sentMessages)
+        .map((message) => JSON.parse(message));
+      expect(firstRequests.some((request) => request.method === "thread/resume")).toBe(false);
+      expect(firstRequests.filter((request) => request.method === "turn/start")).toEqual([
+        expect.objectContaining({ params: expect.objectContaining({ threadId }) }),
+      ]);
+      expect(notifications).toContainEqual({
+        method: "warning",
+        params: { threadId, message: expect.stringContaining("selected environment will apply from the next turn") },
+      });
+      MockTransport.threadResumeError = undefined;
+      await client.startTurn({
+        threadId, input: [{ type: "text", text: "Next turn" }], codexEnvironmentRuntime: runtime,
       });
       const requests = MockTransport.instances.flatMap((transport) => transport.sentMessages)
         .map((message) => JSON.parse(message));

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -97,6 +97,13 @@
     "rowsChanged": 1,
     "statements": 1
   },
+  "existing-thread-environment-setup": {
+    "commits": 2,
+    "note": "one existing-thread environment selection, including setup hydration and runtime persistence; no per-event writes",
+    "observedWalBytes": 24720,
+    "rowsChanged": 2,
+    "statements": 2
+  },
   "federated-child-archive-ungroup": {
     "commits": 2,
     "note": "clear one child-owner parent overlay and refresh its root-owner pin",

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -12,6 +12,7 @@ import type {
 import { buildFederatedThreadRef } from "@pwragent/shared";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { DesktopBackendRegistry } from "../app-server/backend-registry";
+import { CodexEnvironmentHydrationStore } from "../app-server/codex-environment-hydration-store";
 import { ensureStarMapIntakeLaunchpad } from "../app-server/star-map-intake";
 import { AutomationStore } from "../automations/automation-store";
 import { DesktopAutomationService } from "../automations/desktop-automation-service";
@@ -667,6 +668,40 @@ describe("sqlite write metrics", () => {
     const metrics = readSqliteWriteMetrics();
     expect(metrics?.statements).toBe(2);
     expect(metrics?.commits).toBe(2);
+  });
+
+  it("budgets setup when an existing thread selects an environment", async () => {
+    const environmentDir = path.join(tempDir, ".codex", "environments");
+    mkdirSync(environmentDir, { recursive: true });
+    writeFileSync(path.join(environmentDir, "environment.toml"),
+      'version = 1\nname = "Fixture"\n[setup]\nscript = "fixture-setup"\n');
+    const registry = new DesktopBackendRegistry({
+      codexClient: createStubBackendClient({ threads: [{
+        id: "environment-thread", source: "codex", title: "Fixture",
+        titleSource: "explicit", updatedAt: 1,
+        linkedDirectories: [{ id: tempDir, kind: "local", label: "Fixture", path: tempDir }],
+      }] }),
+      overlayStore: store as never,
+      codexEnvironmentHydrationStore: new CodexEnvironmentHydrationStore(stateDb),
+      codexEnvironmentCommandRunner: async () => ({
+        output: "ready", exitCode: 0, durationMs: 1,
+        shellEnvironment: { PATH: "/fixture/node/bin:/usr/bin" },
+      }),
+    });
+    try {
+      const { writes } = await measureSqliteWrites(async () => {
+        await registry.setCodexThreadEnvironment({
+          backend: "codex", threadId: "environment-thread", environmentId: "environment",
+        });
+      });
+      expectSqliteWriteBudget({
+        note: "one existing-thread environment selection, including setup hydration and runtime persistence; no per-event writes",
+        scenario: "existing-thread-environment-setup",
+        writes,
+      });
+    } finally {
+      await registry.close();
+    }
   });
 
   it("budgets first-use Star Map intake launchpad initialization", async () => {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
 import { app } from "electron";
+import { PerKeyAsyncLock } from "../util/per-key-async-lock";
 import {
   type AcpBackendId,
   type AcpThreadRewindPoint,
@@ -1104,8 +1105,10 @@ export class AcpBackendAdapter {
   private readonly environmentClients = new Map<string, {
     backend: AcpBackendId;
     environmentKey: string;
+    shellEnvironment?: Record<string, string>;
     entry: AcpClientEntry;
   }>();
+  private readonly environmentClientLocks = new PerKeyAsyncLock();
   // A non-loadable ACP session belongs to the process that created it. Launch
   // selection may replace the current client, but these owners must remain
   // addressable until adapter shutdown so later turns keep using that process.
@@ -1687,26 +1690,33 @@ export class AcpBackendAdapter {
     sessionId: string,
     shellEnvironment?: Record<string, string>,
   ): Promise<void> {
+    await this.environmentClientLocks.run(
+      JSON.stringify([backend, sessionId]),
+      () => this.prepareSessionEnvironmentLocked(backend, sessionId, shellEnvironment),
+    );
+  }
+
+  private async prepareSessionEnvironmentLocked(
+    backend: AcpBackendId,
+    sessionId: string,
+    shellEnvironment?: Record<string, string>,
+  ): Promise<void> {
+    if (this.closed) {
+      throw new Error("ACP backend adapter is closed");
+    }
     const key = JSON.stringify([backend, sessionId]);
     const previous = this.environmentClients.get(key);
     const environmentKey = JSON.stringify(
       Object.entries(shellEnvironment ?? {}).sort(([a], [b]) => a.localeCompare(b)),
     );
-    if ((!previous && !shellEnvironment) || previous?.environmentKey === environmentKey) {
+    if (!previous && !shellEnvironment) {
       return;
     }
     const session = this.getSession(backend, sessionId);
     if (!session) {
       throw new Error(`ACP session not found: ${sessionId}`);
     }
-    const owner = await this.getClientForSession(backend, sessionId);
-    if (session.status === "active") {
-      throw new Error("Wait for the ACP operation to finish before changing its environment.");
-    }
     const agent = await this.resolveInstalledAgent(backend);
-    if (!(owner.supportsSessionLoad?.() ?? acpRuntimeSupportsSessionLoad(agent.runtimeCapabilities))) {
-      throw new Error("This ACP provider cannot reload an existing session with a new environment. Clear the environment selection to continue.");
-    }
     if (!agent.launchDescriptor) {
       throw new Error(`ACP backend ${backend} has no launch descriptor`);
     }
@@ -1717,10 +1727,33 @@ export class AcpBackendAdapter {
         env: { ...agent.launchDescriptor.env, ...shellEnvironment },
       },
     };
+    const launchIdentity = acpAgentLaunchIdentity(configuredAgent);
+    const environmentUnchanged = previous?.environmentKey === environmentKey;
+    if (environmentUnchanged && previous.entry.launchIdentity === launchIdentity) {
+      return;
+    }
+    const owner = previous
+      ? await previous.entry.promise
+      : await this.getClientForSession(backend, sessionId);
+    if (
+      session.status === "active"
+      || owner.hasActiveTurns?.() === true
+      || owner.hasActiveOperations?.() === true
+    ) {
+      // Settings changes take effect once the owning process is idle. Keep
+      // cancellation and other live-session RPCs on that process meanwhile.
+      if (environmentUnchanged) {
+        return;
+      }
+      throw new Error("Wait for the ACP operation to finish before changing its environment.");
+    }
+    if (!(owner.supportsSessionLoad?.() ?? acpRuntimeSupportsSessionLoad(agent.runtimeCapabilities))) {
+      throw new Error("This ACP provider cannot reload an existing session with a new environment. Clear the environment selection to continue.");
+    }
     const client = this.createAcpClient(configuredAgent);
     const entry: AcpClientEntry = {
       client,
-      launchIdentity: acpAgentLaunchIdentity(configuredAgent),
+      launchIdentity,
       promise: Promise.resolve(client),
       supportsSessionLoad: true,
     };
@@ -1737,7 +1770,12 @@ export class AcpBackendAdapter {
       await this.disposeAcpClient(entry);
       throw error;
     }
-    this.environmentClients.set(key, { backend, environmentKey, entry });
+    this.environmentClients.set(key, {
+      backend,
+      environmentKey,
+      shellEnvironment: shellEnvironment ? { ...shellEnvironment } : undefined,
+      entry,
+    });
     if (previous) {
       await this.disposeAcpClient(previous.entry);
     }
@@ -1747,9 +1785,25 @@ export class AcpBackendAdapter {
     backend: AcpBackendId,
     sessionId: string,
   ): Promise<AcpRuntimeClient> {
-    const environmentClient = this.environmentClients.get(JSON.stringify([backend, sessionId]));
-    if (environmentClient) {
-      return await environmentClient.entry.promise;
+    const key = JSON.stringify([backend, sessionId]);
+    if (this.environmentClients.has(key)) {
+      return await this.environmentClientLocks.run(key, async () => {
+        if (this.closed) {
+          throw new Error("ACP backend adapter is closed");
+        }
+        const previous = this.environmentClients.get(key)!;
+        try {
+          await this.prepareSessionEnvironmentLocked(backend, sessionId, previous.shellEnvironment);
+        } catch (error) {
+          // As with shared clients, a broken replacement must not strand the
+          // original session. Turn preparation still reports the launch error.
+          if (this.closed) {
+            throw error;
+          }
+          return await previous.entry.promise;
+        }
+        return await this.environmentClients.get(key)!.entry.promise;
+      });
     }
     let current: AcpRuntimeClient;
     try {

--- a/apps/desktop/src/main/app-server/acp-backend-adapter.ts
+++ b/apps/desktop/src/main/app-server/acp-backend-adapter.ts
@@ -1101,6 +1101,11 @@ export class AcpBackendAdapter {
     request: AppServerPendingRequestNotification,
   ) => Promise<unknown>;
   private readonly acpClients = new Map<AcpBackendId, AcpClientEntry>();
+  private readonly environmentClients = new Map<string, {
+    backend: AcpBackendId;
+    environmentKey: string;
+    entry: AcpClientEntry;
+  }>();
   // A non-loadable ACP session belongs to the process that created it. Launch
   // selection may replace the current client, but these owners must remain
   // addressable until adapter shutdown so later turns keep using that process.
@@ -1676,10 +1681,76 @@ export class AcpBackendAdapter {
     }
   }
 
+  /** Called under the registry's session prompt lock, before starting a turn. */
+  async prepareSessionEnvironment(
+    backend: AcpBackendId,
+    sessionId: string,
+    shellEnvironment?: Record<string, string>,
+  ): Promise<void> {
+    const key = JSON.stringify([backend, sessionId]);
+    const previous = this.environmentClients.get(key);
+    const environmentKey = JSON.stringify(
+      Object.entries(shellEnvironment ?? {}).sort(([a], [b]) => a.localeCompare(b)),
+    );
+    if ((!previous && !shellEnvironment) || previous?.environmentKey === environmentKey) {
+      return;
+    }
+    const session = this.getSession(backend, sessionId);
+    if (!session) {
+      throw new Error(`ACP session not found: ${sessionId}`);
+    }
+    const owner = await this.getClientForSession(backend, sessionId);
+    if (session.status === "active") {
+      throw new Error("Wait for the ACP operation to finish before changing its environment.");
+    }
+    const agent = await this.resolveInstalledAgent(backend);
+    if (!(owner.supportsSessionLoad?.() ?? acpRuntimeSupportsSessionLoad(agent.runtimeCapabilities))) {
+      throw new Error("This ACP provider cannot reload an existing session with a new environment. Clear the environment selection to continue.");
+    }
+    if (!agent.launchDescriptor) {
+      throw new Error(`ACP backend ${backend} has no launch descriptor`);
+    }
+    const configuredAgent = {
+      ...agent,
+      launchDescriptor: {
+        ...agent.launchDescriptor,
+        env: { ...agent.launchDescriptor.env, ...shellEnvironment },
+      },
+    };
+    const client = this.createAcpClient(configuredAgent);
+    const entry: AcpClientEntry = {
+      client,
+      launchIdentity: acpAgentLaunchIdentity(configuredAgent),
+      promise: Promise.resolve(client),
+      supportsSessionLoad: true,
+    };
+    try {
+      await client.initialize();
+      if (client.supportsSessionLoad?.() === false) {
+        throw new Error("This ACP provider cannot reload an existing session with a new environment.");
+      }
+      await client.ensureSession(session);
+      if (this.closed) {
+        throw new Error("ACP backend adapter is closed");
+      }
+    } catch (error) {
+      await this.disposeAcpClient(entry);
+      throw error;
+    }
+    this.environmentClients.set(key, { backend, environmentKey, entry });
+    if (previous) {
+      await this.disposeAcpClient(previous.entry);
+    }
+  }
+
   async getClientForSession(
     backend: AcpBackendId,
     sessionId: string,
   ): Promise<AcpRuntimeClient> {
+    const environmentClient = this.environmentClients.get(JSON.stringify([backend, sessionId]));
+    if (environmentClient) {
+      return await environmentClient.entry.promise;
+    }
     let current: AcpRuntimeClient;
     try {
       current = await this.getClient(backend);
@@ -2138,6 +2209,9 @@ export class AcpBackendAdapter {
     }
     this.closed = true;
     const acpClients = [
+      ...[...this.environmentClients.values()].map(
+        ({ backend, entry }): [AcpBackendId, AcpClientEntry] => [backend, entry],
+      ),
       ...this.acpClients.entries(),
       ...[...this.retainedAcpClients.entries()].flatMap(([backend, entries]) =>
         [...entries].map(
@@ -2146,6 +2220,7 @@ export class AcpBackendAdapter {
       ),
     ];
     this.acpClients.clear();
+    this.environmentClients.clear();
     this.retainedAcpClients.clear();
     this.acpClientResolutions.clear();
     this.liveToolUpdateResolver.clear();
@@ -2229,6 +2304,10 @@ export class AcpBackendAdapter {
     backend: AcpBackendId,
     sessionId: string,
   ): AcpClientEntry | undefined {
+    const environmentClient = this.environmentClients.get(JSON.stringify([backend, sessionId]));
+    if (environmentClient) {
+      return environmentClient.entry;
+    }
     const current = this.acpClients.get(backend);
     if (current?.client.ownsSession?.(sessionId) === true) {
       return current;

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -11969,6 +11969,17 @@ export class DesktopBackendRegistry {
       throw new Error("ACP turns require text or image input");
     }
 
+    const overlay = await this.overlayStore.getThreadOverlayState({
+      backend: params.backend,
+      threadId: params.threadId,
+    });
+    await this.acpBackend.prepareSessionEnvironment(
+      params.backend,
+      params.threadId,
+      overlay?.codexEnvironmentRuntime?.executionTarget === "local"
+        ? overlay.codexEnvironmentRuntime.shellEnvironment
+        : undefined,
+    );
     const client = await this.acpBackend.getClientForSession(
       params.backend,
       params.threadId,
@@ -16288,6 +16299,12 @@ export class DesktopBackendRegistry {
         throw new Error("Desktop backend registry closed before turn start");
       }
     }
+    // A selection already in flight must finish before this turn reads its runtime.
+    await this.withCodexEnvironmentRuntimeLock(
+      params.backend,
+      params.threadId,
+      async () => {},
+    );
     const migrationResult = await this.applyThreadModelMigration({
       backend: params.backend,
       threadId: params.threadId,
@@ -21452,6 +21469,16 @@ export class DesktopBackendRegistry {
   async setCodexThreadEnvironment(
     request: SetCodexThreadEnvironmentRequest,
   ): Promise<SetCodexThreadEnvironmentResponse> {
+    return this.withCodexEnvironmentRuntimeLock(
+      request.backend,
+      request.threadId,
+      () => this.setCodexThreadEnvironmentLocked(request),
+    );
+  }
+
+  private async setCodexThreadEnvironmentLocked(
+    request: SetCodexThreadEnvironmentRequest,
+  ): Promise<SetCodexThreadEnvironmentResponse> {
     if (!request.environmentId) {
       await this.overlayStore.setThreadCodexEnvironmentRuntime?.({
         backend: request.backend,
@@ -21505,8 +21532,35 @@ export class DesktopBackendRegistry {
       overlay?.codexEnvironmentRuntime?.environmentId === environment.id
         ? overlay.codexEnvironmentRuntime
         : undefined;
+    let setupRuntime = existingRuntime;
+    let setupError: CodexEnvironmentStartupError | undefined;
+    if (
+      !existingRuntime
+      || existingRuntime.setupStatus === "failed"
+      || (environment.setupScript && !existingRuntime.setupStatus)
+    ) {
+      try {
+        setupRuntime = await applyLocalCodexEnvironmentSelection({
+          commandRunner: this.codexEnvironmentCommandRunner,
+          cwd,
+          env: this.codexEnvironmentCommandEnv,
+          hydrationStore: this.codexEnvironmentHydrationStore,
+          selection: {
+            environment,
+            executionTarget: existingRuntime?.executionTarget ?? "local",
+            runSetup: true,
+          },
+        });
+      } catch (error) {
+        if (!(error instanceof CodexEnvironmentStartupError)) {
+          throw error;
+        }
+        setupRuntime = error.runtime;
+        setupError = error;
+      }
+    }
     const codexEnvironmentRuntime: CodexThreadEnvironmentRuntime = {
-      ...(existingRuntime ?? {}),
+      ...(setupRuntime ?? {}),
       environmentId: environment.id,
       environmentName: environment.name,
       executionTarget: existingRuntime?.executionTarget ?? "local",
@@ -21530,6 +21584,10 @@ export class DesktopBackendRegistry {
       threadId: request.threadId,
       codexEnvironmentRuntime,
     });
+
+    if (setupError) {
+      throw setupError;
+    }
 
     return {
       backend: request.backend,

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -8928,9 +8928,32 @@ export class CodexAppServerClient {
     const shellEnvironmentChanged = pendingFirstTurnResult !== undefined
       && this.pendingFirstTurnShellEnvironments.get(params.threadId)
         !== JSON.stringify(params.codexEnvironmentRuntime?.shellEnvironment);
+    // The registry negotiates dynamicTools before supplying it. Environment
+    // changes must negotiate the same no-rollout resume extension themselves.
+    let supportsPendingEnvironmentRefresh = params.dynamicTools !== undefined;
+    if (shellEnvironmentChanged && !supportsPendingEnvironmentRefresh) {
+      const capabilities = await this.readServerCapabilities().catch(() => undefined);
+      supportsPendingEnvironmentRefresh =
+        capabilities?.codeModeOutputReducer?.protocolVersion === 1
+        && capabilities.codeModeOutputReducer.dynamicToolsResumeField === "dynamicTools";
+    }
     const refreshPendingFirstTurn =
       pendingFirstTurnResult !== undefined
+      && supportsPendingEnvironmentRefresh
       && (params.dynamicTools !== undefined || shellEnvironmentChanged);
+    if (shellEnvironmentChanged && !supportsPendingEnvironmentRefresh) {
+      // Stock Codex has no shell-environment override on turn/start. Preserve
+      // the existing thread and apply the selection via resume on the next turn.
+      for (const listener of this.notificationListeners) {
+        await listener({
+          method: "warning",
+          params: {
+            threadId: params.threadId,
+            message: "This Codex version cannot change the environment before the first turn. This turn uses the thread's original environment; the selected environment will apply from the next turn.",
+          },
+        });
+      }
+    }
     let resumeResult = pendingFirstTurnResult;
     if (!pendingFirstTurnResult || refreshPendingFirstTurn) {
       const resume = requestWithFallbacks({

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7423,6 +7423,7 @@ export class CodexAppServerClient {
     ) => Promise<unknown> | unknown
   >();
   private readonly pendingFirstTurnThreadResults = new Map<string, unknown>();
+  private readonly pendingFirstTurnShellEnvironments = new Map<string, string | undefined>();
   private readonly helperThreadIds = new Set<string>();
   private readonly helperTurnWaiters = new Map<
     string,
@@ -7602,6 +7603,7 @@ export class CodexAppServerClient {
     this.rejectHelperTurnWaiters(new Error("codex app server client closed"));
     this.pendingThreadListings.clear();
     this.pendingFirstTurnThreadResults.clear();
+    this.pendingFirstTurnShellEnvironments.clear();
     this.recordedThreadNames.clear();
     this.helperThreadIds.clear();
     this.completedHelperTurnResults.clear();
@@ -8836,6 +8838,10 @@ export class CodexAppServerClient {
     }
 
     this.pendingFirstTurnThreadResults.set(threadId, result);
+    this.pendingFirstTurnShellEnvironments.set(
+      threadId,
+      JSON.stringify(params.codexEnvironmentRuntime?.shellEnvironment),
+    );
     await this.recordThreadNameWithCodex(result);
 
     return {
@@ -8878,6 +8884,10 @@ export class CodexAppServerClient {
     }
 
     this.pendingFirstTurnThreadResults.set(threadId, result);
+    this.pendingFirstTurnShellEnvironments.set(
+      threadId,
+      JSON.stringify(params.codexEnvironmentRuntime?.shellEnvironment),
+    );
     await this.recordThreadNameWithCodex(result);
 
     return {
@@ -8915,9 +8925,12 @@ export class CodexAppServerClient {
     // PwrAgent fork explicitly advertises a dynamic-tools resume extension
     // that supports this no-rollout refresh. The registry passes a complete
     // replacement catalog only after negotiating that exact capability.
+    const shellEnvironmentChanged = pendingFirstTurnResult !== undefined
+      && this.pendingFirstTurnShellEnvironments.get(params.threadId)
+        !== JSON.stringify(params.codexEnvironmentRuntime?.shellEnvironment);
     const refreshPendingFirstTurn =
       pendingFirstTurnResult !== undefined
-      && params.dynamicTools !== undefined;
+      && (params.dynamicTools !== undefined || shellEnvironmentChanged);
     let resumeResult = pendingFirstTurnResult;
     if (!pendingFirstTurnResult || refreshPendingFirstTurn) {
       const resume = requestWithFallbacks({
@@ -8944,7 +8957,11 @@ export class CodexAppServerClient {
         ),
         timeoutMs: this.options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
       });
+      // Environment overrides are applied by resume; continuing after a
+      // failure would silently run the turn with the previous toolchain.
       resumeResult = params.dynamicTools !== undefined
+        || params.codexEnvironmentRuntime?.shellEnvironment !== undefined
+        || shellEnvironmentChanged
         ? await resume
         : await resume.catch((error: unknown) => {
             // A shared Codex profile can be readable here while another
@@ -9000,6 +9017,7 @@ export class CodexAppServerClient {
     const threadId = extractThreadIdFromValue(result) ?? params.threadId;
     const turnId = extractTurnIdFromValue(result) ?? `pending:${threadId}`;
     this.pendingFirstTurnThreadResults.delete(params.threadId);
+    this.pendingFirstTurnShellEnvironments.delete(params.threadId);
     await this.recordDerivedThreadNameWithCodex({
       threadId: params.threadId,
       input: params.input,
@@ -9394,6 +9412,7 @@ export class CodexAppServerClient {
       throw new Error("codex app server review/start did not return turnId");
     }
     this.pendingFirstTurnThreadResults.delete(params.threadId);
+    this.pendingFirstTurnShellEnvironments.delete(params.threadId);
 
     return {
       threadId: params.threadId,


### PR DESCRIPTION
Selecting an environment on an existing thread previously saved metadata without running setup. This change runs the setup script in the thread workspace, captures its exported environment, and makes a subsequent turn wait for setup before using the selected toolchain. Changing only the selected action does not rerun setup; failed setup can be retried by selecting the environment again.

Codex applies captured variables through thread/resume and does not silently continue if that refresh fails. Before a thread's first turn, immediate refresh requires the advertised no-rollout resume extension. Stock Codex keeps the first send usable with the original environment, displays a warning, and applies the selection through resume from the following turn. This preserves the thread and does not send unsupported resume requests before its rollout exists.

ACP reloads the selected session in a separate process with the captured environment, preserving other threads and restoring defaults when the selection is cleared. Environment-specific clients revalidate their provider launch descriptor when idle, including after clearing the selection. Active turns and operations retain their owner; concurrent lookups share one replacement; a failed replacement leaves the original session available. ACP providers without session-loading support report an explicit error and retain the original session.

## Validation

- Registry, Codex client, and ACP adapter suites: 937 tests passed.
- Regression coverage includes setup readiness, captured variables, retries, negotiated first-turn refresh, stock-Codex deferral and warning, session isolation, provider configuration changes, active-operation deferral, concurrent replacement, clearing, and reload failures.
- Environment runtime suite and SQLite selection budget passed during initial implementation.
- Desktop typecheck, ESLint (existing warnings only), and dependency-boundary checks passed.
- Checked-in SQLite budget: two commits and approximately 24.7 KB WAL per selection, including hydration and runtime persistence. At 100 selections/day, approximately 2.5 MB/day; no per-output-event writes.

No live desktop or provider smoke test was performed.
