### PR TITLE
fix(desktop): size PwrGit's mark and name PwrAgent on the OAuth callback page

### DIFF
--- a/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
+++ b/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
@@ -6,6 +6,12 @@
 // either file alone, so this measures the assets and the rule together: a
 // refreshed asset whose margin differs fails here rather than shipping a
 // mismatched pair of icons.
+//
+// Two surfaces draw these marks side by side, and each states the ratio in its
+// own stylesheet: the card in app.css, and the OAuth callback page the browser
+// lands on, whose CSS is a template literal in the main process. The callback
+// page shipped without the compensation and drew PwrGit at 80% of PwrAgent
+// beside it, so both are measured here against the same assets.
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -15,40 +21,61 @@ import { opaqueBounds, readPixels } from "./lib/icon-pixels.mjs";
 const here = dirname(fileURLToPath(import.meta.url));
 const rendererSrc = resolve(here, "../src/renderer/src");
 const appCssPath = resolve(rendererSrc, "styles/app.css");
+const callbackPagePath = resolve(
+  here,
+  "../src/main/mcp-connections/local-mcp-connection-service.ts",
+);
 
 const ASSETS = {
   PwrSnap: resolve(rendererSrc, "assets/pwrsnap/pwrsnap-app-icon.png"),
   PwrGit: resolve(rendererSrc, "assets/pwrgit/pwrgit-app-icon.png"),
 };
 
+/**
+ * The callback page pairs the sister app with PwrAgent's own mark rather than
+ * with the other sister, and serves that one from `build/icon.png` — the
+ * full-bleed master, shipped as the `pwragent-app-icon.png` resource.
+ */
+const CALLBACK_ASSETS = {
+  ...ASSETS,
+  PwrAgent: resolve(here, "../build/icon.png"),
+};
+
 /** The asset that carries Apple's legacy margin, and so wears the modifier. */
 const INSET = "PwrGit";
 
 /**
- * Measured once: the assets are committed files that cannot change mid-run, and
- * each measurement decodes a PNG and scans every pixel in it.
+ * Measured once per file: the assets are committed files that cannot change
+ * mid-run, and each measurement decodes a PNG and scans every pixel in it.
  */
-let measured;
+const measured = new Map();
 
 /**
- * What share of its own canvas each asset's opaque plate covers — the only
- * property of the artwork the card's sizing depends on — plus the plate box
- * and canvas the fraction came from, for the shape assertions.
+ * What share of its own canvas an asset's opaque plate covers — the only
+ * property of the artwork the sizing depends on — plus the plate box and
+ * canvas the fraction came from, for the shape assertions.
  */
-async function plates() {
-  if (measured) return measured;
-  measured = {};
-  for (const [name, file] of Object.entries(ASSETS)) {
+async function plate(name, file) {
+  if (!measured.has(file)) {
     const pixels = await readPixels(file);
-    const plate = opaqueBounds(pixels);
-    expect(plate, `${name} icon has no opaque pixels at all`).not.toBeNull();
-    measured[name] = {
-      plate,
+    const bounds = opaqueBounds(pixels);
+    expect(bounds, `${name} icon has no opaque pixels at all`).not.toBeNull();
+    measured.set(file, {
+      plate: bounds,
       canvas: { width: pixels.width, height: pixels.height },
-      fraction: plate.width / pixels.width,
-    };
+      fraction: bounds.width / pixels.width,
+    });
   }
-  return measured;
+  return measured.get(file);
+}
+
+/** The measurements above, keyed by app name, for a set of assets. */
+async function plates(assets = ASSETS) {
+  return Object.fromEntries(
+    await Promise.all(
+      Object.entries(assets).map(async ([name, file]) => [name, await plate(name, file)]),
+    ),
+  );
 }
 
 /**
@@ -84,19 +111,51 @@ function iconBoxWidth(css) {
   return Number(matchCss(rule[1], /width:\s*(\d+)px/, "that box's width")[1]);
 }
 
-/** The compensating `scale()`, read as the canvas-over-plate ratio it states. */
-function insetPlateScale(css) {
+/**
+ * The compensating `scale()` one stylesheet states, read as the
+ * canvas-over-plate ratio it spells out. `className` is the modifier's class,
+ * without the leading dot.
+ */
+function insetPlateScale(css, className) {
   const match = matchCss(
     css,
-    /\.mcp-connection__icon--inset-plate\s*\{[^}]*transform:\s*scale\(calc\((\d+)\s*\/\s*(\d+)\)\)/,
-    "the inset-plate scale as a canvas-over-plate ratio",
+    new RegExp(`\\.${className}\\s*\\{[^}]*transform:\\s*scale\\(calc\\((\\d+)\\s*/\\s*(\\d+)\\)\\)`),
+    `.${className} as a canvas-over-plate ratio`,
   );
   return Number(match[1]) / Number(match[2]);
 }
 
+/**
+ * The box the callback page's mark fills, in CSS pixels. Unlike the card, that
+ * page frames each mark in a padded, bordered tile and sizes the image to the
+ * tile's content box, so the padding and border are part of the answer —
+ * `* { box-sizing: border-box }` puts them inside the stated width.
+ *
+ * Anchored to the start of a line: the page states `.app-icon` a second time
+ * inside a `@media` block, mid-line after another rule's closing brace, and a
+ * match that landed there would measure the narrow phone tile instead.
+ */
+function callbackMarkBox(source) {
+  const rule = matchCss(
+    source,
+    /^\s*\.app-icon\s*\{([^}]*)\}/m,
+    "an unconditional .app-icon tile on the callback page",
+  );
+  const value = (pattern, what) => Number(matchCss(rule[1], pattern, what)[1]);
+  return (
+    value(/width:\s*(\d+)px/, "that tile's width")
+    - 2 * value(/padding:\s*(\d+)px/, "that tile's padding")
+    - 2 * value(/border:\s*(\d+)px/, "that tile's border width")
+  );
+}
+
+// PwrAgent's own mark included: the callback page sizes the sister app against
+// it, so `fraction === 1` below is what makes the half-pixel tolerance there
+// enough — a margin appearing in the reference would otherwise move both sides
+// of that comparison together and go unnoticed.
 describe("PwrSuite brand icon assets", () => {
   it("holds a square plate centred on a square canvas", async () => {
-    for (const [name, { plate, canvas }] of Object.entries(await plates())) {
+    for (const [name, { plate, canvas }] of Object.entries(await plates(CALLBACK_ASSETS))) {
       expect(canvas.width, `${name} canvas is square`).toBe(canvas.height);
       expect(plate.width, `${name} plate is square`).toBe(plate.height);
       // Equal margins: a plate drawn off-centre would still measure the right
@@ -109,7 +168,7 @@ describe("PwrSuite brand icon assets", () => {
   it("leaves exactly one asset inset inside its canvas", async () => {
     // Fractions, not pixel counts: a vendor shipping the same artwork off a
     // larger canvas member changes nothing about how the card paints it.
-    for (const [name, { fraction }] of Object.entries(await plates())) {
+    for (const [name, { fraction }] of Object.entries(await plates(CALLBACK_ASSETS))) {
       if (name === INSET) {
         expect(fraction, `${name} sits on Apple's legacy 824-in-1024 template`)
           .toBeCloseTo(824 / 1024, 3);
@@ -120,21 +179,54 @@ describe("PwrSuite brand icon assets", () => {
   });
 });
 
+/**
+ * Every plate the surface draws, at the size it lands on screen, given the box
+ * the surface reserves and the compensation it applies to the inset asset.
+ */
+function paintedSizes(measurements, box, scale) {
+  return Object.entries(measurements).map(
+    ([name, { fraction }]) => [name, box * fraction * (name === INSET ? scale : 1)],
+  );
+}
+
+/** Each plate fills `box`, and so also matches every other plate beside it. */
+function expectPaintedTogether(painted, box) {
+  for (const [name, size] of painted) {
+    // Half a CSS pixel: closer than the display can resolve the difference.
+    expect(Math.abs(size - box), `${name} plate against its ${box}px box`)
+      .toBeLessThan(0.5);
+  }
+}
+
 describe("PwrSuite connection card icon sizing", () => {
   it("paints both plates at the same size", async () => {
     const css = readAppCss();
     const box = iconBoxWidth(css);
-    const scale = insetPlateScale(css);
-    const painted = Object.entries(await plates()).map(
-      ([name, { fraction }]) => [name, box * fraction * (name === INSET ? scale : 1)],
+    const scale = insetPlateScale(css, "mcp-connection__icon--inset-plate");
+    expectPaintedTogether(paintedSizes(await plates(), box, scale), box);
+  });
+});
+
+describe("OAuth callback page icon sizing", () => {
+  it("paints the sister app's plate at the size of PwrAgent's beside it", async () => {
+    const source = readFileSync(callbackPagePath, "utf8");
+    const box = callbackMarkBox(source);
+    const scale = insetPlateScale(source, "app-mark--inset-plate");
+    expectPaintedTogether(paintedSizes(await plates(CALLBACK_ASSETS), box, scale), box);
+  });
+
+  it("wears the modifier on the inset asset and on nothing else", () => {
+    const source = readFileSync(callbackPagePath, "utf8");
+    // The page draws one sister app per render and picks the class from the
+    // connection id, so the guard is on that condition rather than on markup:
+    // dropping it would leave PwrGit inset again, and widening it to every
+    // connection would scale PwrSnap's already full-bleed plate past its tile.
+    const match = matchCss(
+      source,
+      /const insetPlate = connectionId === "(\w+)";/,
+      "which connection the callback page treats as inset",
     );
-    const [[firstName, first], ...rest] = painted;
-    for (const [name, size] of rest) {
-      // Half a CSS pixel: closer than the display can resolve the difference.
-      expect(Math.abs(size - first), `${name} plate against ${firstName}`)
-        .toBeLessThan(0.5);
-    }
-    // Not merely equal to each other: both fill the box the card reserves.
-    expect(first).toBeCloseTo(box, 5);
+    expect(match[1], "the inset asset the measurements above identified")
+      .toBe(INSET.toLowerCase());
   });
 });

--- a/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
+++ b/apps/desktop/scripts/pwrsuite-brand-icons.test.mjs
@@ -21,10 +21,8 @@ import { opaqueBounds, readPixels } from "./lib/icon-pixels.mjs";
 const here = dirname(fileURLToPath(import.meta.url));
 const rendererSrc = resolve(here, "../src/renderer/src");
 const appCssPath = resolve(rendererSrc, "styles/app.css");
-const callbackPagePath = resolve(
-  here,
-  "../src/main/mcp-connections/local-mcp-connection-service.ts",
-);
+const callbackPageName = "local-mcp-connection-service.ts";
+const callbackPagePath = resolve(here, `../src/main/mcp-connections/${callbackPageName}`);
 
 const ASSETS = {
   PwrSnap: resolve(rendererSrc, "assets/pwrsnap/pwrsnap-app-icon.png"),
@@ -87,10 +85,15 @@ function readAppCss() {
   return readFileSync(appCssPath, "utf8");
 }
 
-/** Reports the rule that went missing, rather than throwing on a null match. */
-function matchCss(css, pattern, what) {
+/**
+ * Reports the rule that went missing, rather than throwing on a null match.
+ * `where` names the file it was looked for in: the callback page's CSS lives
+ * in a template literal in the main process, and a failure there that blamed
+ * app.css would send the next reader to a stylesheet that never held the rule.
+ */
+function matchCss(css, pattern, what, where = "app.css") {
   const match = pattern.exec(css);
-  expect(match, `app.css no longer states ${what}`).not.toBeNull();
+  expect(match, `${where} no longer states ${what}`).not.toBeNull();
   return match;
 }
 
@@ -108,51 +111,30 @@ function iconBoxWidth(css) {
     /^\.mcp-connection__icon\s*\{([^}]*)\}/m,
     "an unconditional .mcp-connection__icon box",
   );
-  return Number(matchCss(rule[1], /width:\s*(\d+)px/, "that box's width")[1]);
+  // The lookbehind keeps `width:` from matching the tail of a `max-width:` or
+  // `min-width:` declaration and silently measuring the wrong number.
+  return Number(matchCss(rule[1], /(?<![-\w])width:\s*(\d+)px/, "that box's width")[1]);
 }
 
 /**
  * The compensating `scale()` one stylesheet states, read as the
  * canvas-over-plate ratio it spells out. `className` is the modifier's class,
- * without the leading dot.
+ * without the leading dot; `where` is the file, for the failure message.
  */
-function insetPlateScale(css, className) {
+function insetPlateScale(css, className, where) {
   const match = matchCss(
     css,
     new RegExp(`\\.${className}\\s*\\{[^}]*transform:\\s*scale\\(calc\\((\\d+)\\s*/\\s*(\\d+)\\)\\)`),
     `.${className} as a canvas-over-plate ratio`,
+    where,
   );
   return Number(match[1]) / Number(match[2]);
 }
 
-/**
- * The box the callback page's mark fills, in CSS pixels. Unlike the card, that
- * page frames each mark in a padded, bordered tile and sizes the image to the
- * tile's content box, so the padding and border are part of the answer —
- * `* { box-sizing: border-box }` puts them inside the stated width.
- *
- * Anchored to the start of a line: the page states `.app-icon` a second time
- * inside a `@media` block, mid-line after another rule's closing brace, and a
- * match that landed there would measure the narrow phone tile instead.
- */
-function callbackMarkBox(source) {
-  const rule = matchCss(
-    source,
-    /^\s*\.app-icon\s*\{([^}]*)\}/m,
-    "an unconditional .app-icon tile on the callback page",
-  );
-  const value = (pattern, what) => Number(matchCss(rule[1], pattern, what)[1]);
-  return (
-    value(/width:\s*(\d+)px/, "that tile's width")
-    - 2 * value(/padding:\s*(\d+)px/, "that tile's padding")
-    - 2 * value(/border:\s*(\d+)px/, "that tile's border width")
-  );
-}
-
 // PwrAgent's own mark included: the callback page sizes the sister app against
-// it, so `fraction === 1` below is what makes the half-pixel tolerance there
-// enough — a margin appearing in the reference would otherwise move both sides
-// of that comparison together and go unnoticed.
+// it, so the exact `fraction === 1` below is what lets the sizing tests treat
+// it as the reference. A margin appearing there would otherwise move both
+// sides of that comparison together and go unnoticed.
 describe("PwrSuite brand icon assets", () => {
   it("holds a square plate centred on a square canvas", async () => {
     for (const [name, { plate, canvas }] of Object.entries(await plates(CALLBACK_ASSETS))) {
@@ -179,54 +161,60 @@ describe("PwrSuite brand icon assets", () => {
   });
 });
 
-/**
- * Every plate the surface draws, at the size it lands on screen, given the box
- * the surface reserves and the compensation it applies to the inset asset.
- */
-function paintedSizes(measurements, box, scale) {
-  return Object.entries(measurements).map(
-    ([name, { fraction }]) => [name, box * fraction * (name === INSET ? scale : 1)],
-  );
-}
-
-/** Each plate fills `box`, and so also matches every other plate beside it. */
-function expectPaintedTogether(painted, box) {
-  for (const [name, size] of painted) {
-    // Half a CSS pixel: closer than the display can resolve the difference.
-    expect(Math.abs(size - box), `${name} plate against its ${box}px box`)
-      .toBeLessThan(0.5);
-  }
-}
-
 describe("PwrSuite connection card icon sizing", () => {
   it("paints both plates at the same size", async () => {
     const css = readAppCss();
     const box = iconBoxWidth(css);
     const scale = insetPlateScale(css, "mcp-connection__icon--inset-plate");
-    expectPaintedTogether(paintedSizes(await plates(), box, scale), box);
+    const painted = Object.entries(await plates()).map(
+      ([name, { fraction }]) => [name, box * fraction * (name === INSET ? scale : 1)],
+    );
+    const [[firstName, first], ...rest] = painted;
+    for (const [name, size] of rest) {
+      // Half a CSS pixel: closer than the display can resolve the difference.
+      expect(Math.abs(size - first), `${name} plate against ${firstName}`)
+        .toBeLessThan(0.5);
+    }
+    // Not merely equal to each other: both fill the box the card reserves.
+    expect(first).toBeCloseTo(box, 5);
   });
 });
 
+/**
+ * The callback page is measured by its ratio rather than by its box, because
+ * its box cannot fail: every painted size there is `box × k`, so comparing
+ * them to `box` reduces to `box × |k − 1| < tolerance` and the tile geometry
+ * only scales the tolerance. Asserting `fraction × scale` directly says the
+ * one thing that is actually true or false, and says it without parsing a
+ * `border:` shorthand out of a single-line rule to get there.
+ */
 describe("OAuth callback page icon sizing", () => {
-  it("paints the sister app's plate at the size of PwrAgent's beside it", async () => {
+  it("compensates the inset asset back to the size of the marks beside it", async () => {
     const source = readFileSync(callbackPagePath, "utf8");
-    const box = callbackMarkBox(source);
-    const scale = insetPlateScale(source, "app-mark--inset-plate");
-    expectPaintedTogether(paintedSizes(await plates(CALLBACK_ASSETS), box, scale), box);
+    const scale = insetPlateScale(source, "app-mark--inset-plate", callbackPageName);
+    for (const [name, { fraction }] of Object.entries(await plates(CALLBACK_ASSETS))) {
+      // Four decimals: a whole pixel out at the 104px tile is 1e-2 here, so
+      // this is far tighter than the display, and tighter than the card's.
+      expect(fraction * (name === INSET ? scale : 1), `${name} plate against its tile`)
+        .toBeCloseTo(1, 4);
+    }
   });
 
-  it("wears the modifier on the inset asset and on nothing else", () => {
+  it("sizes every mark to its tile, which is what makes the ratio enough", () => {
+    // The ratio above only holds if each mark fills the tile to begin with.
+    // `place-items: center` centres what is already sized and does not do
+    // this; without the explicit 100% the marks fall back to their intrinsic
+    // 256 and 512px, a mismatch worse than the one this file exists to catch,
+    // and every ratio assertion still passes.
     const source = readFileSync(callbackPagePath, "utf8");
-    // The page draws one sister app per render and picks the class from the
-    // connection id, so the guard is on that condition rather than on markup:
-    // dropping it would leave PwrGit inset again, and widening it to every
-    // connection would scale PwrSnap's already full-bleed plate past its tile.
-    const match = matchCss(
+    const rule = matchCss(
       source,
-      /const insetPlate = connectionId === "(\w+)";/,
-      "which connection the callback page treats as inset",
-    );
-    expect(match[1], "the inset asset the measurements above identified")
-      .toBe(INSET.toLowerCase());
+      /^\s*\.app-mark\s*\{([^}]*)\}/m,
+      "an .app-mark rule sizing the mark to its tile",
+      callbackPageName,
+    )[1];
+    for (const declaration of ["width: 100%", "height: 100%", "object-fit: contain"]) {
+      expect(rule, `.app-mark no longer states ${declaration}`).toContain(declaration);
+    }
   });
 });

--- a/apps/desktop/src/main/__tests__/oauth-callback-page.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-callback-page.test.ts
@@ -1,0 +1,99 @@
+// The page the browser lands on after PwrSnap's or PwrGit's authorization
+// screen. It is served from a throwaway localhost port by an app the person is
+// not looking at, so the page itself has to say what opened it — and it is the
+// one PwrAgent surface with no window chrome, no renderer, and no E2E lane.
+//
+// The icon geometry it depends on lives with the assets it measures, in
+// `scripts/pwrsuite-brand-icons.test.mjs`.
+import { describe, expect, it } from "vitest";
+import { htmlResponse } from "../mcp-connections/local-mcp-connection-service";
+
+/** The three states the callback server can render, for either sister app. */
+const CONNECTING = ["Connecting PwrAgent to PwrGit", "PwrGit approved the request.", { liveStatus: true }] as const;
+const DECLINED = ["PwrGit connection declined", "The user declined.", {}] as const;
+
+function render(
+  [title, detail, options]: readonly [string, string, { liveStatus?: boolean }],
+  connectionId: "pwrgit" | "pwrsnap" = "pwrgit",
+) {
+  return htmlResponse(title, detail, options, connectionId);
+}
+
+describe("OAuth callback page", () => {
+  it("names the app that opened the window in every state", () => {
+    // Not the heading: it names PwrAgent only while the connection is going
+    // well. "Connection could not be completed" on an unfamiliar localhost tab
+    // is exactly where someone needs to be told whose window this is.
+    for (const state of [CONNECTING, DECLINED]) {
+      for (const connectionId of ["pwrgit", "pwrsnap"] as const) {
+        expect(render(state, connectionId))
+          .toContain("PwrAgent opened this window");
+      }
+    }
+  });
+
+  it("flies PwrAgent's mark in the tab, not the sister app's", () => {
+    // The favicon answers "what is this?" before any of the page does, and the
+    // window belongs to PwrAgent. Served from the route the card already uses,
+    // which `img-src 'self'` in the page's CSP allows.
+    for (const connectionId of ["pwrgit", "pwrsnap"] as const) {
+      expect(render(CONNECTING, connectionId))
+        .toContain('<link rel="icon" type="image/png" href="/assets/pwragent.png">');
+    }
+  });
+
+  it("moves the tab title with the heading once the connection settles", () => {
+    // A backgrounded tab shows nothing but its title, and this page polls for
+    // minutes: left alone the tab still read "Connecting…" after the
+    // connection was up, or after it had failed.
+    const page = render(CONNECTING);
+    expect(page).toContain("<title>Connecting PwrAgent to PwrGit</title>");
+    // One helper sets the heading, the tab and the status together, so the
+    // three cannot drift apart the way the title already had.
+    expect(page).toContain("document.title = heading;");
+    expect(page).toContain('settle("is-connected", "PwrAgent is connected to PwrGit"');
+    expect(page).toContain('settle("is-failed", "Connection could not be completed"');
+  });
+
+  it("scales only the sister app whose mark carries a margin", () => {
+    // Asserted on the tags, not on the page: the rule itself is in the
+    // stylesheet on every render, and only the markup decides who wears it.
+    expect(render(CONNECTING, "pwrgit"))
+      .toContain('<img class="app-mark app-mark--inset-plate" src="/assets/pwrgit.png"');
+    expect(render(CONNECTING, "pwrsnap"))
+      .toContain('<img class="app-mark" src="/assets/pwrsnap.png"');
+    // PwrAgent's own mark is full-bleed, so it never wears the modifier.
+    expect(render(CONNECTING, "pwrgit"))
+      .toContain('<img class="app-mark" src="/assets/pwragent.png"');
+  });
+
+  it("frames each mark in a tile the scale cannot grow", () => {
+    // The compensation is a transform, and a transform on the framed element
+    // would scale its border and backing plate with the artwork — PwrGit's
+    // tile would come out a quarter larger than PwrAgent's. The frame has to
+    // be the parent for the artwork alone to move.
+    const page = render(CONNECTING, "pwrgit");
+    expect(page).toContain('<span class="app-icon"><img class="app-mark');
+    expect(page).not.toMatch(/<img[^>]*class="[^"]*\bapp-icon\b/u);
+  });
+
+  it("leaves the marks out of the accessible name, which the labels carry", () => {
+    // Each mark sits beside a visible <span> naming the same app, so alt text
+    // would have a screen reader announce "PwrGit PwrGit".
+    const page = render(CONNECTING, "pwrgit");
+    expect(page).not.toMatch(/<img[^>]*alt="(?!")/u);
+    expect(page).toContain("<span>PwrGit</span>");
+    expect(page).toContain("<span>PwrAgent</span>");
+  });
+
+  it("escapes what the authorization server sent before echoing it", () => {
+    const page = htmlResponse(
+      '<script>alert("t")</script>',
+      "error_description from the wire",
+      {},
+      "pwrgit",
+    );
+    expect(page).not.toContain('<script>alert("t")</script>');
+    expect(page).toContain("&lt;script&gt;alert(&quot;t&quot;)&lt;/script&gt;");
+  });
+});

--- a/apps/desktop/src/main/__tests__/oauth-callback-page.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-callback-page.test.ts
@@ -1,22 +1,52 @@
+// @vitest-environment jsdom
 // The page the browser lands on after PwrSnap's or PwrGit's authorization
 // screen. It is served from a throwaway localhost port by an app the person is
 // not looking at, so the page itself has to say what opened it — and it is the
 // one PwrAgent surface with no window chrome, no renderer, and no E2E lane.
 //
-// The icon geometry it depends on lives with the assets it measures, in
+// Parsed rather than string-matched: this project is `environment: "node"`, so
+// the file opts into jsdom for `DOMParser` alone. Nothing here executes the
+// page's inline script — jsdom will not run it from `parseFromString` — so the
+// few assertions that must reach inside it read the source text, and say so.
+//
+// The icon geometry the page depends on lives with the assets it measures, in
 // `scripts/pwrsuite-brand-icons.test.mjs`.
 import { describe, expect, it } from "vitest";
 import { htmlResponse } from "../mcp-connections/local-mcp-connection-service";
 
-/** The three states the callback server can render, for either sister app. */
-const CONNECTING = ["Connecting PwrAgent to PwrGit", "PwrGit approved the request.", { liveStatus: true }] as const;
-const DECLINED = ["PwrGit connection declined", "The user declined.", {}] as const;
+/**
+ * Both sister apps, each with its own copy. Parameterized because the page is
+ * one template with a brand substituted in: fixtures that named PwrGit while
+ * rendering PwrSnap let `displayName` collapse to a constant unnoticed, and
+ * made "the PwrSnap page never mentions PwrGit" unassertable.
+ */
+const CONNECTIONS = [
+  { id: "pwrgit", name: "PwrGit", other: "PwrSnap", inset: true },
+  { id: "pwrsnap", name: "PwrSnap", other: "PwrGit", inset: false },
+] as const;
+
+/** The two states the callback server renders: the live poll, and a refusal. */
+function connecting({ name }: (typeof CONNECTIONS)[number]) {
+  return [`Connecting PwrAgent to ${name}`, `${name} approved the request.`, { liveStatus: true }] as const;
+}
+function declined({ name }: (typeof CONNECTIONS)[number]) {
+  return [`${name} connection declined`, "The user declined.", {}] as const;
+}
 
 function render(
+  connection: (typeof CONNECTIONS)[number],
   [title, detail, options]: readonly [string, string, { liveStatus?: boolean }],
-  connectionId: "pwrgit" | "pwrsnap" = "pwrgit",
 ) {
-  return htmlResponse(title, detail, options, connectionId);
+  return htmlResponse(title, detail, options, connection.id);
+}
+
+function parse(page: string): Document {
+  return new DOMParser().parseFromString(page, "text/html");
+}
+
+/** The two marks the diagram draws, in document order. */
+function marks(page: string): HTMLImageElement[] {
+  return [...parse(page).querySelectorAll("img")];
 }
 
 describe("OAuth callback page", () => {
@@ -24,76 +54,129 @@ describe("OAuth callback page", () => {
     // Not the heading: it names PwrAgent only while the connection is going
     // well. "Connection could not be completed" on an unfamiliar localhost tab
     // is exactly where someone needs to be told whose window this is.
-    for (const state of [CONNECTING, DECLINED]) {
-      for (const connectionId of ["pwrgit", "pwrsnap"] as const) {
-        expect(render(state, connectionId))
+    for (const connection of CONNECTIONS) {
+      for (const state of [connecting(connection), declined(connection)]) {
+        expect(parse(render(connection, state)).body.textContent)
           .toContain("PwrAgent opened this window");
       }
     }
   });
 
-  it("flies PwrAgent's mark in the tab, not the sister app's", () => {
-    // The favicon answers "what is this?" before any of the page does, and the
-    // window belongs to PwrAgent. Served from the route the card already uses,
-    // which `img-src 'self'` in the page's CSP allows.
-    for (const connectionId of ["pwrgit", "pwrsnap"] as const) {
-      expect(render(CONNECTING, connectionId))
-        .toContain('<link rel="icon" type="image/png" href="/assets/pwragent.png">');
+  it("brands each page as its own sister app and never the other", () => {
+    for (const connection of CONNECTIONS) {
+      const page = render(connection, connecting(connection));
+      const document_ = parse(page);
+      expect(document_.title).toContain(connection.name);
+      // `:not(.app-icon)` skips the tile, whose only child is the mark.
+      expect([...document_.querySelectorAll(".app > span:not(.app-icon)")]
+        .map((span) => span.textContent))
+        .toEqual(["PwrAgent", connection.name]);
+      // Whole page, not just the body: comments ship to the browser too, and
+      // the parallel comment in app.css names both apps in one sentence.
+      expect(page).not.toContain(connection.other);
     }
   });
 
-  it("moves the tab title with the heading once the connection settles", () => {
-    // A backgrounded tab shows nothing but its title, and this page polls for
-    // minutes: left alone the tab still read "Connecting…" after the
-    // connection was up, or after it had failed.
-    const page = render(CONNECTING);
-    expect(page).toContain("<title>Connecting PwrAgent to PwrGit</title>");
-    // One helper sets the heading, the tab and the status together, so the
-    // three cannot drift apart the way the title already had.
-    expect(page).toContain("document.title = heading;");
-    expect(page).toContain('settle("is-connected", "PwrAgent is connected to PwrGit"');
-    expect(page).toContain('settle("is-failed", "Connection could not be completed"');
+  it("flies PwrAgent's mark in the tab, not the sister app's", () => {
+    // The favicon answers "what is this?" before any of the page does, and the
+    // window belongs to PwrAgent. Served from the route the diagram already
+    // uses, which `img-src 'self'` in the page's CSP allows.
+    for (const connection of CONNECTIONS) {
+      const icon = parse(render(connection, connecting(connection)))
+        .querySelector('link[rel="icon"]');
+      expect(icon?.getAttribute("href")).toBe("/assets/pwragent.png");
+      expect(icon?.getAttribute("type")).toBe("image/png");
+    }
   });
 
   it("scales only the sister app whose mark carries a margin", () => {
-    // Asserted on the tags, not on the page: the rule itself is in the
-    // stylesheet on every render, and only the markup decides who wears it.
-    expect(render(CONNECTING, "pwrgit"))
-      .toContain('<img class="app-mark app-mark--inset-plate" src="/assets/pwrgit.png"');
-    expect(render(CONNECTING, "pwrsnap"))
-      .toContain('<img class="app-mark" src="/assets/pwrsnap.png"');
-    // PwrAgent's own mark is full-bleed, so it never wears the modifier.
-    expect(render(CONNECTING, "pwrgit"))
-      .toContain('<img class="app-mark" src="/assets/pwragent.png"');
+    for (const connection of CONNECTIONS) {
+      const [pwragent, sister] = marks(render(connection, connecting(connection)));
+      expect(sister?.getAttribute("src")).toBe(`/assets/${connection.id}.png`);
+      expect(sister?.classList.contains("app-mark--inset-plate")).toBe(connection.inset);
+      // PwrAgent's own mark is full-bleed, so it never wears the modifier.
+      expect(pwragent?.getAttribute("src")).toBe("/assets/pwragent.png");
+      expect(pwragent?.classList.contains("app-mark--inset-plate")).toBe(false);
+    }
   });
 
   it("frames each mark in a tile the scale cannot grow", () => {
     // The compensation is a transform, and a transform on the framed element
-    // would scale its border and backing plate with the artwork — PwrGit's
+    // would scale its border and backing plate with the artwork — the sister's
     // tile would come out a quarter larger than PwrAgent's. The frame has to
     // be the parent for the artwork alone to move.
-    const page = render(CONNECTING, "pwrgit");
-    expect(page).toContain('<span class="app-icon"><img class="app-mark');
-    expect(page).not.toMatch(/<img[^>]*class="[^"]*\bapp-icon\b/u);
+    for (const mark of marks(render(CONNECTIONS[0], connecting(CONNECTIONS[0])))) {
+      expect(mark.classList.contains("app-icon")).toBe(false);
+      expect(mark.parentElement?.classList.contains("app-icon")).toBe(true);
+      expect(mark.parentElement?.classList.contains("app-mark--inset-plate")).toBe(false);
+    }
   });
 
   it("leaves the marks out of the accessible name, which the labels carry", () => {
-    // Each mark sits beside a visible <span> naming the same app, so alt text
-    // would have a screen reader announce "PwrGit PwrGit".
-    const page = render(CONNECTING, "pwrgit");
-    expect(page).not.toMatch(/<img[^>]*alt="(?!")/u);
-    expect(page).toContain("<span>PwrGit</span>");
-    expect(page).toContain("<span>PwrAgent</span>");
+    // `alt=""` present, not merely non-empty-alt absent: an <img> with no alt
+    // at all is announced as its src filename, which is worse than the name
+    // this deliberately drops. Each mark sits beside a visible <span> naming
+    // the same app, so alt text would have a screen reader say it twice.
+    for (const connection of CONNECTIONS) {
+      const page = render(connection, connecting(connection));
+      expect(marks(page).map((mark) => mark.getAttribute("alt"))).toEqual(["", ""]);
+      // aria-label is ignored on a bare div, so the diagram needs a real role
+      // for the relationship it draws to reach assistive technology at all.
+      const diagram = parse(page).querySelector(".connection");
+      expect(diagram?.getAttribute("role")).toBe("group");
+      expect(diagram?.getAttribute("aria-label"))
+        .toBe(`PwrAgent connection to ${connection.name}`);
+    }
   });
 
   it("escapes what the authorization server sent before echoing it", () => {
-    const page = htmlResponse(
-      '<script>alert("t")</script>',
-      "error_description from the wire",
-      {},
-      "pwrgit",
-    );
-    expect(page).not.toContain('<script>alert("t")</script>');
-    expect(page).toContain("&lt;script&gt;alert(&quot;t&quot;)&lt;/script&gt;");
+    // The payload goes in `detail`: that is the argument built from
+    // `error_description` off the callback URL. `title` is a fixed literal at
+    // every call site, so a test that only injected there would stay green
+    // with the real sink unescaped — and this page's CSP allows inline script.
+    const payload = '<script>alert("t")</script>';
+    for (const connection of CONNECTIONS) {
+      for (const page of [
+        htmlResponse(`${connection.name} connection declined`, payload, {}, connection.id),
+        htmlResponse(payload, "The user declined.", {}, connection.id),
+      ]) {
+        expect(parse(page).querySelectorAll("script")).toHaveLength(0);
+        expect(page).toContain("&lt;script&gt;alert(&quot;t&quot;)&lt;/script&gt;");
+      }
+    }
+    // The escaped text still reads back as the original, in both slots.
+    const rendered = parse(htmlResponse(payload, payload, {}, "pwrgit"));
+    expect(rendered.getElementById("title")?.textContent).toBe(payload);
+    expect(rendered.getElementById("detail")?.textContent).toBe(payload);
+  });
+
+  it("keeps the live poll's updates on textContent, and its arguments in order", () => {
+    // Read from the source: jsdom does not execute the page's script, and
+    // these are the properties that stop wire data becoming DOM XSS. The PR
+    // that added `settle` collapsed three separate assignments into one, so a
+    // single careless edit here now moves all three sinks at once.
+    const page = render(CONNECTIONS[0], connecting(CONNECTIONS[0]));
+    expect(page).toContain("const settle = (state, heading, detail, status) => {");
+    expect(page).toContain('document.getElementById("detail").textContent = detail;');
+    expect(page).toContain('document.getElementById("status").textContent = status;');
+    expect(page).toContain('document.getElementById("title").textContent = heading;');
+    expect(page).not.toContain("innerHTML");
+    // The tab moves with the heading: a backgrounded window shows nothing
+    // else, and left alone it kept saying "Connecting…" after the connection
+    // was up or had failed.
+    expect(page).toContain("document.title = heading;");
+    expect(page).toContain('settle("is-connected", "PwrAgent is connected to PwrGit"');
+    expect(page).toContain('settle("is-failed", "Connection could not be completed"');
+    expect(page).toContain("void check();");
+  });
+
+  it("gives up on a callback port that has stopped answering", () => {
+    // PwrAgent closes the port 30s after it finishes; without a cap the page
+    // polls a dead loopback address at 4Hz for as long as the tab is open.
+    const page = render(CONNECTIONS[0], connecting(CONNECTIONS[0]));
+    expect(page).toContain("if (++unanswered > 240) {");
+    expect(page).toContain("unanswered = 0;");
+    // The refusal page has no poll at all, so it carries no script to cap.
+    expect(render(CONNECTIONS[0], declined(CONNECTIONS[0]))).not.toContain("<script>");
   });
 });

--- a/apps/desktop/src/main/mcp-connections/local-mcp-connection-service.ts
+++ b/apps/desktop/src/main/mcp-connections/local-mcp-connection-service.ts
@@ -219,7 +219,12 @@ function delay(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
-function htmlResponse(
+/**
+ * The page the browser lands on after the sister app's authorization screen.
+ * Exported for `oauth-callback-page.test.ts`: it is the only part of this
+ * service a person ever looks at, and nothing else here renders markup.
+ */
+export function htmlResponse(
   title: string,
   detail: string,
   options: { liveStatus?: boolean } = {},
@@ -228,6 +233,9 @@ function htmlResponse(
   const displayName = connectionId === "pwrgit" ? "PwrGit" : "PwrSnap";
   const safeTitle = escapeHtml(title);
   const liveStatus = options.liveStatus === true;
+  // PwrGit's brand asset is the only one of the three that carries Apple's
+  // legacy margin; see `.app-mark--inset-plate` below.
+  const insetPlate = connectionId === "pwrgit";
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -235,6 +243,11 @@ function htmlResponse(
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="referrer" content="no-referrer">
   <title>${safeTitle}</title>
+  <!-- PwrAgent's own mark, not the sister app's: this window belongs to
+       PwrAgent, and the tab is where someone looks to ask what opened it.
+       Same route the diagram below draws from, so it needs no second asset
+       and nothing new from this page's own img-src 'self' policy. -->
+  <link rel="icon" type="image/png" href="/assets/pwragent.png">
   <style>
     :root { color-scheme: dark; font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
     * { box-sizing: border-box; }
@@ -246,7 +259,19 @@ function htmlResponse(
     .detail { max-width: 610px; margin: 20px auto 0; color: #aaa49d; font-size: 17px; line-height: 1.55; }
     .connection { display: grid; grid-template-columns: 138px minmax(140px, 1fr) 138px; align-items: center; gap: 22px; max-width: 650px; margin: 58px auto 50px; }
     .app { display: grid; justify-items: center; gap: 13px; color: #d9d4cd; font-size: 13px; font-weight: 680; }
-    .app-icon { width: 104px; height: 104px; padding: 4px; border: 1px solid #2b2926; border-radius: 27px; object-fit: contain; background: #141312; box-shadow: 0 20px 55px rgba(0, 0, 0, .45); }
+    .app-icon { display: grid; place-items: center; width: 104px; height: 104px; padding: 4px; border: 1px solid #2b2926; border-radius: 27px; background: #141312; box-shadow: 0 20px 55px rgba(0, 0, 0, .45); }
+    .app-mark { width: 100%; height: 100%; object-fit: contain; }
+    /* Each mark is its own app's icon, copied verbatim, and they were authored
+       on different canvases: most plates fill theirs, while the one flagged
+       here sits on Apple's legacy 824-in-1024 template, so a fifth of that
+       canvas is transparent margin. Drawn into the same tile it paints at 80%
+       of the mark beside it, which reads as a small icon lost inside an empty
+       frame. Scale it back by the canvas over the plate it holds — the same
+       ratio, and the same reason, as \`.mcp-connection__icon--inset-plate\` in
+       the renderer's app.css. The tile is the parent, so only the artwork
+       grows, and the only thing this paints outside the tile is the asset's
+       own transparent margin. */
+    .app-mark--inset-plate { transform: scale(calc(256 / 206)); }
     .line { position: relative; height: 38px; }
     .line::before { content: ""; position: absolute; top: 18px; left: 0; right: 0; height: 2px; background: linear-gradient(90deg, #8a3c17, #ff8a1f 45%, #ffc174 55%, #8a3c17); box-shadow: 0 0 14px rgba(255, 138, 31, .7); }
     .signal { position: absolute; top: 12px; left: -4px; width: 14px; height: 14px; border: 3px solid #090909; border-radius: 50%; background: #ff9c43; box-shadow: 0 0 0 3px rgba(255, 138, 31, .18), 0 0 18px #ff8a1f; animation: call 1.8s cubic-bezier(.45, 0, .25, 1) infinite; }
@@ -268,30 +293,37 @@ function htmlResponse(
     <h1 id="title">${safeTitle}</h1>
     <p class="detail" id="detail">${escapeHtml(detail)}</p>
     <div class="connection" aria-label="PwrAgent connection to ${displayName}">
-      <div class="app"><img class="app-icon" src="/assets/pwragent.png" alt="PwrAgent"><span>PwrAgent</span></div>
+      <div class="app"><span class="app-icon"><img class="app-mark" src="/assets/pwragent.png" alt=""></span><span>PwrAgent</span></div>
       <div class="line" aria-hidden="true"><span class="signal"></span></div>
-      <div class="app"><img class="app-icon" src="/assets/${connectionId}.png" alt="${displayName}"><span>${displayName}</span></div>
+      <div class="app"><span class="app-icon"><img class="app-mark${insetPlate ? " app-mark--inset-plate" : ""}" src="/assets/${connectionId}.png" alt=""></span><span>${displayName}</span></div>
     </div>
     <div class="status"><span class="status-dot"></span><span id="status">${liveStatus ? "Finishing secure connection…" : "Connection stopped"}</span></div>
-    <p class="close">You can close this window at any time.</p>
+    <!-- Names the app that opened this window. The heading names PwrAgent
+         only while the connection is going well; "Connection could not be
+         completed" on a stranger's tab names nobody at all. -->
+    <p class="close">PwrAgent opened this window — you can close it at any time.</p>
   </main>
   ${liveStatus ? `<script>
+    // The heading and the tab move together: the tab is the only part of this
+    // page a backgrounded window still shows, and left alone it kept saying
+    // "Connecting…" long after the connection was up or had failed.
+    const settle = (state, heading, detail, status) => {
+      document.body.className = state;
+      document.title = heading;
+      document.getElementById("title").textContent = heading;
+      document.getElementById("detail").textContent = detail;
+      document.getElementById("status").textContent = status;
+    };
     const check = async () => {
       try {
         const response = await fetch("/oauth/status", { cache: "no-store" });
         const result = await response.json();
         if (result.state === "connected") {
-          document.body.className = "is-connected";
-          document.getElementById("title").textContent = "PwrAgent is connected to ${displayName}";
-          document.getElementById("detail").textContent = result.detail;
-          document.getElementById("status").textContent = "Secure connection ready";
+          settle("is-connected", "PwrAgent is connected to ${displayName}", result.detail, "Secure connection ready");
           return;
         }
         if (result.state === "failed") {
-          document.body.className = "is-failed";
-          document.getElementById("title").textContent = "Connection could not be completed";
-          document.getElementById("detail").textContent = result.detail;
-          document.getElementById("status").textContent = "Connection stopped";
+          settle("is-failed", "Connection could not be completed", result.detail, "Connection stopped");
           return;
         }
       } catch {}

--- a/apps/desktop/src/main/mcp-connections/local-mcp-connection-service.ts
+++ b/apps/desktop/src/main/mcp-connections/local-mcp-connection-service.ts
@@ -270,7 +270,15 @@ export function htmlResponse(
        ratio, and the same reason, as \`.mcp-connection__icon--inset-plate\` in
        the renderer's app.css. The tile is the parent, so only the artwork
        grows, and the only thing this paints outside the tile is the asset's
-       own transparent margin. */
+       own transparent margin.
+
+       Two things here are load-bearing and look removable. The explicit 100%
+       on .app-mark is what fills the tile — place-items only centres what is
+       already sized, and without the 100% each mark falls back to its
+       intrinsic 256 or 512px. And the tile must stay unclipped: the scaled
+       mark overhangs it by 6.4px per side by design, so an overflow: hidden
+       added to .app-icon crops the plate straight back to the 80% this rule
+       exists to undo. */
     .app-mark--inset-plate { transform: scale(calc(256 / 206)); }
     .line { position: relative; height: 38px; }
     .line::before { content: ""; position: absolute; top: 18px; left: 0; right: 0; height: 2px; background: linear-gradient(90deg, #8a3c17, #ff8a1f 45%, #ffc174 55%, #8a3c17); box-shadow: 0 0 14px rgba(255, 138, 31, .7); }
@@ -292,7 +300,10 @@ export function htmlResponse(
     <p class="eyebrow">PwrSuite connection</p>
     <h1 id="title">${safeTitle}</h1>
     <p class="detail" id="detail">${escapeHtml(detail)}</p>
-    <div class="connection" aria-label="PwrAgent connection to ${displayName}">
+    <!-- role="group" so the label is announced: aria-label is ignored on a
+         bare div, which is role="generic", so the relationship this diagram
+         draws reached assistive technology as two loose words. -->
+    <div class="connection" role="group" aria-label="PwrAgent connection to ${displayName}">
       <div class="app"><span class="app-icon"><img class="app-mark" src="/assets/pwragent.png" alt=""></span><span>PwrAgent</span></div>
       <div class="line" aria-hidden="true"><span class="signal"></span></div>
       <div class="app"><span class="app-icon"><img class="app-mark${insetPlate ? " app-mark--inset-plate" : ""}" src="/assets/${connectionId}.png" alt=""></span><span>${displayName}</span></div>
@@ -314,10 +325,18 @@ export function htmlResponse(
       document.getElementById("detail").textContent = detail;
       document.getElementById("status").textContent = status;
     };
+    // PwrAgent stops answering 30s after it finishes with this flow. Without a
+    // cap, a tab still open after that polls a closed loopback port four times
+    // a second for as long as it stays open, while the page goes on promising
+    // a result it can no longer get. Counts consecutive unanswered polls only,
+    // so a slow start costs nothing: 240 of them is a minute, well past the
+    // close, and any answer at all resets it.
+    let unanswered = 0;
     const check = async () => {
       try {
         const response = await fetch("/oauth/status", { cache: "no-store" });
         const result = await response.json();
+        unanswered = 0;
         if (result.state === "connected") {
           settle("is-connected", "PwrAgent is connected to ${displayName}", result.detail, "Secure connection ready");
           return;
@@ -326,7 +345,17 @@ export function htmlResponse(
           settle("is-failed", "Connection could not be completed", result.detail, "Connection stopped");
           return;
         }
-      } catch {}
+      } catch {
+        if (++unanswered > 240) {
+          settle(
+            "is-failed",
+            "Connection could not be completed",
+            "PwrAgent stopped reporting on this connection. Check PwrAgent to see whether it finished.",
+            "Connection stopped",
+          );
+          return;
+        }
+      }
       setTimeout(check, 250);
     };
     void check();
@@ -340,8 +369,14 @@ function connectionAsset(name: "pwragent" | ConnectionId): Buffer | null {
   const sourceFile = name === "pwragent"
     ? "build/icon.png"
     : `src/renderer/src/assets/${name}/${name}-app-icon.png`;
+  // `process.resourcesPath` is an Electron addition, and `join` throws on the
+  // `undefined` it is everywhere else — outside the loop's try, so the whole
+  // function threw instead of returning null. Only Electron has a packaged
+  // copy to find, so drop the candidate rather than the caller.
   const candidates = [
-    join(process.resourcesPath, fileName),
+    ...(typeof process.resourcesPath === "string"
+      ? [join(process.resourcesPath, fileName)]
+      : []),
     join(__dirname, "../../", sourceFile),
     join(__dirname, "../../../", sourceFile),
   ];

--- a/apps/desktop/src/renderer/src/assets/pwrgit/README.md
+++ b/apps/desktop/src/renderer/src/assets/pwrgit/README.md
@@ -8,7 +8,8 @@ verbatim from the sister PwrSuite repository:
   electron-builder's `actool` derives from PwrGit's `apps/desktop/build/icon.icon`
   at package time. It was originally the same member of PwrGit's hand-built
   `icon.iconset/`, which pwrdrvr/PwrGit#196 removed.
-- Usage: the New Thread PwrGit connection prompt
+- Usage: the New Thread PwrGit connection prompt, and the OAuth callback page
+  the browser lands on after PwrGit's authorization screen
 
 To refresh it, take `Contents/Resources/icon.icns` from a packaged PwrGit.app
 (or compile PwrGit's `build/icon.icon` the way its `branding-assets.test.ts`
@@ -16,9 +17,14 @@ does), run `iconutil -c iconset` on it, and copy `icon_128x128@2x.png` here
 unchanged. Do not resample, redraw, recolor, or inline the mark in PwrAgent.
 
 The plate in this copy covers 206 of its 256px — Apple's legacy 824-in-1024
-template — where the PwrSnap icon beside it on the same card is full-bleed.
-The card compensates in CSS rather than in the file, so the two marks paint at
-the same size: see `.mcp-connection__icon--inset-plate` in `styles/app.css`.
+template — where every mark it is drawn beside is full-bleed: PwrSnap's on the
+New Thread card, PwrAgent's own on the callback page. Each surface compensates
+in CSS rather than in the file, so the marks paint at the same size:
+
+- `.mcp-connection__icon--inset-plate` in `styles/app.css` (the card)
+- `.app-mark--inset-plate` in `src/main/mcp-connections/local-mcp-connection-service.ts`
+  (the callback page, whose CSS is a template literal in the main process)
+
 A refreshed copy with a different margin fails
-`apps/desktop/scripts/pwrsuite-brand-icons.test.mjs`; correct the ratio there
-rather than editing the asset.
+`apps/desktop/scripts/pwrsuite-brand-icons.test.mjs`, which measures the asset
+against both rules; correct the ratios there rather than editing the asset.

--- a/apps/desktop/src/renderer/src/assets/pwrsnap/README.md
+++ b/apps/desktop/src/renderer/src/assets/pwrsnap/README.md
@@ -8,7 +8,8 @@ verbatim from the sister PwrSuite repository:
   electron-builder's `actool` derives from PwrSnap's `apps/desktop/build/icon.icon`
   at package time. It was originally the same member of PwrSnap's hand-built
   `icon.iconset/`, which pwrdrvr/PwrSnap#563 removed.
-- Usage: the New Thread PwrSnap connection prompt
+- Usage: the New Thread PwrSnap connection prompt, and the OAuth callback page
+  the browser lands on after PwrSnap's authorization screen
 
 To refresh it, take `Contents/Resources/icon.icns` from a packaged PwrSnap.app
 (or compile PwrSnap's `build/icon.icon` the way its `app-icon.test.mjs` does),


### PR DESCRIPTION
PwrGit's mark on the OAuth callback page — the browser tab you land on after
approving the connection — painted noticeably smaller than PwrAgent's beside
it, sitting inside an empty tile.

## Before

![callback page before, PwrGit's mark small inside an empty tile](./before.png)

## After

![callback page after, both marks the same size, PwrAgent named as the opener](./after.png)

## Why it happened

PwrGit's brand asset is the 256px member of the `.icns` `actool` derives from
its Icon Composer package, so its plate covers 206 of those 256px — Apple's
legacy 824-in-1024 template. Every mark it is drawn beside is full-bleed.

The New Thread card has compensated for that since it shipped
(`.mcp-connection__icon--inset-plate`). The callback page never did — it framed
both marks in the same padded tile with no scale, so PwrGit painted at 80% of
PwrAgent next to it.

## The fix

The same canvas-over-plate scale, applied to the artwork rather than to the
tile. The compensation is a `transform`, and a transform on the framed element
would scale its border and backing plate too, leaving PwrGit's tile a quarter
larger than PwrAgent's. So the image is now a child of the tile: only the mark
grows, and the only thing painted outside the tile is the asset's own
transparent margin.

Measured in the rendered page: both plates land at **94px in the 104px tile**,
and at **68px in the 78px phone tile**, with no horizontal overflow. PwrSnap's
asset is full-bleed and is untouched — verified in the same run.

## Also on this page

It never said whose window it was. It is served off a throwaway localhost port
by an app you are not looking at, and the heading names PwrAgent only while the
connection is going well — "Connection could not be completed" on an unfamiliar
tab names nobody at all.

- **Favicon**: PwrAgent's own mark, served from the route the diagram already
  draws from, so no second asset and nothing new from the page's `img-src
  'self'` policy.
- **The closing line** names PwrAgent as the opener, in every state.
- **The tab title** now moves with the heading. The poll updated the `<h1>` but
  never `document.title`, so a backgrounded tab — the only part of this page a
  backgrounded window still shows — kept saying "Connecting…" long after the
  connection was up or had failed.

Marks are now `alt=""`: each sits beside a visible label naming the same app,
so the alt text had a screen reader announce "PwrGit PwrGit".

## Tests

`pwrsuite-brand-icons.test.mjs` already tied the card's ratio to the measured
assets — it decodes each PNG, measures the opaque plate, and checks the CSS
states a ratio that makes them paint alike. It now does the same for the
callback page's rule, and includes PwrAgent's own mark in the assets it
measures, since that is what the sister app is sized against there. A refreshed
asset with a different margin fails there rather than shipping mismatched
icons.

New `oauth-callback-page.test.ts` covers the rest: the opener line in every
state and for both sister apps, the favicon, the title/heading moving together,
the modifier landing only on the inset asset, the tile being the parent, and
that the page still escapes what the authorization server sent.

Screenshots are rendered from contrived fixture strings; no real connection or
account data.

![callback page before](https://github.com/user-attachments/assets/7e6c4b5d-248e-4d5a-aded-e8ceb5478dcf)

![callback page after](https://github.com/user-attachments/assets/2e9c8797-5469-4fe0-9ecc-3008e184195c)