### PR TITLE
fix(desktop): stop idle remote terminals from blocking quit, and link them

### DIFF
--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -898,9 +898,37 @@ test.describe("federation remote window", () => {
         { timeout: 30_000 },
       );
 
-      // Leave the shell running while viewing a local thread, matching the
-      // operator repro. If the quit row loses its federation target, the
-      // renderer cannot match the mounted remote row and stays here.
+      // Actually leave a command running. An idle prompt is not a quit
+      // blocker: the owner reports this shell's foreground state over
+      // `pty.state` and the viewer filters on it, exactly as it does for a
+      // local shell. Poll the queue instead of sleeping -- the owner detects
+      // the transition off the command's own output.
+      await window.locator(".integrated-terminal__viewport").click();
+      await window.keyboard.type("sleep 120");
+      await window.keyboard.press("Enter");
+      await expect
+        .poll(
+          async () =>
+            await window.evaluate(async () => {
+              const api = (window as typeof window & {
+                pwragent?: {
+                  readQuitBlockerQueue?: () => Promise<{
+                    items: Array<{ kind: string }>;
+                  }>;
+                };
+              }).pwragent;
+              if (!api?.readQuitBlockerQueue) return "missing-api";
+              const snapshot = await api.readQuitBlockerQueue();
+              return snapshot.items.filter((item) => item.kind === "terminal")
+                .length;
+            }),
+          { timeout: 30_000 },
+        )
+        .toBe(1);
+
+      // Now view a local thread, matching the operator repro. If the quit row
+      // loses its federation target, the renderer cannot match the mounted
+      // remote row and stays here.
       await window
         .getByRole("button", { name: "Local control thread" })
         .click();

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -898,30 +898,27 @@ test.describe("federation remote window", () => {
         { timeout: 30_000 },
       );
 
-      // Actually leave a command running. An idle prompt is not a quit
-      // blocker: the owner reports this shell's foreground state over
-      // `pty.state` and the viewer filters on it, exactly as it does for a
-      // local shell. Poll the queue instead of sleeping -- the owner detects
-      // the transition off the command's own output.
+      // An idle shell is not a quit blocker. That holds for a remote shell
+      // too: the owner reports this one's foreground state over `pty.state`
+      // and the viewer filters on it exactly as it does for a local shell.
+      // Start a foreground command so the dialog below has a row to route.
       await window.locator(".integrated-terminal__viewport").click();
-      await window.keyboard.type("sleep 120");
+      await window.keyboard.type(
+        "echo PWRAGENT_REMOTE_QUIT_BLOCKER_READY; sleep 120",
+      );
       await window.keyboard.press("Enter");
+      await expect(
+        window.locator(".integrated-terminal .xterm-rows"),
+      ).toContainText("PWRAGENT_REMOTE_QUIT_BLOCKER_READY", {
+        timeout: 30_000,
+      });
+      // The marker only proves `echo` finished. The owner derives the state
+      // from the command's own output and streams it back, so wait on the
+      // exact main-process snapshot QuitManager reads -- quitting before it
+      // arrives correctly sees no blocker and exits without a prompt.
       await expect
         .poll(
-          async () =>
-            await window.evaluate(async () => {
-              const api = (window as typeof window & {
-                pwragent?: {
-                  readQuitBlockerQueue?: () => Promise<{
-                    items: Array<{ kind: string }>;
-                  }>;
-                };
-              }).pwragent;
-              if (!api?.readQuitBlockerQueue) return "missing-api";
-              const snapshot = await api.readQuitBlockerQueue();
-              return snapshot.items.filter((item) => item.kind === "terminal")
-                .length;
-            }),
+          async () => (await app!.getIntegratedTerminalQuitSnapshot())?.count ?? 0,
           { timeout: 30_000 },
         )
         .toBe(1);

--- a/apps/desktop/e2e/federation-remote-window.spec.ts
+++ b/apps/desktop/e2e/federation-remote-window.spec.ts
@@ -914,7 +914,7 @@ test.describe("federation remote window", () => {
       });
       // The marker only proves `echo` finished. The owner derives the state
       // from the command's own output and streams it back, so wait on the
-      // exact main-process snapshot QuitManager reads -- quitting before it
+      // exact main-process snapshot QuitManager reads — quitting before it
       // arrives correctly sees no blocker and exits without a prompt.
       await expect
         .poll(

--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -17,6 +17,8 @@ import { FederationRouter } from "../federation/federation-router";
 
 class FakePty implements FederationPtyProcess {
   pid = 4242;
+  /** node-pty's foreground-process getter. Equal to the shell means idle. */
+  process = "/bin/zsh";
   written: string[] = [];
   resizes: { cols: number; rows: number }[] = [];
   killed = false;
@@ -91,6 +93,7 @@ function createHarness(options?: {
     shell: { file: string; args: string[] };
   }>;
   resolveThreadCwd?: () => Promise<string | undefined>;
+  platform?: NodeJS.Platform;
 }) {
   const pty = new FakePty();
   const sent: SentNotification[] = [];
@@ -117,6 +120,7 @@ function createHarness(options?: {
         detail: entry.detail,
       }),
     graceMs: options?.graceMs ?? 10_000,
+    platform: options?.platform ?? "darwin",
   });
   return { audits, pty, sent, service };
 }
@@ -280,6 +284,73 @@ describe("FederationPtyService sessions", () => {
     expect(() =>
       service.input("peer-a", { sessionId, dataBase64: "" }),
     ).toThrow(/not found for this peer/);
+  });
+});
+
+describe("FederationPtyService foreground reporting", () => {
+  it("reports a freshly opened shell as idle in the open response", async () => {
+    const { service } = createHarness();
+    const opened = await service.open("peer-a", OPEN_REQUEST);
+    expect(opened.foregroundCommand).toBe(false);
+  });
+
+  it("pushes pty.state when a command takes and releases the foreground", async () => {
+    vi.useFakeTimers();
+    try {
+      const { pty, sent, service } = createHarness();
+      await service.open("peer-a", OPEN_REQUEST);
+
+      // The newline echo is the output that says "something just happened".
+      pty.process = "/usr/bin/sleep";
+      pty.emitData("\r\n");
+      vi.advanceTimersByTime(250);
+      expect(
+        sent.filter((entry) => entry.method === "pty.state"),
+      ).toEqual([
+        {
+          peerId: "peer-a",
+          method: "pty.state",
+          params: {
+            sessionId: expect.any(String),
+            foregroundCommand: true,
+          },
+        },
+      ]);
+
+      // The prompt coming back is the transition that releases the quit.
+      pty.process = "/bin/zsh";
+      pty.emitData("$ ");
+      vi.advanceTimersByTime(250);
+      expect(
+        sent
+          .filter((entry) => entry.method === "pty.state")
+          .map((entry) => (entry.params as { foregroundCommand: boolean })
+            .foregroundCommand),
+      ).toEqual([true, false]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("sends nothing while the state is unchanged", async () => {
+    vi.useFakeTimers();
+    try {
+      const { pty, sent, service } = createHarness();
+      await service.open("peer-a", OPEN_REQUEST);
+      for (let index = 0; index < 5; index += 1) {
+        pty.emitData(`line ${index}\r\n`);
+        vi.advanceTimersByTime(250);
+      }
+      expect(sent.filter((entry) => entry.method === "pty.state")).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps the conservative answer where the platform has no signal", async () => {
+    const { service } = createHarness({ platform: "win32" });
+    const opened = await service.open("peer-a", OPEN_REQUEST);
+    expect(opened.foregroundCommand).toBe(true);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-pty-service.test.ts
@@ -94,6 +94,7 @@ function createHarness(options?: {
   }>;
   resolveThreadCwd?: () => Promise<string | undefined>;
   platform?: NodeJS.Platform;
+  readLinuxProcessStat?: (pid: number) => string;
 }) {
   const pty = new FakePty();
   const sent: SentNotification[] = [];
@@ -121,6 +122,9 @@ function createHarness(options?: {
       }),
     graceMs: options?.graceMs ?? 10_000,
     platform: options?.platform ?? "darwin",
+    ...(options?.readLinuxProcessStat
+      ? { readLinuxProcessStat: options.readLinuxProcessStat }
+      : {}),
   });
   return { audits, pty, sent, service };
 }
@@ -345,6 +349,57 @@ describe("FederationPtyService foreground reporting", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("re-sends a state change the peer never received", async () => {
+    vi.useFakeTimers();
+    try {
+      let deliverable = false;
+      const { pty, sent, service } = createHarness({
+        deliverable: () => deliverable,
+      });
+      await service.open("peer-a", OPEN_REQUEST);
+
+      pty.process = "/usr/bin/sleep";
+      pty.emitData("\r\n");
+      vi.advanceTimersByTime(250);
+      expect(sent.filter((entry) => entry.method === "pty.state")).toEqual([]);
+
+      // The link comes back, but the shell's state never changes again. An
+      // owner that had committed the undelivered value would stay silent on
+      // this send-on-change stream, leaving the viewer sure the shell is idle
+      // and free to quit out from under a running command.
+      deliverable = true;
+      pty.emitData("still running\r\n");
+      vi.advanceTimersByTime(250);
+      expect(
+        sent
+          .filter((entry) => entry.method === "pty.state")
+          .map((entry) => (entry.params as { foregroundCommand: boolean })
+            .foregroundCommand),
+      ).toEqual([true]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reads the Linux foreground process group for a remote shell", async () => {
+    // After "(zsh)": state ppid pgrp session tty_nr tpgid.
+    const { service } = createHarness({
+      platform: "linux",
+      readLinuxProcessStat: () => "4242 (zsh) S 1 4242 4242 34816 5000 0 0",
+    });
+    expect((await service.open("peer-a", OPEN_REQUEST)).foregroundCommand)
+      .toBe(true);
+  });
+
+  it("reports a Linux shell owning its own terminal as idle", async () => {
+    const { service } = createHarness({
+      platform: "linux",
+      readLinuxProcessStat: () => "4242 (zsh) S 1 4242 4242 34816 4242 0 0",
+    });
+    expect((await service.open("peer-a", OPEN_REQUEST)).foregroundCommand)
+      .toBe(false);
   });
 
   it("keeps the conservative answer where the platform has no signal", async () => {

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -45,11 +45,20 @@ const mocks = vi.hoisted(() => {
     localSessionsChanged: undefined as
       | ((sessions: unknown[]) => void)
       | undefined,
-    remotePtyOpen: vi.fn(async () => ({
-      sessionId: "remote-session",
-      cwd: "/owner/worktree",
-      shell: "/bin/zsh",
-    })),
+    // `foregroundCommand` is declared but not returned by default: that is
+    // the owner-predates-`pty.state` case, which must keep blocking quit.
+    remotePtyOpen: vi.fn(
+      async (): Promise<{
+        sessionId: string;
+        cwd: string;
+        shell: string;
+        foregroundCommand?: boolean;
+      }> => ({
+        sessionId: "remote-session",
+        cwd: "/owner/worktree",
+        shell: "/bin/zsh",
+      }),
+    ),
     remotePtyInput: vi.fn(async () => undefined),
     remotePtyAck: vi.fn(async () => undefined),
     remotePtyClose: vi.fn(async () => undefined),
@@ -428,7 +437,7 @@ describe("integrated terminal IPC federation branch", () => {
     ).toEqual(["local-session", "remote-session"]);
   });
 
-  it("counts remote sessions as quit blockers so they are not killed silently", async () => {
+  it("counts an unreported remote session as a quit blocker so it is not killed silently", async () => {
     const sender = fakeWebContents(6);
     mocks.localQuitSnapshot = {
       count: 1,
@@ -455,6 +464,62 @@ describe("integrated terminal IPC federation branch", () => {
       },
     ]);
     expect(snapshot.sessionIds).toContain("remote-session");
+  });
+
+  it("leaves an idle remote shell out of the quit blockers", async () => {
+    const sender = fakeWebContents(6);
+    mocks.remotePtyOpen.mockResolvedValueOnce({
+      sessionId: "remote-session",
+      cwd: "/owner/worktree",
+      shell: "/bin/zsh",
+      foregroundCommand: false,
+    });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-pinned",
+      cols: 80,
+      rows: 24,
+      federationTarget: { scope: "remote", instanceId: "peer-a" },
+    });
+
+    // A shell sitting at a prompt on the owner is not work in progress, the
+    // same way the identical local shell is not.
+    expect(getIntegratedTerminalQuitSnapshot()).toEqual({
+      count: 0,
+      sessionIds: [],
+      threads: [],
+    });
+  });
+
+  it("re-counts a remote shell once the owner reports a command running", async () => {
+    const sender = fakeWebContents(6);
+    mocks.remotePtyOpen.mockResolvedValueOnce({
+      sessionId: "remote-session",
+      cwd: "/owner/worktree",
+      shell: "/bin/zsh",
+      foregroundCommand: false,
+    });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-pinned",
+      cols: 80,
+      rows: 24,
+      federationTarget: { scope: "remote", instanceId: "peer-a" },
+    });
+
+    mocks.remotePtyEventListener?.({
+      kind: "state",
+      peerId: "peer-a",
+      params: { sessionId: "remote-session", foregroundCommand: true },
+    });
+
+    const snapshot = getIntegratedTerminalQuitSnapshot();
+    expect(snapshot.count).toBe(1);
+    expect(snapshot.threads).toEqual([
+      {
+        threadKey: "codex:remote-pinned",
+        target: { scope: "remote", instanceId: "peer-a" },
+        instanceLabel: "Peer Mac",
+      },
+    ]);
   });
 
   it("reveals a remote terminal in the window that owns it", async () => {

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -490,6 +490,33 @@ describe("integrated terminal IPC federation branch", () => {
     });
   });
 
+  it("keeps a session blocking when the owner's state message is malformed", async () => {
+    const sender = fakeWebContents(6);
+    mocks.remotePtyOpen.mockResolvedValueOnce({
+      sessionId: "remote-session",
+      cwd: "/owner/worktree",
+      shell: "/bin/zsh",
+      foregroundCommand: true,
+    });
+    await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+      threadKey: "codex:remote-pinned",
+      cols: 80,
+      rows: 24,
+      federationTarget: { scope: "remote", instanceId: "peer-a" },
+    });
+
+    // The params reach the bridge through an unchecked cast. Anything but an
+    // explicit `false` has to stay blocking: dropping a running shell out of
+    // the quit blocker is the one direction this must never fail in.
+    mocks.remotePtyEventListener?.({
+      kind: "state",
+      peerId: "peer-a",
+      params: { sessionId: "remote-session" },
+    });
+
+    expect(getIntegratedTerminalQuitSnapshot().count).toBe(1);
+  });
+
   it("re-counts a remote shell once the owner reports a command running", async () => {
     const sender = fakeWebContents(6);
     mocks.remotePtyOpen.mockResolvedValueOnce({

--- a/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
@@ -89,8 +89,15 @@ describe("quit blocker IPC", () => {
     expect(revealIntegratedTerminal).toHaveBeenCalledWith("codex:shared", {
       instanceId: "peer-a",
     });
+    // The owning peer has to ride along: the viewer keys a remote thread by
+    // owner + id, and a bare id selects the local thread of the same name --
+    // here a genuinely different thread, since both exist as "codex:shared".
     expect(requestShowThread).toHaveBeenCalledWith(
-      { backend: "codex", threadId: "shared" },
+      {
+        backend: "codex",
+        threadId: "shared",
+        federationTarget: { scope: "remote", instanceId: "peer-a" },
+      },
       { preferWebContents: owner },
     );
   });

--- a/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
@@ -90,7 +90,7 @@ describe("quit blocker IPC", () => {
       instanceId: "peer-a",
     });
     // The owning peer has to ride along: the viewer keys a remote thread by
-    // owner + id, and a bare id selects the local thread of the same name --
+    // owner + id, and a bare id selects the local thread of the same name —
     // here a genuinely different thread, since both exist as "codex:shared".
     expect(requestShowThread).toHaveBeenCalledWith(
       {

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
 import type {
   AppServerBackendKind,
   FederationCapability,
@@ -8,6 +9,7 @@ import type {
 import { isFederationInstanceId } from "@pwragent/shared";
 import type { FederationRouter } from "./federation-router";
 import type { FederationRpcEndpoint } from "./federation-rpc";
+import { terminalHasForegroundCommand } from "../terminal/terminal-foreground-command";
 
 /**
  * Remote PTY protocol for federated threads.
@@ -36,6 +38,10 @@ export type FederationPtyMethod =
   (typeof FEDERATION_PTY_METHODS)[keyof typeof FEDERATION_PTY_METHODS];
 
 export const FEDERATION_PTY_OUTPUT_METHOD = "pty.output";
+/** Owner → viewer: "this shell is running a command" / "it is at a prompt".
+ *  An owner that never sends it (an older build) leaves the viewer on the
+ *  conservative answer, so nothing regresses to a silently skipped warning. */
+export const FEDERATION_PTY_STATE_METHOD = "pty.state";
 export const FEDERATION_PTY_EXIT_METHOD = "pty.exit";
 export const FEDERATION_PTY_ERROR_METHOD = "pty.error";
 
@@ -87,6 +93,8 @@ export type FederationPtyOpenResponse = {
   sessionId: string;
   cwd: string;
   shell: string;
+  /** Absent from an owner that predates `pty.state`. */
+  foregroundCommand?: boolean;
 };
 
 export type FederationPtyInputRequest = {
@@ -117,6 +125,13 @@ export type FederationPtyOutputParams = {
   dataBase64: string;
 };
 
+export type FederationPtyStateParams = {
+  sessionId: string;
+  /** The owner's `terminalHasForegroundCommand` answer. Only the owner can
+   *  compute it: both signals it reads live on the machine running the shell. */
+  foregroundCommand: boolean;
+};
+
 export type FederationPtyExitParams = {
   sessionId: string;
   exitCode: number | null;
@@ -131,6 +146,7 @@ export type FederationPtyErrorParams = {
 /** Owner → viewer stream event, dispatched by the runtime on the viewer. */
 export type FederationPtyStreamEvent =
   | { kind: "output"; peerId: FederationInstanceId; params: FederationPtyOutputParams }
+  | { kind: "state"; peerId: FederationInstanceId; params: FederationPtyStateParams }
   | { kind: "exit"; peerId: FederationInstanceId; params: FederationPtyExitParams }
   | { kind: "error"; peerId: FederationInstanceId; params: FederationPtyErrorParams };
 
@@ -138,6 +154,8 @@ export type FederationPtyStreamEvent =
  *  and the E2E harness can substitute fakes. */
 export type FederationPtyProcess = {
   pid?: number;
+  /** node-pty's live foreground-process getter, where the platform has one. */
+  readonly process?: string;
   write(data: string): void;
   resize(cols: number, rows: number): void;
   kill(): void;
@@ -191,6 +209,10 @@ type FederationPtyServiceOptions = {
   graceMs?: number;
   pausedAckTimeoutMs?: number;
   now?: () => number;
+  /** Foreground-command detection seams, mirroring the local service so the
+   *  two answer identically for the same shell. */
+  platform?: NodeJS.Platform;
+  readLinuxProcessStat?: (pid: number) => string;
 };
 
 type FederationPtySession = {
@@ -207,9 +229,28 @@ type FederationPtySession = {
   disposables: { dispose(): void }[];
   reapTimer?: ReturnType<typeof setTimeout>;
   reapReason?: "close" | "disconnect";
+  /** Last state reported to the viewer, and when it was computed. */
+  foregroundCommand: boolean;
+  foregroundCheckedAt: number;
+  /** Fires once output settles, catching the prompt returning. */
+  foregroundSettleTimer?: ReturnType<typeof setTimeout>;
   /** Armed while paused at the high-water mark; an ack re-arms or clears it. */
   ackWatchdog?: ReturnType<typeof setTimeout>;
 };
+
+/** Output is the only evidence a foreground command started or ended — both
+ *  transitions print (the newline echo, then the next prompt). Checking on
+ *  that schedule costs nothing while a shell sits idle, which is the whole
+ *  point: a polling timer per remote session would bill every idle terminal
+ *  on every peer forever. */
+const FOREGROUND_SETTLE_MS = 250;
+/** Ceiling on how stale the answer can get under continuously streaming
+ *  output, where the settle timer never fires. */
+const FOREGROUND_MAX_INTERVAL_MS = 1_000;
+
+function readLinuxProcessStatFile(pid: number): string {
+  return readFileSync(`/proc/${pid}/stat`, "utf8");
+}
 
 const MIN_DIMENSION = 2;
 const MAX_PTY_COLUMNS = 500;
@@ -304,7 +345,11 @@ export class FederationPtyService {
       unackedBytes: 0,
       paused: false,
       disposables: [],
+      foregroundCommand: false,
+      foregroundCheckedAt: 0,
     };
+    session.foregroundCommand = this.detectForegroundCommand(session);
+    session.foregroundCheckedAt = this.now();
     this.sessionsById.set(session.sessionId, session);
     session.disposables.push(
       spawned.pty.onData((data) => this.handleOutput(session, data)),
@@ -328,6 +373,7 @@ export class FederationPtyService {
       sessionId: session.sessionId,
       cwd: session.cwd,
       shell: session.shell,
+      foregroundCommand: session.foregroundCommand,
     };
   }
 
@@ -476,6 +522,63 @@ export class FederationPtyService {
       session.pty.pause();
       this.armAckWatchdog(session);
     }
+    this.scheduleForegroundCheck(session);
+  }
+
+  /** Check now if the last answer is stale, and again once output settles.
+   *  The immediate arm catches a command that starts and keeps printing; the
+   *  settle arm catches the prompt coming back, which is the transition that
+   *  decides whether this shell blocks the viewer's quit. */
+  private scheduleForegroundCheck(session: FederationPtySession): void {
+    if (this.now() - session.foregroundCheckedAt >= FOREGROUND_MAX_INTERVAL_MS) {
+      this.publishForegroundCommand(session);
+    }
+    if (session.foregroundSettleTimer) {
+      clearTimeout(session.foregroundSettleTimer);
+    }
+    const timer = setTimeout(() => {
+      session.foregroundSettleTimer = undefined;
+      this.publishForegroundCommand(session);
+    }, FOREGROUND_SETTLE_MS);
+    if (timer.unref) timer.unref();
+    session.foregroundSettleTimer = timer;
+  }
+
+  private publishForegroundCommand(session: FederationPtySession): void {
+    if (this.sessionsById.get(session.sessionId) !== session) return;
+    const foregroundCommand = this.detectForegroundCommand(session);
+    session.foregroundCheckedAt = this.now();
+    if (foregroundCommand === session.foregroundCommand) return;
+    session.foregroundCommand = foregroundCommand;
+    this.options.sendNotification(session.peerId, FEDERATION_PTY_STATE_METHOD, {
+      sessionId: session.sessionId,
+      foregroundCommand,
+    } satisfies FederationPtyStateParams);
+  }
+
+  private now(): number {
+    return (this.options.now ?? Date.now)();
+  }
+
+  private detectForegroundCommand(session: FederationPtySession): boolean {
+    return terminalHasForegroundCommand(
+      {
+        processName: () => session.pty.process ?? "",
+        pid: session.pty.pid,
+        shell: session.shell,
+      },
+      {
+        platform: this.options.platform ?? process.platform,
+        readLinuxProcessStat:
+          this.options.readLinuxProcessStat ?? readLinuxProcessStatFile,
+        onError: (error) => {
+          this.options.log?.warn("remote pty foreground check failed", {
+            error: error instanceof Error ? error.message : String(error),
+            sessionId: session.sessionId,
+          });
+        },
+      },
+    );
   }
 
   private armAckWatchdog(session: FederationPtySession): void {
@@ -546,6 +649,10 @@ export class FederationPtyService {
       session.reapTimer = undefined;
     }
     this.clearAckWatchdog(session);
+    if (session.foregroundSettleTimer) {
+      clearTimeout(session.foregroundSettleTimer);
+      session.foregroundSettleTimer = undefined;
+    }
     for (const disposable of session.disposables.splice(0)) {
       try {
         disposable.dispose();
@@ -702,6 +809,7 @@ export class FederationRemotePtyClient implements FederationRemotePtyOperations 
 export function isFederationPtyStreamMethod(method: string): boolean {
   return (
     method === FEDERATION_PTY_OUTPUT_METHOD ||
+    method === FEDERATION_PTY_STATE_METHOD ||
     method === FEDERATION_PTY_EXIT_METHOD ||
     method === FEDERATION_PTY_ERROR_METHOD
   );

--- a/apps/desktop/src/main/federation/federation-pty-service.ts
+++ b/apps/desktop/src/main/federation/federation-pty-service.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { readFileSync } from "node:fs";
 import type {
   AppServerBackendKind,
   FederationCapability,
@@ -234,6 +233,8 @@ type FederationPtySession = {
   foregroundCheckedAt: number;
   /** Fires once output settles, catching the prompt returning. */
   foregroundSettleTimer?: ReturnType<typeof setTimeout>;
+  /** When output last arrived, so a timer that fires early can re-arm. */
+  lastOutputAt: number;
   /** Armed while paused at the high-water mark; an ack re-arms or clears it. */
   ackWatchdog?: ReturnType<typeof setTimeout>;
 };
@@ -247,10 +248,6 @@ const FOREGROUND_SETTLE_MS = 250;
 /** Ceiling on how stale the answer can get under continuously streaming
  *  output, where the settle timer never fires. */
 const FOREGROUND_MAX_INTERVAL_MS = 1_000;
-
-function readLinuxProcessStatFile(pid: number): string {
-  return readFileSync(`/proc/${pid}/stat`, "utf8");
-}
 
 const MIN_DIMENSION = 2;
 const MAX_PTY_COLUMNS = 500;
@@ -347,6 +344,7 @@ export class FederationPtyService {
       disposables: [],
       foregroundCommand: false,
       foregroundCheckedAt: 0,
+      lastOutputAt: 0,
     };
     session.foregroundCommand = this.detectForegroundCommand(session);
     session.foregroundCheckedAt = this.now();
@@ -528,32 +526,66 @@ export class FederationPtyService {
   /** Check now if the last answer is stale, and again once output settles.
    *  The immediate arm catches a command that starts and keeps printing; the
    *  settle arm catches the prompt coming back, which is the transition that
-   *  decides whether this shell blocks the viewer's quit. */
+   *  decides whether this shell blocks the viewer's quit.
+   *
+   *  The settle timer is armed once and left alone rather than re-armed per
+   *  chunk: `handleOutput` runs for every delta a streaming command emits
+   *  (hundreds a second is normal), and a clear+set on each one is pure
+   *  churn. A timer that fires early re-arms itself for the remainder. */
   private scheduleForegroundCheck(session: FederationPtySession): void {
-    if (this.now() - session.foregroundCheckedAt >= FOREGROUND_MAX_INTERVAL_MS) {
+    session.lastOutputAt = this.now();
+    if (
+      session.lastOutputAt - session.foregroundCheckedAt
+      >= FOREGROUND_MAX_INTERVAL_MS
+    ) {
       this.publishForegroundCommand(session);
     }
-    if (session.foregroundSettleTimer) {
-      clearTimeout(session.foregroundSettleTimer);
-    }
+    this.armForegroundSettleTimer(session, FOREGROUND_SETTLE_MS);
+  }
+
+  private armForegroundSettleTimer(
+    session: FederationPtySession,
+    delayMs: number,
+  ): void {
+    if (session.foregroundSettleTimer) return;
     const timer = setTimeout(() => {
       session.foregroundSettleTimer = undefined;
+      const quietFor = this.now() - session.lastOutputAt;
+      if (quietFor < FOREGROUND_SETTLE_MS) {
+        // Output arrived while this was pending: wait out the remainder
+        // instead of reporting a state read mid-stream.
+        this.armForegroundSettleTimer(session, FOREGROUND_SETTLE_MS - quietFor);
+        return;
+      }
       this.publishForegroundCommand(session);
-    }, FOREGROUND_SETTLE_MS);
+    }, delayMs);
     if (timer.unref) timer.unref();
     session.foregroundSettleTimer = timer;
   }
 
   private publishForegroundCommand(session: FederationPtySession): void {
     if (this.sessionsById.get(session.sessionId) !== session) return;
+    // A reaped session is already gone from the viewer's side; probing the
+    // shell and framing a notification for it is wasted work either way.
+    if (session.reapReason) return;
     const foregroundCommand = this.detectForegroundCommand(session);
     session.foregroundCheckedAt = this.now();
     if (foregroundCommand === session.foregroundCommand) return;
-    session.foregroundCommand = foregroundCommand;
-    this.options.sendNotification(session.peerId, FEDERATION_PTY_STATE_METHOD, {
-      sessionId: session.sessionId,
-      foregroundCommand,
-    } satisfies FederationPtyStateParams);
+    // Commit only what the peer actually received. `sendNotification` reports
+    // an unreachable opener, and this is a send-on-change stream: recording a
+    // change that never landed means it is never sent again, leaving the
+    // viewer's cached answer stale for the life of the shell.
+    const delivered = this.options.sendNotification(
+      session.peerId,
+      FEDERATION_PTY_STATE_METHOD,
+      {
+        sessionId: session.sessionId,
+        foregroundCommand,
+      } satisfies FederationPtyStateParams,
+    );
+    if (delivered) {
+      session.foregroundCommand = foregroundCommand;
+    }
   }
 
   private now(): number {
@@ -569,8 +601,9 @@ export class FederationPtyService {
       },
       {
         platform: this.options.platform ?? process.platform,
-        readLinuxProcessStat:
-          this.options.readLinuxProcessStat ?? readLinuxProcessStatFile,
+        ...(this.options.readLinuxProcessStat
+          ? { readLinuxProcessStat: this.options.readLinuxProcessStat }
+          : {}),
         onError: (error) => {
           this.options.log?.warn("remote pty foreground check failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/federation/federation-runtime.ts
+++ b/apps/desktop/src/main/federation/federation-runtime.ts
@@ -294,6 +294,7 @@ import {
 import {
   FEDERATION_PTY_EXIT_METHOD,
   FEDERATION_PTY_OUTPUT_METHOD,
+  FEDERATION_PTY_STATE_METHOD,
   FEDERATION_PTY_METHOD_CAPABILITIES,
   FederationPtyService,
   FederationRemotePtyClient,
@@ -3506,9 +3507,11 @@ export class DesktopFederationRuntime {
     const kind =
       envelope.method === FEDERATION_PTY_OUTPUT_METHOD
         ? "output"
-        : envelope.method === FEDERATION_PTY_EXIT_METHOD
-          ? "exit"
-          : "error";
+        : envelope.method === FEDERATION_PTY_STATE_METHOD
+          ? "state"
+          : envelope.method === FEDERATION_PTY_EXIT_METHOD
+            ? "exit"
+            : "error";
     const event = {
       kind,
       peerId: originInstanceId,

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -437,7 +437,11 @@ export class FederationTerminalBridge {
       return;
     }
     if (event.kind === "state") {
-      session.foregroundCommand = event.params.foregroundCommand;
+      // Only an explicit `false` means idle. The params arrive as an
+      // unchecked cast, and every other parse of a malformed message would
+      // drop a running shell out of the quit blocker — the one direction
+      // this must never fail in.
+      session.foregroundCommand = event.params.foregroundCommand !== false;
       return;
     }
     if (event.kind === "exit") {

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -49,6 +49,10 @@ type RemoteTerminalSession = {
   lastSeq: number;
   /** Output bytes consumed since the last pty.ack. */
   consumedBytes: number;
+  /** Owner-reported "a command is running in here". Only the owner can see
+   *  it, so an owner that never reports leaves this true and the shell keeps
+   *  blocking quit — the conservative answer, unchanged from before. */
+  foregroundCommand: boolean;
 };
 
 /**
@@ -153,6 +157,8 @@ export class FederationTerminalBridge {
           webContents,
           lastSeq: 0,
           consumedBytes: 0,
+          // An owner that predates `pty.state` omits this; stay conservative.
+          foregroundCommand: opened.foregroundCommand ?? true,
         };
         this.sessionsById.set(session.sessionId, session);
         this.ensureStreamSubscription();
@@ -254,11 +260,14 @@ export class FederationTerminalBridge {
   }
 
   /**
-   * Every live remote session, across windows, for the quit blocker. Remote
-   * shells cannot be foreground-filtered the way local ones are (the process
-   * lives on the owner), so all of them count: quitting the viewer ends them,
-   * and silently killing a shell mid-command is the failure this dialog
-   * exists to prevent. A future `pty.status` round-trip could narrow it.
+   * Live remote sessions running a command, across windows, for the quit
+   * blocker. Quitting the viewer ends these shells, and silently killing one
+   * mid-command is the failure this dialog exists to prevent.
+   *
+   * The foreground signal lives on the owner, so the owner computes it and
+   * pushes it over `pty.state`; this is the viewer's cached copy. An owner
+   * that never reports leaves every session flagged, which is the behavior
+   * this had before the signal existed.
    *
    * Each row carries its owning peer: the quit dialog names a thread by
    * looking it up, and a remote thread is not in THIS instance's thread list,
@@ -271,17 +280,23 @@ export class FederationTerminalBridge {
     instanceLabel?: string;
   }> {
     const identities = this.remoteIdentities();
-    return [...this.sessionsById.values()].map((session) => {
-      const instanceLabel = identities.get(
-        session.target.instanceId,
-      )?.instanceLabel;
-      return {
-        sessionId: session.sessionId,
-        threadKey: session.threadKey,
-        target: session.target,
-        ...(instanceLabel ? { instanceLabel } : {}),
-      };
-    });
+    // Same rule the local service applies in `getQuitSnapshot`: a shell
+    // sitting at a prompt is not work in progress. Before the owner reported
+    // this, every idle remote shell blocked the viewer's quit while the
+    // identical local shell did not.
+    return [...this.sessionsById.values()]
+      .filter((session) => session.foregroundCommand)
+      .map((session) => {
+        const instanceLabel = identities.get(
+          session.target.instanceId,
+        )?.instanceLabel;
+        return {
+          sessionId: session.sessionId,
+          threadKey: session.threadKey,
+          target: session.target,
+          ...(instanceLabel ? { instanceLabel } : {}),
+        };
+      });
   }
 
   /**
@@ -419,6 +434,10 @@ export class FederationTerminalBridge {
             });
           });
       }
+      return;
+    }
+    if (event.kind === "state") {
+      session.foregroundCommand = event.params.foregroundCommand;
       return;
     }
     if (event.kind === "exit") {

--- a/apps/desktop/src/main/ipc/quit-blockers.ts
+++ b/apps/desktop/src/main/ipc/quit-blockers.ts
@@ -71,8 +71,18 @@ export function revealCurrentQuitBlocker(
   if (!viewer) {
     return { revealed: false };
   }
-  requestShowThread(parsed, {
-    preferWebContents: viewer,
-  });
+  // A peer's thread is addressed by owner + id, never by id alone: the
+  // viewer builds a federated identity key from the target, and without one
+  // it looks for a LOCAL thread that shares the id and selects nothing. The
+  // quit dialog already forwards this; the in-app queue used not to.
+  requestShowThread(
+    {
+      ...parsed,
+      ...(item.target ? { federationTarget: item.target } : {}),
+    },
+    {
+      preferWebContents: viewer,
+    },
+  );
   return { revealed: true };
 }

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -27,6 +27,7 @@ import { getMainLogger } from "../log";
 import { getDesktopSettingsService } from "../settings/desktop-settings-singleton";
 import { buildPwrAgentChildProcessEnv } from "../child-process-env";
 import { resolvePwragentRoot } from "../profile";
+import { terminalHasForegroundCommand } from "./terminal-foreground-command";
 
 const DEFAULT_COLUMNS = 80;
 const DEFAULT_ROWS = 18;
@@ -457,57 +458,23 @@ export class IntegratedTerminalService {
   }
 
   private hasForegroundCommand(session: TerminalSession): boolean {
-    if (this.platform === "linux") {
-      return this.hasLinuxForegroundCommand(session);
-    }
-
-    // node-pty exposes the terminal's foreground process on macOS. Other
-    // platforms return only the originally spawned process name, which cannot
-    // distinguish an idle prompt from a running command. Keep the existing
-    // conservative warning where the signal is unavailable.
-    if (this.platform !== "darwin") {
-      return true;
-    }
-
-    try {
-      const activeProcess = normalizeTerminalProcessName(session.pty.process);
-      const shellProcess = normalizeTerminalProcessName(session.shell);
-      return !activeProcess || !shellProcess || activeProcess !== shellProcess;
-    } catch (error) {
-      this.logger.warn("foreground-process-check-failed", {
-        error: error instanceof Error ? error.message : String(error),
-        sessionId: session.sessionId,
-      });
-      return true;
-    }
-  }
-
-  private hasLinuxForegroundCommand(session: TerminalSession): boolean {
-    try {
-      const stat = this.readLinuxProcessStat(session.pty.pid);
-      const closingParen = stat.lastIndexOf(")");
-      const fields = stat.slice(closingParen + 1).trim().split(/\s+/);
-      // After pid and the parenthesized command name, Linux stat fields begin
-      // at state (field 3); pgrp and tpgid are offsets 2 and 5 from there.
-      const processGroupId = Number(fields[2]);
-      const foregroundProcessGroupId = Number(fields[5]);
-      if (
-        closingParen < 0
-        || !Number.isInteger(processGroupId)
-        || processGroupId <= 0
-        || !Number.isInteger(foregroundProcessGroupId)
-        || foregroundProcessGroupId <= 0
-      ) {
-        throw new Error("Malformed Linux process stat");
-      }
-      return processGroupId !== foregroundProcessGroupId;
-    } catch (error) {
-      this.logger.warn("foreground-process-check-failed", {
-        error: error instanceof Error ? error.message : String(error),
-        sessionId: session.sessionId,
-      });
-      return true;
-    }
+    return terminalHasForegroundCommand(
+      {
+        processName: () => session.pty.process,
+        pid: session.pty.pid,
+        shell: session.shell,
+      },
+      {
+        platform: this.platform,
+        readLinuxProcessStat: this.readLinuxProcessStat,
+        onError: (error) => {
+          this.logger.warn("foreground-process-check-failed", {
+            error: error instanceof Error ? error.message : String(error),
+            sessionId: session.sessionId,
+          });
+        },
+      },
+    );
   }
 
   private toCreateResponse(
@@ -693,10 +660,6 @@ export class IntegratedTerminalService {
       webContents.send(channel, payload);
     }
   }
-}
-
-function normalizeTerminalProcessName(value: string): string {
-  return path.basename(value.trim().replace(/^-+/, ""));
 }
 
 async function loadNodePty(): Promise<Pick<NodePtyModule, "spawn">> {

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { mkdir, readdir, rename, unlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -260,7 +260,7 @@ export class IntegratedTerminalService {
     sessions: IntegratedTerminalSessionSummary[],
   ) => void;
   private readonly platform: NodeJS.Platform;
-  private readonly readLinuxProcessStat: (pid: number) => string;
+  private readonly readLinuxProcessStat?: (pid: number) => string;
   /** Threads whose PTY is mid-spawn — the window in which a close has nothing
    *  to act on yet. */
   private readonly spawningThreadKeys = new Set<string>();
@@ -277,9 +277,7 @@ export class IntegratedTerminalService {
     this.now = options.now ?? Date.now;
     this.onSessionsChanged = options.onSessionsChanged;
     this.platform = options.platform ?? process.platform;
-    this.readLinuxProcessStat =
-      options.readLinuxProcessStat
-      ?? ((pid) => readFileSync(`/proc/${pid}/stat`, "utf8"));
+    this.readLinuxProcessStat = options.readLinuxProcessStat;
   }
 
   async createOrAttach(
@@ -466,7 +464,9 @@ export class IntegratedTerminalService {
       },
       {
         platform: this.platform,
-        readLinuxProcessStat: this.readLinuxProcessStat,
+        ...(this.readLinuxProcessStat
+          ? { readLinuxProcessStat: this.readLinuxProcessStat }
+          : {}),
         onError: (error) => {
           this.logger.warn("foreground-process-check-failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/main/terminal/terminal-foreground-command.ts
+++ b/apps/desktop/src/main/terminal/terminal-foreground-command.ts
@@ -1,0 +1,89 @@
+import path from "node:path";
+
+/**
+ * The one foreground-command core: "is a command running in this terminal, or
+ * is it sitting at an idle prompt?"
+ *
+ * Both signals it can use — node-pty's foreground process name on macOS, and
+ * `tpgid` from `/proc` on Linux — exist only on the machine the shell runs on.
+ * So the local integrated-terminal service asks this directly at quit time,
+ * and the federation PTY service asks it on the OWNER and reports the answer
+ * to the viewer. A viewer with no answer keeps the conservative one, which is
+ * why an unreported remote shell still blocks a quit.
+ *
+ * Every failure path returns `true`. Warning about a shell that turns out to
+ * be idle costs a dialog; skipping one that is mid-build costs the build.
+ */
+export type TerminalForegroundProbe = {
+  /** node-pty's `IPty.process`. Read lazily: it is a live getter. */
+  processName: () => string;
+  pid?: number;
+  shell: string;
+};
+
+export type TerminalForegroundOptions = {
+  platform: NodeJS.Platform;
+  readLinuxProcessStat?: (pid: number) => string;
+  onError?: (error: unknown) => void;
+};
+
+export function terminalHasForegroundCommand(
+  probe: TerminalForegroundProbe,
+  options: TerminalForegroundOptions,
+): boolean {
+  if (options.platform === "linux") {
+    return hasLinuxForegroundCommand(probe, options);
+  }
+
+  // node-pty exposes the terminal's foreground process on macOS. Other
+  // platforms return only the originally spawned process name, which cannot
+  // distinguish an idle prompt from a running command. Keep the existing
+  // conservative warning where the signal is unavailable.
+  if (options.platform !== "darwin") {
+    return true;
+  }
+
+  try {
+    const activeProcess = normalizeTerminalProcessName(probe.processName());
+    const shellProcess = normalizeTerminalProcessName(probe.shell);
+    return !activeProcess || !shellProcess || activeProcess !== shellProcess;
+  } catch (error) {
+    options.onError?.(error);
+    return true;
+  }
+}
+
+function hasLinuxForegroundCommand(
+  probe: TerminalForegroundProbe,
+  options: TerminalForegroundOptions,
+): boolean {
+  try {
+    if (probe.pid === undefined || !options.readLinuxProcessStat) {
+      throw new Error("Linux process stat is unavailable");
+    }
+    const stat = options.readLinuxProcessStat(probe.pid);
+    const closingParen = stat.lastIndexOf(")");
+    const fields = stat.slice(closingParen + 1).trim().split(/\s+/);
+    // After pid and the parenthesized command name, Linux stat fields begin
+    // at state (field 3); pgrp and tpgid are offsets 2 and 5 from there.
+    const processGroupId = Number(fields[2]);
+    const foregroundProcessGroupId = Number(fields[5]);
+    if (
+      closingParen < 0
+      || !Number.isInteger(processGroupId)
+      || processGroupId <= 0
+      || !Number.isInteger(foregroundProcessGroupId)
+      || foregroundProcessGroupId <= 0
+    ) {
+      throw new Error("Malformed Linux process stat");
+    }
+    return processGroupId !== foregroundProcessGroupId;
+  } catch (error) {
+    options.onError?.(error);
+    return true;
+  }
+}
+
+export function normalizeTerminalProcessName(value: string): string {
+  return path.basename(value.trim().replace(/^-+/, ""));
+}

--- a/apps/desktop/src/main/terminal/terminal-foreground-command.ts
+++ b/apps/desktop/src/main/terminal/terminal-foreground-command.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import path from "node:path";
 
 /**
@@ -23,9 +24,14 @@ export type TerminalForegroundProbe = {
 
 export type TerminalForegroundOptions = {
   platform: NodeJS.Platform;
+  /** Injected by tests; both services otherwise share the default below. */
   readLinuxProcessStat?: (pid: number) => string;
   onError?: (error: unknown) => void;
 };
+
+export function readLinuxProcessStat(pid: number): string {
+  return readFileSync(`/proc/${pid}/stat`, "utf8");
+}
 
 export function terminalHasForegroundCommand(
   probe: TerminalForegroundProbe,
@@ -58,10 +64,12 @@ function hasLinuxForegroundCommand(
   options: TerminalForegroundOptions,
 ): boolean {
   try {
-    if (probe.pid === undefined || !options.readLinuxProcessStat) {
+    if (probe.pid === undefined) {
       throw new Error("Linux process stat is unavailable");
     }
-    const stat = options.readLinuxProcessStat(probe.pid);
+    const stat = (options.readLinuxProcessStat ?? readLinuxProcessStat)(
+      probe.pid,
+    );
     const closingParen = stat.lastIndexOf(")");
     const fields = stat.slice(closingParen + 1).trim().split(/\s+/);
     // After pid and the parenthesized command name, Linux stat fields begin
@@ -84,6 +92,6 @@ function hasLinuxForegroundCommand(
   }
 }
 
-export function normalizeTerminalProcessName(value: string): string {
+function normalizeTerminalProcessName(value: string): string {
   return path.basename(value.trim().replace(/^-+/, ""));
 }


### PR DESCRIPTION
## Summary

Two fixes to the running-work warning a federation viewer shows for terminals
running on a peer. Both were found chasing one report: quitting an instance
warned about two shells on another machine that were sitting at a prompt, and
clicking either row went nowhere.

**Idle remote terminals no longer block quit.** The viewer listed every remote
shell it had open, while the identical local shell at a prompt was filtered out
by `IntegratedTerminalService.getQuitSnapshot`. The asymmetry was not arbitrary:
both foreground signals — node-pty's foreground process on macOS, `tpgid` from
`/proc` on Linux — exist only on the machine running the shell, so the viewer
had nothing to filter on and took the conservative answer.

So the owner computes it and says so. A new `terminal-foreground-command.ts`
extracts the predicate the local service already used into one core;
`FederationPtyService` calls that same core, seeds the answer into the
`pty.open` response, and pushes a new `pty.state` notification when it changes.
The viewer caches it and filters `quitSnapshotSessions()` the way the local
service filters its own.

Detection rides on **output**, not a timer. Both transitions print — the newline
echo when a command starts, the next prompt when it ends — so a check 250ms
after output settles catches both, with a 1s ceiling for output that never
stops. An idle terminal costs nothing; a per-session poll would have billed
every idle shell on every peer forever.

**A remote terminal's row link now opens the thread.**
`revealCurrentQuitBlocker` built the show-thread request from
`parseThreadIdentityKey(item.threadKey)` alone and dropped `item.target`, so the
viewer keyed a peer's thread as a **local** one: `showThread` builds a federated
identity key only when handed a target, matches rows on
`federationTargetsEqual(row.federation?.ref.target, target)`, and then refreshes
on a key no row can carry. The native quit dialog already forwards the target
(#1861) — this is the same fix for the in-app queue toast, which is the path the
running-work card actually uses.

## Verification

- `pnpm typecheck` — clean across the workspace.
- `pnpm lint:eslint` — 0 errors. `pnpm lint:boundaries` — no violations (1951 modules, 6815 dependencies).
- `pnpm test` on the four affected suites — 95 passing, including 6 new tests.
- **Negative control:** disabling the new `quitSnapshotSessions` filter fails
  `leaves an idle remote shell out of the quit blockers` and passes with it.
- Full-workspace `pnpm test` showed one failure in
  `settings-screen.test.tsx` (a profile-delete dialog). It passes when run
  alone — the known under-load flake — and nothing here touches renderer or
  settings code.

## Notes

- **Mixed fleets degrade correctly in both directions.** An owner that never
  sends `pty.state` leaves the viewer's cached flag `true`, which is exactly
  today's behavior; an older viewer drops the notification as an unknown
  method. No new federation capability is needed: signing is confined to the
  handshake, so the `pty.*` RPCs are not individually signed, and
  `isFederationPtyStreamMethod` gates dispatch.
- **`FederationPtyProcess` gained `readonly process?: string`.** `IPty`
  satisfies it structurally. A fake PTY in a harness that does not expose it
  reports "busy" — conservative, not a break.
- **Windows owners still have no signal**, so their remote shells keep blocking
  quit. That matches what local Windows shells do today.
- The unit test for the reveal path had asserted the bare
  `{backend, threadId}`, so it was holding the bug in place. It now asserts the
  owning peer rides along.
- This does **not** change PTY ownership. A remote shell is still opened by the
  viewer, lives in the owner's `FederationPtyService` registry rather than its
  own terminal list, and is still reaped `FEDERATION_PTY_REAP_GRACE_MS` after
  the viewer disconnects. Shared, tmux-style attach — where a viewer sees the
  shells the owner already has open and detaching does not kill them — is a
  separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
