### PR TITLE
fix(desktop): allow local PR branch reviews and surface startup errors

### DIFF
--- a/apps/desktop/src/main/__tests__/review-workspace-guard.test.ts
+++ b/apps/desktop/src/main/__tests__/review-workspace-guard.test.ts
@@ -27,31 +27,65 @@ describe("assertReviewWorkspaceMatchesAttachedPullRequest", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("rejects a base review from an unrelated checkout", async () => {
-    const runGit = vi.fn(async (_cwd: string, args: string[]) => {
-      if (args[0] === "rev-parse" && args[1] === "--verify") {
-        return { stdout: PR_HEAD };
-      }
-      if (args[0] === "merge-base") {
-        throw new Error("not an ancestor");
-      }
-      if (args[0] === "rev-parse" && args[1] === "HEAD") {
-        return { stdout: CURRENT_HEAD };
-      }
-      throw new Error(`Unexpected git command: ${args.join(" ")}`);
-    });
+  it.each(["missing PR object", "rewritten PR history"])(
+    "allows the checked-out PR branch with %s",
+    async (reason) => {
+      const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+        if (args[0] === "symbolic-ref") {
+          return { stdout: "refs/heads/agent/pwragent-build-version\n" };
+        }
+        if (args[0] === "merge-base") {
+          throw new Error(reason);
+        }
+        if (args[0] === "rev-parse" && args[1] === "HEAD") {
+          return { stdout: CURRENT_HEAD };
+        }
+        throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      });
 
-    await expect(
-      assertReviewWorkspaceMatchesAttachedPullRequest({
+      await expect(assertReviewWorkspaceMatchesAttachedPullRequest({
         cwd: "/worktree",
         prs: [pullRequest()],
+        resolveGitHubRepos: async () => [{
+          host: "github.com", owner: "pwrdrvr", repo: "codex",
+        }],
         runGit,
         target: { type: "baseBranch", branch: "pwragent" },
-      }),
-    ).rejects.toThrow(
-      "current checkout 970b7f2ff4 does not contain attached #9 head e82f8783f9",
-    );
-  });
+      })).resolves.toBeUndefined();
+    },
+  );
+
+  it.each(["refs/heads/unrelated", "refs/heads/agent/pwragent-build-version-copy", ""])(
+    "rejects a base review from an unrelated checkout (%s)",
+    async (branch) => {
+      const runGit = vi.fn(async (_cwd: string, args: string[]) => {
+        if (args[0] === "symbolic-ref") {
+          if (!branch) {
+            throw new Error("detached HEAD");
+          }
+          return { stdout: branch };
+        }
+        if (args[0] === "merge-base") {
+          throw new Error("not an ancestor");
+        }
+        if (args[0] === "rev-parse" && args[1] === "HEAD") {
+          return { stdout: CURRENT_HEAD };
+        }
+        throw new Error(`Unexpected git command: ${args.join(" ")}`);
+      });
+
+      await expect(
+        assertReviewWorkspaceMatchesAttachedPullRequest({
+          cwd: "/worktree",
+          prs: [pullRequest()],
+          runGit,
+          target: { type: "baseBranch", branch: "pwragent" },
+        }),
+      ).rejects.toThrow(
+        "current checkout 970b7f2ff4 does not contain attached #9 head e82f8783f9",
+      );
+    },
+  );
 
   it("matches the origin-qualified spelling of an attached PR base", async () => {
     const runGit = vi.fn(async (_cwd: string, args: string[]) => {

--- a/apps/desktop/src/main/app-server/review-workspace-guard.ts
+++ b/apps/desktop/src/main/app-server/review-workspace-guard.ts
@@ -151,6 +151,20 @@ export async function assertReviewWorkspaceMatchesAttachedPullRequest(params: {
     return;
   }
 
+  // A base-branch review targets local changes, including unpushed or rebased
+  // work. The published PR SHA need not exist in this checkout. Use the actual
+  // symbolic branch (not a cached thread label) before falling back to ancestry
+  // for detached HEADs or differently named local branches.
+  const currentBranch = await runGit(cwd, ["symbolic-ref", "--quiet", "HEAD"])
+    .then((result) => result.stdout.trim())
+    .catch(() => "");
+  if (matchingPullRequests.some((pr) =>
+    Boolean(pr.headRefName?.trim())
+    && currentBranch === `refs/heads/${pr.headRefName?.trim()}`
+  )) {
+    return;
+  }
+
   const ancestry = await Promise.all(
     matchingPullRequests.map(async (pr) =>
       await commitIsAncestorOfHead(runGit, cwd, pr.headSha ?? "")

--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -5770,7 +5770,13 @@ export function Composer(props: ComposerProps) {
       }
       inFlightReviewSubmissionKeyRef.current = undefined;
       if (!options?.queued) {
-        recoverSubmittedComposerDraft(submittedSnapshot);
+        if (recoverSubmittedComposerDraft(submittedSnapshot)) {
+          setReviewConfig(reviewConfig ?? createReviewConfig({
+            directory: props.directory,
+            reviewCommand,
+            thread: props.thread,
+          }));
+        }
       }
       props.onPendingStatusChange?.(undefined);
       updateSending(false);
@@ -5779,7 +5785,13 @@ export function Composer(props: ComposerProps) {
       props.onActiveTurnIdChange?.(undefined);
       restoreQueuedTurnIfClaimed(options?.queued, options?.queueClaimed);
       releaseQueuedTurnScopeLockIfClaimed(options?.queued, options?.queueClaimed);
-      setSendError(error instanceof Error ? error.message : String(error));
+      const message = error instanceof Error ? error.message : String(error);
+      setSendError(message);
+      showComposerNotice({
+        title: "Review failed to start",
+        message,
+        tone: "error",
+      });
     }
   };
 
@@ -11118,6 +11130,11 @@ export function Composer(props: ComposerProps) {
               </div>
             ) : null}
 
+            {sendError ? (
+              <p className="composer__meta composer__meta--error" role="alert">
+                {sendError}
+              </p>
+            ) : null}
             <div className="composer__review-actions">
               <button
                 type="button"
@@ -12183,7 +12200,7 @@ export function Composer(props: ComposerProps) {
           text={props.launchpadError}
         />
       ) : null}
-      {sendError ? <p className="composer__meta composer__meta--error">{sendError}</p> : null}
+      {sendError && !isReviewComposerOpen ? <p className="composer__meta composer__meta--error" role="alert">{sendError}</p> : null}
       {agentThreadError ? (
         <p className="composer__meta composer__meta--error" role="alert">
           {agentThreadError}

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -12599,6 +12599,58 @@ describe("Composer", () => {
     expect(screen.queryByRole("group", { name: "Review target" })).not.toBeInTheDocument();
   });
 
+  it("shows a review startup failure as an error toast and permits retry", async () => {
+    const onShowNotice = vi.fn();
+    const startReview = vi.fn().mockRejectedValue(new Error("Review not started: checkout verification failed."));
+
+    render(
+      <Composer
+        desktopApi={{
+          onAgentEvent: () => () => undefined,
+          startReview,
+        }}
+        onShowNotice={onShowNotice}
+        disabled={false}
+        skills={[]}
+        thread={{
+          id: "thread-1",
+          title: "Review thread",
+          titleSource: "explicit",
+          source: "codex",
+          executionMode: "default",
+          linkedDirectories: [],
+          inbox: { inInbox: false },
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Reply"), {
+      target: { value: "/review" },
+    });
+    await clickButton("Send");
+    fireEvent.click(screen.getByRole("button", { name: /Review one commit by SHA/i }));
+    const commitInput = await screen.findByRole("combobox", {
+      name: "Commit SHA",
+    });
+    fireEvent.change(commitInput, {
+      target: { value: "abc123def456" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+
+    await waitFor(() => {
+      expect(onShowNotice).toHaveBeenCalledWith(expect.objectContaining({
+        title: "Review failed to start",
+        message: "Review not started: checkout verification failed.",
+        tone: "error",
+      }));
+    });
+    expect(screen.getByRole("alert")).toHaveTextContent("checkout verification failed");
+    expect(screen.getByRole("combobox", { name: "Commit SHA" })).toHaveValue("abc123def456");
+    expect(screen.getByRole("button", { name: "Start review" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Start review" }));
+    await waitFor(() => expect(startReview).toHaveBeenCalledTimes(2));
+  });
+
   it("still accepts a pasted raw commit SHA", async () => {
     const startReview = vi.fn(async (request: StartReviewRequest) => ({
       backend: request.backend,


### PR DESCRIPTION
## Problem and change

Starting a base-branch review could reject the very PR branch it told the operator to check out. The workspace guard required the published PR head to be an ancestor of local HEAD, treating missing Git objects and rewritten or unpushed history as evidence of a wrong checkout.

Accept the actual symbolic PR branch in the selected workspace/repository before falling back to ancestry for detached or differently named checkouts. Base-branch reviews continue to compare local HEAD; this does not fetch, reset, or promise to review the published PR head. Unrelated checkouts remain guarded.

Review startup failures now show an error toast and an inline alert inside the review panel. Restore the selected target and reviewer for retry when no newer draft has been entered. Preserve newer reply edits when a request fails asynchronously.

## Validation

- Added regressions and observed three failing cases before the fixes: missing PR object, rewritten history, and absent startup error toast.
- Full workspace-guard and composer test files: 327 tests passing.
- `pnpm lint:eslint`: passed (existing warnings only).
- `pnpm typecheck`: passed.

UI behavior is covered by component tests; no live desktop screenshot was captured.
