### PR TITLE
perf(desktop): avoid Git probes for standard directory metadata

### DIFF
--- a/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
@@ -334,12 +334,35 @@ describe("directory enrichment invalidation", () => {
     expect(git).toHaveBeenCalledTimes(3);
   });
 
+  it("uses zero Git subprocesses to enrich 216 cold standard checkouts", async () => {
+    git.mockImplementation((_command: string, args: string[], _options: unknown,
+      callback: (error: Error | null, result: { stdout: string; stderr: string }) => void) => {
+      callback(null, { stdout: args.includes("--show-toplevel") ? args[1]
+        : args.includes("--porcelain") ? `worktree ${args[1]}\n` : "main", stderr: "" });
+    });
+    const enrich = createThreadDirectoryEnricher();
+    for (let index = 0; index < 216; index += 1) {
+      const cwd = path.join(root, `cold-${index}`);
+      const admin = path.join(cwd, ".git");
+      await fs.mkdir(path.join(admin, "refs", "heads"), { recursive: true });
+      await fs.writeFile(path.join(admin, "config"), "[core]\n repositoryformatversion = 0\n bare = false\n");
+      await fs.writeFile(path.join(admin, "HEAD"), "ref: refs/heads/main\n");
+      await fs.writeFile(path.join(admin, "refs", "heads", "main"), `${"a".repeat(40)}\n`);
+      expect(await enrich(cwd, "thread-list")).toMatchObject({
+        observedGitBranch: "main",
+        linkedDirectories: [{ path: cwd.replace(/\\/g, "/"), kind: "local" }],
+      });
+    }
+    expect(git).not.toHaveBeenCalled();
+  });
+
   it("preserves real Git worktree mappings, branch switches and detached HEAD", async () => {
     const run = await initializeRealGit();
     const worktree = path.join(root, "linked");
     await run(["-C", repo, "worktree", "add", "-b", "feature/fixture", worktree]);
     const enrich = createThreadDirectoryEnricher();
     const first = await enrich(worktree);
+    expect(git).not.toHaveBeenCalled();
     const normalized = (value: string) => value.replace(/\\/g, "/");
     expect(first).toMatchObject({
       observedGitBranch: "feature/fixture",
@@ -350,11 +373,24 @@ describe("directory enrichment invalidation", () => {
     expect(git).not.toHaveBeenCalled();
     await run(["-C", worktree, "checkout", "-b", "feature/next"]);
     expect((await enrich(worktree)).observedGitBranch).toBe("feature/next");
-    expect(git).toHaveBeenCalledTimes(1);
+    expect(git).not.toHaveBeenCalled();
     git.mockClear();
     await run(["-C", worktree, "checkout", "--detach"]);
     expect((await enrich(worktree)).observedGitBranch).toBe("HEAD");
-    expect(git).toHaveBeenCalledTimes(1);
+    expect(git).not.toHaveBeenCalled();
+  });
+
+  it("reads packed branch refs without Git and falls back for configuration includes", async () => {
+    const run = await initializeRealGit();
+    await run(["-C", repo, "pack-refs", "--all"]);
+    const enrich = createThreadDirectoryEnricher();
+    expect((await enrich(repo)).observedGitBranch).toBe("main");
+    expect(git).not.toHaveBeenCalled();
+    const included = path.join(root, "included-config");
+    await fs.writeFile(included, "[core]\n bare = false\n");
+    await run(["-C", repo, "config", "include.path", included]);
+    expect((await enrich(repo)).observedGitBranch).toBe("main");
+    expect(git).toHaveBeenCalledTimes(3);
   });
 
   it("discovers the physical repository behind a symlinked subdirectory", async () => {

--- a/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
+++ b/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
@@ -5,6 +5,7 @@ export type GitDirectoryObservation = {
   repository: boolean;
   relationship: string;
   head: string;
+  checkout?: { repositoryPath: string; worktreePath?: string; branch: string };
 };
 
 type FileState = Awaited<ReturnType<typeof fileState>>;
@@ -103,8 +104,52 @@ export function createGitDirectoryObserver(): (
       ? refs
       : await fileState(path.join(commonDir, "reftable", "tables.list"));
     if (refs?.directory || commonRefs?.directory) return undefined;
+    // Resolve only conventional files-based repositories here. Unusual layouts,
+    // ref storage and configuration continue through Git's discovery path.
+    let checkout: GitDirectoryObservation["checkout"];
+    const configText = config && !config.directory
+      ? await pointer(path.join(commonDir, "config"), config) : "";
+    const standardConfig = /bare\s*=\s*false/i.test(configText)
+      && !/\[\s*(?:include|extensions)|worktree\s*=|bare\s*=\s*true/i.test(configText);
+    const environmentOverride = Object.keys(process.env).some((key) =>
+      /^(?:GIT_DIR|GIT_WORK_TREE|GIT_COMMON_DIR|GIT_CONFIG.*)$/.test(key) && process.env[key],
+    );
+    if (standardConfig && !worktreeConfig && !refs && !commonRefs && !environmentOverride) {
+      const headText = (await pointer(path.join(gitdir, "HEAD"), head)).trim();
+      const branchRef = headText.match(/^ref: (refs\/heads\/[a-zA-Z0-9_./-]+)$/)?.[1];
+      let branch: string | undefined;
+      if (/^[a-fA-F0-9]{40}(?:[a-fA-F0-9]{24})?$/.test(headText)) {
+        branch = "HEAD";
+      } else if (branchRef && !branchRef.includes("..") && !branchRef.endsWith(".lock")) {
+        // Do not infer a branch for unborn or symbolic-ref chains. Git remains
+        // authoritative for those cases, including its error behavior.
+        const refPath = path.join(commonDir, branchRef);
+        const refState = await fileState(refPath);
+        const refText = refState && !refState.directory ? (await pointer(refPath, refState)).trim() : "";
+        const packedPath = path.join(commonDir, "packed-refs");
+        const packedState = refState ? undefined : await fileState(packedPath);
+        const packed = packedState && !packedState.directory ? await pointer(packedPath, packedState) : "";
+        if (/^[a-fA-F0-9]{40}(?:[a-fA-F0-9]{24})?$/.test(refText)
+          || packed.split("\n").some((line) => {
+            const [oid, ref] = line.trim().split(" ");
+            return ref === branchRef && /^[a-fA-F0-9]{40}(?:[a-fA-F0-9]{24})?$/.test(oid);
+          })) {
+          branch = branchRef.slice("refs/heads/".length);
+        }
+      }
+      if (branch && dotGit.directory && commonDir === dotGitPath) {
+        checkout = { repositoryPath: parent, branch };
+      } else if (branch && !dotGit.directory && path.basename(commonDir) === ".git"
+        && path.dirname(path.dirname(gitdir)) === commonDir && backlink && !backlink.directory) {
+        const target = (await pointer(path.join(gitdir, "gitdir"), backlink)).trim();
+        if (path.resolve(gitdir, target) === dotGitPath) {
+          checkout = { repositoryPath: path.dirname(commonDir), worktreePath: parent, branch };
+        }
+      }
+    }
     return {
       repository: true,
+      checkout,
       relationship: JSON.stringify([
         resolved, directory.signature, dotGitPath, dotGit.signature, link,
         gitdir, admin.signature, common, commonInfo.signature,

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -359,6 +359,18 @@ export function createThreadDirectoryEnricher(): (
     let value: ThreadDirectoryEnrichment;
     if (before && !before.repository) {
       value = { linkedDirectories: [buildFallbackLinkedDirectory(key)] };
+    } else if (before?.checkout) {
+      const { repositoryPath, worktreePath, branch } = before.checkout;
+      value = {
+        linkedDirectories: [{
+          id: toDirectoryId(repositoryPath),
+          path: toDirectoryId(repositoryPath),
+          worktreePath: worktreePath ? toDirectoryId(worktreePath) : undefined,
+          label: path.basename(repositoryPath) || repositoryPath,
+          kind: worktreePath ? "worktree" : "local",
+        }],
+        observedGitBranch: branch,
+      };
     } else if (sameRelationship) {
       const branch = await runGit(key, ["rev-parse", "--abbrev-ref", "HEAD"], context)
         .catch(() => undefined);


### PR DESCRIPTION
Cold directory enrichment launched three Git processes for every checkout even though the filesystem observer had already located its Git metadata. The September 11 startup capture recorded 648 commands (216 of each probe), with 2.3 seconds sampled in process spawning.

Resolve conventional checkouts and linked worktrees from the observer's Git pointer files, configuration, and loose/packed HEAD evidence. Feed these facts into the existing enrichment cache, preserving before/after observation fencing. Reftable, unborn/symbolic heads, configuration includes/overrides, and unsupported layouts retain the Git fallback.

Validation:
- A 216-checkout cold regression failed with 648 commands before the fix and passes with zero commands after it.
- Real-Git tests cover linked worktree mappings, branch switches, detached HEAD, packed refs, symlinked subdirectories, and configuration-include fallback. Existing reftable and failure recovery tests pass.
- All 34 focused tests, ESLint, desktop TypeScript, and diff checks pass.

This targets startup subprocess amplification. Repeated enrichment requests for missing directories and the separate managed-subagent SQL scan remain outside this change. No SQLite writes or persistent cache were added; live CPU improvement remains to be measured.
