### PR TITLE
feat(desktop): rank Star Map intake projects and reveal the new thread

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -10644,6 +10644,46 @@ describe("CodexAppServerClient", () => {
     await client.close();
   });
 
+  it("lets turnTimeoutMs bound turn/start, which can carry the answer", async () => {
+    // `turn/start` returns the finished structured record on some servers
+    // (the immediate-record branch exists for exactly that), so bounding it
+    // at `timeoutMs` would make a raised `turnTimeoutMs` a silent no-op.
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    MockTransport.threadStartResult = {
+      thread: { id: "budget-helper" },
+      instructionSources: [],
+    };
+    // Never answered: the only thing that can settle this is a timeout.
+    MockTransport.turnStartResult = undefined;
+    const client = new CodexAppServerClient({
+      command: "codex",
+      directoryResolver: async () => [],
+    });
+    let settled = false;
+    const probePromise = client.generateStructuredObject({
+      prompt: "Return the requested status object.",
+      schema: {
+        type: "object",
+        required: ["status"],
+        properties: { status: { type: "string" } },
+      },
+      isMatch: (record) => record.status === "complete",
+      timeoutMs: 60,
+      turnTimeoutMs: 5_000,
+    }).then((result) => {
+      settled = true;
+      return result;
+    });
+    await waitForLatestTransportRequest("turn/start");
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // Bounded by timeoutMs this would have rejected at 60ms.
+    expect(settled).toBe(false);
+
+    await client.close();
+    await probePromise.catch(() => undefined);
+  });
+
   it("uses a fresh helper thread for every title and unsubscribes each one", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const client = new CodexAppServerClient({

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -254,6 +254,88 @@ describe("dispatchStarMapIntake", () => {
     }
   });
 
+  it("ranks by reported confidence rather than the resolver's array order", async () => {
+    // The prompt asks for most-likely-first and nothing enforces it, so a
+    // strong pick emitted second must still create the thread.
+    generateStructuredObject.mockResolvedValue(
+      ranked([
+        { directoryKey: "dir-snap", confidence: 0.3 },
+        { directoryKey: "dir-agent", confidence: 0.92 },
+      ]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-unsorted",
+      request: "Fix the thread list",
+    });
+
+    expect(response.status).toBe("created");
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ directoryKey: "dir-agent" }),
+      expect.anything(),
+    );
+  });
+
+  it("orders a low-confidence disambiguation list by confidence", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([
+        { directoryKey: "dir-snap", confidence: 0.1 },
+        { directoryKey: "dir-agent", confidence: 0.4 },
+      ]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-unsorted-low",
+      request: "Do something",
+    });
+
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      expect(response.candidates.map((entry) => entry.directoryKey)).toEqual([
+        "dir-agent",
+        "dir-snap",
+      ]);
+    }
+  });
+
+  it("separates a resolver that could not run from one that pointed nowhere", async () => {
+    generateStructuredObject.mockResolvedValue({
+      status: "unavailable",
+      reason: "codex_structured_generation_unavailable",
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-unresolved",
+      request: "Do a thing somewhere",
+    });
+
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      // Not "recent": nothing judged that no project matched.
+      expect(response.candidateSource).toBe("unresolved");
+    }
+  });
+
+  it("truncates an overlong reason on a character boundary", async () => {
+    const reason = `${"x".repeat(119)}🛰️ trailing`;
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.2, reason }]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-long-reason",
+      request: "Do a thing somewhere",
+    });
+
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      const truncated = response.candidates[0]?.reason ?? "";
+      expect([...truncated]).toHaveLength(120);
+      // A code-unit slice would leave the high half of the surrogate pair.
+      expect(truncated).not.toMatch(/[\uD800-\uDBFF]$/u);
+    }
+  });
+
   it("drops resolver candidates that name a directory outside the registry", async () => {
     generateStructuredObject.mockResolvedValue(
       ranked([

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -446,6 +446,81 @@ describe("dispatchStarMapIntake", () => {
     });
   });
 
+  it("names the real problem when no projects are registered", async () => {
+    readLocalNavigationDirectoryIndex.mockResolvedValue([]);
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-empty-registry",
+      request: "Do a thing",
+    });
+
+    // Not a candidate list with no rows: a heading promising options above
+    // nothing is a dead end with no way forward.
+    expect(response.status).toBe("failed");
+    if (response.status === "failed") {
+      expect(response.error).toContain("No projects are registered");
+    }
+    expect(generateStructuredObject).not.toHaveBeenCalled();
+  });
+
+  it("caps how many directories reach the resolver prompt", async () => {
+    readLocalNavigationDirectoryIndex.mockResolvedValue(
+      Array.from({ length: 200 }, (_unused, index) =>
+        directory(`dir-${index}`, `Project${index}`, {
+          latestUpdatedAt: index,
+        }),
+      ),
+    );
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-199", confidence: 0.9 }]),
+    );
+
+    await dispatchStarMapIntake({
+      requestId: "req-many",
+      request: "Do a thing",
+    });
+
+    const prompt = generateStructuredObject.mock.calls[0]?.[0].prompt as string;
+    const listed = prompt.match(/^- key=/gmu)?.length ?? 0;
+    expect(listed).toBeLessThanOrEqual(80);
+    // Most recently active survive the cut; the oldest do not.
+    expect(prompt).toContain("key=dir-199");
+    expect(prompt).not.toContain("key=dir-0 ");
+    expect(prompt).toContain("less recently active directories omitted");
+  });
+
+  it("asks rather than letting a lone label match overrule the resolver", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-agent", confidence: 0.45 }]),
+    );
+
+    // "PwrSnap" appears literally, but the resolver ranked PwrAgent first.
+    const response = await dispatchStarMapIntake({
+      requestId: "req-disagree",
+      request: "Port the PwrSnap helper",
+    });
+
+    expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(response.status).toBe("needs_disambiguation");
+  });
+
+  it("still short-circuits when a lone label match is the resolver's pick", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.45 }]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agree",
+      request: "Port the PwrSnap helper",
+    });
+
+    expect(response.status).toBe("created");
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ directoryKey: "dir-snap" }),
+      expect.anything(),
+    );
+  });
+
   it("rejects empty requests without touching the registry", async () => {
     const response = await dispatchStarMapIntake({
       requestId: "req-6",

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -360,6 +360,25 @@ describe("dispatchStarMapIntake", () => {
     }
   });
 
+  it("gives the resolver a longer answering budget than the protocol round-trips", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-agent", confidence: 0.9 }]),
+    );
+
+    await dispatchStarMapIntake({
+      requestId: "req-budget",
+      request: "Fix the thread list",
+    });
+
+    const call = generateStructuredObject.mock.calls[0]?.[0] as {
+      timeoutMs: number;
+      turnTimeoutMs: number;
+    };
+    // One number for both would make a wedged server's cleanup — which runs
+    // on the timeout path — as slow as the thinking budget is generous.
+    expect(call.turnTimeoutMs).toBeGreaterThan(call.timeoutMs);
+  });
+
   it("gives the resolver each directory's current branch", async () => {
     generateStructuredObject.mockResolvedValue(
       ranked([{ directoryKey: "dir-agent", confidence: 0.9 }]),

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -28,6 +28,7 @@ import { dispatchStarMapIntake } from "../app-server/star-map-intake";
 function directory(
   key: string,
   label: string,
+  options?: { latestUpdatedAt?: number; currentBranch?: string },
 ): NavigationDirectoryRow {
   return {
     key,
@@ -35,15 +36,37 @@ function directory(
     label,
     path: `/repos/${label}`,
     counts: { total: 0, active: 0, unread: 0, review: 0 },
+    latestUpdatedAt: options?.latestUpdatedAt,
+    ...(options?.currentBranch
+      ? { gitStatus: { currentBranch: options.currentBranch } }
+      : {}),
     pinnedRootCount: 0, unpinnedRootCount: 0, launchpadPresent: false,
   } as unknown as NavigationDirectoryRow;
+}
+
+/** The ranked shape the resolver now returns. */
+function ranked(
+  entries: Array<{ directoryKey: string; confidence: number; reason?: string }>,
+) {
+  return {
+    status: "ok",
+    object: {
+      candidates: entries.map((entry) => ({
+        reason: "because",
+        ...entry,
+      })),
+    },
+  };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
   readLocalNavigationDirectoryIndex.mockResolvedValue([
-      directory("dir-snap", "PwrSnap"),
-      directory("dir-agent", "PwrAgent"),
+      directory("dir-snap", "PwrSnap", { latestUpdatedAt: 10 }),
+      directory("dir-agent", "PwrAgent", {
+        currentBranch: "feat/icons",
+        latestUpdatedAt: 20,
+      }),
   ]);
   materializeDirectoryLaunchpad.mockResolvedValue({
     backend: "codex",
@@ -68,14 +91,9 @@ beforeEach(() => {
 
 describe("dispatchStarMapIntake", () => {
   it("creates a thread in the backend-resolved directory with the request as first turn", async () => {
-    generateStructuredObject.mockResolvedValue({
-      status: "ok",
-      object: {
-        title: "Investigate PwrSnap issue",
-        directoryKey: "dir-snap",
-        confidence: 0.9,
-      },
-    });
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
 
     const response = await dispatchStarMapIntake({
       requestId: "req-1",
@@ -86,7 +104,6 @@ describe("dispatchStarMapIntake", () => {
       status: "created",
       backend: "codex",
       threadId: "thread-9",
-      title: "Investigate PwrSnap issue",
     });
     expect(ensureDirectoryLaunchpad).toHaveBeenCalledWith({
       directoryKey: "dir-snap",
@@ -167,10 +184,7 @@ describe("dispatchStarMapIntake", () => {
   });
 
   it("asks for disambiguation when no directory clearly matches", async () => {
-    generateStructuredObject.mockResolvedValue({
-      status: "ok",
-      object: { title: "Do a thing", directoryKey: null, confidence: 0.1 },
-    });
+    generateStructuredObject.mockResolvedValue(ranked([]));
 
     const response = await dispatchStarMapIntake({
       requestId: "req-3",
@@ -179,12 +193,126 @@ describe("dispatchStarMapIntake", () => {
 
     expect(response.status).toBe("needs_disambiguation");
     if (response.status === "needs_disambiguation") {
+      // Recency order, not registry order: dir-agent is the newer of the two.
+      expect(response.candidateSource).toBe("recent");
       expect(response.candidates.map((entry) => entry.directoryKey)).toEqual([
-        "dir-snap",
         "dir-agent",
+        "dir-snap",
       ]);
     }
     expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+  });
+
+  it("offers the resolver's ranking with its reasons when no pick is confident enough", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([
+        { directoryKey: "dir-agent", confidence: 0.4, reason: "mentions threads" },
+        { directoryKey: "dir-snap", confidence: 0.2, reason: "also takes shots" },
+      ]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-ranked",
+      request: "Tidy up the thread list",
+    });
+
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      expect(response.candidateSource).toBe("resolver");
+      expect(response.candidates).toEqual([
+        {
+          directoryKey: "dir-agent",
+          label: "PwrAgent",
+          path: "/repos/PwrAgent",
+          reason: "mentions threads",
+        },
+        {
+          directoryKey: "dir-snap",
+          label: "PwrSnap",
+          path: "/repos/PwrSnap",
+          reason: "also takes shots",
+        },
+      ]);
+    }
+  });
+
+  it("labels a multi-name request as a name match, not a recency fallback", async () => {
+    generateStructuredObject.mockResolvedValue(ranked([]));
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-both",
+      request: "Port the PwrSnap capture helper into PwrAgent",
+    });
+
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      expect(response.candidateSource).toBe("label");
+      expect(response.candidates.map((entry) => entry.directoryKey)).toEqual([
+        "dir-agent",
+        "dir-snap",
+      ]);
+    }
+  });
+
+  it("drops resolver candidates that name a directory outside the registry", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([
+        { directoryKey: "dir-invented", confidence: 0.95 },
+        { directoryKey: "dir-snap", confidence: 0.3 },
+      ]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-hallucinated",
+      request: "Do a thing somewhere",
+    });
+
+    // The invented leader must not create a thread, and must not survive
+    // into the list the operator picks from.
+    expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(response.status).toBe("needs_disambiguation");
+    if (response.status === "needs_disambiguation") {
+      expect(response.candidates.map((entry) => entry.directoryKey)).toEqual([
+        "dir-snap",
+      ]);
+    }
+  });
+
+  it("gives the resolver each directory's current branch", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-agent", confidence: 0.9 }]),
+    );
+
+    await dispatchStarMapIntake({
+      requestId: "req-branch",
+      request: "Finish the icon work",
+    });
+
+    const prompt = generateStructuredObject.mock.calls[0]?.[0].prompt as string;
+    expect(prompt).toContain("branch=feat/icons");
+  });
+
+  it("names the resolved project on the creating event", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
+
+    await dispatchStarMapIntake({
+      requestId: "req-label",
+      request: "Look into the screenshot issue",
+    });
+
+    const creating = publishLocalEvent.mock.calls
+      .map(
+        (call) =>
+          (call as unknown as [{
+            notification: {
+              params: { phase: string; directoryLabel?: string };
+            };
+          }])[0].notification.params,
+      )
+      .find((params) => params.phase === "creating");
+    expect(creating?.directoryLabel).toBe("PwrSnap");
   });
 
   it("honors a disambiguation resubmit without re-resolving", async () => {
@@ -199,10 +327,9 @@ describe("dispatchStarMapIntake", () => {
   });
 
   it("reports creation failures with a failed status event", async () => {
-    generateStructuredObject.mockResolvedValue({
-      status: "ok",
-      object: { title: "T", directoryKey: "dir-snap", confidence: 0.9 },
-    });
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
     materializeDirectoryLaunchpad.mockRejectedValue(
       new Error("launchpad exploded"),
     );

--- a/apps/desktop/src/main/__tests__/star-map-window-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-window-ipc.test.ts
@@ -262,6 +262,7 @@ describe("star map window IPC", () => {
       status: "needs_disambiguation",
       requestId: "request-forged",
       candidates: [],
+      candidateSource: "resolver",
     });
 
     await handlerFor(STAR_MAP_INTAKE_CHANNEL)({}, {

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -799,6 +799,8 @@ type BackendClient = {
     system?: string;
     isMatch: (record: Record<string, unknown>) => boolean;
     timeoutMs?: number;
+    /** Model answering budget, separate from the protocol round-trips. */
+    turnTimeoutMs?: number;
   }): ReturnType<ThreadTitleGenerator["generateTitle"]>;
   listSkills(params?: {
     cwd?: string;
@@ -22447,6 +22449,8 @@ export class DesktopBackendRegistry {
     schema: Record<string, unknown>;
     schemaName?: string;
     timeoutMs?: number;
+    /** Model answering budget, separate from the protocol round-trips. */
+    turnTimeoutMs?: number;
   }): Promise<ThreadTitleAdapterResult> {
     const defaults = await this.overlayStore.getLaunchpadDefaults();
     const backend = params.backend === "codex"
@@ -22472,6 +22476,7 @@ export class DesktopBackendRegistry {
             structuredRequiredFieldMatches(params.schema, record, key)
           ),
         timeoutMs: params.timeoutMs,
+        turnTimeoutMs: params.turnTimeoutMs,
       });
     }
 

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -28,6 +28,14 @@ const MAX_DISAMBIGUATION_CANDIDATES = 8;
  */
 const AUTO_CREATE_CONFIDENCE = 0.5;
 const MAX_CANDIDATE_REASON_CHARS = 120;
+/**
+ * Cut a reason at a character boundary, so a clause ending in an emoji or
+ * other non-BMP character does not leave a lone surrogate in the row.
+ */
+function truncateReason(reason: string): string {
+  if (reason.length <= MAX_CANDIDATE_REASON_CHARS) return reason;
+  return [...reason].slice(0, MAX_CANDIDATE_REASON_CHARS).join("");
+}
 
 /**
  * The resolver ranks; it does not choose. One pick plus a confidence number
@@ -204,11 +212,16 @@ async function resolveViaConfiguredBackend(params: {
           && Number.isFinite(record.confidence)
             ? record.confidence
             : 0,
-        reason: reason
-          ? reason.slice(0, MAX_CANDIDATE_REASON_CHARS)
-          : undefined,
+        reason: reason ? truncateReason(reason) : undefined,
       });
     }
+    // Order by the confidence the resolver reported rather than by the
+    // order it happened to emit. The prompt asks for most-likely-first, but
+    // nothing enforces that, and `AUTO_CREATE_CONFIDENCE` is checked against
+    // the leading entry — so a model that sorts its own array wrongly would
+    // ask the operator about a project it was sure of. Array#sort is stable,
+    // so equal confidences keep the resolver's order.
+    ranked.sort((left, right) => right.confidence - left.confidence);
     return ranked.slice(0, MAX_DISAMBIGUATION_CANDIDATES);
   } catch (error) {
     log.warn("star map intake structured resolution unavailable", {
@@ -329,7 +342,15 @@ export async function dispatchStarMapIntake(
             candidateSource = "resolver";
             ranked = resolved;
           } else {
-            candidateSource = fuzzy.length > 0 ? "label" : "recent";
+            // `undefined` means the resolver could not run; `[]` means it ran
+            // and pointed nowhere. Collapsing the two would make the dialog
+            // claim "no project matched" about a judgment never made, which
+            // is the class of copy this whole surface exists to remove.
+            candidateSource = fuzzy.length > 0
+              ? "label"
+              : resolved
+                ? "recent"
+                : "unresolved";
             ranked = (
               fuzzy.length > 0 ? fuzzy : [...directories].sort(byRecency)
             ).map((directory) => ({ directory, confidence: 0 }));

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -42,6 +42,15 @@ const INTAKE_TIMEOUT_MS = 20_000;
  */
 const INTAKE_TURN_TIMEOUT_MS = 90_000;
 const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
+/**
+ * How many directories the resolver is shown. Every registered directory
+ * used to go into the prompt, so latency and token cost grew with the
+ * registry forever and a large enough one crowds the request itself out of
+ * the model's attention — the same unbounded-input problem
+ * `INTAKE_PREFERENCES_MAX_CHARS` already solves for AGENTS.md. Most-recently
+ * active first, so the ones cut are the ones the operator has not touched.
+ */
+const INTAKE_MAX_PROMPT_DIRECTORIES = 80;
 const MAX_DISAMBIGUATION_CANDIDATES = 8;
 /**
  * Create without asking at or above this much confidence in the leading
@@ -177,6 +186,9 @@ async function resolveViaConfiguredBackend(params: {
   const byKey = new Map(
     params.directories.map((directory) => [directory.key, directory]),
   );
+  const promptDirectories = [...params.directories]
+    .sort(byRecency)
+    .slice(0, INTAKE_MAX_PROMPT_DIRECTORIES);
   const startedAt = Date.now();
   try {
     const result = await getDesktopBackendRegistry().generateStructuredObject({
@@ -204,7 +216,13 @@ async function resolveViaConfiguredBackend(params: {
           ? `Operator thread-startup preferences (AGENTS.md):\n${params.preferences}\n`
           : "",
         "Registered project directories:",
-        ...params.directories.map((directory) => `- ${describeDirectory(directory)}`),
+        ...promptDirectories.map((directory) => `- ${describeDirectory(directory)}`),
+        ...(promptDirectories.length < params.directories.length
+          ? [
+              `(${params.directories.length - promptDirectories.length} less`
+              + " recently active directories omitted.)",
+            ]
+          : []),
         "",
         `Task request: ${params.text}`,
       ].join("\n"),
@@ -253,6 +271,7 @@ async function resolveViaConfiguredBackend(params: {
     log.info("star map intake resolved", {
       candidateCount: candidates.length,
       directoryCount: params.directories.length,
+      promptDirectoryCount: promptDirectories.length,
       elapsedMs: Date.now() - startedAt,
       leadingConfidence: candidates[0]?.confidence,
       preferencesChars: params.preferences?.length ?? 0,
@@ -341,6 +360,14 @@ export async function dispatchStarMapIntake(
     const directories = (await readLocalNavigationDirectoryIndex()).filter(
       (directory) => directory.kind !== "unlinked",
     );
+    if (directories.length === 0) {
+      // Every path below ends in a list of projects to choose from, and with
+      // no projects that list is empty — a heading promising options above
+      // nothing, with no way forward. Name the actual problem instead.
+      throw new Error(
+        "No projects are registered on this instance. Add a directory first.",
+      );
+    }
 
     let directoryKey = request.directoryKey;
     if (
@@ -361,7 +388,14 @@ export async function dispatchStarMapIntake(
         directoryKey = leading.directory.key;
       } else {
         const fuzzy = fuzzyMatchDirectories(text, directories);
-        if (fuzzy.length === 1) {
+        // A request that literally names one project is strong evidence, so
+        // it still short-circuits — but not over the resolver's objection.
+        // When the resolver ranked something else first, a raw substring hit
+        // beating a reasoned pick is exactly the call the operator should
+        // make, so fall through and show them both.
+        const resolverAgrees =
+          !leading || leading.directory.key === fuzzy[0]?.key;
+        if (fuzzy.length === 1 && resolverAgrees) {
           directoryKey = fuzzy[0].key;
         } else {
           // Prefer the resolver's ranking; then the label match; then the

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import type {
   NavigationDirectoryRow,
   StarMapIntakeCandidate,
+  StarMapIntakeCandidateSource,
   StarMapIntakePhase,
   StarMapIntakeRequest,
   StarMapIntakeResponse,
@@ -20,23 +21,48 @@ const log = getMainLogger("pwragent:star-map-intake");
 const INTAKE_TIMEOUT_MS = 20_000;
 const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
 const MAX_DISAMBIGUATION_CANDIDATES = 8;
+/**
+ * Create without asking at or above this much confidence in the leading
+ * project. Below it the operator picks — but from the resolver's ranking,
+ * not from the registry in storage order.
+ */
+const AUTO_CREATE_CONFIDENCE = 0.5;
+const MAX_CANDIDATE_REASON_CHARS = 120;
 
+/**
+ * The resolver ranks; it does not choose. One pick plus a confidence number
+ * throws away everything it knew about the runners-up, which is exactly what
+ * the operator needs when the pick is not confident enough to act on.
+ *
+ * No title field: `materializeDirectoryLaunchpad` schedules thread-title
+ * generation from this same first turn, so asking for one here bought a
+ * second title that nothing ever read.
+ */
 const INTAKE_SCHEMA: Record<string, unknown> = {
   type: "object",
   properties: {
-    title: { type: "string" },
-    directoryKey: { type: ["string", "null"] },
-    confidence: { type: "number" },
-    notes: { type: ["string", "null"] },
+    candidates: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: {
+          directoryKey: { type: "string" },
+          confidence: { type: "number" },
+          reason: { type: "string" },
+        },
+        required: ["directoryKey", "confidence", "reason"],
+        additionalProperties: false,
+      },
+    },
   },
-  required: ["title", "directoryKey", "confidence"],
+  required: ["candidates"],
   additionalProperties: false,
 };
 
-type IntakeResolution = {
-  title?: string;
-  directoryKey?: string;
+type RankedDirectory = {
+  directory: NavigationDirectoryRow;
   confidence: number;
+  reason?: string;
 };
 
 function publishIntakeStatus(params: {
@@ -45,6 +71,12 @@ function publishIntakeStatus(params: {
   message?: string;
   backend?: string;
   threadId?: string;
+  /**
+   * The project the intake resolved to, sent with `creating`. This is the
+   * only moment the operator can still catch a wrong pick — after this the
+   * thread exists — and in the confident path nothing else ever names it.
+   */
+  directoryLabel?: string;
 }): void {
   // publishLocalEvent fans out to this instance's windows AND to remote
   // viewers over the federation backend-event channel, so the requesting
@@ -91,26 +123,48 @@ function describeDirectory(directory: NavigationDirectoryRow): string {
   ];
   if (directory.path) parts.push(`path=${directory.path}`);
   parts.push(`threads=${directory.counts.total}`);
+  // The branch an operator is sitting on is often the only thing their
+  // request names ("finish the icon work"), and it costs one short field.
+  if (directory.gitStatus?.currentBranch) {
+    parts.push(`branch=${directory.gitStatus.currentBranch}`);
+  }
   return parts.join(" | ");
+}
+
+/** Most-recently-active first; never-used directories sort last. */
+function byRecency(
+  left: NavigationDirectoryRow,
+  right: NavigationDirectoryRow,
+): number {
+  return (right.latestUpdatedAt ?? 0) - (left.latestUpdatedAt ?? 0);
 }
 
 async function resolveViaConfiguredBackend(params: {
   text: string;
   preferences?: string;
   directories: NavigationDirectoryRow[];
-}): Promise<IntakeResolution | undefined> {
+}): Promise<RankedDirectory[] | undefined> {
+  const byKey = new Map(
+    params.directories.map((directory) => [directory.key, directory]),
+  );
   try {
     const result = await getDesktopBackendRegistry().generateStructuredObject({
       timeoutMs: INTAKE_TIMEOUT_MS,
       schema: INTAKE_SCHEMA,
       schemaName: "star_map_intake_resolution",
       system: [
-        "You resolve a natural-language task request to one of the",
-        "operator's registered project directories and give the task a",
-        "short thread title.",
-        "Pick directoryKey ONLY from the provided list; null when no",
-        "directory clearly matches.",
-        "confidence is 0..1 for the directory pick.",
+        "You rank the operator's registered project directories against a",
+        "natural-language task request.",
+        "Return the plausible directories, most likely first, at most",
+        `${MAX_DISAMBIGUATION_CANDIDATES}. Use directoryKey values from the`,
+        "provided list only.",
+        "confidence is 0..1 that the task belongs to that directory.",
+        "reason is one short clause (under 12 words) naming the evidence",
+        "you used, addressed to the operator: \"matches the PwrSnap",
+        "screenshot work\", not \"the request mentions screenshots\".",
+        "When nothing in the request points anywhere, return an empty",
+        "array rather than guessing: the operator is then asked to pick,",
+        "and an invented ranking makes that harder, not easier.",
         "Return JSON matching the schema exactly.",
       ].join("\n"),
       prompt: [
@@ -126,24 +180,36 @@ async function resolveViaConfiguredBackend(params: {
     if (result.status !== "ok") {
       throw new Error(result.reason);
     }
-    const object = result.object as {
-      title?: unknown;
-      directoryKey?: unknown;
-      confidence?: unknown;
-    };
-    const directoryKey =
-      typeof object.directoryKey === "string"
-      && params.directories.some((directory) => directory.key === object.directoryKey)
-        ? object.directoryKey
-        : undefined;
-    return {
-      title: typeof object.title === "string" ? object.title.trim() : undefined,
-      directoryKey,
-      confidence:
-        typeof object.confidence === "number" && Number.isFinite(object.confidence)
-          ? object.confidence
-          : 0,
-    };
+    const object = result.object as { candidates?: unknown };
+    if (!Array.isArray(object.candidates)) return [];
+    const seen = new Set<string>();
+    const ranked: RankedDirectory[] = [];
+    for (const entry of object.candidates) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const record = entry as {
+        directoryKey?: unknown;
+        confidence?: unknown;
+        reason?: unknown;
+      };
+      if (typeof record.directoryKey !== "string") continue;
+      const directory = byKey.get(record.directoryKey);
+      if (!directory || seen.has(directory.key)) continue;
+      seen.add(directory.key);
+      const reason =
+        typeof record.reason === "string" ? record.reason.trim() : "";
+      ranked.push({
+        directory,
+        confidence:
+          typeof record.confidence === "number"
+          && Number.isFinite(record.confidence)
+            ? record.confidence
+            : 0,
+        reason: reason
+          ? reason.slice(0, MAX_CANDIDATE_REASON_CHARS)
+          : undefined,
+      });
+    }
+    return ranked.slice(0, MAX_DISAMBIGUATION_CANDIDATES);
   } catch (error) {
     log.warn("star map intake structured resolution unavailable", {
       error: error instanceof Error ? error.message : String(error),
@@ -171,13 +237,12 @@ function fuzzyMatchDirectories(
     .map((entry) => entry.directory);
 }
 
-function candidateOf(
-  directory: NavigationDirectoryRow,
-): StarMapIntakeCandidate {
+function candidateOf(entry: RankedDirectory): StarMapIntakeCandidate {
   return {
-    directoryKey: directory.key,
-    label: directory.label,
-    path: directory.path,
+    directoryKey: entry.directory.key,
+    label: entry.directory.label,
+    path: entry.directory.path,
+    ...(entry.reason ? { reason: entry.reason } : {}),
   };
 }
 
@@ -197,10 +262,18 @@ export async function ensureStarMapIntakeLaunchpad(
 
 /**
  * The Star Map [+] intake: resolve the operator's natural-language request
- * to a project (Grok structured call over the directory registry +
- * AGENTS.md preferences, deterministic label match as fallback), then
- * materialize the directory's launchpad with the request as the first
- * turn. Runs on the instance that owns the [+] card.
+ * to a project (structured call over the directory registry + AGENTS.md
+ * preferences, deterministic label match as fallback), then materialize the
+ * directory's launchpad with the request as the first turn. Runs on the
+ * instance that owns the [+] card.
+ *
+ * The resolver ranks rather than picks, and the ranking survives a low
+ * score: below `AUTO_CREATE_CONFIDENCE` the operator chooses, but from the
+ * resolver's order with its reasons attached. The previous shape discarded
+ * the whole resolution below the threshold and fell through to a substring
+ * match on directory labels — so a request that never typed a project name
+ * produced the entire registry in storage order, which reads as the intake
+ * having thought about nothing.
  */
 export async function dispatchStarMapIntake(
   request: StarMapIntakeRequest,
@@ -221,7 +294,6 @@ export async function dispatchStarMapIntake(
     );
 
     let directoryKey = request.directoryKey;
-    let title: string | undefined;
     if (
       directoryKey
       && !directories.some((directory) => directory.key === directoryKey)
@@ -235,20 +307,38 @@ export async function dispatchStarMapIntake(
         preferences,
         directories,
       });
-      if (resolved && resolved.directoryKey && resolved.confidence >= 0.5) {
-        directoryKey = resolved.directoryKey;
-        title = resolved.title;
+      const leading = resolved?.[0];
+      if (leading && leading.confidence >= AUTO_CREATE_CONFIDENCE) {
+        directoryKey = leading.directory.key;
       } else {
         const fuzzy = fuzzyMatchDirectories(text, directories);
         if (fuzzy.length === 1) {
           directoryKey = fuzzy[0].key;
-          title = resolved?.title;
         } else {
-          const ranked = fuzzy.length > 0 ? fuzzy : directories;
+          // Prefer the resolver's ranking; then the label match; then the
+          // registry by recency. Recency is the last of those because it
+          // answers a different question than the request did — but "what
+          // you were working in" beats whatever order storage returned.
+          //
+          // The source travels with the list because the dialog's copy has
+          // to match it: "closest match first" over a recency fallback
+          // claims a judgment nobody made.
+          let candidateSource: StarMapIntakeCandidateSource;
+          let ranked: RankedDirectory[];
+          if (resolved && resolved.length > 0) {
+            candidateSource = "resolver";
+            ranked = resolved;
+          } else {
+            candidateSource = fuzzy.length > 0 ? "label" : "recent";
+            ranked = (
+              fuzzy.length > 0 ? fuzzy : [...directories].sort(byRecency)
+            ).map((directory) => ({ directory, confidence: 0 }));
+          }
           publishIntakeStatus({ requestId, phase: "needs_disambiguation" });
           return {
             status: "needs_disambiguation",
             requestId,
+            candidateSource,
             candidates: ranked
               .slice(0, MAX_DISAMBIGUATION_CANDIDATES)
               .map(candidateOf),
@@ -257,11 +347,15 @@ export async function dispatchStarMapIntake(
       }
     }
 
-    publishIntakeStatus({ requestId, phase: "creating" });
     const directory = directories.find((entry) => entry.key === directoryKey);
     if (!directory) {
       throw new Error(`Directory is no longer available: ${directoryKey}`);
     }
+    publishIntakeStatus({
+      requestId,
+      phase: "creating",
+      directoryLabel: directory.label,
+    });
     const registry = getDesktopBackendRegistry();
     const launchpad = await ensureStarMapIntakeLaunchpad(registry, directory);
     const materialized = await registry.materializeDirectoryLaunchpad(
@@ -286,7 +380,6 @@ export async function dispatchStarMapIntake(
       requestId,
       backend: materialized.backend,
       threadId: materialized.threadId,
-      title,
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -18,7 +18,29 @@ import {
 
 const log = getMainLogger("pwragent:star-map-intake");
 
+/**
+ * Budget for one protocol round-trip to the app server — a config read, a
+ * thread start, an MCP attestation, a turn start, and the interrupt and
+ * unsubscribe that clean up after a failure. Deliberately NOT the model's
+ * thinking budget: those cleanup calls run on the timeout path, so a number
+ * chosen to give a hard question more thinking time would also multiply how
+ * long a wedged server takes to report that it is wedged.
+ */
 const INTAKE_TIMEOUT_MS = 20_000;
+/**
+ * How long the resolver may take to answer.
+ *
+ * This was 20s, inherited from `DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS` by
+ * copying the constant rather than by measuring this call. The title helper
+ * summarizes one message into one line. This one is handed every registered
+ * directory plus up to `INTAKE_PREFERENCES_MAX_CHARS` of AGENTS.md and asked
+ * to rank up to `MAX_DISAMBIGUATION_CANDIDATES` projects with a written
+ * reason for each — a bigger prompt, a bigger answer, and an actual
+ * judgment. On expiry the whole resolution is discarded and the operator is
+ * handed a list ordered by recency, so the cost of being too short is that
+ * they waited and got nothing. Err long.
+ */
+const INTAKE_TURN_TIMEOUT_MS = 90_000;
 const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
 const MAX_DISAMBIGUATION_CANDIDATES = 8;
 /**
@@ -155,9 +177,11 @@ async function resolveViaConfiguredBackend(params: {
   const byKey = new Map(
     params.directories.map((directory) => [directory.key, directory]),
   );
+  const startedAt = Date.now();
   try {
     const result = await getDesktopBackendRegistry().generateStructuredObject({
       timeoutMs: INTAKE_TIMEOUT_MS,
+      turnTimeoutMs: INTAKE_TURN_TIMEOUT_MS,
       schema: INTAKE_SCHEMA,
       schemaName: "star_map_intake_resolution",
       system: [
@@ -222,9 +246,21 @@ async function resolveViaConfiguredBackend(params: {
     // ask the operator about a project it was sure of. Array#sort is stable,
     // so equal confidences keep the resolver's order.
     ranked.sort((left, right) => right.confidence - left.confidence);
-    return ranked.slice(0, MAX_DISAMBIGUATION_CANDIDATES);
+    const candidates = ranked.slice(0, MAX_DISAMBIGUATION_CANDIDATES);
+    // The only record of what this call actually costs. `INTAKE_TURN_TIMEOUT_MS`
+    // was last set by reasoning about prompt size, because a successful
+    // resolution logged nothing and there was no number to set it from.
+    log.info("star map intake resolved", {
+      candidateCount: candidates.length,
+      directoryCount: params.directories.length,
+      elapsedMs: Date.now() - startedAt,
+      leadingConfidence: candidates[0]?.confidence,
+      preferencesChars: params.preferences?.length ?? 0,
+    });
+    return candidates;
   } catch (error) {
     log.warn("star map intake structured resolution unavailable", {
+      elapsedMs: Date.now() - startedAt,
       error: error instanceof Error ? error.message : String(error),
     });
     return undefined;

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -9071,6 +9071,7 @@ export class CodexAppServerClient {
     system?: string;
     isMatch: StructuredRecordPredicate;
     timeoutMs?: number;
+    turnTimeoutMs?: number;
   }): Promise<ThreadTitleAdapterResult> {
     return await this.runHelperStructuredTurn(params);
   }
@@ -9153,6 +9154,18 @@ export class CodexAppServerClient {
     system?: string;
     isMatch: StructuredRecordPredicate;
     timeoutMs?: number;
+    /**
+     * How long the model itself may take to answer, separately from the
+     * protocol round-trips around it. `timeoutMs` governs seven different
+     * requests here — an MCP config read, thread start, MCP attestation,
+     * turn start, and, in `finally`, a turn interrupt and an unsubscribe —
+     * so raising it to buy a harder question more thinking time also grants
+     * every wedged round-trip the same extra hang, including the cleanup
+     * that runs on the timeout path. A caller with a big prompt needs the
+     * one budget raised and the other left alone. Defaults to `timeoutMs`,
+     * so a caller that does not care is unaffected.
+     */
+    turnTimeoutMs?: number;
   }): Promise<ThreadTitleAdapterResult> {
     await this.ensureInitialized();
 
@@ -9160,6 +9173,7 @@ export class CodexAppServerClient {
     let helperTurnId: string | undefined;
     let helperTurnCompleted = false;
     const timeoutMs = params.timeoutMs ?? DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS;
+    const turnTimeoutMs = params.turnTimeoutMs ?? timeoutMs;
     const helperWorkspaceDir = await ensureCodexThreadTitleWorkspace();
     const helperModel = params.model?.trim() || DEFAULT_CODEX_THREAD_TITLE_MODEL;
     const helperReasoningEffort =
@@ -9297,7 +9311,7 @@ export class CodexAppServerClient {
       const helperResult = await this.waitForHelperTurnTitle({
         threadId: helperThreadId,
         turnId: helperTurnId,
-        timeoutMs,
+        timeoutMs: turnTimeoutMs,
       });
       helperTurnCompleted = true;
       return {

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -9283,7 +9283,12 @@ export class CodexAppServerClient {
             protocolCompatibility,
           ),
         ],
-        timeoutMs,
+        // This request can carry the finished answer (see the immediate
+        // record check below), so it is the one round-trip that also has to
+        // honour the model's budget. Bounding it at `timeoutMs` would make
+        // a raised `turnTimeoutMs` a no-op whenever the app server
+        // completes the helper turn inside `turn/start`.
+        timeoutMs: Math.max(timeoutMs, turnTimeoutMs),
       });
       helperTurnId = extractTurnIdFromValue(turnStartResult);
       const immediateObject = findStructuredRecord(turnStartResult, params.isMatch);

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -11,6 +11,7 @@ import type {
   CelestialIconId,
   FederationTarget,
   StarMapIntakeCandidate,
+  StarMapIntakeCandidateSource,
   StarMapIntakePhase,
 } from "@pwragent/shared";
 import { MAX_STAR_MAP_INTAKE_IMAGE_UPLOADS } from "../../../../shared/star-map-intake";
@@ -39,6 +40,17 @@ export type IntakeDialogTarget = {
 const PHASE_COPY: Partial<Record<StarMapIntakePhase, string>> = {
   resolving: "Finding the right project…",
   creating: "Creating the thread…",
+};
+
+/**
+ * Say which question the list answers. "Which project?" over a recency
+ * fallback implies a judgment that was never made, and the operator reads
+ * the first row as a recommendation it is not.
+ */
+const CANDIDATE_HINT: Record<StarMapIntakeCandidateSource, string> = {
+  resolver: "Closest match first — pick the project:",
+  label: "Your request names more than one project:",
+  recent: "No project matched. Your most recent, newest first:",
 };
 
 type IntakeImageAttachment = {
@@ -88,7 +100,17 @@ export function IntakeDialog(props: {
     IntakeImageAttachment[]
   >([]);
   const [preparingImageCount, setPreparingImageCount] = useState(0);
-  const [candidates, setCandidates] = useState<StarMapIntakeCandidate[]>();
+  const [candidates, setCandidates] = useState<{
+    entries: StarMapIntakeCandidate[];
+    source: StarMapIntakeCandidateSource;
+  }>();
+  /**
+   * The project the owning instance resolved to, streamed with `creating`.
+   * When the resolver is confident it never asks, so this line is the only
+   * place the operator sees the pick while it is still worth seeing.
+   */
+  const [resolvedDirectoryLabel, setResolvedDirectoryLabel] =
+    useState<string>();
   const requestIdRef = useRef<string | undefined>(undefined);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const previewUrlsRef = useRef(new Set<string>());
@@ -118,9 +140,13 @@ export function IntakeDialog(props: {
         requestId: string;
         phase: StarMapIntakePhase;
         message?: string;
+        directoryLabel?: string;
       };
       if (params.requestId !== requestIdRef.current) return;
       setPhase(params.phase);
+      if (params.directoryLabel) {
+        setResolvedDirectoryLabel(params.directoryLabel);
+      }
       if (params.phase === "failed" && params.message) {
         setError(params.message);
       }
@@ -306,6 +332,7 @@ export function IntakeDialog(props: {
     setError(undefined);
     setAttachmentError(undefined);
     setCandidates(undefined);
+    setResolvedDirectoryLabel(undefined);
     setPhase("resolving");
     void props.desktopApi
       .dispatchStarMapIntake({
@@ -337,7 +364,10 @@ export function IntakeDialog(props: {
         }
         if (response.status === "needs_disambiguation") {
           setPhase("needs_disambiguation");
-          setCandidates(response.candidates);
+          setCandidates({
+            entries: response.candidates,
+            source: response.candidateSource,
+          });
           return;
         }
         setPhase("failed");
@@ -446,8 +476,10 @@ export function IntakeDialog(props: {
         ) : null}
         {candidates ? (
           <div className="star-map-intake__candidates">
-            <p className="star-map-intake__hint">Which project?</p>
-            {candidates.map((candidate) => (
+            <p className="star-map-intake__hint">
+              {CANDIDATE_HINT[candidates.source]}
+            </p>
+            {candidates.entries.map((candidate) => (
               <button
                 key={candidate.directoryKey}
                 type="button"
@@ -457,6 +489,11 @@ export function IntakeDialog(props: {
                 <span className="star-map-intake__candidate-label">
                   {candidate.label}
                 </span>
+                {candidate.reason ? (
+                  <span className="star-map-intake__candidate-reason">
+                    {candidate.reason}
+                  </span>
+                ) : null}
                 {candidate.path ? (
                   <span className="star-map-intake__candidate-path">
                     {candidate.path}
@@ -478,7 +515,9 @@ export function IntakeDialog(props: {
                 ? error
                 : preparingImages
                   ? "Preparing image…"
-                  : PHASE_COPY[phase as StarMapIntakePhase] ?? "")}
+                  : phase === "creating" && resolvedDirectoryLabel
+                    ? `Creating the thread in ${resolvedDirectoryLabel}…`
+                    : PHASE_COPY[phase as StarMapIntakePhase] ?? "")}
           </span>
           <button
             type="button"

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -125,8 +125,21 @@ export function IntakeDialog(props: {
   const requestIdRef = useRef<string | undefined>(undefined);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const previewUrlsRef = useRef(new Set<string>());
+  const closedRef = useRef(false);
   const busy = phase === "resolving" || phase === "creating";
   const preparingImages = preparingImageCount > 0;
+  /**
+   * Resolving is abandonable; creating is not. Nothing exists yet while the
+   * resolver is thinking, so trapping the operator there buys nothing — and
+   * it can think for up to `INTAKE_TURN_TIMEOUT_MS`. Once the launchpad is
+   * being materialized a thread is on its way, and a dialog that vanished
+   * mid-flight would leave the operator unsure whether it landed.
+   */
+  const dismissable = phase !== "creating" && !preparingImages;
+  const close = useCallback(() => {
+    closedRef.current = true;
+    props.onClose();
+  }, [props]);
 
   useEffect(() => {
     textareaRef.current?.focus();
@@ -364,15 +377,19 @@ export function IntakeDialog(props: {
       .then((response) => {
         if (response.requestId !== requestIdRef.current) return;
         if (response.status === "created") {
-          setPhase("done");
+          // Reaches the map even if the operator walked away mid-resolve:
+          // the thread exists, so it still deserves its reveal.
           props.onCreated({
             instanceId: props.target.instanceId,
             backend: response.backend,
             threadId: response.threadId,
           });
-          props.onClose();
+          if (closedRef.current) return;
+          setPhase("done");
+          close();
           return;
         }
+        if (closedRef.current) return;
         if (response.status === "needs_disambiguation") {
           setPhase("needs_disambiguation");
           setCandidates({
@@ -385,6 +402,7 @@ export function IntakeDialog(props: {
         setError(response.error);
       })
       .catch((err: unknown) => {
+        if (closedRef.current) return;
         setPhase("failed");
         setError(err instanceof Error ? err.message : String(err));
       });
@@ -412,9 +430,9 @@ export function IntakeDialog(props: {
       aria-modal="true"
       aria-label={`New thread on ${props.target.label}`}
       onKeyDown={(event) => {
-        if (event.key === "Escape" && !busy && !preparingImages) {
+        if (event.key === "Escape" && dismissable) {
           event.stopPropagation();
-          props.onClose();
+          close();
         }
       }}
     >
@@ -424,7 +442,7 @@ export function IntakeDialog(props: {
         aria-label="Close intake"
         tabIndex={-1}
         onClick={() => {
-          if (!busy && !preparingImages) props.onClose();
+          if (dismissable) close();
         }}
       />
       <div className="star-map-intake__panel">
@@ -437,8 +455,8 @@ export function IntakeDialog(props: {
             type="button"
             className="star-map-intake__close"
             aria-label="Close"
-            disabled={busy || preparingImages}
-            onClick={props.onClose}
+            disabled={!dismissable}
+            onClick={close}
           >
             ✕
           </button>

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -61,7 +61,9 @@ const CANDIDATE_HINT: Record<StarMapIntakeCandidateSource, string> = {
  * which is worse than the bare "Which project?" this replaced.
  */
 function candidateHint(source: StarMapIntakeCandidateSource | undefined) {
-  return (source && CANDIDATE_HINT[source]) ?? "Which project?";
+  // `||`, not `??`: an empty-string source is as unusable as a missing one,
+  // and would otherwise render the unlabelled list this exists to prevent.
+  return (source && CANDIDATE_HINT[source]) || "Which project?";
 }
 
 type IntakeImageAttachment = {
@@ -136,10 +138,11 @@ export function IntakeDialog(props: {
    * mid-flight would leave the operator unsure whether it landed.
    */
   const dismissable = phase !== "creating" && !preparingImages;
+  const { onClose } = props;
   const close = useCallback(() => {
     closedRef.current = true;
-    props.onClose();
-  }, [props]);
+    onClose();
+  }, [onClose]);
 
   useEffect(() => {
     textareaRef.current?.focus();

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -51,7 +51,18 @@ const CANDIDATE_HINT: Record<StarMapIntakeCandidateSource, string> = {
   resolver: "Closest match first — pick the project:",
   label: "Your request names more than one project:",
   recent: "No project matched. Your most recent, newest first:",
+  unresolved: "Could not check the projects. Your most recent, newest first:",
 };
+
+/**
+ * Fall back rather than index blindly. A remote [+] runs the intake on the
+ * peer that owns it, so a peer predating `candidateSource` answers without
+ * one — and a bare lookup would render the list with no heading at all,
+ * which is worse than the bare "Which project?" this replaced.
+ */
+function candidateHint(source: StarMapIntakeCandidateSource | undefined) {
+  return (source && CANDIDATE_HINT[source]) ?? "Which project?";
+}
 
 type IntakeImageAttachment = {
   bytes: Uint8Array;
@@ -379,6 +390,21 @@ export function IntakeDialog(props: {
       });
   };
 
+  /**
+   * One status line, in precedence order. Named branches rather than a
+   * chain of ternaries inside JSX: the ordering between an attachment
+   * error, a failure, and a phase is the whole meaning of this string.
+   */
+  const statusMessage = (() => {
+    if (attachmentError) return attachmentError;
+    if (phase === "failed") return error ?? "";
+    if (preparingImages) return "Preparing image…";
+    if (phase === "creating" && resolvedDirectoryLabel) {
+      return `Creating the thread in ${resolvedDirectoryLabel}…`;
+    }
+    return PHASE_COPY[phase as StarMapIntakePhase] ?? "";
+  })();
+
   return createPortal(
     <div
       className="star-map-intake"
@@ -477,7 +503,7 @@ export function IntakeDialog(props: {
         {candidates ? (
           <div className="star-map-intake__candidates">
             <p className="star-map-intake__hint">
-              {CANDIDATE_HINT[candidates.source]}
+              {candidateHint(candidates.source)}
             </p>
             {candidates.entries.map((candidate) => (
               <button
@@ -510,14 +536,7 @@ export function IntakeDialog(props: {
             }${phase === "failed" || attachmentError ? " is-failed" : ""}`}
             role="status"
           >
-            {attachmentError
-              ?? (phase === "failed"
-                ? error
-                : preparingImages
-                  ? "Preparing image…"
-                  : phase === "creating" && resolvedDirectoryLabel
-                    ? `Creating the thread in ${resolvedDirectoryLabel}…`
-                    : PHASE_COPY[phase as StarMapIntakePhase] ?? "")}
+            {statusMessage}
           </span>
           <button
             type="button"

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -119,6 +119,10 @@ import {
 import type { StarMapCardMenuAction } from "./StarMapCardMenu";
 import { useStarMapChatCards } from "./useStarMapChatCards";
 import { IntakeDialog, type IntakeDialogTarget } from "./IntakeDialog";
+import {
+  findStarMapIntakeRevealTarget,
+  type StarMapIntakeReveal,
+} from "./star-map-intake-reveal";
 import { StarMapRenameDialog } from "./StarMapRenameDialog";
 import {
   readStoredPreferences,
@@ -291,6 +295,13 @@ const STAR_MAP_LOCATED_MS = 1_600;
  * happens to satisfy it.
  */
 const STAR_MAP_SUMMON_TIMEOUT_MS = 2_000;
+/**
+ * How long a just-created thread has to show up in a feed before the intake
+ * reveal is abandoned. Longer than a summon, because this waits on a
+ * poll-driven refresh (and, for a remote [+], on federation) rather than on
+ * a layout pass that has already been scheduled.
+ */
+const STAR_MAP_INTAKE_REVEAL_TIMEOUT_MS = 30_000;
 
 
 /**
@@ -3481,6 +3492,59 @@ export function StarMapScreen(props: StarMapScreenProps) {
   );
 
   /**
+   * A thread the [+] intake just created, waiting for the feed that owns it
+   * to hand us a summary. Intake answers with ids, not a
+   * `NavigationThreadSummary`, and every reveal below needs the summary —
+   * so the reveal cannot happen in the response handler.
+   */
+  const [pendingIntakeReveal, setPendingIntakeReveal] =
+    useState<StarMapIntakeReveal>();
+
+  /**
+   * Land the operator on the thread they just asked for. Creating a thread
+   * and then leaving the operator to find its card is the map's version of
+   * opening a file and not showing it: the intake knows exactly which card
+   * is new, and it is the only moment when that is true.
+   *
+   * Deferred to the feed rather than done in the response handler, because
+   * both halves of the reveal — flying to the card and opening its chat —
+   * need the thread summary, which arrives on the next refresh.
+   */
+  useEffect(() => {
+    if (!pendingIntakeReveal) return;
+    const thread = findStarMapIntakeRevealTarget({
+      localInstanceId,
+      localThreads,
+      remoteThreadsByInstance: remote.threadsByInstance,
+      reveal: pendingIntakeReveal,
+    });
+    if (!thread) return;
+    setPendingIntakeReveal(undefined);
+    flyToThread(thread);
+    openThread(thread);
+  }, [
+    flyToThread,
+    localInstanceId,
+    localThreads,
+    openThread,
+    pendingIntakeReveal,
+    remote.threadsByInstance,
+  ]);
+
+  /**
+   * Give up on a reveal whose thread never reached a feed. Without this the
+   * effect above stays armed, and an unrelated refresh minutes later flies
+   * the map somewhere the operator stopped expecting.
+   */
+  useEffect(() => {
+    if (!pendingIntakeReveal) return;
+    const timer = window.setTimeout(() => {
+      setPendingIntakeReveal(undefined);
+    }, STAR_MAP_INTAKE_REVEAL_TIMEOUT_MS);
+    return () => window.clearTimeout(timer);
+  }, [pendingIntakeReveal]);
+
+  /**
    * The bodies the edge arrows can point at, in the current lens: every
    * instance in the radial and lane lenses, every project sun in
    * Projects. Canvas units, like the bodies themselves. The arrows only
@@ -5305,12 +5369,15 @@ export function StarMapScreen(props: StarMapScreenProps) {
           target={intakeTarget}
           onClose={() => setIntakeTarget(undefined)}
           onCreated={(created) => {
-            markThreadEntering(
-              buildThreadIdentityKey(
-                created.backend as NavigationThreadSummary["source"],
-                created.threadId,
-              ),
+            const threadKey = buildThreadIdentityKey(
+              created.backend as NavigationThreadSummary["source"],
+              created.threadId,
             );
+            markThreadEntering(threadKey);
+            setPendingIntakeReveal({
+              instanceId: created.instanceId,
+              threadKey,
+            });
             if (created.instanceId === localInstanceId) {
               void onRefreshLocalThreads();
             } else {

--- a/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/StarMapScreen.tsx
@@ -3520,12 +3520,17 @@ export function StarMapScreen(props: StarMapScreenProps) {
     });
     if (!thread) return;
     setPendingIntakeReveal(undefined);
+    // Mark entering HERE, not when intake answered: the mark is dropped on a
+    // 2s timer and the card cannot render until this refresh lands, so a
+    // slower-than-2s refresh would leave the arrival with no animation.
+    markThreadEntering(pendingIntakeReveal.threadKey);
     flyToThread(thread);
     openThread(thread);
   }, [
     flyToThread,
     localInstanceId,
     localThreads,
+    markThreadEntering,
     openThread,
     pendingIntakeReveal,
     remote.threadsByInstance,
@@ -5373,7 +5378,9 @@ export function StarMapScreen(props: StarMapScreenProps) {
               created.backend as NavigationThreadSummary["source"],
               created.threadId,
             );
-            markThreadEntering(threadKey);
+            // The entering mark is placed by the reveal effect, once the feed
+            // actually carries the thread. Marking now would expire before
+            // the card exists.
             setPendingIntakeReveal({
               instanceId: created.instanceId,
               threadKey,

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -356,7 +356,9 @@ describe("IntakeDialog", () => {
     const { dispatchStarMapIntake, onCreated } = setup(undefined);
     dispatchStarMapIntake.mockImplementation(
       async (request: { requestId: string }) =>
-        (await new Promise((resolve) => {
+        // Annotated: a bare `new Promise` here is contextually typed from
+        // the mock's `Promise<never>` return, so `resolve` would take never.
+        (await new Promise<unknown>((resolve) => {
           settle = () =>
             resolve({
               status: "created",

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -219,6 +219,44 @@ describe("IntakeDialog", () => {
     });
   });
 
+  it("keeps a heading when a peer answers without a candidate source", async () => {
+    // A remote [+] runs on the peer that owns it; one predating
+    // `candidateSource` answers without the field.
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "needs_disambiguation",
+          requestId: request.requestId,
+          candidates: [{ directoryKey: "dir-a", label: "PwrSnap" }],
+        }) as never,
+    );
+
+    submitText("Do a thing");
+    await waitFor(() => {
+      expect(screen.getByText("Which project?")).toBeTruthy();
+    });
+    expect(screen.getByRole("button", { name: /PwrSnap/ })).toBeTruthy();
+  });
+
+  it("says the resolver could not run rather than claiming nothing matched", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "needs_disambiguation",
+          requestId: request.requestId,
+          candidateSource: "unresolved",
+          candidates: [{ directoryKey: "dir-a", label: "PwrSnap" }],
+        }) as never,
+    );
+
+    submitText("Do a thing");
+    await waitFor(() => {
+      expect(screen.getByText(/Could not check the projects/)).toBeTruthy();
+    });
+  });
+
   it("names the resolved project while the thread is being created", async () => {
     const { dispatchStarMapIntake, emitAgentEvent } = setup(undefined);
     dispatchStarMapIntake.mockImplementation(

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -25,9 +25,18 @@ function setup(
     async (_request: { requestId: string; directoryKey?: string }) =>
       dispatchResult as never,
   );
+  // The owning instance streams progress over this channel, so the tests
+  // that assert on progress copy need to be able to push into it.
+  const agentEventListeners = new Set<(event: never) => void>();
+  const emitAgentEvent = (event: unknown) => {
+    for (const listener of agentEventListeners) listener(event as never);
+  };
   const desktopApi: DesktopApi = {
     dispatchStarMapIntake,
-    onAgentEvent: vi.fn(() => () => undefined),
+    onAgentEvent: vi.fn((listener: (event: never) => void) => {
+      agentEventListeners.add(listener);
+      return () => agentEventListeners.delete(listener);
+    }),
   };
   const onClose = vi.fn();
   const onCreated = vi.fn();
@@ -40,7 +49,7 @@ function setup(
       onCreated={onCreated}
     />,
   );
-  return { dispatchStarMapIntake, onClose, onCreated };
+  return { dispatchStarMapIntake, emitAgentEvent, onClose, onCreated };
 }
 
 function pastePng(bytes = new Uint8Array([137, 80, 78, 71])) {
@@ -163,8 +172,14 @@ describe("IntakeDialog", () => {
           : {
               status: "needs_disambiguation",
               requestId: request.requestId,
+              candidateSource: "resolver",
               candidates: [
-                { directoryKey: "dir-a", label: "PwrSnap", path: "/r/PwrSnap" },
+                {
+                  directoryKey: "dir-a",
+                  label: "PwrSnap",
+                  path: "/r/PwrSnap",
+                  reason: "the screenshot pipeline lives here",
+                },
                 { directoryKey: "dir-b", label: "PwrAgent" },
               ],
             }) as never,
@@ -172,12 +187,60 @@ describe("IntakeDialog", () => {
 
     submitText("Do a thing");
     await waitFor(() => {
-      expect(screen.getByText("Which project?")).toBeTruthy();
+      expect(screen.getByText(/Closest match first/)).toBeTruthy();
     });
+    // The reason is why this list beats the bare registry dump it replaced.
+    expect(
+      screen.getByText("the screenshot pipeline lives here"),
+    ).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: /PwrSnap/ }));
     await waitFor(() => {
       expect(dispatchStarMapIntake).toHaveBeenCalledWith(
         expect.objectContaining({ directoryKey: "dir-a" }),
+      );
+    });
+  });
+
+  it("says so when the list is a recency fallback rather than a ranking", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "needs_disambiguation",
+          requestId: request.requestId,
+          candidateSource: "recent",
+          candidates: [{ directoryKey: "dir-a", label: "PwrSnap" }],
+        }) as never,
+    );
+
+    submitText("Do a thing");
+    await waitFor(() => {
+      expect(screen.getByText(/No project matched/)).toBeTruthy();
+    });
+  });
+
+  it("names the resolved project while the thread is being created", async () => {
+    const { dispatchStarMapIntake, emitAgentEvent } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) => {
+        emitAgentEvent({
+          notification: {
+            method: "starMap/intake/status",
+            params: {
+              requestId: request.requestId,
+              phase: "creating",
+              directoryLabel: "PwrSnap",
+            },
+          },
+        });
+        return new Promise(() => {}) as never;
+      },
+    );
+
+    submitText("Look into the screenshot issue");
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "Creating the thread in PwrSnap…",
       );
     });
   });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -302,6 +302,86 @@ describe("IntakeDialog", () => {
     });
   });
 
+  it("lets the operator abandon a slow resolve", async () => {
+    // The resolver may think for up to INTAKE_TURN_TIMEOUT_MS, and nothing
+    // has been created yet, so the dialog must not trap them there.
+    const { dispatchStarMapIntake, onClose } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async () => new Promise(() => {}) as never,
+    );
+
+    submitText("Something slow");
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "Finding the right project",
+      );
+    });
+    const closeButton = screen.getByRole("button", { name: "Close" });
+    expect(closeButton.hasAttribute("disabled")).toBe(false);
+    fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps the dialog up while the thread is being created", async () => {
+    const { dispatchStarMapIntake, onClose, emitAgentEvent } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) => {
+        emitAgentEvent({
+          notification: {
+            method: "starMap/intake/status",
+            params: { requestId: request.requestId, phase: "creating" },
+          },
+        });
+        return new Promise(() => {}) as never;
+      },
+    );
+
+    submitText("Something being created");
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "Creating the thread",
+      );
+    });
+    // A thread is on its way; vanishing now would leave the operator unsure
+    // whether it landed.
+    expect(
+      screen.getByRole("button", { name: "Close" }).hasAttribute("disabled"),
+    ).toBe(true);
+    fireEvent.keyDown(screen.getByRole("dialog"), { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("still reveals a thread created after the operator walked away", async () => {
+    let settle: (response: unknown) => void = () => undefined;
+    const { dispatchStarMapIntake, onCreated } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        (await new Promise((resolve) => {
+          settle = () =>
+            resolve({
+              status: "created",
+              requestId: request.requestId,
+              backend: "codex",
+              threadId: "thread-late",
+            });
+        })) as never,
+    );
+
+    submitText("Start it and let me get on with things");
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toContain(
+        "Finding the right project",
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    settle(undefined);
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith(
+        expect.objectContaining({ threadId: "thread-late" }),
+      );
+    });
+  });
+
   it("keeps the submit disabled while empty", () => {
     setup(undefined);
     const submit = screen.getByRole("button", { name: "Start thread" });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-intake-reveal.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-intake-reveal.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import type { NavigationThreadSummary } from "@pwragent/shared";
+import { findStarMapIntakeRevealTarget } from "../star-map-intake-reveal";
+
+function thread(
+  id: string,
+  source: NavigationThreadSummary["source"] = "codex",
+): NavigationThreadSummary {
+  return { id, source, title: id } as unknown as NavigationThreadSummary;
+}
+
+const LOCAL = "pwr_local";
+
+describe("findStarMapIntakeRevealTarget", () => {
+  it("waits while the owning feed has not carried the thread yet", () => {
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [thread("thread-old")],
+        remoteThreadsByInstance: new Map(),
+        reveal: { instanceId: LOCAL, threadKey: "codex:thread-new" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("reveals a local thread once the refresh carries it", () => {
+    const created = thread("thread-new");
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [thread("thread-old"), created],
+        remoteThreadsByInstance: new Map(),
+        reveal: { instanceId: LOCAL, threadKey: "codex:thread-new" },
+      }),
+    ).toBe(created);
+  });
+
+  it("reveals a thread created through a remote instance's [+]", () => {
+    const created = thread("thread-new");
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [],
+        remoteThreadsByInstance: new Map([["pwr_peer", [created]]]),
+        reveal: { instanceId: "pwr_peer", threadKey: "codex:thread-new" },
+      }),
+    ).toBe(created);
+  });
+
+  it("does not reveal a same-id thread belonging to another instance", () => {
+    // Thread ids are backend-scoped, not globally unique, so a search across
+    // every feed would fly the map to the wrong instance's card.
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [thread("thread-new")],
+        remoteThreadsByInstance: new Map(),
+        reveal: { instanceId: "pwr_peer", threadKey: "codex:thread-new" },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("distinguishes threads that share an id across backends", () => {
+    const acp = thread("thread-new", "acp:grok");
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [thread("thread-new"), acp],
+        remoteThreadsByInstance: new Map(),
+        reveal: { instanceId: LOCAL, threadKey: "acp:grok:thread-new" },
+      }),
+    ).toBe(acp);
+  });
+
+  it("resolves nothing without a pending reveal", () => {
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [thread("thread-new")],
+        remoteThreadsByInstance: new Map(),
+        reveal: undefined,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-intake-reveal.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-intake-reveal.test.ts
@@ -86,14 +86,16 @@ describe("findStarMapIntakeRevealTarget", () => {
     ).toBe(created);
   });
 
-  it("reveals a thread captured while health is momentarily absent", () => {
+  it("keeps a remote reveal remote while health is momentarily absent", () => {
+    // The placeholder tolerance is for a reveal captured UNDER it, not for
+    // every reveal that outlives a health blip.
     const created = thread("thread-new");
     expect(
       findStarMapIntakeRevealTarget({
         localInstanceId: "local",
-        localThreads: [created],
-        remoteThreadsByInstance: new Map(),
-        reveal: { instanceId: LOCAL, threadKey: "codex:thread-new" },
+        localThreads: [thread("thread-new")],
+        remoteThreadsByInstance: new Map([["pwr_peer", [created]]]),
+        reveal: { instanceId: "pwr_peer", threadKey: "codex:thread-new" },
       }),
     ).toBe(created);
   });

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-intake-reveal.test.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/star-map-intake-reveal.test.ts
@@ -72,6 +72,32 @@ describe("findStarMapIntakeRevealTarget", () => {
     ).toBe(acp);
   });
 
+  it("reveals a thread captured before federation health named this instance", () => {
+    // `localInstanceId` is `health?.instanceId ?? "local"`, so a [+] clicked
+    // before health lands captures the placeholder.
+    const created = thread("thread-new");
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: LOCAL,
+        localThreads: [created],
+        remoteThreadsByInstance: new Map(),
+        reveal: { instanceId: "local", threadKey: "codex:thread-new" },
+      }),
+    ).toBe(created);
+  });
+
+  it("reveals a thread captured while health is momentarily absent", () => {
+    const created = thread("thread-new");
+    expect(
+      findStarMapIntakeRevealTarget({
+        localInstanceId: "local",
+        localThreads: [created],
+        remoteThreadsByInstance: new Map(),
+        reveal: { instanceId: LOCAL, threadKey: "codex:thread-new" },
+      }),
+    ).toBe(created);
+  });
+
   it("resolves nothing without a pending reveal", () => {
     expect(
       findStarMapIntakeRevealTarget({

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-intake-reveal.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-intake-reveal.ts
@@ -4,6 +4,15 @@ import {
 } from "@pwragent/shared";
 
 /**
+ * The stand-in `StarMapScreen` uses for this instance until federation
+ * health reports its durable id (`health?.instanceId ?? "local"`). A reveal
+ * captured under the placeholder must still resolve as local once the
+ * durable id lands, the same transition `chatCards.remapOwner` handles for
+ * open chat cards.
+ */
+export const STAR_MAP_LOCAL_INSTANCE_PLACEHOLDER = "local";
+
+/**
  * A thread the [+] intake created, waiting to be revealed on the map.
  *
  * Intake answers with a backend and a thread id, not a
@@ -24,7 +33,8 @@ export type StarMapIntakeReveal = {
  * Which feed matters: a thread created through a remote instance's [+] will
  * never appear in `localThreads`, and searching every feed for a matching
  * key would reveal the wrong instance's thread whenever two instances share
- * a backend thread id.
+ * a backend thread id. The one exception is the `"local"` placeholder on
+ * either side, which only ever stands in for this instance.
  */
 export function findStarMapIntakeRevealTarget(params: {
   localInstanceId: string;
@@ -37,10 +47,13 @@ export function findStarMapIntakeRevealTarget(params: {
 }): NavigationThreadSummary | undefined {
   const reveal = params.reveal;
   if (!reveal) return undefined;
-  const threads =
+  const isLocal =
     reveal.instanceId === params.localInstanceId
-      ? params.localThreads
-      : params.remoteThreadsByInstance.get(reveal.instanceId) ?? [];
+    || reveal.instanceId === STAR_MAP_LOCAL_INSTANCE_PLACEHOLDER
+    || params.localInstanceId === STAR_MAP_LOCAL_INSTANCE_PLACEHOLDER;
+  const threads = isLocal
+    ? params.localThreads
+    : params.remoteThreadsByInstance.get(reveal.instanceId) ?? [];
   return threads.find(
     (thread) =>
       buildThreadIdentityKey(thread.source, thread.id) === reveal.threadKey,

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-intake-reveal.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-intake-reveal.ts
@@ -1,0 +1,48 @@
+import {
+  buildThreadIdentityKey,
+  type NavigationThreadSummary,
+} from "@pwragent/shared";
+
+/**
+ * A thread the [+] intake created, waiting to be revealed on the map.
+ *
+ * Intake answers with a backend and a thread id, not a
+ * `NavigationThreadSummary` — but flying to a card and opening its chat both
+ * need the summary. So the reveal cannot happen when the response lands; it
+ * waits for the feed that owns the thread to carry it.
+ */
+export type StarMapIntakeReveal = {
+  /** The instance whose [+] ran the intake. */
+  instanceId: string;
+  threadKey: string;
+};
+
+/**
+ * The summary to reveal, or undefined while the owning feed has not caught
+ * up yet.
+ *
+ * Which feed matters: a thread created through a remote instance's [+] will
+ * never appear in `localThreads`, and searching every feed for a matching
+ * key would reveal the wrong instance's thread whenever two instances share
+ * a backend thread id.
+ */
+export function findStarMapIntakeRevealTarget(params: {
+  localInstanceId: string;
+  localThreads: readonly NavigationThreadSummary[];
+  remoteThreadsByInstance: ReadonlyMap<
+    string,
+    readonly NavigationThreadSummary[]
+  >;
+  reveal: StarMapIntakeReveal | undefined;
+}): NavigationThreadSummary | undefined {
+  const reveal = params.reveal;
+  if (!reveal) return undefined;
+  const threads =
+    reveal.instanceId === params.localInstanceId
+      ? params.localThreads
+      : params.remoteThreadsByInstance.get(reveal.instanceId) ?? [];
+  return threads.find(
+    (thread) =>
+      buildThreadIdentityKey(thread.source, thread.id) === reveal.threadKey,
+  );
+}

--- a/apps/desktop/src/renderer/src/features/star-map/star-map-intake-reveal.ts
+++ b/apps/desktop/src/renderer/src/features/star-map/star-map-intake-reveal.ts
@@ -47,10 +47,12 @@ export function findStarMapIntakeRevealTarget(params: {
 }): NavigationThreadSummary | undefined {
   const reveal = params.reveal;
   if (!reveal) return undefined;
+  // Only a reveal captured UNDER the placeholder needs the tolerance. Also
+  // accepting it whenever `localInstanceId` is the placeholder would send a
+  // genuinely remote reveal to the local feed every time health drops.
   const isLocal =
     reveal.instanceId === params.localInstanceId
-    || reveal.instanceId === STAR_MAP_LOCAL_INSTANCE_PLACEHOLDER
-    || params.localInstanceId === STAR_MAP_LOCAL_INSTANCE_PLACEHOLDER;
+    || reveal.instanceId === STAR_MAP_LOCAL_INSTANCE_PLACEHOLDER;
   const threads = isLocal
     ? params.localThreads
     : params.remoteThreadsByInstance.get(reveal.instanceId) ?? [];

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -13313,6 +13313,12 @@ a.button {
   font-weight: 600;
 }
 
+.star-map-intake__candidate-reason {
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.35;
+}
+
 .star-map-intake__candidate-path {
   color: var(--text-muted);
   font-size: 11px;

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -468,7 +468,23 @@ export type StarMapIntakeCandidate = {
   directoryKey: string;
   label: string;
   path?: string;
+  /**
+   * One short clause saying why this project is a candidate, from whatever
+   * ranked it. A bare list of project names is not an answer the operator
+   * can act on: every name is plausible, so the pick costs a re-read of the
+   * whole registry. The reason is what makes one row cheaper than the rest.
+   */
+  reason?: string;
 };
+
+/** What ordered the candidate list, so the dialog can say so honestly. */
+export type StarMapIntakeCandidateSource =
+  /** The resolver ranked them against the request. */
+  | "resolver"
+  /** The request names these projects literally; the resolver did not rank. */
+  | "label"
+  /** Nothing matched the request at all; ordered by directory recency. */
+  | "recent";
 
 /**
  * A PwrAgent-owned staged attachment supplied with a Star Map intake task.
@@ -502,13 +518,14 @@ export type StarMapIntakeResponse =
       requestId: string;
       backend: string;
       threadId: string;
-      title?: string;
     }
   | {
       status: "needs_disambiguation";
       requestId: string;
-      /** Ranked candidate projects for the operator to pick from. */
+      /** Candidate projects, best first. */
       candidates: StarMapIntakeCandidate[];
+      /** Whether `candidates` is a real ranking or a recency fallback. */
+      candidateSource: StarMapIntakeCandidateSource;
     }
   | {
       status: "failed";

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -484,7 +484,9 @@ export type StarMapIntakeCandidateSource =
   /** The request names these projects literally; the resolver did not rank. */
   | "label"
   /** Nothing matched the request at all; ordered by directory recency. */
-  | "recent";
+  | "recent"
+  /** The resolver could not run; ordered by directory recency. */
+  | "unresolved";
 
 /**
  * A PwrAgent-owned staged attachment supplied with a Star Map intake task.


### PR DESCRIPTION
## What happened

Creating a thread from the Star Map `[+]` worked, but every step after "type
the prompt" was worse than it needed to be:

1. It thought for a while, said it was looking for a project, then showed a
   list of *all* projects.
2. Picking one created the thread — and then left the operator to find the
   new card on the map and open its chat themselves.

## Why the list looked like it hadn't thought about anything

It had, and then threw the answer away.

The resolver (an ephemeral Codex helper thread — no tools, MCP off, scratch
cwd — handed the directory registry and `~/.pwragent/AGENTS.md` as text)
returned a single `directoryKey` plus a confidence. Anything under `0.5` was
discarded **whole**. The fallback was `fuzzyMatchDirectories`, a literal
substring match of each directory label against the request text. A request
that never typed a project name matched nothing, and the final line was:

```ts
const ranked = fuzzy.length > 0 ? fuzzy : directories;
```

— the entire registry, in storage order, first 8, presented under the heading
"Which project?" as though it were an answer. The resolver's own ranking of
those same directories was already in hand and unused.

## Changes

**The resolver ranks instead of picking.** It now returns plausible
directories best-first, each with a confidence and a one-clause reason. At or
above the same `0.5` threshold the leading one is created without asking
(unchanged behavior); below it the operator picks from *that* ranking, with
the reasons shown. It is also told each directory's current branch, which is
often the only thing a request names ("finish the icon work").

**The list says what it is.** `candidateSource` travels with the candidates
so the copy can match what actually produced them — a resolver ranking, a
request that named several projects literally, or a pure recency fallback
when nothing matched at all. The recency fallback is ordered by
`latestUpdatedAt` rather than registry order.

**The new thread is revealed.** `onCreated` marked the card "entering" and
refreshed the feed, and stopped. `flyToThread` and `openThread` already
existed in the same component, already wired to the jump dialog — intake now
uses both, so the camera lands on the new card and its chat opens. The reveal
waits on the owning feed (intake answers with ids; both halves need a
`NavigationThreadSummary`) and expires after 30s so a later unrelated refresh
cannot fly the map somewhere unexpected.

**The confident path names its pick.** The `creating` status event now
carries the resolved project, so the status line reads "Creating the thread
in acme-console…". When the resolver is confident it never asks, so this is
the only moment the operator sees the pick while it is still worth seeing.

**Dropped the dead title.** The intake asked its helper for a thread title,
returned it over IPC, and both call sites ignored it — while
`materializeDirectoryLaunchpad` scheduled real title generation from the same
first turn anyway. Two ephemeral helpers, one title used.

## The 20-second budget

`INTAKE_TIMEOUT_MS` was 20s, inherited from
`DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS` by copying the constant rather than by
measuring this call. The title helper turns one message into one line; the
resolver is handed every registered directory plus up to 8,000 chars of
AGENTS.md and asked to rank up to eight projects with a written reason each.
On expiry the whole resolution is discarded and the operator waits and gets a
recency list.

Raising that one number was not enough, because it governed seven requests:
an MCP config read, thread start, MCP attestation, turn start, and — in
`finally`, on the timeout path — a turn interrupt and an unsubscribe. Tripling
it would have tripled how long a wedged app server takes to report that it is
wedged, and the dialog awaits that cleanup. So `runHelperStructuredTurn` gains
an optional `turnTimeoutMs` covering only the model wait, defaulting to
`timeoutMs` so the title path is unchanged. Intake keeps 20s for round-trips
and takes 90s for the answer.

A 90s wait has to be escapable, and the dialog blocked Escape, the backdrop
and the close button for all of `resolving` — where nothing has been created
yet. Closing is now allowed until `creating` begins; a thread that lands after
the operator walked away still reaches the map, since it exists and still
deserves its reveal.

Resolution latency, candidate count and prompt size are now logged on both
paths. A successful resolve logged nothing, which is why this constant was set
by reasoning about prompt size instead of from a measurement.

## Disambiguation list, before and after

100% contrived fixture data.

![Star Map intake candidate list, before and after](./intake-candidates-before-after.png)

## Testing

- `pnpm test` — 793 files, 11,411 passed, 7 skipped.
- `pnpm lint:eslint` (0 errors), `pnpm lint:colors`, `pnpm lint:boundaries`,
  `pnpm typecheck`.
- New coverage: resolver ranking with reasons, hallucinated `directoryKey`
  rejection, `label` vs `recent` candidate sources, branch in the resolver
  prompt, project named on the `creating` event, and the reveal target
  resolution (including that a same-id thread on another instance is not
  revealed).
- The reveal's feed-matching rule is extracted to
  `star-map-intake-reveal.ts` so it is testable — `StarMapScreen` itself has
  no unit harness, and no replay fixture can materialize a real launchpad.
- Contrast checked for the new reason line: 9.23:1 dark, 8.49:1 light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
