### PR TITLE
fix(desktop): keep managed Codex workers ephemeral

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -26364,7 +26364,7 @@ command = "pnpm dev"
     expect(codexClient.lastStartThreadParams).toMatchObject({
       approvalPolicy: "never",
       cwd: "/repo/worktree",
-      ephemeral: false,
+      ephemeral: true,
       fastMode: true,
       model: "gpt-5.5",
       reasoningEffort: "high",
@@ -26792,7 +26792,7 @@ command = "pnpm dev"
     expect(codexClient.lastStartReviewParams).toBeUndefined();
     expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/repo/selected",
-      ephemeral: false,
+      ephemeral: true,
     });
     expect(
       codexClient.lastStartThreadParams?.codexEnvironmentRuntime,
@@ -26865,7 +26865,7 @@ command = "pnpm dev"
     expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/remote/selected",
       codexEnvironmentRuntime: remoteRuntime,
-      ephemeral: false,
+      ephemeral: true,
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "remote-project-review",
@@ -36419,7 +36419,7 @@ script = "printf setup"
     expect(codexClient.lastStartReviewParams).toBeUndefined();
     expect(codexClient.lastStartThreadParams).toMatchObject({
       cwd: "/repo/pwragent",
-      ephemeral: false,
+      ephemeral: true,
     });
     expect(codexClient.lastStartTurnParams).toMatchObject({
       threadId: "thread-1",
@@ -42745,7 +42745,7 @@ script = "printf setup"
     expect(String(payload.parentAgentGuidance)).toContain("Do not sleep");
     expect(String(payload.parentAgentGuidance)).not.toContain("make at most one startup observation");
     expect(codexClient.lastStartThreadParams).toMatchObject({
-      ephemeral: false,
+      ephemeral: true,
       model: "gpt-5.6-luna",
       reasoningEffort: "medium",
       approvalPolicy: "on-request",
@@ -42988,7 +42988,7 @@ script = "printf setup"
 
     expect(response).toMatchObject({ success: true });
     expect(codexClient.lastStartThreadParams).toMatchObject({
-      ephemeral: false,
+      ephemeral: true,
       model: "gpt-5.6-luna",
     });
     expect(codexClient.lastStartThreadParams?.threadSource).toBe("subagent");
@@ -43065,7 +43065,7 @@ script = "printf setup"
       approvalPolicy: "never",
       codexEnvironmentRuntime,
       cwd: "/repo/app",
-      ephemeral: false,
+      ephemeral: true,
       sandbox: "danger-full-access",
     });
     expect(codexClient.lastStartThreadParams?.threadSource).toBe("subagent");

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -17483,12 +17483,10 @@ export class DesktopBackendRegistry {
     const thread = await client.startThread({
       ...(params.cwd ? { cwd: params.cwd } : {}),
       approvalPolicy: modeSettings.approvalPolicy,
-      // Keep review children durable so their inspection-only transcript can
-      // use thread/read with includeTurns, and mark them as subagents so
-      // PwrAgent excludes them from ordinary navigation. This classification
-      // does not claim Codex-native ThreadSpawn parentage, which Codex reserves
-      // for workers created by spawn_agent.
-      ephemeral: false,
+      // Do not persist managed workers in the shared Codex history: other
+      // profiles and the Codex app cannot rely on our local navigation filter.
+      // Progress, results, and usage remain on the parent's sub-agent record.
+      ephemeral: true,
       threadSource: "subagent" as CodexThreadSource,
       sandbox: modeSettings.sandbox,
       ...params.modelSettings,
@@ -35254,12 +35252,10 @@ export class DesktopBackendRegistry {
       ...(cwd ? { cwd } : {}),
       approvalPolicy: modeSettings.approvalPolicy,
       dynamicTools,
-      // Keep monitor children durable so their inspection-only transcript can
-      // use thread/read with includeTurns, and mark them as subagents so
-      // PwrAgent excludes them from ordinary navigation. This classification
-      // does not claim Codex-native ThreadSpawn parentage, which Codex reserves
-      // for workers created by spawn_agent.
-      ephemeral: false,
+      // Do not persist managed workers in the shared Codex history: other
+      // profiles and the Codex app cannot rely on our local navigation filter.
+      // Progress, results, and usage remain on the parent's sub-agent record.
+      ephemeral: true,
       model: params.preferredModel,
       reasoningEffort: params.preferredReasoningEffort,
       sandbox: modeSettings.sandbox,

--- a/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/__tests__/ThreadContextPanel.test.tsx
@@ -574,7 +574,7 @@ describe("ThreadContextPanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("offers a transcript for a detached review child", () => {
+  it("does not offer a transcript for an ephemeral managed review child", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true }));
     (window as Window & { pwragent?: unknown }).pwragent = {
       openSubAgentTranscriptWindow,
@@ -601,10 +601,10 @@ describe("ThreadContextPanel", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Details" }));
     expect(
-      within(screen.getByRole("dialog")).getByRole("button", {
+      within(screen.getByRole("dialog")).queryByRole("button", {
         name: "Open transcript",
       }),
-    ).toBeInTheDocument();
+    ).not.toBeInTheDocument();
   });
 
   it("labels Codex native sub-agent usage separately from monitor usage", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/SubAgentDetailsModal.tsx
@@ -124,7 +124,13 @@ export function SubAgentDetailsModal(props: SubAgentDetailsModalProps) {
   const model = subAgent.preferredModel ?? usage?.model ?? usage?.cost?.model;
   const fastMode = subAgent.preferredFastMode ?? usage?.fastMode;
   const running = !isTerminalSubAgent(subAgent);
+  // Managed Codex monitors and reviews are ephemeral; only native Codex
+  // subagents and ACP workers have reloadable child transcripts.
+  const hasDurableTranscript =
+    (subAgent.backend ?? props.defaultBackend) !== "codex"
+    || subAgent.monitorId.startsWith("codex-native:");
   const transcriptThreadId =
+    hasDurableTranscript &&
     subAgent.monitorThreadId &&
     subAgent.monitorThreadId !== props.parentThreadId
       ? subAgent.monitorThreadId

--- a/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/context-panels/__tests__/SubAgentDetailsModal.test.tsx
@@ -136,6 +136,22 @@ describe("SubAgentDetailsModal", () => {
     expect(screen.getByText("gpt-5.6-luna · medium")).toBeInTheDocument();
   });
 
+  it.each(["monitor-1", "review:turn-1"])(
+    "keeps managed Codex worker %s details without offering a transcript",
+    (monitorId) => {
+      const openSubAgentTranscriptWindow = vi.fn();
+      (window as Window & { pwragent?: unknown }).pwragent = {
+        openSubAgentTranscriptWindow,
+      };
+      renderModal({ monitorId, status: "success", lastMessage: "Validation passed." });
+
+      expect(screen.queryByRole("button", { name: "Open transcript" })).not.toBeInTheDocument();
+      expect(screen.getByText(LONG_TASK)).toBeInTheDocument();
+      expect(screen.getByText("Validation passed.")).toBeInTheDocument();
+      expect(openSubAgentTranscriptWindow).not.toHaveBeenCalled();
+    },
+  );
+
   it("opens a native child transcript on the instance that owns it", () => {
     const openSubAgentTranscriptWindow = vi.fn(async () => ({ opened: true as const }));
     (window as Window & { pwragent?: unknown }).pwragent = {


### PR DESCRIPTION
Managed Codex monitors and review workers currently persist as ordinary threads in the shared Codex history. Other PwrAgent profiles lack the parent records needed to hide them, and the Codex app cannot use those local records either.

Create both worker types with `ephemeral: true` and remove their Open transcript action. Parent sub-agent cards continue to retain task, progress, result, and usage details. Native Codex subagents and ACP workers keep transcript access. Existing durable workers are not deleted or migrated.

Validation: focused backend lifecycle and renderer tests; `pnpm lint:eslint`; `pnpm typecheck`; `pnpm lint:boundaries`; `git diff --check`.
