### PR TITLE
fix(desktop): recover runtime leases and exit after renderer loss

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-environment-runtime.test.ts
@@ -182,13 +182,12 @@ describe("codex environment runtime", () => {
         }),
       ]);
 
-      await expect(expectEventually(async () => await readFile(outputPath, "utf8"))).resolves.toBe(
-        "hydrated",
-      );
-      // File creation proves the shell ran, not that the detached Windows Job
-      // and its PowerShell launcher have released their cwd handles. Await the
-      // owner lifecycle before deleting that cwd.
+      // A detached start acknowledges the launcher, not completion of the
+      // command. Wait for its lifecycle event before reading the output: a
+      // cold Windows Job launch can exceed the file poll's ten-second window.
+      // Exit also proves the launcher released its cwd handles before cleanup.
       await expect(detachedExit).resolves.toMatchObject({ exitCode: 0 });
+      await expect(readFile(outputPath, "utf8")).resolves.toBe("hydrated");
     } finally {
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/apps/desktop/src/main/__tests__/federation-health.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-health.test.ts
@@ -143,19 +143,11 @@ describe("applyFederationLeaseSnapshot", () => {
     });
   });
 
-  it("keeps the lease-held reason after the holder's lease record disappears", () => {
-    // The holder released or expired, so snapshot() no longer carries
-    // leaseHolder — but this instance is still deliberately stopped and
-    // health must keep saying why instead of reverting to "disconnected".
+  it("reports pending recovery after the holder exits", () => {
     const health = stoppedHealth();
-
-    applyFederationLeaseSnapshot(health, leaseHeldElsewhere());
-
-    expect(health).toMatchObject({
-      status: "degraded",
-      unavailableReason:
-        "Federation is already active in another PwrAgent instance for this profile.",
-    });
+    const disabledReason = "Waiting to retry Federation after the previous owner stopped.";
+    applyFederationLeaseSnapshot(health, leaseHeldElsewhere({ disabledReason }));
+    expect(health).toMatchObject({ status: "degraded", unavailableReason: disabledReason });
     expect(health.leaseHolder).toBeUndefined();
   });
 

--- a/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
+++ b/apps/desktop/src/main/__tests__/fixtures/sqlite-write-budgets.json
@@ -384,6 +384,20 @@
     "rowsChanged": 8,
     "statements": 8
   },
+  "runtime-lease-recovery-live-hour": {
+    "commits": 0,
+    "note": "one hour of blocked messaging and federation recovery checks",
+    "observedWalBytes": 0,
+    "rowsChanged": 0,
+    "statements": 0
+  },
+  "runtime-lease-recovery-takeover": {
+    "commits": 3,
+    "note": "automatic takeover of both leases after grace, then one idle hour",
+    "observedWalBytes": 41200,
+    "rowsChanged": 4,
+    "statements": 4
+  },
   "scheduled-bounded-projection-reads": {
     "commits": 0,
     "note": "205 payload-backed schedules, complete bounded paging and external version observation: zero commits; 0 MB/day added WAL",

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -6,6 +6,7 @@ const processEventHandlers = new Map<string, (...args: unknown[]) => void>();
 // Captures the listeners createMainWindow's return value registers via
 // `window.on(...)` — lets tests drive the main window's "close" handler
 // (quit-on-main-window-close).
+const mainRendererHandlers = new Map<string, (...args: unknown[]) => void>();
 const mainWindowHandlers = new Map<string, (...args: unknown[]) => void>();
 const createMainWindowMock = vi.fn();
 const registerAppServerIpcHandlersMock = vi.fn();
@@ -537,10 +538,12 @@ vi.mock("../profile", () => ({
 const runtimeMessagingLeaseCoordinatorMock = {
   start: messagingLeaseStartMock,
   shutdownSync: messagingLeaseShutdownSyncMock,
+  stopRecovery: vi.fn(),
 };
 
 const runtimeFederationLeaseCoordinatorMock = {
   shutdownSync: federationLeaseShutdownSyncMock,
+  stopRecovery: vi.fn(),
 };
 
 vi.mock("../app-server/backend-registry", () => ({
@@ -610,11 +613,13 @@ describe("bootstrapApp", () => {
       },
     );
     mainWindowHandlers.clear();
+    mainRendererHandlers.clear();
     createMainWindowMock.mockReset();
     // createMainWindow returns the BrowserWindow; index.ts wraps each call in
     // quitAppOnMainWindowClose(window), which calls window.on("close", …).
     // Return a stub that records its listeners so tests can invoke them.
     createMainWindowMock.mockImplementation(() => ({
+      webContents: { on: (event: string, handler: (...args: unknown[]) => void) => mainRendererHandlers.set(event, handler) },
       on: (event: string, handler: (...args: unknown[]) => void) => {
         mainWindowHandlers.set(event, handler);
       },
@@ -1082,6 +1087,42 @@ describe("bootstrapApp", () => {
       onShown: expect.any(Function),
       startupCpuProfiler: startupProfilerInstance,
     });
+  });
+
+  it.each(["oom", "crashed", "killed", "abnormal-exit", "launch-failed", "integrity-failure", "memory-eviction"])(
+    "shuts down resources without a renderer confirmation after %s", async (reason) => {
+      startupProfilerInstance.start.mockResolvedValue();
+      await import("../index");
+      await flushMicrotasks();
+      requestQuitMock.mockClear();
+      mainRendererHandlers.get("render-process-gone")!({}, { reason, exitCode: 1 });
+      await flushMicrotasks();
+      expect(requestQuitMock).not.toHaveBeenCalled();
+      expect(disposeDesktopMessagingRuntimeMock).toHaveBeenCalled();
+      await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
+      expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1);
+      expect(federationLeaseShutdownSyncMock).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("renderer loss bypasses an unanswered quit confirmation", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    await import("../index");
+    await flushMicrotasks();
+    requestQuitMock.mockReturnValue(new Promise(() => {}));
+    mainWindowHandlers.get("close")!({ preventDefault: vi.fn() });
+    mainRendererHandlers.get("render-process-gone")!({}, { reason: "oom", exitCode: 1 });
+    await vi.waitFor(() => expect(quitMock).toHaveBeenCalledTimes(1));
+    expect(disposeDesktopFederationRuntimeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not shut down for a clean renderer exit", async () => {
+    startupProfilerInstance.start.mockResolvedValue();
+    await import("../index");
+    await flushMicrotasks();
+    mainRendererHandlers.get("render-process-gone")!({}, { reason: "clean-exit", exitCode: 0 });
+    await flushMicrotasks();
+    expect(disposeDesktopFederationRuntimeMock).not.toHaveBeenCalled();
   });
 
   it("quits the app when the main window is closed", async () => {

--- a/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-federation-lease.test.ts
@@ -21,6 +21,7 @@ const activeCoordinators: RuntimeFederationLeaseCoordinator[] = [];
 function createRuntime(): FederationLeaseRuntime {
   return {
     stop: vi.fn(async () => {}),
+    restart: vi.fn(async () => {}),
   };
 }
 
@@ -452,6 +453,7 @@ describe("RuntimeFederationLeaseCoordinator", () => {
 
   it("releases the lease even when runtime stop fails during startup cleanup", async () => {
     const runtime: FederationLeaseRuntime = {
+      restart: vi.fn(async () => {}),
       stop: vi.fn(async () => {
         throw new Error("stop failed");
       }),

--- a/apps/desktop/src/main/__tests__/runtime-lease-recovery.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-lease-recovery.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RuntimeLeaseManager } from "../runtime-lease-manager";
+import { RuntimeFederationLeaseCoordinator } from "../runtime-federation-lease";
+import { RuntimeMessagingLeaseCoordinator } from "../runtime-messaging-lease";
+import { RUNTIME_LEASE_RETRY_MS } from "../runtime-lease-retry";
+import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
+import { StateDb } from "../state/state-db";
+import { measureSqliteWrites, SQLITE_WRITE_METRICS_ENV } from "../state/sqlite-write-metrics";
+import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
+import type { DesktopMessagingConfig } from "../messaging/messaging-config";
+import type { DesktopMessagingRuntime } from "../messaging/messaging-runtime";
+
+let db: StateDb;
+let directory: string;
+let store: AppRuntimeInstanceStore;
+let owner: RuntimeLeaseManager;
+let ownerAlive: boolean;
+let federation: RuntimeFederationLeaseCoordinator;
+let messaging: RuntimeMessagingLeaseCoordinator;
+let messagingEnabled: boolean;
+const config: DesktopMessagingConfig = {
+  enabled: true,
+  inputDebounceMs: 500,
+  telegram: {
+    channel: "telegram",
+    enabled: true,
+    botToken: "fixture-token",
+    streamingResponses: false,
+    authorizedActorIds: [],
+    authorizedSupergroupIds: [],
+  },
+};
+const messagingRuntime = {
+  isEnabled: () => messagingEnabled,
+  applyConfig: vi.fn(async () => { messagingEnabled = true; }),
+  stop: vi.fn(async () => { messagingEnabled = false; }),
+} as unknown as DesktopMessagingRuntime;
+const federationRuntime = {
+  stop: vi.fn(async () => {}),
+  restart: vi.fn(async () => { await federation.applyMode(federationRuntime, "gateway"); }),
+};
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_800_000_000_000);
+  vi.stubEnv(SQLITE_WRITE_METRICS_ENV, "1");
+  directory = mkdtempSync(path.join(os.tmpdir(), "pwragent-lease-recovery-"));
+  db = StateDb.open(path.join(directory, "state.db"), { profileName: "dev" });
+  store = new AppRuntimeInstanceStore(db);
+  ownerAlive = true;
+  messagingEnabled = false;
+  vi.clearAllMocks();
+  const options = { store, profileName: "dev", systemBootedAt: 0, cwd: "/tmp/fixture", processIsAlive: () => ownerAlive };
+  owner = new RuntimeLeaseManager({ ...options, instanceId: "owner", processId: 123 });
+  owner.acquire("messaging");
+  owner.acquire("federation");
+  const challenger = new RuntimeLeaseManager({ ...options, instanceId: "challenger", processId: 456 });
+  federation = new RuntimeFederationLeaseCoordinator({ leaseManager: challenger });
+  messaging = new RuntimeMessagingLeaseCoordinator({ leaseManager: challenger });
+});
+
+afterEach(() => {
+  federation.shutdownSync();
+  messaging.shutdownSync();
+  vi.useRealTimers();
+  db.close();
+  rmSync(directory, { recursive: true, force: true });
+  vi.unstubAllEnvs();
+});
+
+async function startBlocked() {
+  await federation.applyMode(federationRuntime, "gateway");
+  await messaging.applyResolvedConfig(messagingRuntime, config);
+  expect(federation.snapshot().leaseHeld).toBe(false);
+  expect(messaging.snapshot().leaseHeld).toBe(false);
+}
+
+function expectRecovered() {
+  expect(federation.snapshot().leaseHeld).toBe(true);
+  expect(messaging.snapshot().leaseHeld).toBe(true);
+  expect(messagingEnabled).toBe(true);
+  expect(federationRuntime.restart).toHaveBeenCalledTimes(1);
+}
+
+describe("automatic runtime lease recovery", () => {
+  it("writes nothing during an hour blocked behind a live owner", async () => {
+    await startBlocked();
+    const { writes } = await measureSqliteWrites(async () => {
+      await vi.advanceTimersByTimeAsync(3_600_000);
+    });
+    expectSqliteWriteBudget({ scenario: "runtime-lease-recovery-live-hour", note: "one hour of blocked messaging and federation recovery checks", writes });
+    expect(federationRuntime.restart).not.toHaveBeenCalled();
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+  });
+
+  it("recovers both leases after a dead owner grace without a manual toggle", async () => {
+    ownerAlive = false;
+    await startBlocked();
+    expect(federation.snapshot().disabledReason).toContain("Waiting to retry");
+    expect(federation.snapshot().leaseHolder).toBeUndefined();
+    const { writes } = await measureSqliteWrites(async () => {
+      await vi.advanceTimersByTimeAsync(60_000 - 1);
+      expect(federation.snapshot().leaseHeld).toBe(false);
+      expect(messaging.snapshot().leaseHeld).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      expectRecovered();
+      await vi.advanceTimersByTimeAsync(3_600_000);
+    });
+    expectSqliteWriteBudget({ scenario: "runtime-lease-recovery-takeover", note: "automatic takeover of both leases after grace, then one idle hour", writes });
+    expect(federationRuntime.restart).toHaveBeenCalledTimes(1);
+  });
+
+  it("observes an owner that dies after startup and waits the full grace", async () => {
+    await startBlocked();
+    ownerAlive = false;
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    expect(store.getInstance("owner")?.exitedAt).toBe(Date.now());
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(messagingEnabled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    // One restart observes the death; the second acquires after grace.
+    expect(federationRuntime.restart).toHaveBeenCalledTimes(2);
+    expect(federation.snapshot().leaseHeld).toBe(true);
+    expect(messagingEnabled).toBe(true);
+  });
+
+  it("takes over released leases on the next check", async () => {
+    await startBlocked();
+    owner.release("messaging");
+    owner.release("federation");
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    expectRecovered();
+  });
+
+  it.each(["disabled", "shutdown"])("cancels recovery on %s", async (action) => {
+    await startBlocked();
+    if (action === "disabled") {
+      await federation.applyMode(federationRuntime, "disabled", true);
+      await messaging.disableForSession(messagingRuntime);
+    } else {
+      federation.stopRecovery();
+      messaging.stopRecovery();
+    }
+    ownerAlive = false;
+    owner.release("messaging");
+    owner.release("federation");
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(federationRuntime.restart).not.toHaveBeenCalled();
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not rearm recovery when shutdown races a pending stop", async () => {
+    let finishStop!: () => void;
+    vi.mocked(messagingRuntime.stop).mockImplementationOnce(() => new Promise<void>((resolve) => { finishStop = resolve; }));
+    const start = messaging.applyResolvedConfig(messagingRuntime, config);
+    messaging.stopRecovery();
+    finishStop();
+    await start;
+    owner.release("messaging");
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+    await messaging.applyResolvedConfig(messagingRuntime, config);
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not steal a lease acquired by another challenger during grace", async () => {
+    ownerAlive = false;
+    await startBlocked();
+    await vi.advanceTimersByTimeAsync(59_999);
+    vi.setSystemTime(Date.now() + 1);
+    const winner = new RuntimeLeaseManager({
+      store, instanceId: "winner", processId: 789, profileName: "dev",
+      cwd: "/tmp/winner", systemBootedAt: 0, processIsAlive: () => false,
+    });
+    expect(winner.acquire("federation")).toEqual({ acquired: true });
+    expect(winner.acquire("messaging")).toEqual({ acquired: true });
+    ownerAlive = true;
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(federationRuntime.restart).not.toHaveBeenCalled();
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+    winner.release("federation");
+    winner.release("messaging");
+  });
+
+  it("a newer disabled config supersedes the blocked messaging config", async () => {
+    await startBlocked();
+    await messaging.applyResolvedConfig(messagingRuntime, { ...config, enabled: false });
+    owner.release("messaging");
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/__tests__/runtime-lease-recovery.test.ts
+++ b/apps/desktop/src/main/__tests__/runtime-lease-recovery.test.ts
@@ -10,7 +10,7 @@ import { AppRuntimeInstanceStore } from "../state/app-runtime-instance-store";
 import { StateDb } from "../state/state-db";
 import { measureSqliteWrites, SQLITE_WRITE_METRICS_ENV } from "../state/sqlite-write-metrics";
 import { expectSqliteWriteBudget } from "./fixtures/sqlite-write-budget";
-import type { DesktopMessagingConfig } from "../messaging/messaging-config";
+import type { DesktopMessagingConfigLoadOptions, DesktopMessagingConfig } from "../messaging/messaging-config";
 import type { DesktopMessagingRuntime } from "../messaging/messaging-runtime";
 
 let db: StateDb;
@@ -35,6 +35,7 @@ const config: DesktopMessagingConfig = {
 };
 const messagingRuntime = {
   isEnabled: () => messagingEnabled,
+  failClosedFullAccessPolicy: vi.fn(),
   applyConfig: vi.fn(async () => { messagingEnabled = true; }),
   stop: vi.fn(async () => { messagingEnabled = false; }),
 } as unknown as DesktopMessagingRuntime;
@@ -73,7 +74,7 @@ afterEach(() => {
 
 async function startBlocked() {
   await federation.applyMode(federationRuntime, "gateway");
-  await messaging.applyResolvedConfig(messagingRuntime, config);
+  await messaging.applyLatestConfig(messagingRuntime, async () => config);
   expect(federation.snapshot().leaseHeld).toBe(false);
   expect(messaging.snapshot().leaseHeld).toBe(false);
 }
@@ -155,14 +156,15 @@ describe("automatic runtime lease recovery", () => {
   it("does not rearm recovery when shutdown races a pending stop", async () => {
     let finishStop!: () => void;
     vi.mocked(messagingRuntime.stop).mockImplementationOnce(() => new Promise<void>((resolve) => { finishStop = resolve; }));
-    const start = messaging.applyResolvedConfig(messagingRuntime, config);
+    const start = messaging.applyLatestConfig(messagingRuntime, async () => config);
+    await vi.advanceTimersByTimeAsync(0);
     messaging.stopRecovery();
     finishStop();
     await start;
     owner.release("messaging");
     await vi.advanceTimersByTimeAsync(120_000);
     expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
-    await messaging.applyResolvedConfig(messagingRuntime, config);
+    await messaging.applyLatestConfig(messagingRuntime, async () => config);
     expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
   });
 
@@ -183,6 +185,70 @@ describe("automatic runtime lease recovery", () => {
     expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
     winner.release("federation");
     winner.release("messaging");
+  });
+
+  it.each(["replaced", "cleared"])("reloads a secret %s by another instance before takeover", async (change) => {
+    let currentConfig = config;
+    const loadConfig = vi.fn(async () => currentConfig);
+    await messaging.start(messagingRuntime, loadConfig);
+    currentConfig = {
+      ...config,
+      telegram: change === "cleared" ? undefined : { ...config.telegram!, botToken: "replacement-token" },
+    };
+    owner.release("messaging");
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    expect(loadConfig).toHaveBeenCalledTimes(2);
+    if (change === "cleared") {
+      expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+      expect(messaging.snapshot().leaseHeld).toBe(false);
+    } else {
+      expect(messagingRuntime.applyConfig).toHaveBeenCalledExactlyOnceWith(currentConfig, { allowStart: true });
+    }
+  });
+
+  it("preserves the session enable override when reloading for takeover", async () => {
+    let token = "old-token";
+    const loadConfig = vi.fn(async (options?: DesktopMessagingConfigLoadOptions) => ({
+      ...config,
+      enabled: options?.messagingEnabledOverride ?? false,
+      telegram: { ...config.telegram!, botToken: token },
+    }));
+    await messaging.applyLatestConfig(messagingRuntime, loadConfig, { messagingEnabledOverride: true });
+    token = "new-token";
+    owner.release("messaging");
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    expect(loadConfig).toHaveBeenLastCalledWith({ messagingEnabledOverride: true, logStartupEligibility: false });
+    expect(messagingRuntime.applyConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ enabled: true, telegram: expect.objectContaining({ botToken: "new-token" }) }),
+      { allowStart: true },
+    );
+  });
+
+  it.each(["disable", "shutdown", "new-config"])("discards an in-flight recovery read superseded by %s", async (action) => {
+    let finishRead!: (value: DesktopMessagingConfig) => void;
+    const loadConfig = vi.fn(async () => config);
+    await messaging.start(messagingRuntime, loadConfig);
+    loadConfig.mockImplementationOnce(() => new Promise((resolve) => { finishRead = resolve; }));
+    owner.release("messaging");
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    if (action === "disable") await messaging.disableForSession(messagingRuntime);
+    else if (action === "shutdown") messaging.stopRecovery();
+    else await messaging.applyLatestConfig(messagingRuntime, async () => ({ ...config, enabled: false }));
+    finishRead(config);
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+    expect(messaging.snapshot().leaseHeld).toBe(false);
+  });
+
+  it("fails closed when the recovery configuration cannot be loaded", async () => {
+    const loadConfig = vi.fn(async () => config);
+    await messaging.start(messagingRuntime, loadConfig);
+    loadConfig.mockRejectedValueOnce(new Error("shared secrets unavailable"));
+    owner.release("messaging");
+    await vi.advanceTimersByTimeAsync(RUNTIME_LEASE_RETRY_MS);
+    expect(messagingRuntime.failClosedFullAccessPolicy).toHaveBeenCalled();
+    expect(messagingRuntime.applyConfig).not.toHaveBeenCalled();
+    expect(messaging.snapshot().leaseHeld).toBe(false);
   });
 
   it("a newer disabled config supersedes the blocked messaging config", async () => {

--- a/apps/desktop/src/main/federation/federation-health.ts
+++ b/apps/desktop/src/main/federation/federation-health.ts
@@ -36,10 +36,8 @@ export function buildFederationHealthStatus(params: {
 /**
  * Overlay the profile lease state onto a health snapshot. Another live
  * instance holding this profile's federation lease keeps this instance's
- * runtime deliberately stopped, and it stays stopped after the holder
- * exits — the lease record (and with it the holder metadata) disappears
- * while the stop reason does not. Surface the reason either way, with the
- * holder's identity only while it is still live.
+ * runtime stopped until recovery acquires ownership. The coordinator distinguishes
+ * a live holder from a dead owner whose grace period is still running.
  */
 export function applyFederationLeaseSnapshot(
   health: FederationHealthStatus,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -752,6 +752,8 @@ const runMainProcessShutdownBarrier = createShutdownBarrier({
 
 async function disposeMainProcessResources(source: string): Promise<void> {
   mainProcessShutdownPromise ??= (async () => {
+    getExistingRuntimeMessagingLeaseCoordinator()?.stopRecovery();
+    getExistingRuntimeFederationLeaseCoordinator()?.stopRecovery();
     e2eShutdownDiagnostics.beginOverall();
     try {
       // Electron emits before-quit while renderer windows are still live. Close
@@ -877,6 +879,20 @@ function isWindowCreationBlocked(): boolean {
  * app.quit() re-closing this window during teardown, so there's no loop.
  */
 function quitAppOnMainWindowClose(window: BrowserWindow): void {
+  window.webContents.on("render-process-gone", (_event, details) => {
+    if (
+      details.reason === "clean-exit"
+      || mainProcessShutdownPromise
+      || mainProcessResourcesDisposed
+      || isUpdateInstallInProgress()
+    ) return;
+    const source = `main-renderer-${details.reason}`;
+    mainLog.error("main renderer lost; shutting down app", details);
+    // A dead renderer cannot answer the active-turn confirmation dialog.
+    beginQuitInProgress(source);
+    appQuitManager.allowImmediateQuit();
+    quitAfterResourceShutdown(source);
+  });
   window.on("close", (event) => {
     if (appQuitManager.isQuitAllowed()) {
       return;

--- a/apps/desktop/src/main/runtime-federation-lease.ts
+++ b/apps/desktop/src/main/runtime-federation-lease.ts
@@ -1,5 +1,6 @@
 import type { DesktopFederationMode } from "@pwragent/shared";
 import { getMainLogger } from "./log";
+import { RuntimeLeaseRetry } from "./runtime-lease-retry";
 import {
   getRuntimeLeaseManager,
   RuntimeLeaseManager,
@@ -13,6 +14,7 @@ import {
  */
 export type FederationLeaseRuntime = {
   stop(): Promise<void>;
+  restart(): Promise<void>;
 };
 
 const leaseLog = getMainLogger("pwragent:federation-lease");
@@ -59,6 +61,8 @@ type RuntimeFederationLeaseCoordinatorOptions = RuntimeLeaseManagerOptions & {
 export class RuntimeFederationLeaseCoordinator {
   private readonly leaseManager: RuntimeLeaseManager;
   private disabledReasonKind: RuntimeFederationDisabledReasonKind | undefined;
+  private readonly retry = new RuntimeLeaseRetry();
+  private shuttingDown = false;
 
   constructor(options: RuntimeFederationLeaseCoordinatorOptions = {}) {
     this.leaseManager =
@@ -81,10 +85,12 @@ export class RuntimeFederationLeaseCoordinator {
    * session override, without changing the saved profile configuration.
    */
   async applyMode(
-    _runtime: FederationLeaseRuntime,
+    runtime: FederationLeaseRuntime,
     mode: DesktopFederationMode,
     disabledForSession = false,
   ): Promise<RuntimeFederationLeaseApplyResult> {
+    const generation = this.retry.cancel();
+    if (this.shuttingDown) return { enabled: false, disabledReasonKind: "runtime_stopped" };
     if (mode === "disabled") {
       this.leaseManager.release("federation");
       this.disabledReasonKind = disabledForSession ? "runtime_stopped" : "saved_disabled";
@@ -98,6 +104,7 @@ export class RuntimeFederationLeaseCoordinator {
     const acquire = this.leaseManager.acquire("federation");
     if (!acquire.acquired) {
       this.disabledReasonKind = "lease_held";
+      this.retry.schedule(this.leaseManager, "federation", generation, () => runtime.restart());
       return {
         enabled: false,
         disabledReasonKind: "lease_held",
@@ -119,6 +126,7 @@ export class RuntimeFederationLeaseCoordinator {
   async releaseAfterStartupFailure(
     runtime: FederationLeaseRuntime,
   ): Promise<void> {
+    this.retry.cancel();
     try {
       await runtime.stop();
     } catch (error) {
@@ -131,7 +139,13 @@ export class RuntimeFederationLeaseCoordinator {
     }
   }
 
+  stopRecovery(): void {
+    this.shuttingDown = true;
+    this.retry.cancel();
+  }
+
   shutdownSync(): void {
+    this.stopRecovery();
     this.leaseManager.release("federation");
   }
 
@@ -143,9 +157,9 @@ export class RuntimeFederationLeaseCoordinator {
       ...(this.disabledReasonKind
         ? {
             disabledReasonKind: this.disabledReasonKind,
-            disabledReason: federationDisabledReasonMessage(
-              this.disabledReasonKind,
-            ),
+            disabledReason: this.disabledReasonKind === "lease_held" && !lease.leaseHolder
+              ? "Waiting to retry Federation after the previous owner stopped."
+              : federationDisabledReasonMessage(this.disabledReasonKind),
           }
         : {}),
       ...(lease.leaseHolder ? { leaseHolder: lease.leaseHolder } : {}),

--- a/apps/desktop/src/main/runtime-lease-manager.ts
+++ b/apps/desktop/src/main/runtime-lease-manager.ts
@@ -1,4 +1,5 @@
 import os from "node:os";
+import { RUNTIME_LEASE_DEAD_OWNER_GRACE_MS } from "./state/app-runtime-instance-store";
 import {
   getProcessRuntimeIdentity,
   isProfileRuntimeIdentityLive,
@@ -198,6 +199,7 @@ export class RuntimeLeaseManager {
       lease
       && lease.status === "active"
       && lease.ownerInstanceId !== this.instanceId
+      && this.holderIsAlive(lease)
         ? this.describeLeaseHolder(lease)
         : undefined;
     return {
@@ -209,6 +211,26 @@ export class RuntimeLeaseManager {
 
   getInstance(): AppRuntimeInstanceRecord | undefined {
     return this.store.getInstance(this.instanceId);
+  }
+
+  /** Avoid repeated acquisition writes while an owner is live or in its grace. */
+  shouldRetryAcquisition(kind: RuntimeLeaseKind): boolean {
+    if (this.instanceExited) return false;
+    const lease = this.readLease(kind);
+    if (!lease || lease.status !== "active") return true;
+    const owner = this.store.getInstance(lease.ownerInstanceId);
+    if (!owner) {
+      return lease.expiresAt === Number.MAX_SAFE_INTEGER || this.now() >= lease.expiresAt;
+    }
+    if (this.isOwnerAlive(owner)) return false;
+    return owner.exitedAt === undefined
+      || this.ownerPredatesCurrentBoot(owner)
+      || this.now() >= owner.exitedAt + RUNTIME_LEASE_DEAD_OWNER_GRACE_MS;
+  }
+
+  private holderIsAlive(lease: MessagingRuntimeLeaseRecord): boolean {
+    const owner = this.store.getInstance(lease.ownerInstanceId);
+    return Boolean(owner && this.isOwnerAlive(owner));
   }
 
   markExited(): void {

--- a/apps/desktop/src/main/runtime-lease-retry.ts
+++ b/apps/desktop/src/main/runtime-lease-retry.ts
@@ -15,6 +15,10 @@ export class RuntimeLeaseRetry {
     return ++this.generation;
   }
 
+  isCurrent(generation: number): boolean {
+    return generation === this.generation;
+  }
+
   schedule(
     manager: RuntimeLeaseManager,
     kind: RuntimeLeaseKind,

--- a/apps/desktop/src/main/runtime-lease-retry.ts
+++ b/apps/desktop/src/main/runtime-lease-retry.ts
@@ -1,0 +1,45 @@
+import { getMainLogger } from "./log";
+import type { RuntimeLeaseKind, RuntimeLeaseManager } from "./runtime-lease-manager";
+
+export const RUNTIME_LEASE_RETRY_MS = 5_000;
+const log = getMainLogger("pwragent:runtime-lease-retry");
+
+/** Only blocked runtimes poll. Checks are read-only; acquisition stays atomic. */
+export class RuntimeLeaseRetry {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private generation = 0;
+
+  cancel(): number {
+    clearTimeout(this.timer);
+    this.timer = undefined;
+    return ++this.generation;
+  }
+
+  schedule(
+    manager: RuntimeLeaseManager,
+    kind: RuntimeLeaseKind,
+    generation: number,
+    retry: () => Promise<unknown>,
+  ): void {
+    if (generation !== this.generation) return;
+    clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      if (generation !== this.generation) return;
+      try {
+        if (!manager.shouldRetryAcquisition(kind)) {
+          this.schedule(manager, kind, generation, retry);
+          return;
+        }
+        // A denied acquisition schedules the next check through its coordinator.
+        void retry().catch((error: unknown) => {
+          log.error("runtime lease recovery failed", { kind, error: String(error) });
+        });
+      } catch (error) {
+        log.error("runtime lease recovery check failed", { kind, error: String(error) });
+        this.schedule(manager, kind, generation, retry);
+      }
+    }, RUNTIME_LEASE_RETRY_MS);
+    this.timer.unref?.();
+  }
+}

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -100,10 +100,10 @@ export class RuntimeMessagingLeaseCoordinator {
       };
     }
 
-    const config = await this.loadConfigFailClosed(runtime, loadConfig, {
+    return this.applyLatestConfig(runtime, loadConfig, {
       logStartupEligibility: true,
+      allowStart: true,
     });
-    return this.applyResolvedConfig(runtime, config, { allowStart: true });
   }
 
   async applyLatestConfig(
@@ -111,13 +111,23 @@ export class RuntimeMessagingLeaseCoordinator {
     loadConfig: DesktopMessagingConfigLoader,
     options: DesktopMessagingConfigLoadOptions & { allowStart?: boolean } = {},
   ): Promise<RuntimeMessagingLeaseApplyResult> {
-    this.retry.cancel();
+    const generation = this.retry.cancel();
     const config = await this.loadConfigFailClosed(runtime, loadConfig, {
       logStartupEligibility: options.logStartupEligibility,
       messagingEnabledOverride: options.messagingEnabledOverride,
     });
+    // A stop or newer configuration can supersede an asynchronous secret read.
+    if (!this.retry.isCurrent(generation)) {
+      return { enabled: false, disabledReasonKind: "runtime_stopped" };
+    }
     return this.applyResolvedConfig(runtime, config, {
       allowStart: options.allowStart ?? true,
+      // Shared secrets can change without a TOML notification in this process.
+      // Retain the loader and session override, never the resolved credentials.
+      recover: () => this.applyLatestConfig(runtime, loadConfig, {
+        ...options,
+        logStartupEligibility: false,
+      }),
     });
   }
 
@@ -137,7 +147,10 @@ export class RuntimeMessagingLeaseCoordinator {
   async applyResolvedConfig(
     runtime: DesktopMessagingRuntime,
     config: DesktopMessagingConfig,
-    options: { allowStart?: boolean } = {},
+    options: {
+      allowStart?: boolean;
+      recover?: () => Promise<RuntimeMessagingLeaseApplyResult>;
+    } = {},
   ): Promise<RuntimeMessagingLeaseApplyResult> {
     const generation = this.retry.cancel();
     if (this.shuttingDown) return { enabled: false, disabledReasonKind: "runtime_stopped" };
@@ -186,12 +199,9 @@ export class RuntimeMessagingLeaseCoordinator {
     const acquire = this.leaseManager.acquire("messaging");
     if (!acquire.acquired) {
       await runtime.stop();
-      this.retry.schedule(
-        this.leaseManager,
-        "messaging",
-        generation,
-        () => this.applyResolvedConfig(runtime, config, options),
-      );
+      if (options.recover) {
+        this.retry.schedule(this.leaseManager, "messaging", generation, options.recover);
+      }
       return {
         enabled: false,
         disabledReasonKind: "lease_held",

--- a/apps/desktop/src/main/runtime-messaging-lease.ts
+++ b/apps/desktop/src/main/runtime-messaging-lease.ts
@@ -14,6 +14,7 @@ import type {
 } from "./messaging/messaging-runtime";
 import { resolveRuntimeMessagingOverride } from "./runtime-flags";
 import { getMainLogger } from "./log";
+import { RuntimeLeaseRetry } from "./runtime-lease-retry";
 import {
   getRuntimeLeaseManager,
   PWRAGENT_INSTANCE_ROOT_ENV,
@@ -60,6 +61,8 @@ export class RuntimeMessagingLeaseCoordinator {
   private readonly leaseManager: RuntimeLeaseManager;
   private readonly env?: NodeJS.ProcessEnv;
   private readonly argv?: readonly string[];
+  private readonly retry = new RuntimeLeaseRetry();
+  private shuttingDown = false;
 
   constructor(options: RuntimeMessagingLeaseCoordinatorOptions = {}) {
     this.leaseManager =
@@ -79,6 +82,7 @@ export class RuntimeMessagingLeaseCoordinator {
     runtime: DesktopMessagingRuntime,
     loadConfig: DesktopMessagingConfigLoader,
   ): Promise<RuntimeMessagingLeaseApplyResult> {
+    this.retry.cancel();
     const override = resolveRuntimeMessagingOverride({
       env: this.env,
       argv: this.argv,
@@ -107,6 +111,7 @@ export class RuntimeMessagingLeaseCoordinator {
     loadConfig: DesktopMessagingConfigLoader,
     options: DesktopMessagingConfigLoadOptions & { allowStart?: boolean } = {},
   ): Promise<RuntimeMessagingLeaseApplyResult> {
+    this.retry.cancel();
     const config = await this.loadConfigFailClosed(runtime, loadConfig, {
       logStartupEligibility: options.logStartupEligibility,
       messagingEnabledOverride: options.messagingEnabledOverride,
@@ -134,6 +139,8 @@ export class RuntimeMessagingLeaseCoordinator {
     config: DesktopMessagingConfig,
     options: { allowStart?: boolean } = {},
   ): Promise<RuntimeMessagingLeaseApplyResult> {
+    const generation = this.retry.cancel();
+    if (this.shuttingDown) return { enabled: false, disabledReasonKind: "runtime_stopped" };
     const desiredMessagingEnabled = config.enabled !== false;
     this.recordStart({
       desiredMessagingEnabled,
@@ -179,6 +186,12 @@ export class RuntimeMessagingLeaseCoordinator {
     const acquire = this.leaseManager.acquire("messaging");
     if (!acquire.acquired) {
       await runtime.stop();
+      this.retry.schedule(
+        this.leaseManager,
+        "messaging",
+        generation,
+        () => this.applyResolvedConfig(runtime, config, options),
+      );
       return {
         enabled: false,
         disabledReasonKind: "lease_held",
@@ -208,10 +221,17 @@ export class RuntimeMessagingLeaseCoordinator {
   }
 
   async shutdown(runtime: DesktopMessagingRuntime): Promise<void> {
+    this.stopRecovery();
     await this.stopRuntimeAndRelease(runtime, "runtime_stopped");
   }
 
+  stopRecovery(): void {
+    this.shuttingDown = true;
+    this.retry.cancel();
+  }
+
   shutdownSync(): void {
+    this.stopRecovery();
     this.leaseManager.release("messaging");
   }
 
@@ -223,7 +243,11 @@ export class RuntimeMessagingLeaseCoordinator {
       effectiveMessagingEnabled: instance?.effectiveMessagingEnabled ?? false,
       disabledReasonKind: instance?.disabledReason,
       ...(instance?.disabledReason
-        ? { disabledReason: runtimeDisabledReasonMessage(instance.disabledReason) }
+        ? {
+            disabledReason: instance.disabledReason === "lease_held" && !lease.leaseHolder
+              ? "Waiting to retry Messaging after the previous owner stopped."
+              : runtimeDisabledReasonMessage(instance.disabledReason),
+          }
         : {}),
       leaseHeld: lease.leaseHeld,
       ...(lease.leaseHolder ? { leaseHolder: lease.leaseHolder } : {}),
@@ -242,6 +266,7 @@ export class RuntimeMessagingLeaseCoordinator {
     runtime: DesktopMessagingRuntime,
     disabledReason: AppRuntimeMessagingDisabledReason,
   ): Promise<void> {
+    this.retry.cancel();
     await runtime.stop();
     this.leaseManager.release("messaging");
     this.leaseManager.recordMessagingState({


### PR DESCRIPTION
## Summary

- I fixed messaging and Federation staying stopped after a force-killed owner's lease became reclaimable. Blocked runtimes now check every five seconds and acquire automatically after the existing one-minute dead-owner grace period, or after the owner releases its lease.
- I preserved atomic acquisition and cancellation on explicit disable, changed configuration, and shutdown. Waiting behind a live owner or through the grace period performs no repeated SQLite writes. The status message now distinguishes a live holder from pending recovery.
- I routed fatal primary-renderer exits, including OOM and external kills, through bounded resource shutdown and lease release. This bypasses unanswered quit confirmations in a dead renderer and leaves clean renderer exits alone.

## Verification

- I ran the full SQLite write survey: 785 files passed; 11,306 tests passed and 7 skipped. I also ran focused regression tests after the final changes, including automatic recovery, competing challengers, cancellation during a pending stop, renderer failure reasons, and a crash during quit confirmation.
- I verified the production build, typecheck, ESLint, dependency boundaries, SQL lint, Codex storage boundary, and theme-color lint.
- I recorded checked-in SQLite budgets: one blocked hour adds 0 commits / 0 bytes (0 MB/day); automatic takeover of both leases after grace costs 3 commits / about 41 KB, followed by 0 recurring writes.

## Notes

- I preserved the one-minute dead-owner safety grace. Healthy owners are never preempted, and explicitly disabled runtimes remain stopped.
- I tested with contrived runtime identities and temporary databases. I did not restart or terminate the operator's running app.
