### PR TITLE
perf(desktop): refresh directory metadata on demand

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1112,6 +1112,7 @@ vi.mock("../app-server/backend-registry", () => {
     canonicalizeNavigationThreadPullRequests: async (threads: unknown[]) => threads,
     getNavigationInputRequestThreadKeys: () => new Set<string>(),
     refreshThreadGitWorkingStates,
+    refreshThreadDirectoryRelationship: vi.fn(async () => undefined),
     scheduleWorktreeGitWorkingStateRefresh,
     getThreadGitWorkingStateCache,
     loadThreadGitWorkingStateCache,

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -451,6 +451,10 @@ const sampleGitWorkingState = {
   baseAheadCommitCount: 16,
 };
 
+function activeWorkingStateThread(params: Parameters<typeof multiProjectThread>[0]): AppServerThreadSummary {
+  return { ...multiProjectThread(params), threadStatus: "active" };
+}
+
 function multiProjectThread(params: {
   worktreePath: string;
 }): AppServerThreadSummary {
@@ -3475,6 +3479,20 @@ describe("DesktopBackendRegistry", () => {
     }
   });
 
+  it("does not start an automatic Git fleet for inactive history", async () => {
+    const readWorkingStateEntries = vi.fn();
+    const registry = new DesktopBackendRegistry({
+      codexClient: new MockBackendClient({ threads: [] }),
+      overlayStore: createOverlayStoreMock(),
+      gitWorkingStateService: { readWorkingStateEntries } as unknown as GitWorkingStateService,
+    });
+    const threads = Array.from({ length: 500 }, (_, index) =>
+      multiProjectThread({ worktreePath: `/worktrees/inactive-${index}` }));
+    expect(await registry.refreshThreadGitWorkingStates(threads)).toEqual({ scheduledCount: 0 });
+    expect(readWorkingStateEntries).not.toHaveBeenCalled();
+    await registry.close();
+  });
+
   it("schedules a stale working-state probe without awaiting the Git fleet", async () => {
     // A navigation serving path must answer from cache. Holding the snapshot
     // until the fleet returns is what put a Git probe on every messaging
@@ -3506,7 +3524,7 @@ describe("DesktopBackendRegistry", () => {
     try {
       await expect(
         registry.refreshThreadGitWorkingStates([
-          multiProjectThread({ worktreePath }),
+          activeWorkingStateThread({ worktreePath }),
         ]),
       ).resolves.toEqual({ scheduledCount: 1 });
       expect(overlayStore.writeThreadGitWorkingStateCacheEntry)
@@ -3570,7 +3588,7 @@ describe("DesktopBackendRegistry", () => {
     try {
       await expect(
         registry.refreshThreadGitWorkingStates([
-          multiProjectThread({ worktreePath }),
+          activeWorkingStateThread({ worktreePath }),
         ]),
       ).resolves.toEqual({ scheduledCount: 1 });
       await expectEventually(
@@ -3658,7 +3676,7 @@ describe("DesktopBackendRegistry", () => {
           // Reversed, so a naive prefix would take the freshest eight and
           // only rotation can produce the ascending expectation below.
           worktreePaths
-            .map((worktreePath) => multiProjectThread({ worktreePath }))
+            .map((worktreePath) => activeWorkingStateThread({ worktreePath }))
             .reverse(),
         ),
       ).resolves.toEqual({
@@ -3713,7 +3731,7 @@ describe("DesktopBackendRegistry", () => {
     try {
       await expect(
         registry.refreshThreadGitWorkingStates([
-          multiProjectThread({ worktreePath }),
+          activeWorkingStateThread({ worktreePath }),
         ]),
       ).resolves.toEqual({ scheduledCount: 0 });
       expect(readWorkingStateEntries).not.toHaveBeenCalled();
@@ -3753,7 +3771,7 @@ describe("DesktopBackendRegistry", () => {
       (_unused, index) => `${worktreePath}-${index}`,
     );
     const threads = worktreePaths.map((path) =>
-      multiProjectThread({ worktreePath: path }),
+      activeWorkingStateThread({ worktreePath: path }),
     );
     expect(Math.ceil(
       worktreePaths.length / BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
@@ -3821,7 +3839,7 @@ describe("DesktopBackendRegistry", () => {
       overlayStore,
     });
     const hydrated = await registry.hydrateThreadGitWorkingStates([
-      multiProjectThread({ worktreePath }),
+      activeWorkingStateThread({ worktreePath }),
     ]);
 
     try {
@@ -3860,7 +3878,7 @@ describe("DesktopBackendRegistry", () => {
       overlayStore,
     });
     const singleDirectoryThread = (path: string): AppServerThreadSummary => {
-      const thread = multiProjectThread({ worktreePath: path });
+      const thread = activeWorkingStateThread({ worktreePath: path });
       return {
         ...thread,
         linkedDirectories: thread.linkedDirectories.slice(0, 1),
@@ -3923,7 +3941,7 @@ describe("DesktopBackendRegistry", () => {
 
     try {
       await registry.refreshThreadGitWorkingStates([
-        multiProjectThread({ worktreePath }),
+        activeWorkingStateThread({ worktreePath }),
       ]);
       await expectEventually(async () => workingStateEvents.length, 1);
       expect(workingStateEvents[0]?.notification.params).toEqual(
@@ -14925,6 +14943,7 @@ script = "echo setup"
     await registry.listThreads({
       backend: "codex",
       callerReason: "workspace-handoff",
+      enrichDirectories: true,
     });
 
     expect(codexClient.listThreadsCallCount).toBe(2);
@@ -15037,6 +15056,32 @@ script = "echo setup"
     await registry.close();
   });
 
+  it("does not enrich inactive directory history for startup or navigation listings", async () => {
+    const threads = Array.from({ length: 500 }, (_, index): AppServerThreadSummary => ({
+      id: `cold-${index}`, source: "codex", title: `Cold ${index}`, titleSource: "explicit",
+      projectKey: `/fixture/.codex/worktrees/${index}/repo`, linkedDirectories: [],
+    }));
+    const codexClient = new MockBackendClient({ threads });
+    const enrichThreadDirectories = vi.fn(async (rows: AppServerThreadSummary[]) => rows);
+    Object.assign(codexClient, { enrichThreadDirectories });
+    const registry = new DesktopBackendRegistry({ codexClient, overlayStore: createOverlayStoreMock() });
+    for (const callerReason of ["startup-provider-refresh", "startup-prewarm", "navigation-snapshot", "thread-list"] as const) {
+      await registry.listThreads({ backend: "codex", callerReason, forceRefresh: true });
+      expect(codexClient.lastListThreadsParams?.enrichDirectories).toBe(false);
+    }
+    expect(enrichThreadDirectories).not.toHaveBeenCalled();
+    await registry.readThread({ backend: "codex", threadId: "cold-10" });
+    expect(enrichThreadDirectories).toHaveBeenCalledExactlyOnceWith([expect.objectContaining({ id: "cold-10" })], "selected-thread");
+    await registry.publishLocalEvent({ backend: "codex", notification: {
+      method: "turn/started", params: { threadId: "cold-20", turn: { id: "demand-turn", status: "inProgress", items: [] } },
+    } } as AgentEvent);
+    await flushAsync();
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(2);
+    expect(enrichThreadDirectories).toHaveBeenLastCalledWith([expect.objectContaining({ id: "cold-20" })], "selected-thread");
+
+    await registry.close();
+  });
+
   it("backfills Codex worktree parent directories so directory view shows one project", async () => {
     const projectA = "/Users/fixture-user/projects/ProjectA";
     const worktree1 = "/Users/fixture-user/.codex/worktrees/wt1/ProjectA";
@@ -15143,7 +15188,8 @@ script = "echo setup"
     let listResolved = false;
     const listPromise = registry.listThreads({
       backend: "codex",
-      callerReason: "startup-prewarm",
+      callerReason: "directory-relationship-reconcile",
+      enrichDirectories: false,
     });
     void listPromise.then(() => {
       listResolved = true;
@@ -15200,7 +15246,8 @@ script = "echo setup"
 
     await registry.listThreads({
       backend: "codex",
-      callerReason: "startup-prewarm",
+      callerReason: "directory-relationship-reconcile",
+      enrichDirectories: false,
       filter: "force-new-cache-key",
     });
 
@@ -15262,7 +15309,8 @@ script = "echo setup"
 
     await registry.listThreads({
       backend: "codex",
-      callerReason: "startup-prewarm",
+      callerReason: "directory-relationship-reconcile",
+      enrichDirectories: false,
     });
 
     expect(codexClient.listThreadsCallCount).toBe(2);
@@ -15397,7 +15445,7 @@ script = "echo setup"
     expect(enrichThreadDirectories).not.toHaveBeenCalled();
 
     await registry.listThreads({
-      callerReason: "navigation-snapshot",
+      callerReason: "directory-relationship-reconcile",
       enrichDirectories: false,
     });
 
@@ -15953,7 +16001,7 @@ script = "echo setup"
     await registry.close();
   });
 
-  it("runs the full Codex directory reconcile once after three distinct selected-thread repairs", async () => {
+  it("does not expand selected-thread repairs into a full-history reconcile", async () => {
     const projectA = "/Users/example/ProjectA";
     const makeCheapThread = (index: number): AppServerThreadSummary => {
       const projectKey = `/Users/example/.codex/worktrees/worktree-${index}/ProjectA`;
@@ -16012,34 +16060,16 @@ script = "echo setup"
     expect(fullReconcileCalls()).toHaveLength(0);
     await registry.readThread({ backend: "codex", threadId: "thread-3" });
 
-    await waitForCondition(() =>
-      enrichThreadDirectories.mock.calls.some(
-        ([threads]) =>
-          threads.length === 2 &&
-          threads.map((thread) => thread.id).join(",") === "thread-4,thread-5",
-      ),
-    );
-    expect(fullReconcileCalls()).toHaveLength(1);
-    const hasFullReconcileEvent = () =>
-      events.some(
-        (event) =>
-          event.backend === "codex" &&
-          event.notification.method === "navigation/threadDirectories/updated" &&
-          (event.notification.params as { reason?: string; threadIds?: string[] })
-            .reason === "full-reconcile" &&
-          (event.notification.params as { threadIds?: string[] }).threadIds?.join(
-            ",",
-          ) === "thread-4,thread-5",
-      );
-    await waitForCondition(hasFullReconcileEvent);
-    expect(hasFullReconcileEvent()).toBe(true);
+    await flushAsync();
+    expect(fullReconcileCalls()).toHaveLength(0);
+    expect(enrichThreadDirectories).toHaveBeenCalledTimes(3);
 
     const lateThread = makeCheapThread(6);
     codexClient.setThreads([...cheapThreads, lateThread]);
     await registry.readThread({ backend: "codex", threadId: "thread-6" });
     await flushAsync();
 
-    expect(fullReconcileCalls()).toHaveLength(1);
+    expect(fullReconcileCalls()).toHaveLength(0);
 
     unsubscribe();
     await registry.close();
@@ -45058,7 +45088,7 @@ script = "printf setup"
     ]);
     expect(codexClient.listThreadsCallCount).toBe(1);
     expect(codexClient.lastListThreadsParams).toEqual({
-      enrichDirectories: true,
+      enrichDirectories: false,
       filter: "thread",
     });
 
@@ -46910,7 +46940,7 @@ script = "printf setup"
     ).resolves.toEqual([expect.objectContaining({ id: "thread-archived" })]);
 
     expect(codexClient.listThreadsCalls.map((call) => call.params)).toEqual([
-      { archived: true, enrichDirectories: true },
+      { archived: true, enrichDirectories: false },
       { archived: false, enrichDirectories: false },
     ]);
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -46177,6 +46177,92 @@ script = "printf setup"
     await registry.close();
   });
 
+  it.each([false, true])("discovers archive worktrees after a cheap listing (shared checkout: %s)", async (shared) => {
+    const worktreePath = "/repo/checkouts/feature";
+    const directory = {
+      id: "directory:/repo/app",
+      label: "app",
+      path: "/repo/app",
+      kind: "worktree" as const,
+      worktreePath,
+    };
+    const target: AppServerThreadSummary = {
+      id: "archive-target",
+      title: "Archive target",
+      titleSource: "explicit",
+      source: "codex",
+      projectKey: worktreePath,
+      linkedDirectories: [directory],
+      updatedAt: 1,
+    };
+    const sibling: AppServerThreadSummary = {
+      ...target,
+      id: "unvisited-sibling",
+      title: "Unvisited sibling",
+      projectKey: `${worktreePath}/src`,
+    };
+    const codexClient = new MockBackendClient({
+      initializeResult: { methods: ["thread/list", "thread/archive"] },
+    });
+    vi.spyOn(codexClient, "listThreads").mockImplementation(async (params) => {
+      if (params?.archived) return [];
+      return (shared ? [target, sibling] : [target]).map((thread) =>
+        params?.enrichDirectories || (shared && thread === target)
+          ? thread
+          : {
+              ...thread,
+              linkedDirectories: [{
+                id: `directory:${thread.projectKey}`,
+                label: "feature",
+                path: thread.projectKey!,
+                kind: "local" as const,
+              }],
+            },
+      );
+    });
+    const archiveWorktree = vi.fn(async () => ({
+      id: "archive-snapshot",
+      backend: "codex" as const,
+      threadId: target.id,
+      worktreePath,
+      repositoryPath: "/repo/app",
+      snapshotRef: "refs/codex/snapshots/archive-snapshot",
+      snapshotCommit: "abc123",
+      sourceHead: "def456",
+      createdAt: 1000,
+      archivedAt: 1000,
+      state: "archived" as const,
+      ignoredFilesExcluded: true,
+    }));
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      worktreeArchiveService: { archive: archiveWorktree } as unknown as WorktreeArchiveService,
+    });
+    try {
+      await registry.listThreads({ backend: "codex", callerReason: "navigation-snapshot" });
+      const response = await registry.archiveThread({ backend: "codex", threadId: target.id });
+      if (shared) {
+        expect(archiveWorktree).not.toHaveBeenCalled();
+        expect(response.cleanup).toEqual([expect.objectContaining({
+          worktreePath,
+          removedWorktree: false,
+          skippedReason: "Worktree is still used by another active thread: unvisited-sibling.",
+        })]);
+      } else {
+        expect(archiveWorktree).toHaveBeenCalledWith({
+          backend: "codex",
+          threadId: target.id,
+          worktreePath,
+          repositoryPath: "/repo/app",
+        });
+        expect(response.cleanup).toEqual([expect.objectContaining({ removedWorktree: true })]);
+      }
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("retains parent worktree snapshots for archived same-worktree children", async () => {
     const worktreePath = "/Users/test/.codex/worktrees/shared/PwrAgnt";
     const parentThread: AppServerThreadSummary = {

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1864,6 +1864,16 @@ describe("CodexAppServerClient", () => {
       source: "codex",
     });
 
+    threadDirectoryEnricher.mockResolvedValueOnce({ linkedDirectories: [{
+      id: primaryThread!.projectKey!, path: primaryThread!.projectKey!, label: "Refreshed", kind: "local",
+    }] });
+    await client.enrichThreadDirectories([primaryThread!], "selected-thread");
+    threadDirectoryEnricher.mockClear();
+    const later = await client.listThreads({ enrichDirectories: false });
+    expect(later.find((thread) => thread.id === "thread-2")?.linkedDirectories)
+      .toEqual([expect.objectContaining({ label: "Refreshed" })]);
+    expect(threadDirectoryEnricher).not.toHaveBeenCalled();
+
     await client.close();
   });
 

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -97,6 +97,20 @@
     "rowsChanged": 1,
     "statements": 1
   },
+  "directory-demand-first-repair": {
+    "commits": 1,
+    "note": "one previously unknown directory relationship repaired on demand",
+    "observedWalBytes": 16480,
+    "rowsChanged": 1,
+    "statements": 1
+  },
+  "directory-demand-unchanged-refreshes": {
+    "commits": 0,
+    "note": "100 unchanged directory demand refreshes add no SQLite commits",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
   "existing-thread-environment-setup": {
     "commits": 2,
     "note": "one existing-thread environment selection, including setup hydration and runtime persistence; no per-event writes",

--- a/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/thread-read-budgets.json
@@ -40,13 +40,13 @@
     "providerListCalls": 0
   },
   "worktree-navigation-refresh": {
-    "directoryEnrichments": 1,
+    "directoryEnrichments": 0,
     "note": "one navigation refresh over a single worktree-backed thread",
     "providerListCalls": 1
   },
   "worktree-turns-after-enrichment": {
-    "directoryEnrichments": 0,
-    "note": "five turns on an already-enriched worktree thread",
+    "directoryEnrichments": 10,
+    "note": "five turns refresh one known worktree at start and completion; labels add no reads",
     "providerListCalls": 0
   }
 }

--- a/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
+++ b/apps/desktop/src/main/__tests__/sqlite-write-metrics.test.ts
@@ -704,6 +704,36 @@ describe("sqlite write metrics", () => {
     }
   });
 
+  it("budgets demand-driven directory repair and unchanged refreshes", async () => {
+    const cwd = path.join(tempDir, ".codex", "worktrees", "one", "repo");
+    const thread: AppServerThreadSummary = {
+      id: "directory-demand", source: "codex", title: "Demand", titleSource: "explicit",
+      projectKey: cwd, linkedDirectories: [],
+    };
+    const client = Object.assign(createStubBackendClient({ threads: [thread] }), {
+      enrichThreadDirectories: async () => [{ ...thread, linkedDirectories: [{
+        id: tempDir, path: tempDir, worktreePath: cwd, label: "repo", kind: "worktree" as const,
+      }] }],
+    });
+    const registry = new DesktopBackendRegistry({ codexClient: client, overlayStore: store as never });
+    try {
+      const { writes } = await measureSqliteWrites(() => registry.refreshThreadDirectoryRelationship({
+        backend: "codex", threadId: thread.id,
+      }));
+      expectSqliteWriteBudget({ scenario: "directory-demand-first-repair",
+        note: "one previously unknown directory relationship repaired on demand", writes });
+      const { writes: unchanged } = await measureSqliteWrites(async () => {
+        for (let index = 0; index < 100; index += 1) {
+          await registry.refreshThreadDirectoryRelationship({ backend: "codex", threadId: thread.id });
+        }
+      });
+      expectSqliteWriteBudget({ scenario: "directory-demand-unchanged-refreshes",
+        note: "100 unchanged directory demand refreshes add no SQLite commits", writes: unchanged });
+    } finally {
+      await registry.close();
+    }
+  });
+
   it("budgets first-use Star Map intake launchpad initialization", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: createStubBackendClient(),

--- a/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-directory-enrichment-cache.test.ts
@@ -119,7 +119,7 @@ describe("directory enrichment invalidation", () => {
     const enrich = createThreadDirectoryEnricher();
     fail = true;
     await enrich(repo);
-    expect(record.mock.calls.filter(([, delta]) => delta.gitFailed)).toHaveLength(3);
+    expect(record.mock.calls.filter(([, delta]) => delta.gitFailed)).toHaveLength(2);
     expect(record).toHaveBeenCalledWith(expect.objectContaining({ reason: "cold" }), { resultNotCached: 1 });
     record.mockClear();
     await enrich(path.join(root, "missing"));
@@ -230,7 +230,7 @@ describe("directory enrichment invalidation", () => {
     await fs.writeFile(path.join(worktree, ".git"), `gitdir: ${nextAdmin}\n`);
     branch = "second";
     expect((await enrich(worktree)).observedGitBranch).toBe("second");
-    expect(git).toHaveBeenCalledTimes(3);
+    expect(git).toHaveBeenCalledTimes(2);
   });
 
   it("does not rediscover topology for ordinary edits, commits or sibling worktrees", async () => {
@@ -268,7 +268,7 @@ describe("directory enrichment invalidation", () => {
     git.mockClear();
     await fs.writeFile(path.join(repo, ".git", "config.worktree"), "[core]\n bare = false\n");
     await enrich(repo);
-    expect(git).toHaveBeenCalledTimes(3);
+    expect(git).toHaveBeenCalledTimes(2);
   });
 
   it("invalidates a directory symlink when its target changes", async () => {
@@ -331,7 +331,53 @@ describe("directory enrichment invalidation", () => {
     branch = "new-head";
     git.mockClear();
     expect((await enrich(repo)).observedGitBranch).toBe(branch);
-    expect(git).toHaveBeenCalledTimes(3);
+    expect(git).toHaveBeenCalledTimes(2);
+  });
+
+  it("shares one Git worktree inventory across 216 cold sibling checkouts", async () => {
+    const worktrees = Array.from({ length: 216 }, (_, index) => path.join(root, `linked-${index}`));
+    for (const [index, cwd] of worktrees.entries()) {
+      const admin = path.join(repo, ".git", "worktrees", `${index}`);
+      await fs.mkdir(admin, { recursive: true });
+      await fs.mkdir(cwd);
+      await fs.writeFile(path.join(cwd, ".git"), `gitdir: ${admin}\n`);
+      await fs.writeFile(path.join(admin, "commondir"), "../..\n");
+      await fs.writeFile(path.join(admin, "HEAD"), "ref: refs/heads/main\n");
+    }
+    git.mockImplementation((_command: string, args: string[], _options: unknown,
+      callback: (error: Error | null, result: { stdout: string; stderr: string }) => void) => {
+      callback(null, { stdout: args.includes("--show-toplevel")
+        ? args.includes("--abbrev-ref") ? `${args[1]}\nmain` : args[1]
+        : args.includes("--abbrev-ref") ? "main" : [repo, ...worktrees].map((cwd) => `worktree ${cwd}`).join("\n"), stderr: "" });
+    });
+    const enrich = createThreadDirectoryEnricher();
+    // Separate batches exercise both pending coalescing and settled reuse.
+    for (let offset = 0; offset < worktrees.length; offset += 8) {
+      const batch = worktrees.slice(offset, offset + 8);
+      const values = await Promise.all(batch.map((cwd) => enrich(cwd, "selected-thread")));
+      values.forEach((value, index) => expect(value).toMatchObject({
+        observedGitBranch: "main", linkedDirectories: [{
+          path: repo.replace(/\\/g, "/"), worktreePath: batch[index].replace(/\\/g, "/"), kind: "worktree",
+        }],
+      }));
+    }
+    expect(git).toHaveBeenCalledTimes(217);
+    expect(git.mock.calls.filter(([, args]) => args.includes("--porcelain"))).toHaveLength(1);
+  });
+
+  it("lets Git reject discovery across an inherited ceiling", async () => {
+    await initializeRealGit();
+    const cwd = path.join(repo, "sub");
+    await fs.mkdir(cwd);
+    vi.stubEnv("GIT_CEILING_DIRECTORIES", repo);
+    try {
+      expect(await createThreadDirectoryEnricher()(cwd)).toMatchObject({
+        linkedDirectories: [{ path: cwd.replace(/\\/g, "/"), kind: "local" }],
+      });
+      expect(git.mock.calls.every(([, args]) => args.includes("--show-toplevel"))).toBe(true);
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("preserves real Git worktree mappings, branch switches and detached HEAD", async () => {

--- a/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
+++ b/apps/desktop/src/main/__tests__/thread-read-budget.test.ts
@@ -319,11 +319,11 @@ describe("directory enrichment budget", () => {
     titleSource: "explicit",
   });
 
-  it("enriches a worktree thread's directories once per backfill-capable listing", async () => {
+  it("does not enrich a worktree merely to list it in navigation", async () => {
     const { client, registry } = build([WORKTREE_THREAD]);
     await registry.listThreads(NAVIGATION_REFRESH);
 
-    expect(client.directoryEnrichmentCallCount).toBeGreaterThan(0);
+    expect(client.directoryEnrichmentCallCount).toBe(0);
     expectThreadReadBudget({
       note: "one navigation refresh over a single worktree-backed thread",
       reads: client.counts,
@@ -331,9 +331,10 @@ describe("directory enrichment budget", () => {
     });
   });
 
-  it("does not re-enrich a worktree thread for label reads across turns", async () => {
+  it("refreshes a known worktree at turn boundaries without label-read amplification", async () => {
     const { client, registry } = build([WORKTREE_THREAD]);
     await registry.listThreads(NAVIGATION_REFRESH);
+    await registry.refreshThreadDirectoryRelationship({ backend: "codex", threadId: WORKTREE_THREAD.id });
     client.resetCounts();
 
     for (let turn = 0; turn < 5; turn += 1) {
@@ -341,8 +342,10 @@ describe("directory enrichment budget", () => {
         method: "turn/started",
         params: { threadId: "thread-worktree", turnId: `turn-${turn}`, turn: { id: `turn-${turn}` } },
       });
+      const readsBeforeLabel = { ...client.counts };
       expect(registry.getThreadInfo({ backend: "codex", threadId: "thread-worktree" })?.title)
         .toBe("Worktree thread");
+      expect(client.counts).toEqual(readsBeforeLabel);
       await publishNotification(registry, {
         method: "turn/completed",
         params: {
@@ -354,7 +357,7 @@ describe("directory enrichment budget", () => {
     }
 
     expectThreadReadBudget({
-      note: "five turns on an already-enriched worktree thread",
+      note: "five turns refresh one known worktree at start and completion; labels add no reads",
       reads: client.counts,
       scenario: "worktree-turns-after-enrichment",
     });

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -38316,10 +38316,18 @@ export class DesktopBackendRegistry {
       event.notification.method === "turn/started"
       || event.notification.method === "turn/completed"
     )) {
-      void this.repairCodexThreadDirectoryRelationship({
-        reason: "selected-thread",
-        threadId: event.notification.params.threadId,
+      // Lifecycle notifications must not discover a workspace by listing the
+      // provider. Notification-context reconciliation already owns that read
+      // for unseen threads; refresh only a workspace we have observed.
+      const known = this.getCachedThreadSummary({
+        backend: "codex", threadId: event.notification.params.threadId,
       });
+      if (known?.projectKey?.trim()) {
+        void this.repairCodexThreadDirectoryRelationship({
+          reason: "selected-thread",
+          threadId: event.notification.params.threadId,
+        });
+      }
     }
 
     this.rememberThreadTitleFromEvent(event);

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6008,19 +6008,9 @@ let threadListCacheSequence = 0;
 function shouldEnrichThreadDirectories(
   callerReason?: ThreadListCallerReason,
 ): boolean {
-  switch (callerReason) {
-    case "active-turn-branch-adoption":
-    case "branch-drift":
-    case "messaging-navigation-snapshot":
-    case "navigation-snapshot":
-    case "navigation-snapshot:active-recent":
-    case "startup-prewarm":
-    case "title-generation":
-    case "turn-cwd":
-      return false;
-    default:
-      return true;
-  }
+  // Lists serve cached/provider metadata. Only explicit reconciliation may
+  // enrich a collection; interaction and lifecycle refreshes target one thread.
+  return callerReason === "directory-relationship-reconcile";
 }
 
 /**
@@ -6078,17 +6068,7 @@ function isCodexMissingRolloutArchiveError(
 function shouldBackfillCodexDirectoryRelationships(
   callerReason?: ThreadListCallerReason,
 ): boolean {
-  switch (callerReason) {
-    case "directory-relationship-reconcile":
-    case "messaging-navigation-snapshot":
-    case "navigation-snapshot":
-    case "navigation-snapshot:active-recent":
-    case "startup-prewarm":
-    case "startup-provider-refresh":
-      return true;
-    default:
-      return false;
-  }
+  return callerReason === "directory-relationship-reconcile";
 }
 
 type MessagingArchiveCleanupStore = Pick<
@@ -8717,7 +8697,7 @@ export class DesktopBackendRegistry {
   private readonly attemptedTitleGenerations = new Set<string>();
   /** Launch placeholders stay helper-eligible until renamed or attempted. */
   private readonly systemPlaceholderTitleThreadKeys = new Set<string>();
-  private readonly repairedDirectoryThreadKeys = new Set<string>();
+  private readonly pendingDirectoryRepairs = new Map<string, Promise<void>>();
   private readonly failedDirectoryRelationshipLogKeys = new Set<string>();
   private readonly pendingCodexWorkspaceCwdSyncs = new Map<
     string,
@@ -8726,7 +8706,6 @@ export class DesktopBackendRegistry {
       promise: Promise<void>;
     }
   >();
-  private fullDirectoryReconcileDispatched = false;
   private titleGenerationSequence = 0;
   /**
    * Gate for the Codex `listThreads` probe. Returns `true` while the
@@ -13424,10 +13403,13 @@ export class DesktopBackendRegistry {
     //
     // Exclude in-flight worktrees before the cap, not after: a round whose
     // whole batch is already in flight must still reach the paths behind it.
-    const worktreePaths = this.selectStaleThreadWorkingStatePaths(threads, {
-      exclude: new Set(this.pendingThreadGitWorkingStateByPath.keys()),
-      limit: options.limit ?? BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
-    });
+    const worktreePaths = this.selectStaleThreadWorkingStatePaths(
+      threads.filter((thread) => thread.threadStatus === "active"),
+      {
+        exclude: new Set(this.pendingThreadGitWorkingStateByPath.keys()),
+        limit: options.limit ?? BACKGROUND_WORKTREE_WORKING_STATE_BATCH_SIZE,
+      },
+    );
     if (worktreePaths.length === 0) {
       return { scheduledCount: 0 };
     }
@@ -23877,22 +23859,10 @@ export class DesktopBackendRegistry {
     }
   }
 
-  private findCachedCodexThread(threadId: string): AppServerThreadSummary | undefined {
-    for (const state of this.threadListCache.values()) {
-      const thread = state.threads?.find(
-        (candidate) => candidate.source === "codex" && candidate.id === threadId,
-      );
-      if (thread) {
-        return thread;
-      }
-    }
-    return undefined;
-  }
-
   private async readCheapCodexThreadForRepair(
     threadId: string,
   ): Promise<AppServerThreadSummary | undefined> {
-    const cached = this.findCachedCodexThread(threadId);
+    const cached = this.getCachedThreadSummary({ backend: "codex", threadId });
     if (cached) {
       return cached;
     }
@@ -23911,7 +23881,35 @@ export class DesktopBackendRegistry {
     return threads.find((thread) => thread.id === threadId);
   }
 
+  async refreshThreadDirectoryRelationship(params: {
+    backend: AppServerBackendKind;
+    threadId: string;
+  }): Promise<void> {
+    if (this.closed || params.backend !== "codex") return;
+    await this.repairCodexThreadDirectoryRelationship({
+      reason: "selected-thread", threadId: params.threadId,
+    });
+  }
+
   private async repairCodexThreadDirectoryRelationship(params: {
+    reason: "selected-thread";
+    threadId: string;
+  }): Promise<void> {
+    if (this.closed) return;
+    const existing = this.pendingDirectoryRepairs.get(params.threadId);
+    if (existing) return existing;
+    const pending = this.loadCodexThreadDirectoryRelationship(params);
+    this.pendingDirectoryRepairs.set(params.threadId, pending);
+    try {
+      await pending;
+    } finally {
+      if (this.pendingDirectoryRepairs.get(params.threadId) === pending) {
+        this.pendingDirectoryRepairs.delete(params.threadId);
+      }
+    }
+  }
+
+  private async loadCodexThreadDirectoryRelationship(params: {
     reason: "selected-thread";
     threadId: string;
   }): Promise<void> {
@@ -23930,14 +23928,14 @@ export class DesktopBackendRegistry {
 
     try {
       const cheapThread = await this.readCheapCodexThreadForRepair(params.threadId);
-      if (!cheapThread) {
+      if (!cheapThread?.projectKey?.trim()) {
         return;
       }
 
       const [enrichedThread] = await this.codexClient.enrichThreadDirectories([
         cheapThread,
       ], "selected-thread");
-      if (!enrichedThread) {
+      if (!enrichedThread || this.closed) {
         return;
       }
 
@@ -23950,6 +23948,7 @@ export class DesktopBackendRegistry {
         backend: "codex",
         threadId: params.threadId,
       });
+      if (this.closed) return;
       this.schedulePendingCodexWorkspaceCwdSyncs({
         overlaysByThreadId: { [params.threadId]: overlay },
         threads: [enrichedThread],
@@ -23968,70 +23967,12 @@ export class DesktopBackendRegistry {
         reason: params.reason,
         threadIds: [params.threadId],
       });
-      this.recordCodexDirectoryRelationshipRepair(params.threadId);
     } catch (error) {
       backendRegistryLog.warn("Codex selected thread directory repair failed", {
         error: error instanceof Error ? error.message : String(error),
         threadId: params.threadId,
       });
     }
-  }
-
-  private recordCodexDirectoryRelationshipRepair(threadId: string): void {
-    this.repairedDirectoryThreadKeys.add(`codex:${threadId}`);
-    if (
-      this.repairedDirectoryThreadKeys.size < 3 ||
-      this.fullDirectoryReconcileDispatched
-    ) {
-      return;
-    }
-
-    this.fullDirectoryReconcileDispatched = true;
-    void this.reconcileAllCodexDirectoryRelationships().catch((error) => {
-      backendRegistryLog.warn("Codex full directory relationship reconcile failed", {
-        error: error instanceof Error ? error.message : String(error),
-      });
-    });
-  }
-
-  private async reconcileAllCodexDirectoryRelationships(): Promise<void> {
-    const threads = await this.codexClient.listThreads(
-      {
-        archived: false,
-        enrichDirectories: false,
-      },
-      {
-        callerReason: "directory-relationship-reconcile",
-        ownerId: this.threadListCacheOwnerId,
-      },
-    );
-    const overlaysByThreadId = await this.overlayStore.getThreadOverlayStates({
-      backend: "codex",
-      threadIds: threads.map((thread) => thread.id),
-    });
-    this.schedulePendingCodexWorkspaceCwdSyncs({
-      overlaysByThreadId,
-      threads,
-    });
-    const updatedOverlaysByThreadId =
-      await this.backfillMissingCodexDirectoryRelationships({
-        diagnostics: {
-          callerReason: "directory-relationship-reconcile",
-          ownerId: this.threadListCacheOwnerId,
-        },
-        overlaysByThreadId,
-        threads,
-      });
-    const threadIds = Object.keys(updatedOverlaysByThreadId);
-    if (threadIds.length === 0) {
-      return;
-    }
-
-    this.invalidateThreadListCache("codex");
-    await this.emitCodexDirectoryRelationshipsUpdated({
-      reason: "full-reconcile",
-      threadIds,
-    });
   }
 
   private async emitCodexDirectoryRelationshipsUpdated(params: {
@@ -37310,7 +37251,7 @@ export class DesktopBackendRegistry {
           backend,
           archived,
           callerReason: "agent-thread-inspection-search",
-          enrichDirectories: true,
+          enrichDirectories: false,
         }),
       new ProviderTranscriptThreadSearchAdapter(
         async ({ backend, threadId, limit }) =>
@@ -38370,6 +38311,16 @@ export class DesktopBackendRegistry {
     this.rememberManagedReviewOutput(event);
 
     this.recordTaskMonitorActivity(event);
+
+    if (event.backend === "codex" && (
+      event.notification.method === "turn/started"
+      || event.notification.method === "turn/completed"
+    )) {
+      void this.repairCodexThreadDirectoryRelationship({
+        reason: "selected-thread",
+        threadId: event.notification.params.threadId,
+      });
+    }
 
     this.rememberThreadTitleFromEvent(event);
     if (this.shouldInvalidateThreadListCacheForNotification(event.notification.method)) {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -6008,9 +6008,10 @@ let threadListCacheSequence = 0;
 function shouldEnrichThreadDirectories(
   callerReason?: ThreadListCallerReason,
 ): boolean {
-  // Lists serve cached/provider metadata. Only explicit reconciliation may
-  // enrich a collection; interaction and lifecycle refreshes target one thread.
-  return callerReason === "directory-relationship-reconcile";
+  // Ordinary lists serve cached/provider metadata. Archive safety also needs
+  // canonical worktree roots for unvisited threads sharing a checkout.
+  return callerReason === "directory-relationship-reconcile"
+    || callerReason === "archive-cleanup";
 }
 
 /**

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -7386,6 +7386,7 @@ export class CodexAppServerClient {
   private pendingCloses = 0;
   private serverGeneration = 0;
   private transportClosePromise: Promise<void> | null = null;
+  private readonly lastDirectoryEnrichment = new Map<string, ThreadDirectoryEnrichment>();
   private readonly threadDirectoryEnricher: (
     projectKey?: string,
     caller?: DirectoryEnrichmentCaller,
@@ -8379,11 +8380,13 @@ export class CodexAppServerClient {
           ...publicThread
         } = thread;
         const projectKey = publicThread.projectKey?.trim() || undefined;
+        const remembered = projectKey ? this.lastDirectoryEnrichment.get(path.resolve(projectKey)) : undefined;
         return {
           ...publicThread,
           projectKey,
           gitBranch: publicThread.gitBranch,
-          linkedDirectories: buildProjectKeyLinkedDirectories(projectKey),
+          linkedDirectories: remembered?.linkedDirectories ?? buildProjectKeyLinkedDirectories(projectKey),
+          observedGitBranch: remembered?.observedGitBranch,
           source: "codex" as const,
         };
       });
@@ -8432,6 +8435,7 @@ export class CodexAppServerClient {
             directories.set(directoryKey, pending);
           }
           enrichment = await pending;
+          if (projectKey) this.lastDirectoryEnrichment.set(path.resolve(projectKey), enrichment);
         } catch (error) {
           codexClientLog.warn("thread directory enrichment failed", {
             threadId: thread.id,

--- a/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
+++ b/apps/desktop/src/main/codex-app-server/git-directory-observation.ts
@@ -5,6 +5,8 @@ export type GitDirectoryObservation = {
   repository: boolean;
   relationship: string;
   head: string;
+  commonDirectory?: string;
+  commonVersion?: string;
 };
 
 type FileState = Awaited<ReturnType<typeof fileState>>;
@@ -105,6 +107,8 @@ export function createGitDirectoryObserver(): (
     if (refs?.directory || commonRefs?.directory) return undefined;
     return {
       repository: true,
+      commonDirectory: commonDir,
+      commonVersion: JSON.stringify([commonDir, commonInfo.signature, config?.signature]),
       relationship: JSON.stringify([
         resolved, directory.signature, dotGitPath, dotGit.signature, link,
         gitdir, admin.signature, common, commonInfo.signature,

--- a/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
+++ b/apps/desktop/src/main/codex-app-server/thread-directory-enricher.ts
@@ -213,24 +213,10 @@ function parseGitWorktrees(output: string): string[] {
     .filter(Boolean);
 }
 
-function findContainingWorktree(
-  currentPath: string,
-  worktreePaths: string[],
-): string | undefined {
-  const matches = worktreePaths
-    .map((worktreePath) => path.resolve(worktreePath))
-    .filter(
-      (worktreePath) =>
-        currentPath === worktreePath || currentPath.startsWith(`${worktreePath}${path.sep}`),
-    )
-    .sort((left, right) => right.length - left.length);
-
-  return matches[0];
-}
-
 async function loadThreadDirectoryEnrichment(
   projectKey: string,
   context: DirectoryEnrichmentContext,
+  readWorktrees: (repoRoot: string) => Promise<string[]>,
 ): Promise<ThreadDirectoryEnrichment> {
   if (!projectKey?.trim()) {
     return { linkedDirectories: [] };
@@ -242,17 +228,23 @@ async function loadThreadDirectoryEnrichment(
   }
 
   try {
-    const [repoRoot, worktreeList, observedGitBranch, gitMetadata] =
-      await Promise.all([
-        runGit(currentPath, ["rev-parse", "--show-toplevel"], context),
-        runGit(currentPath, ["worktree", "list", "--porcelain"], context),
-        runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"], context).catch(() => undefined),
-        readGitMetadataEvidence(currentPath),
-      ]);
-    const worktreePaths = parseGitWorktrees(worktreeList);
+    // One Git invocation discovers the top-level path and current branch.
+    // Keep the separate branch fallback for unborn HEAD or partial results.
+    let discovery: string[];
+    try {
+      discovery = (await runGit(currentPath,
+        ["rev-parse", "--show-toplevel", "--abbrev-ref", "HEAD"], context)).split("\n");
+    } catch {
+      discovery = [await runGit(currentPath, ["rev-parse", "--show-toplevel"], context)];
+    }
+    const repoRoot = discovery[0];
+    const [worktreePaths, observedGitBranch, gitMetadata] = await Promise.all([
+      readWorktrees(repoRoot),
+      discovery[1] || runGit(currentPath, ["rev-parse", "--abbrev-ref", "HEAD"], context).catch(() => undefined),
+      readGitMetadataEvidence(currentPath),
+    ]);
     const primaryPath = path.resolve(worktreePaths[0] || repoRoot);
-    const currentWorktreePath =
-      findContainingWorktree(currentPath, worktreePaths) ?? path.resolve(repoRoot);
+    const currentWorktreePath = path.resolve(repoRoot);
     const gitFileRepositoryPath = gitMetadata.inferredRepositoryPath
       ? path.resolve(gitMetadata.inferredRepositoryPath)
       : undefined;
@@ -331,6 +323,43 @@ export function createThreadDirectoryEnricher(): (
   const cache = new Map<string, CachedEnrichment>();
   const pending = new Map<string, Promise<ThreadDirectoryEnrichment>>();
   const observe = createGitDirectoryObserver();
+  const repositoryWorktrees = new Map<string, { version: string; paths: string[]; roots: Set<string> }>();
+  const pendingWorktrees = new Map<string, Promise<string[]>>();
+
+  async function readWorktrees(
+    key: string,
+    repoRoot: string,
+    before: GitDirectoryObservation | undefined,
+    context: DirectoryEnrichmentContext,
+  ): Promise<string[]> {
+    if (!before?.commonDirectory || !before.commonVersion) {
+      return parseGitWorktrees(await runGit(key, ["worktree", "list", "--porcelain"], context));
+    }
+    const common = before.commonDirectory;
+    const cached = repositoryWorktrees.get(common);
+    if (cached?.version === before.commonVersion) {
+      const paths = cached.paths;
+      // A newly added/moved checkout must refresh the inventory. Deleted
+      // siblings do not affect this lookup; a moved primary must refresh too.
+      if (cached.roots.has(path.resolve(repoRoot)) && paths[0] && await pathExists(paths[0])) {
+        return cached.paths;
+      }
+    }
+    const pendingKey = JSON.stringify([common, before.commonVersion]);
+    const existing = pendingWorktrees.get(pendingKey);
+    if (existing) return existing;
+    const pending = runGit(key, ["worktree", "list", "--porcelain"], context).then((output) => {
+      const paths = parseGitWorktrees(output);
+      repositoryWorktrees.set(common, { version: before.commonVersion!, paths, roots: new Set(paths) });
+      return paths;
+    });
+    pendingWorktrees.set(pendingKey, pending);
+    try {
+      return await pending;
+    } finally {
+      if (pendingWorktrees.get(pendingKey) === pending) pendingWorktrees.delete(pendingKey);
+    }
+  }
 
   async function refresh(key: string, caller: DirectoryEnrichmentCaller): Promise<ThreadDirectoryEnrichment> {
     let observationErrors = 0;
@@ -364,7 +393,7 @@ export function createThreadDirectoryEnricher(): (
         .catch(() => undefined);
       value = { ...cached.value, observedGitBranch: branch || undefined };
     } else {
-      value = await loadThreadDirectoryEnrichment(key, context);
+      value = await loadThreadDirectoryEnrichment(key, context, (repoRoot) => readWorktrees(key, repoRoot, before, context));
     }
     // The branch is present only when the complete probe succeeded. Retaining
     // a fallback would hide recovery after a failed executable/filesystem read.

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -3398,6 +3398,7 @@ class DesktopAppServerService {
   async refreshThreadGitWorkingState(
     request: RefreshThreadGitWorkingStateRequest,
   ): Promise<RefreshThreadGitWorkingStateResponse> {
+    await getDesktopBackendRegistry().refreshThreadDirectoryRelationship(request);
     const threadKey = buildThreadIdentityKey(request.backend, request.threadId);
     const worktreePath = this.worktreePathByThreadKey.get(threadKey);
     if (!worktreePath) {


### PR DESCRIPTION
Startup navigation was enriching inactive thread history, issuing three Git commands per cold checkout. Even cheap navigation listings could backfill missing directory relationships, and repairing three selected threads triggered a full-history reconciliation.

Serve provider/last-known directory metadata for ordinary listings. Selection, hover refresh, and observed turn boundaries target individual threads; main-process ownership coalesces overlapping directory repairs. Automatic working-state rounds cover active threads only. Explicit reconciliation remains available, but selected repairs no longer expand into a fleet scan. Previously unknown directory grouping converges as threads are used.

Keep Git authoritative for directory and branch discovery. Combine root/branch discovery into one invocation and share a parsed worktree inventory by common Git directory and configuration generation. Unknown checkout roots or a missing primary refresh the inventory; per-directory filesystem observations still invalidate cached enrichment. No filesystem-only interpretation of Git discovery rules is added. This replaces closed PR #2083.

Validation:
- The 216-sibling-checkout regression fails against origin/main with 648 commands; the fix uses 217 (216 combined discoveries plus one worktree inventory), across separate mapper batches.
- Four startup/navigation reads across 500 inactive threads perform no enrichment. Selection and a turn-start event refresh only their target; three selections do not trigger full-history repair.
- Inactive history schedules no automatic working-state fleet. Existing focused refresh, real worktree/branch/reftable, and failure-recovery coverage passes. A real-Git ceiling regression preserves the fallback directory when discovery is rejected.
- 1,138 tests across seven focused suites pass, plus ESLint, desktop TypeScript, and diff checks.
- Checked-in SQLite budgets: first relationship repair is one commit (~16.5 KB WAL); 100 unchanged refreshes are zero commits/bytes. At 100 new relationships per day the measured projection is ~1.65 MB/day; unchanged refreshes add 0 MB/day.

The complete startup process count still requires a live capture; 5–10 total processes is a target, not a measured result. This PR does not address the separate managed-subagent SQL redesign.
