### PR TITLE
fix(tests): retry the E2E renderer-ready poll through a flaky evaluate

### DIFF
--- a/apps/desktop/e2e/canary-report.ts
+++ b/apps/desktop/e2e/canary-report.ts
@@ -11,10 +11,13 @@ export function describeCanaryFailure(params: {
    *
    * The distinction decides which story gets told, and telling the wrong
    * one is expensive. A hang means a sick guest, and the right response
-   * is to recycle it. A rejection means the harness already knows what
-   * is wrong — a missing onboarding seed, say — and recycling the guest
-   * would be a wasted trip that fixes nothing. Defaults to `true` to
-   * preserve the original behavior for callers that don't distinguish.
+   * is to recycle it. A rejection means the launch failed with something
+   * to read instead of stalling — either a harness diagnosis (a missing
+   * onboarding seed, say) or a failed Playwright/Electron round trip.
+   * Recycling the guest fixes neither, which is all this flag claims:
+   * the two rejection kinds still want different responses from each
+   * other, and the message says so. Defaults to `true` to preserve the
+   * original behavior for callers that don't distinguish.
    */
   timedOut?: boolean;
 }): string {
@@ -51,9 +54,24 @@ export function describeCanaryFailure(params: {
       "Desktop E2E pre-flight failed before any test ran.",
       "",
       "The canary launches one app through the SAME harness every spec uses, so",
-      "this would have failed every spec in turn. The harness rejected with a",
-      "specific diagnosis rather than hanging, so read the error below — it is",
-      "the actual problem, and it is NOT the guest needing to be recycled.",
+      "this would have failed every spec in turn. The harness rejected rather",
+      "than hanging, so start from the error below — whatever it says, it is",
+      "NOT the guest needing to be recycled.",
+      "",
+      "Two unlike things reject here, and they want opposite responses:",
+      "",
+      "  - A harness DIAGNOSIS is deterministic: a missing onboarding seed, the",
+      "    first-run wizard holding the window. It names what to fix and will",
+      "    fail the same way on every lane and every runner.",
+      "  - A failed Playwright <-> Electron ROUND TRIP is not deterministic and",
+      "    diagnoses nothing. \"Resulting promise was garbage collected\" and",
+      "    \"Target closed\" describe the RPC, not the app. Observed here on",
+      "    2026-09-11: one lane died in pre-flight while the other three passed",
+      "    the same commit — one of them on the same runner, seconds later —",
+      "    and the failed lane passed on retry.",
+      "",
+      "So before reading this as a branch defect, check whether the suite's",
+      "other lanes passed on this commit. If they did, retry this one.",
       "",
       params.runnerName
         ? `  Runner: ${params.runnerName}`

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -51,6 +51,7 @@ import {
   type ElectronCloseExecution,
   type ElectronShutdownSummary,
 } from "./electron-shutdown-policy";
+import { tolerateTransientRpcFailure } from "./transient-rpc-poll";
 
 const fixtureDir = path.dirname(fileURLToPath(import.meta.url));
 
@@ -754,15 +755,27 @@ export async function waitForRendererReady(params: {
   const wizardWatch = params.suppressOnboarding
     ? watchForOnboardingWizard(params.window, params)
     : undefined;
+  // Wrapped because `expect.poll` does not retry a THROWING callback, and
+  // this callback crosses the Electron RPC boundary: one
+  // `electronApplication.evaluate: Resulting promise was garbage collected`
+  // ended this poll on its first tick and, through the pre-flight canary,
+  // took down an entire E2E shard before any test ran. See
+  // `tolerateTransientRpcFailure` for the run and the Playwright source.
+  const replayDriverInstalled = tolerateTransientRpcFailure(async () =>
+    await params.electronApp.evaluate(() =>
+      Boolean(globalThis.__PWRAGENT_REPLAY_DRIVER__)
+    )
+  );
   try {
     const ready = params.requiresReplayDriver
       ? expect
-        .poll(async () =>
-          await params.electronApp.evaluate(() =>
-            Boolean(globalThis.__PWRAGENT_REPLAY_DRIVER__)
-          )
-        )
+        .poll(replayDriverInstalled.read, {
+          message:
+            "the replay driver never appeared on the main-process global,"
+            + " so no spec could have driven a turn",
+        })
         .toBe(true)
+        .catch(replayDriverInstalled.rethrowWithLastFailure)
       // Wizard specs: just wait for the renderer to mount. We don't
       // care about the replay driver — there's no thread to replay.
       : params.window.waitForLoadState("domcontentloaded");
@@ -883,50 +896,58 @@ async function applyRendererViewport(params: {
 
   let attempt = 0;
   let previousRequest: NativeContentSize | null = null;
+  // Same RPC tolerance as `waitForRendererReady`, and for the same reason:
+  // each attempt is three round trips, any of which can fail transiently,
+  // and an aborted poll here fails the launch rather than the assertion.
+  // The one behavior this trades away is instant reporting of the
+  // window-destroyed check below — it now surfaces at the poll deadline,
+  // still by name, through `rethrowWithLastFailure`.
+  const resizedViewport = tolerateTransientRpcFailure(async () => {
+    const observed = await window.evaluate(() => ({
+      innerHeight: globalThis.innerHeight,
+      innerWidth: globalThis.innerWidth,
+    }));
+    if (
+      observed.innerHeight === targetSize.height
+      && observed.innerWidth === targetSize.width
+    ) {
+      return observed;
+    }
+
+    const request = nextRendererViewportRequest({
+      attempt,
+      observed,
+      previousRequest,
+      target: targetSize,
+    });
+    previousRequest = request;
+    attempt += 1;
+
+    await electronApp.evaluate(
+      ({ BrowserWindow }, resize) => {
+        const window = BrowserWindow.fromId(resize.windowId);
+        if (!window || window.isDestroyed()) {
+          throw new Error(
+            "Expected the replay E2E BrowserWindow to remain live while resizing",
+          );
+        }
+        window.setContentSize(resize.request.width, resize.request.height);
+      },
+      { request, windowId },
+    );
+
+    return await window.evaluate(() => ({
+      innerHeight: globalThis.innerHeight,
+      innerWidth: globalThis.innerWidth,
+    }));
+  });
   await expect
-    .poll(async () => {
-      const observed = await window.evaluate(() => ({
-        innerHeight: globalThis.innerHeight,
-        innerWidth: globalThis.innerWidth,
-      }));
-      if (
-        observed.innerHeight === targetSize.height
-        && observed.innerWidth === targetSize.width
-      ) {
-        return observed;
-      }
-
-      const request = nextRendererViewportRequest({
-        attempt,
-        observed,
-        previousRequest,
-        target: targetSize,
-      });
-      previousRequest = request;
-      attempt += 1;
-
-      await electronApp.evaluate(
-        ({ BrowserWindow }, resize) => {
-          const window = BrowserWindow.fromId(resize.windowId);
-          if (!window || window.isDestroyed()) {
-            throw new Error(
-              "Expected the replay E2E BrowserWindow to remain live while resizing",
-            );
-          }
-          window.setContentSize(resize.request.width, resize.request.height);
-        },
-        { request, windowId },
-      );
-
-      return await window.evaluate(() => ({
-        innerHeight: globalThis.innerHeight,
-        innerWidth: globalThis.innerWidth,
-      }));
-    })
+    .poll(resizedViewport.read)
     .toMatchObject({
       innerHeight: targetSize.height,
       innerWidth: targetSize.width,
-    });
+    })
+    .catch(resizedViewport.rethrowWithLastFailure);
 }
 
 /**

--- a/apps/desktop/e2e/fixtures/electron-app.ts
+++ b/apps/desktop/e2e/fixtures/electron-app.ts
@@ -900,8 +900,9 @@ async function applyRendererViewport(params: {
   // each attempt is three round trips, any of which can fail transiently,
   // and an aborted poll here fails the launch rather than the assertion.
   // The one behavior this trades away is instant reporting of the
-  // window-destroyed check below — it now surfaces at the poll deadline,
-  // still by name, through `rethrowWithLastFailure`.
+  // window-destroyed check below. That check is deliberate, not an RPC
+  // failure, so it is retried like one and then surfaces verbatim at the
+  // poll deadline through `rethrowWithLastFailure` — later, still by name.
   const resizedViewport = tolerateTransientRpcFailure(async () => {
     const observed = await window.evaluate(() => ({
       innerHeight: globalThis.innerHeight,

--- a/apps/desktop/e2e/fixtures/star-map-window.ts
+++ b/apps/desktop/e2e/fixtures/star-map-window.ts
@@ -12,6 +12,7 @@
 // anybody has, so the wait now reports which one it was.
 import { expect, type ConsoleMessage, type Page } from "@playwright/test";
 import type { launchElectronApp } from "./electron-app";
+import { tolerateTransientRpcFailure } from "./transient-rpc-poll";
 
 type LaunchedApp = Awaited<ReturnType<typeof launchElectronApp>>;
 
@@ -204,30 +205,40 @@ async function waitForStarMapWindow(
  * here. This makes the barrier explicit instead of incidental.
  */
 export async function openStarMapWindow(app: LaunchedApp): Promise<Page> {
-  await expect
-    .poll(
-      async () =>
-        await app.window.evaluate(
-          () =>
-            typeof (
-              window as Window & {
-                pwragent?: { openStarMapWindow?: unknown };
-              }
-            ).pwragent?.openStarMapWindow,
-        ),
-      {
-        message:
-          "the main window's preload bridge never exposed openStarMapWindow,"
-          + " so the header control could never have opened the map",
-      },
+  // Both barriers read across the Electron RPC boundary, so both are wrapped:
+  // `expect.poll` does not retry a THROWING callback, and a round trip can
+  // fail for reasons unrelated to the readiness being polled. See
+  // `tolerateTransientRpcFailure`.
+  const bridgeMethod = tolerateTransientRpcFailure(async () =>
+    await app.window.evaluate(
+      () =>
+        typeof (
+          window as Window & {
+            pwragent?: { openStarMapWindow?: unknown };
+          }
+        ).pwragent?.openStarMapWindow,
     )
-    .toBe("function");
+  );
+  await expect
+    .poll(bridgeMethod.read, {
+      message:
+        "the main window's preload bridge never exposed openStarMapWindow,"
+        + " so the header control could never have opened the map",
+    })
+    .toBe("function")
+    .catch(bridgeMethod.rethrowWithLastFailure);
 
   // A DOM-clickable header can precede native ready-to-show. Wait for the
   // window to be shown, but do not require OS focus: the runner can deliver
   // Playwright input without macOS making this the foreground application.
   const nativeWindow = await app.electronApp.browserWindow(app.window);
-  await expect.poll(() => nativeWindow.evaluate((window) => window.isVisible())).toBe(true);
+  const nativeWindowShown = tolerateTransientRpcFailure(async () =>
+    await nativeWindow.evaluate((window) => window.isVisible())
+  );
+  await expect
+    .poll(nativeWindowShown.read)
+    .toBe(true)
+    .catch(nativeWindowShown.rethrowWithLastFailure);
 
   const errorLog = recordRendererErrors(app.window);
   try {

--- a/apps/desktop/e2e/fixtures/transient-rpc-poll.ts
+++ b/apps/desktop/e2e/fixtures/transient-rpc-poll.ts
@@ -37,8 +37,18 @@
  * `rethrowWithLastFailure` puts the last caught error back into the
  * message. A read that succeeds clears it, so a poll that times out against
  * an app that answered every time is never blamed on a stale blip.
+ *
+ * ONE CONSTRAINT on the matcher, because a failed read reports as
+ * `undefined`: the matcher must be one `undefined` cannot satisfy. Every
+ * caller today is `toBe(true)`, `toBe("function")`, or `toMatchObject`, all
+ * of which treat `undefined` as "keep polling". Under `not.toBe(...)`,
+ * `toBeFalsy()`, or `toBeUndefined()` the tolerance would turn an RPC that
+ * never answered into a poll that PASSES on its first tick — a barrier that
+ * resolves without ever having read the app. Use `assertAnswered` after such
+ * a poll, or do not wrap it.
  */
 export function tolerateTransientRpcFailure<T>(read: () => Promise<T>): {
+  assertAnswered: () => void;
   read: () => Promise<T | undefined>;
   rethrowWithLastFailure: (pollError: unknown) => never;
 } {
@@ -46,6 +56,26 @@ export function tolerateTransientRpcFailure<T>(read: () => Promise<T>): {
   // `undefined` still counts as a failure.
   let lastFailure: { error: unknown } | undefined;
   return {
+    /**
+     * Call after a poll RESOLVED, when the matcher is one `undefined` could
+     * satisfy: a retained failure then means the poll passed on an attempt
+     * that never reached the app.
+     */
+    assertAnswered: () => {
+      if (!lastFailure) {
+        return;
+      }
+
+      throw new Error(
+        [
+          "A poll resolved on an attempt whose call failed, so the value the",
+          "matcher accepted was the absence of an answer rather than app",
+          "state. Give this poll a matcher that `undefined` cannot satisfy.",
+          `  ${describePollFailure(lastFailure.error)}`,
+        ].join("\n"),
+        { cause: lastFailure.error },
+      );
+    },
     read: async () => {
       try {
         const value = await read();
@@ -64,15 +94,25 @@ export function tolerateTransientRpcFailure<T>(read: () => Promise<T>): {
       const explanation = [
         "",
         "The last poll attempt produced no value because the call itself",
-        "failed. That is usually a failed Playwright <-> Electron round trip",
-        "rather than app state:",
+        "threw — either a failed Playwright <-> Electron round trip or a throw",
+        "from inside the callback. The error below says which:",
         `  ${describePollFailure(lastFailure.error)}`,
       ].join("\n");
       if (pollError instanceof Error) {
         // Appended in place: Playwright's own assertion error carries the
         // matcher result and a stack its reporter formats, and rewrapping
-        // would trade both for a plain `Error`.
+        // would trade both for a plain `Error`. `filterStackTrace` rebuilds
+        // the serialized stack from the live `message`, so the explanation
+        // reaches the reporter even though `ExpectError` froze its `stack`
+        // at construction.
         pollError.message += `\n${explanation}`;
+        // The message carries the failure's text; `cause` carries its FRAMES,
+        // which is what a non-RPC throw from inside the callback needs. The
+        // reporter prints it as `[cause]:`, so this echoes one line rather
+        // than replacing the appended text — the canary reads `message`.
+        if (pollError.cause === undefined) {
+          pollError.cause = lastFailure.error;
+        }
         throw pollError;
       }
 

--- a/apps/desktop/e2e/fixtures/transient-rpc-poll.ts
+++ b/apps/desktop/e2e/fixtures/transient-rpc-poll.ts
@@ -1,0 +1,89 @@
+// Retry tolerance for `expect.poll` callbacks that cross the Playwright <->
+// Electron RPC boundary, split out so the retry and the reporting are
+// unit-testable without launching Electron.
+
+/**
+ * Wrap a poll callback so ONE failed round trip retries instead of ending
+ * the poll.
+ *
+ * `expect.poll` retries a failed ASSERTION, not a throwing callback. In
+ * Playwright 1.62.1 `invokePollMatcher` awaits the callback OUTSIDE the
+ * try/catch that decides whether to keep polling:
+ *
+ *     const value = await actual();            // <- not guarded
+ *     try {
+ *       await callMatcherAsStep(...);
+ *       return { continuePolling: false, result: void 0 };
+ *     } catch (error) {
+ *       return { continuePolling: true, result: error };
+ *     }
+ *
+ * So a rejection from the callback propagates straight out and the poll
+ * ends on its first tick, with its whole deadline unspent.
+ *
+ * Every caller here polls across the RPC boundary, where a round trip can
+ * fail for reasons that say nothing about the state being polled.
+ * `electronApplication.evaluate: Resulting promise was garbage collected`
+ * did that to `waitForRendererReady` on 2026-09-11 (run 34654211530,
+ * "macOS Desktop E2E (lane 3 of 4)"). Because that poll is on the launch
+ * path and the pre-flight canary turns a launch failure into "zero tests
+ * ran", one flaky round trip cost the whole shard: lanes 1, 2 and 4 passed
+ * the same commit — lane 4 on the SAME runner, starting the second lane 3
+ * ended — and lane 3 passed on retry.
+ *
+ * Retaining the failure is the other half of this. Swallowing the rejection
+ * silently would leave a genuinely dead app reporting "expected true,
+ * received undefined" at the poll deadline with no mention of the RPC, so
+ * `rethrowWithLastFailure` puts the last caught error back into the
+ * message. A read that succeeds clears it, so a poll that times out against
+ * an app that answered every time is never blamed on a stale blip.
+ */
+export function tolerateTransientRpcFailure<T>(read: () => Promise<T>): {
+  read: () => Promise<T | undefined>;
+  rethrowWithLastFailure: (pollError: unknown) => never;
+} {
+  // Boxed rather than a bare `unknown`, so a callback that rejects with
+  // `undefined` still counts as a failure.
+  let lastFailure: { error: unknown } | undefined;
+  return {
+    read: async () => {
+      try {
+        const value = await read();
+        lastFailure = undefined;
+        return value;
+      } catch (error) {
+        lastFailure = { error };
+        return undefined;
+      }
+    },
+    rethrowWithLastFailure: (pollError) => {
+      if (!lastFailure) {
+        throw pollError;
+      }
+
+      const explanation = [
+        "",
+        "The last poll attempt produced no value because the call itself",
+        "failed. That is usually a failed Playwright <-> Electron round trip",
+        "rather than app state:",
+        `  ${describePollFailure(lastFailure.error)}`,
+      ].join("\n");
+      if (pollError instanceof Error) {
+        // Appended in place: Playwright's own assertion error carries the
+        // matcher result and a stack its reporter formats, and rewrapping
+        // would trade both for a plain `Error`.
+        pollError.message += `\n${explanation}`;
+        throw pollError;
+      }
+
+      throw new Error(
+        `${describePollFailure(pollError)}\n${explanation}`,
+        { cause: lastFailure.error },
+      );
+    },
+  };
+}
+
+function describePollFailure(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-canary-report.test.ts
@@ -117,6 +117,27 @@ describe("desktop E2E pre-flight canary", () => {
     expect(message).not.toContain("60000ms");
   });
 
+  // The framing this replaced was binary: a timeout meant a sick guest and
+  // anything else meant a deterministic problem to fix in the branch. A
+  // transient Playwright round-trip failure is neither, and reading it as the
+  // second sent a whole investigation after a branch defect that did not
+  // exist.
+  it("names the transient round trip alongside the deterministic diagnosis", () => {
+    const message = describeCanaryFailure({
+      timeoutMs: 60_000,
+      runnerName: "some-runner",
+      detail:
+        "electronApplication.evaluate: Resulting promise was garbage collected",
+      timedOut: false,
+    });
+
+    expect(message).toContain("garbage collected");
+    expect(message).toContain("other lanes passed on this commit");
+    // The replaced text told the reader the error "is the actual problem",
+    // which is precisely wrong for a failed round trip.
+    expect(message).not.toContain("the actual problem");
+  });
+
   it("keeps the timeout narrative when the canary gave up waiting", () => {
     const message = describeCanaryFailure({
       timeoutMs: 60_000,

--- a/apps/desktop/src/main/__tests__/e2e-transient-rpc-poll.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-transient-rpc-poll.test.ts
@@ -1,0 +1,175 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { tolerateTransientRpcFailure } from "../../../e2e/fixtures/transient-rpc-poll";
+
+const e2eDir = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../e2e",
+);
+
+/**
+ * The error that motivated the helper, verbatim from
+ * "macOS Desktop E2E (lane 3 of 4)" in run 34654211530.
+ */
+const TRANSIENT_RPC_ERROR =
+  "electronApplication.evaluate: Resulting promise was garbage collected";
+
+/**
+ * Playwright's poll driver, reduced to the one detail that matters:
+ * `invokePollMatcher` awaits the callback OUTSIDE the try/catch that decides
+ * whether to keep polling. Reproduced rather than imported because
+ * `expect.poll` needs a Playwright test runner, and this is precisely the
+ * behavior the helper exists to work with — a test that polled some friendlier
+ * way would prove nothing.
+ */
+async function pollLikePlaywright<T>(params: {
+  attempts: number;
+  read: () => Promise<T>;
+  satisfied: (value: T) => boolean;
+}): Promise<void> {
+  let lastAssertionError: unknown;
+  for (let attempt = 0; attempt < params.attempts; attempt += 1) {
+    const value = await params.read();
+    try {
+      if (!params.satisfied(value)) {
+        throw new Error(`expected a satisfied value, received ${String(value)}`);
+      }
+      return;
+    } catch (error) {
+      // Keep polling, exactly as Playwright does for a failed assertion, and
+      // keep the error — a timed-out poll reports the last one.
+      lastAssertionError = error;
+    }
+  }
+
+  throw lastAssertionError ?? new Error("expected a satisfied value");
+}
+
+/** One transient round-trip failure, then the answer the poll waits for. */
+function oneFlakyRoundTrip(): () => Promise<boolean> {
+  let calls = 0;
+  return async () => {
+    calls += 1;
+    if (calls === 1) {
+      throw new Error(TRANSIENT_RPC_ERROR);
+    }
+    return true;
+  };
+}
+
+describe("tolerateTransientRpcFailure", () => {
+  // The defect, pinned first: without the wrapper a poll designed to retry
+  // gives up on its first tick. This is what killed an E2E shard, because the
+  // poll it happened to hit was on the launch path.
+  it("is needed because a rejected callback ends an unwrapped poll", async () => {
+    await expect(
+      pollLikePlaywright({
+        attempts: 5,
+        read: oneFlakyRoundTrip(),
+        satisfied: Boolean,
+      }),
+    ).rejects.toThrow(TRANSIENT_RPC_ERROR);
+  });
+
+  it("retries the failed round trip and reaches the awaited value", async () => {
+    const tolerated = tolerateTransientRpcFailure(oneFlakyRoundTrip());
+
+    await expect(
+      pollLikePlaywright({
+        attempts: 5,
+        read: tolerated.read,
+        satisfied: Boolean,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // Swallowing silently is the other way to get this wrong: a genuinely dead
+  // app would report "received undefined" at the deadline and never mention
+  // the RPC that never answered.
+  it("reports the retained call failure when the poll times out anyway", async () => {
+    const tolerated = tolerateTransientRpcFailure(async () => {
+      throw new Error(TRANSIENT_RPC_ERROR);
+    });
+    const pollError = await pollLikePlaywright({
+      attempts: 3,
+      read: tolerated.read,
+      satisfied: Boolean,
+    }).catch((error: unknown) => error);
+
+    expect(() => tolerated.rethrowWithLastFailure(pollError)).toThrow(
+      TRANSIENT_RPC_ERROR,
+    );
+    // Appended in place, so Playwright's own assertion error — its matcher
+    // result and its stack — survives to the reporter.
+    expect(pollError).toBeInstanceOf(Error);
+    expect((pollError as Error).message).toContain("received undefined");
+    expect((pollError as Error).message).toContain(TRANSIENT_RPC_ERROR);
+  });
+
+  it("keeps the cause when the poll rejected with something other than an Error", () => {
+    const tolerated = tolerateTransientRpcFailure(async () => {
+      throw TRANSIENT_RPC_ERROR;
+    });
+
+    return expect(tolerated.read())
+      .resolves.toBeUndefined()
+      .then(() => {
+        let thrown: unknown;
+        try {
+          tolerated.rethrowWithLastFailure("poll gave up");
+        } catch (error) {
+          thrown = error;
+        }
+        expect(thrown).toBeInstanceOf(Error);
+        expect((thrown as Error).message).toContain("poll gave up");
+        expect((thrown as Error).message).toContain(TRANSIENT_RPC_ERROR);
+        expect((thrown as Error).cause).toBe(TRANSIENT_RPC_ERROR);
+      });
+  });
+
+  // A poll that timed out against an app that answered every time is a real
+  // readiness failure. Blaming it on a blip from twenty attempts ago would
+  // send the reader after the wrong thing — the mirror image of the
+  // investigation this whole change came out of.
+  it("does not blame a stale failure once a call has answered", async () => {
+    const tolerated = tolerateTransientRpcFailure(oneFlakyRoundTrip());
+    await tolerated.read();
+    await tolerated.read();
+
+    const pollError = new Error("expected true, received false");
+    expect(() => tolerated.rethrowWithLastFailure(pollError)).toThrow(pollError);
+    expect(pollError.message).toBe("expected true, received false");
+  });
+});
+
+// Every `expect.poll` in these fixtures reads across the RPC boundary, so
+// every one of them needs the tolerance. Counting is what catches the case the
+// helper cannot: a NEW poll added later without it. If you add a poll here
+// whose callback cannot fail over the wire, that is what this failing is
+// telling you to justify.
+describe("desktop E2E fixture polls", () => {
+  for (const fixture of ["fixtures/electron-app.ts", "fixtures/star-map-window.ts"]) {
+    it(`routes every poll in ${fixture} through the RPC tolerance`, () => {
+      const code = readFixtureCode(fixture);
+      const polls = code.match(/\.poll\(/g) ?? [];
+      const rethrows = code.match(/rethrowWithLastFailure/g) ?? [];
+
+      expect(polls.length).toBeGreaterThan(0);
+      expect(rethrows.length).toBe(polls.length);
+      expect(code).toContain("tolerateTransientRpcFailure(");
+    });
+  }
+});
+
+/**
+ * Comments in these files legitimately DISCUSS the pattern being counted, so
+ * match against code only — the same reason `e2e-canary-report.test.ts`
+ * strips before asserting.
+ */
+function readFixtureCode(relativePath: string): string {
+  return readFileSync(path.join(e2eDir, relativePath), "utf8")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}

--- a/apps/desktop/src/main/__tests__/e2e-transient-rpc-poll.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-transient-rpc-poll.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -108,25 +108,78 @@ describe("tolerateTransientRpcFailure", () => {
     expect((pollError as Error).message).toContain(TRANSIENT_RPC_ERROR);
   });
 
-  it("keeps the cause when the poll rejected with something other than an Error", () => {
+  it("keeps the cause when the poll rejected with something other than an Error", async () => {
     const tolerated = tolerateTransientRpcFailure(async () => {
       throw TRANSIENT_RPC_ERROR;
     });
+    await expect(tolerated.read()).resolves.toBeUndefined();
 
-    return expect(tolerated.read())
-      .resolves.toBeUndefined()
-      .then(() => {
-        let thrown: unknown;
-        try {
-          tolerated.rethrowWithLastFailure("poll gave up");
-        } catch (error) {
-          thrown = error;
-        }
-        expect(thrown).toBeInstanceOf(Error);
-        expect((thrown as Error).message).toContain("poll gave up");
-        expect((thrown as Error).message).toContain(TRANSIENT_RPC_ERROR);
-        expect((thrown as Error).cause).toBe(TRANSIENT_RPC_ERROR);
-      });
+    const thrown = captureThrow(() =>
+      tolerated.rethrowWithLastFailure("poll gave up")
+    );
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toContain("poll gave up");
+    expect((thrown as Error).message).toContain(TRANSIENT_RPC_ERROR);
+    expect((thrown as Error).cause).toBe(TRANSIENT_RPC_ERROR);
+  });
+
+  // `cause` carries the frames; the appended message carries only the text,
+  // and a throw from inside the callback (not the wire) is the case that
+  // needs the throw site.
+  it("attaches the retained failure as the poll error's cause", async () => {
+    const callbackBug = new TypeError("cannot read properties of undefined");
+    const tolerated = tolerateTransientRpcFailure(async () => {
+      throw callbackBug;
+    });
+    await tolerated.read();
+
+    const pollError = new Error("expected true, received undefined");
+    expect(() => tolerated.rethrowWithLastFailure(pollError)).toThrow(pollError);
+    expect(pollError.cause).toBe(callbackBug);
+  });
+
+  // The viewport poll asserts with `toMatchObject`, which throws its own
+  // non-assertion error on an absent value rather than reporting a diff.
+  // Playwright catches that in the same try that handles a failed assertion,
+  // so the poll keeps going — the property that whole call site rests on.
+  it("keeps polling when the matcher throws on the absent value", async () => {
+    const tolerated = tolerateTransientRpcFailure(oneFlakyRoundTrip());
+
+    await expect(
+      pollLikePlaywright({
+        attempts: 5,
+        read: tolerated.read,
+        satisfied: (value) => {
+          if (value === undefined) {
+            // What jest's `toMatchObject` does with `undefined`.
+            throw new TypeError("received value must be a non-null object");
+          }
+          return value;
+        },
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  // A matcher `undefined` DOES satisfy would otherwise let a poll resolve on
+  // an attempt that never reached the app.
+  it("refuses to call a poll answered when its last call failed", async () => {
+    const tolerated = tolerateTransientRpcFailure(async () => {
+      throw new Error(TRANSIENT_RPC_ERROR);
+    });
+    await tolerated.read();
+
+    expect(() => tolerated.assertAnswered()).toThrow(
+      "matcher accepted was the absence of an answer",
+    );
+  });
+
+  it("calls a poll answered once a call has produced a value", async () => {
+    const tolerated = tolerateTransientRpcFailure(oneFlakyRoundTrip());
+    await tolerated.read();
+    await tolerated.read();
+
+    expect(() => tolerated.assertAnswered()).not.toThrow();
   });
 
   // A poll that timed out against an app that answered every time is a real
@@ -149,10 +202,28 @@ describe("tolerateTransientRpcFailure", () => {
 // helper cannot: a NEW poll added later without it. If you add a poll here
 // whose callback cannot fail over the wire, that is what this failing is
 // telling you to justify.
+//
+// The file list is DISCOVERED rather than written down. A hardcoded pair
+// covered the two files that had polls the day this was written and would have
+// let the next fixture's poll through unexamined, which is the whole failure
+// mode the guard exists for.
 describe("desktop E2E fixture polls", () => {
-  for (const fixture of ["fixtures/electron-app.ts", "fixtures/star-map-window.ts"]) {
-    it(`routes every poll in ${fixture} through the RPC tolerance`, () => {
-      const code = readFixtureCode(fixture);
+  const fixturesWithPolls = readdirSync(path.join(e2eDir, "fixtures"))
+    .filter((entry) => entry.endsWith(".ts"))
+    .map((entry) => ({ code: readFixtureCode(`fixtures/${entry}`), entry }))
+    .filter(({ code }) => code.includes(".poll("));
+
+  // A rename or a move that leaves the scan empty would otherwise pass as
+  // "nothing to check".
+  it("finds the fixtures that poll at all", () => {
+    expect(fixturesWithPolls.map(({ entry }) => entry).sort()).toEqual([
+      "electron-app.ts",
+      "star-map-window.ts",
+    ]);
+  });
+
+  for (const { code, entry } of fixturesWithPolls) {
+    it(`routes every poll in ${entry} through the RPC tolerance`, () => {
       const polls = code.match(/\.poll\(/g) ?? [];
       const rethrows = code.match(/rethrowWithLastFailure/g) ?? [];
 
@@ -162,6 +233,17 @@ describe("desktop E2E fixture polls", () => {
     });
   }
 });
+
+/** The error a function threw, for assertions about more than its message. */
+function captureThrow(act: () => void): unknown {
+  try {
+    act();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error("expected the call to throw");
+}
 
 /**
  * Comments in these files legitimately DISCUSS the pattern being counted, so


### PR DESCRIPTION
## The failure

A macOS E2E shard ran **zero tests** in [run 34654211530](https://github.com/pwrdrvr/PwrAgent/actions/runs/34654211530), lane 3 of 4:

```
Error: Desktop E2E pre-flight failed before any test ran.
  Runner: host_macos_stable_01
Underlying error: electronApplication.evaluate: Resulting promise was garbage collected
   at global-setup.ts:111
```

Nothing was wrong with the branch or the guest. Lanes 1, 2 and 4 passed the same commit; lane 4 ran on the **same runner**, starting at 22:32:27 — the second lane 3 ended — and passed. Lane 3 passed on retry.

## Root cause

`expect.poll` retries a failed **assertion**, not a throwing callback. In the installed Playwright 1.62.1, `invokePollMatcher` awaits the callback *outside* the try/catch that decides whether to keep polling:

```js
const value = await actual();          // <-- OUTSIDE the try
try {
  await callMatcherAsStep(...);
  return { continuePolling: false, result: void 0 };
} catch (error) {
  return { continuePolling: true, result: error };
}
```

`waitForRendererReady` polls the replay-driver global across the Electron RPC boundary, so `evaluate: Resulting promise was garbage collected` — a failed round trip, not app state — ended a loop built to be retried, on its first tick, with the whole deadline unspent. That poll is on the launch path: `finishElectronLaunch` threw, `launchElectronApp` closed the app (which is why a healthy `close-summary` line prints *before* the error in the job log), the pre-flight canary turned it into "zero tests ran", and every spec in the shard was gone.

## The fix

`e2e/fixtures/transient-rpc-poll.ts` — `tolerateTransientRpcFailure` wraps a poll callback so a rejection becomes a retried attempt on the normal interval, and **retains** the error so a poll that times out anyway still names the round trip that never answered instead of reporting a bare `received undefined`. A read that succeeds clears it, so a genuine readiness timeout is never blamed on a stale blip. Playwright's own assertion error is appended to in place, keeping its matcher result and stack for the reporter.

All four `expect.poll` callbacks in the E2E fixtures cross that boundary and are wrapped:

| Poll | Blast radius before |
|---|---|
| `waitForRendererReady` replay driver | the whole shard, via the canary |
| `applyRendererViewport` resize loop | the launch of every `windowSize` spec |
| `openStarMapWindow` preload bridge | the spec |
| `openStarMapWindow` native shown | the spec |

The replay-driver poll also gets a `message`, since its timeout previously read `expected true, received false` with no hint of what was not ready.

## Canary wording

The non-timeout narrative told the reader the error "is the actual problem", making every rejection deterministic and leaving no bucket for a transient RPC error — which is exactly what sent this investigation after a branch defect. It now names both kinds and says to check the other lanes first:

```
Two unlike things reject here, and they want opposite responses:

  - A harness DIAGNOSIS is deterministic: a missing onboarding seed, the
    first-run wizard holding the window. It names what to fix and will
    fail the same way on every lane and every runner.
  - A failed Playwright <-> Electron ROUND TRIP is not deterministic and
    diagnoses nothing. "Resulting promise was garbage collected" and
    "Target closed" describe the RPC, not the app. Observed here on
    2026-09-11: one lane died in pre-flight while the other three passed
    the same commit — one of them on the same runner, seconds later —
    and the failed lane passed on retry.

So before reading this as a branch defect, check whether the suite's
other lanes passed on this commit. If they did, retry this one.
```

## Verification

- `pnpm test` (793 files, 11394 tests), `pnpm typecheck`, `pnpm lint:eslint` (0 errors, 75 warnings — unchanged baseline), `lint:boundaries`, `lint:colors`, `lint:sql`, `lint:codex-storage`.
- New `src/main/__tests__/e2e-transient-rpc-poll.test.ts` (vitest, no Electron — `e2e/` is Playwright's `testDir`): covers the retry, the retained-failure report, the non-`Error` rejection, and the stale-failure case, driven through a loop shaped like Playwright's own poll driver. It also pins that every poll in those two fixtures stays wrapped; verified by mutation (deleting one `.catch` fails it).
- The real proof is the macOS lanes on this PR. No local desktop E2E was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
