### PR TITLE
refactor(desktop): make the terminal id a terminal's identity

### DIFF
--- a/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
+++ b/apps/desktop/e2e/quit-confirmation-dialog.spec.ts
@@ -92,6 +92,11 @@ test("keeps running work reachable after cancelling and following a blocker", as
       )
       .toBe(1);
 
+    // The row link has to name this exact shell, so hold on to its id.
+    const blockingSessionId =
+      (await app.getIntegratedTerminalQuitSnapshot())?.sessionIds[0];
+    expect(blockingSessionId).toBeTruthy();
+
     const dialogPromise = app.electronApp.waitForEvent("window");
     // Not awaited: the modal holds the main process, so this round trip does
     // not resolve until the prompt is answered.
@@ -121,7 +126,15 @@ test("keeps running work reachable after cancelling and following a blocker", as
     expect(rendered.summary).toBe("1 integrated terminal is running.");
     expect(rendered.groups).toEqual(["Integrated terminals"]);
     expect(rendered.rowCount).toBe(1);
-    expect(rendered.firstHref).toMatch(/\/show-thread\/codex%3A.+\/terminal$/);
+    // A terminal row addresses a terminal, not a thread — a thread can own
+    // several shells, and revealing the wrong one is the bug this encodes
+    // against. The segments after the kind are positional: the owning instance
+    // (empty for a local shell) and then the terminal's own id.
+    expect(rendered.firstHref).toMatch(
+      /\/show-thread\/codex%3A[^/]+\/terminal\/\/[^/]+$/,
+    );
+    expect(rendered.firstHref.endsWith(`/terminal//${blockingSessionId}`))
+      .toBe(true);
 
     // The countdown must still be RUNNING here. Things that merely LOOK like
     // engagement must not stop it: the Quit button's `autofocus` fires a

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -26,7 +26,9 @@ const mocks = vi.hoisted(() => {
     localWrite: vi.fn(),
     localClose: vi.fn(),
     localSetPanelHidden: vi.fn(),
-    localRevealSession: vi.fn(() => false),
+    localRevealSession: vi.fn(
+      (): { threadKey: string } | undefined => undefined,
+    ),
     federationWindowIds: new Set<number>(),
     federationTargets: new Map<number, { scope: "remote"; instanceId: string }>(),
     connectedPeers: [
@@ -39,7 +41,7 @@ const mocks = vi.hoisted(() => {
     localQuitSnapshot: {
       count: 0,
       sessionIds: [] as string[],
-      threads: [] as Array<{ threadKey: string }>,
+      threads: [] as Array<{ sessionId: string; threadKey: string }>,
     },
     channelSubscribers: [] as Array<{ id: number; send: (...args: unknown[]) => void }>,
     localSessionsChanged: undefined as
@@ -61,7 +63,11 @@ const mocks = vi.hoisted(() => {
     ),
     remotePtyInput: vi.fn(async () => undefined),
     remotePtyAck: vi.fn(async () => undefined),
-    remotePtyClose: vi.fn(async () => undefined),
+    // Typed params so an assertion can read back WHICH session was closed,
+    // not just that something was.
+    remotePtyClose: vi.fn(
+      async (_params: { sessionId: string }) => undefined,
+    ),
     remotePtyEventListener: undefined as
       | ((event: {
           kind: string;
@@ -180,7 +186,7 @@ describe("integrated terminal IPC federation branch", () => {
       },
     ];
     mocks.localQuitSnapshot = { count: 0, sessionIds: [], threads: [] };
-    mocks.localRevealSession.mockReturnValue(false);
+    mocks.localRevealSession.mockReturnValue(undefined);
     mocks.channelSubscribers = [];
     mocks.localSessionsChanged = undefined;
     disposeIntegratedTerminalIpcHandlers();
@@ -386,7 +392,7 @@ describe("integrated terminal IPC federation branch", () => {
     });
 
     await invoke(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL, sender, {
-      threadKey: "codex:remote-pinned",
+      sessionId: "remote-session",
       hidden: true,
     });
     expect(mocks.localSetPanelHidden).not.toHaveBeenCalled();
@@ -401,6 +407,89 @@ describe("integrated terminal IPC federation branch", () => {
     });
     expect(mocks.remotePtyClose).toHaveBeenCalledTimes(1);
     expect(mocks.localClose).not.toHaveBeenCalled();
+  });
+
+  // The viewer registry got the same treatment as the local one: a thread
+  // groups its remote terminals and no longer names one.
+  describe("several remote terminals on one thread", () => {
+    /** Two live remote terminals on `codex:remote-pinned` in one window. */
+    async function openTwo(sender: ReturnType<typeof fakeWebContents>) {
+      mocks.remotePtyOpen
+        .mockResolvedValueOnce({
+          sessionId: "remote-session-a",
+          cwd: "/owner/worktree",
+          shell: "/bin/zsh",
+        })
+        .mockResolvedValueOnce({
+          sessionId: "remote-session-b",
+          cwd: "/owner/worktree",
+          shell: "/bin/zsh",
+        });
+      const open = async (sessionId?: string) =>
+        await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
+          ...(sessionId ? { sessionId } : {}),
+          threadKey: "codex:remote-pinned",
+          cols: 80,
+          rows: 24,
+          federationTarget: { scope: "remote", instanceId: "peer-a" },
+        });
+      await open();
+      // An id the viewer does not hold opens a second shell on the owner. The
+      // owner still mints the id it answers to — the viewer's registry is
+      // keyed by the owner's, which is what `pty.attach` will have to name.
+      await open("not-a-live-terminal");
+      const sessions = (await invoke(
+        INTEGRATED_TERMINAL_LIST_CHANNEL,
+        sender,
+      )) as Array<{ sessionId: string }>;
+      expect(sessions.map((session) => session.sessionId)).toEqual([
+        "remote-session-a",
+        "remote-session-b",
+      ]);
+    }
+
+    it("closes one of them and leaves its sibling running", async () => {
+      const sender = fakeWebContents(7);
+      await openTwo(sender);
+
+      await invoke(INTEGRATED_TERMINAL_CLOSE_CHANNEL, sender, {
+        sessionId: "remote-session-b",
+      });
+
+      expect(mocks.remotePtyClose).toHaveBeenCalledTimes(1);
+      expect(mocks.remotePtyClose).toHaveBeenCalledWith({
+        sessionId: "remote-session-b",
+      });
+      const remaining = (await invoke(
+        INTEGRATED_TERMINAL_LIST_CHANNEL,
+        sender,
+      )) as Array<{ sessionId: string }>;
+      expect(remaining.map((session) => session.sessionId)).toEqual([
+        "remote-session-a",
+      ]);
+    });
+
+    // The thread key still means "every terminal this thread owns", which is
+    // what a pane whose create has not resolved can ask for.
+    it("closes every one of them when the request names the thread", async () => {
+      const sender = fakeWebContents(7);
+      await openTwo(sender);
+
+      await invoke(INTEGRATED_TERMINAL_CLOSE_CHANNEL, sender, {
+        threadKey: "codex:remote-pinned",
+      });
+
+      expect(
+        mocks.remotePtyClose.mock.calls.map((call) => call[0]),
+      ).toEqual([
+        { sessionId: "remote-session-a" },
+        { sessionId: "remote-session-b" },
+      ]);
+      expect(
+        ((await invoke(INTEGRATED_TERMINAL_LIST_CHANNEL, sender)) as unknown[])
+          .length,
+      ).toBe(0);
+    });
   });
 
   it("broadcasts local and remote sessions together to a main window", async () => {
@@ -442,7 +531,7 @@ describe("integrated terminal IPC federation branch", () => {
     mocks.localQuitSnapshot = {
       count: 1,
       sessionIds: ["local-session"],
-      threads: [{ threadKey: "codex:local-thread" }],
+      threads: [{ sessionId: "local-session", threadKey: "codex:local-thread" }],
     };
     await invoke(INTEGRATED_TERMINAL_CREATE_CHANNEL, sender, {
       threadKey: "codex:remote-pinned",
@@ -456,8 +545,9 @@ describe("integrated terminal IPC federation branch", () => {
     // The owning peer rides along: the quit dialog cannot name a remote
     // thread by asking the LOCAL thread list about it.
     expect(snapshot.threads).toEqual([
-      { threadKey: "codex:local-thread" },
+      { sessionId: "local-session", threadKey: "codex:local-thread" },
       {
+        sessionId: "remote-session",
         threadKey: "codex:remote-pinned",
         target: { scope: "remote", instanceId: "peer-a" },
         instanceLabel: "Peer Mac",
@@ -542,6 +632,7 @@ describe("integrated terminal IPC federation branch", () => {
     expect(snapshot.count).toBe(1);
     expect(snapshot.threads).toEqual([
       {
+        sessionId: "remote-session",
         threadKey: "codex:remote-pinned",
         target: { scope: "remote", instanceId: "peer-a" },
         instanceLabel: "Peer Mac",
@@ -564,11 +655,11 @@ describe("integrated terminal IPC federation branch", () => {
       rows: 24,
     });
     await invoke(INTEGRATED_TERMINAL_SET_PANEL_HIDDEN_CHANNEL, federationWindow, {
-      threadKey: "codex:remote-thread",
+      sessionId: "remote-session",
       hidden: true,
     });
 
-    const result = revealIntegratedTerminal("codex:remote-thread");
+    const result = revealIntegratedTerminal("remote-session");
 
     // Asking only the LOCAL PTY registry reported "no such session" and the
     // quit dialog's terminal row silently did nothing.
@@ -587,16 +678,17 @@ describe("integrated terminal IPC federation branch", () => {
     ).toHaveLength(0);
   });
 
-  it("reports nothing to reveal when no window owns the thread", async () => {
-    mocks.localRevealSession.mockReturnValue(false);
+  it("reports nothing to reveal when no window owns the terminal", async () => {
+    mocks.localRevealSession.mockReturnValue(undefined);
 
-    expect(revealIntegratedTerminal("codex:vanished").revealed).toBe(false);
+    expect(revealIntegratedTerminal("terminal-vanished").revealed).toBe(false);
   });
 
   // Remote mounts allocate a PTY per viewer window, so the same peer thread
-  // can be open twice. Reporting no owner would drop the caller back to the
-  // focused-or-first window, which is the bug the owner exists to avoid.
-  it("names an owner even when two windows host the same remote thread", async () => {
+  // open twice is two terminals with two ids. Addressing the id is what makes
+  // this answerable at all: by thread, the reveal had to pick one of the two
+  // windows and could only promise that its choice had the thread.
+  it("reveals the exact terminal when two windows host the same remote thread", async () => {
     const first = fakeWebContents(21);
     const second = fakeWebContents(22);
     for (const [id, sender] of [
@@ -617,15 +709,14 @@ describe("integrated terminal IPC federation branch", () => {
       });
     }
 
-    const result = revealIntegratedTerminal("codex:shared-thread");
-    expect(result.revealed).toBe(true);
-    expect([first, second]).toContain(result.owner);
+    expect(revealIntegratedTerminal("remote-session-21").owner).toBe(first);
+    expect(revealIntegratedTerminal("remote-session-22").owner).toBe(second);
   });
 
   // A local shell and a peer's shell can share a thread key. Naming the
   // instance must reach the peer's session, not the local registry.
   it("skips the local registry when the caller names an owning instance", async () => {
-    mocks.localRevealSession.mockReturnValue(true);
+    mocks.localRevealSession.mockReturnValue({ threadKey: "codex:shared-key" });
     const federationWindow = fakeWebContents(31);
     mocks.federationWindowIds.add(31);
     mocks.federationTargets.set(31, { scope: "remote", instanceId: "peer-a" });
@@ -635,7 +726,7 @@ describe("integrated terminal IPC federation branch", () => {
       rows: 24,
     });
 
-    const result = revealIntegratedTerminal("codex:shared-key", {
+    const result = revealIntegratedTerminal("remote-session", {
       instanceId: "peer-a",
     });
 
@@ -644,7 +735,7 @@ describe("integrated terminal IPC federation branch", () => {
 
     // ...and a different instance owns nothing here.
     expect(
-      revealIntegratedTerminal("codex:shared-key", { instanceId: "peer-b" })
+      revealIntegratedTerminal("remote-session", { instanceId: "peer-b" })
         .revealed,
     ).toBe(false);
   });

--- a/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-terminal-ipc.test.ts
@@ -469,6 +469,22 @@ describe("integrated terminal IPC federation branch", () => {
       ]);
     });
 
+    it("closes nothing when the named remote terminal is already gone", async () => {
+      const sender = fakeWebContents(7);
+      await openTwo(sender);
+
+      await invoke(INTEGRATED_TERMINAL_CLOSE_CHANNEL, sender, {
+        sessionId: "remote-session-that-exited",
+        threadKey: "codex:remote-pinned",
+      });
+
+      expect(mocks.remotePtyClose).not.toHaveBeenCalled();
+      expect(
+        ((await invoke(INTEGRATED_TERMINAL_LIST_CHANNEL, sender)) as unknown[])
+          .length,
+      ).toBe(2);
+    });
+
     // The thread key still means "every terminal this thread owns", which is
     // what a pane whose create has not resolved can ask for.
     it("closes every one of them when the request names the thread", async () => {

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -716,7 +716,9 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threads: [{ threadKey: "codex:thread-a" }],
+      threads: [
+        { sessionId: response.sessionId, threadKey: "codex:thread-a" },
+      ],
     });
   });
 
@@ -770,7 +772,9 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threads: [{ threadKey: "codex:thread-linux-pipeline" }],
+      threads: [
+        { sessionId: response.sessionId, threadKey: "codex:thread-linux-pipeline" },
+      ],
     });
   });
 
@@ -828,7 +832,9 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threads: [{ threadKey: "codex:thread-linux-lookup-failed" }],
+      threads: [
+        { sessionId: response.sessionId, threadKey: "codex:thread-linux-lookup-failed" },
+      ],
     });
   });
 
@@ -854,7 +860,9 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threads: [{ threadKey: "codex:thread-windows" }],
+      threads: [
+        { sessionId: response.sessionId, threadKey: "codex:thread-windows" },
+      ],
     });
   });
 
@@ -885,7 +893,9 @@ describe("resolveTerminalShell", () => {
     expect(service.getQuitSnapshot()).toEqual({
       count: 1,
       sessionIds: [response.sessionId],
-      threads: [{ threadKey: "codex:thread-lookup-failed" }],
+      threads: [
+        { sessionId: response.sessionId, threadKey: "codex:thread-lookup-failed" },
+      ],
     });
   });
 
@@ -933,7 +943,7 @@ describe("resolveTerminalShell", () => {
 
     // Collapsing the panel is a preference, not a teardown: the PTY lives on
     // and the flag is what lets the UI flag it as "running but hidden".
-    service.setPanelHidden({ threadKey: "codex:thread-a", hidden: true });
+    service.setPanelHidden({ sessionId: response.sessionId, hidden: true });
 
     expect(onSessionsChanged).toHaveBeenCalledTimes(2);
     expect(service.listSessions()[0]?.panelHidden).toBe(true);
@@ -952,11 +962,210 @@ describe("resolveTerminalShell", () => {
     expect(onSessionsChanged).toHaveBeenCalledTimes(2);
 
     // Showing a panel is an explicit act.
-    expect(service.revealSession("codex:thread-a")).toBe(true);
+    expect(service.revealSession(response.sessionId)).toEqual({
+      threadKey: "codex:thread-a",
+    });
     expect(service.listSessions()[0]?.panelHidden).toBe(false);
   });
 
-  it("refuses to reveal a thread with no live session", async () => {
+  // The point of the identity refactor. A thread key groups terminals; it no
+  // longer names one, and every operation below has to land on exactly the
+  // shell it addressed.
+  describe("several terminals on one thread", () => {
+    /** Two live terminals on `codex:thread-a`, oldest first. */
+    async function openTwoOnOneThread(
+      options: { ptyProcess?: string } = {},
+    ) {
+      // `sleep` rather than the shell: a shell sitting at its own prompt is
+      // filtered out of the quit snapshot, and one of the tests below needs
+      // both terminals to be work in progress.
+      const ptys = [
+        fakePty({ process: options.ptyProcess ?? "sh" }),
+        fakePty({ process: options.ptyProcess ?? "sh" }),
+      ];
+      let spawned = 0;
+      const service = new IntegratedTerminalService({
+        loadNodePty: async () => ({
+          spawn: vi.fn(() => ptys[spawned++]!) as unknown as typeof import("node-pty").spawn,
+        }),
+        platform: "darwin",
+      });
+      const first = await service.createOrAttach(
+        { threadKey: "codex:thread-a", cwd: os.tmpdir(), cols: 80, rows: 24 },
+        fakeWebContents(),
+      );
+      // A request naming an id main does not know spawns UNDER that id, which
+      // is how a caller gets a second shell on a thread that already has one.
+      const second = await service.createOrAttach(
+        {
+          sessionId: "terminal-2",
+          threadKey: "codex:thread-a",
+          cwd: os.tmpdir(),
+          cols: 80,
+          rows: 24,
+        },
+        fakeWebContents(),
+      );
+      expect(second.sessionId).toBe("terminal-2");
+      expect(service.listSessions()).toHaveLength(2);
+      return { first, ptys, second, service };
+    }
+
+    it("spawns a second shell for a thread that already has one", async () => {
+      const { first, second, service } = await openTwoOnOneThread();
+
+      expect(first.sessionId).not.toBe(second.sessionId);
+      expect(
+        service.listSessions().map((session) => session.threadKey),
+      ).toEqual(["codex:thread-a", "codex:thread-a"]);
+    });
+
+    // A request with no id still means "this thread's terminal", which is what
+    // keeps the Star Map window and the thread view on one shell.
+    it("attaches an id-less request to the thread's oldest terminal", async () => {
+      const { first, service } = await openTwoOnOneThread();
+
+      const reattached = await service.createOrAttach(
+        { threadKey: "codex:thread-a", cwd: os.tmpdir(), cols: 80, rows: 24 },
+        fakeWebContents(),
+      );
+
+      expect(reattached.sessionId).toBe(first.sessionId);
+      expect(service.listSessions()).toHaveLength(2);
+    });
+
+    it("collapses one terminal's panel and leaves its sibling showing", async () => {
+      const { first, second, service } = await openTwoOnOneThread();
+
+      service.setPanelHidden({ sessionId: second.sessionId, hidden: true });
+
+      const hiddenBySession = new Map(
+        service
+          .listSessions()
+          .map((session) => [session.sessionId, session.panelHidden]),
+      );
+      expect(hiddenBySession.get(first.sessionId)).toBe(false);
+      expect(hiddenBySession.get(second.sessionId)).toBe(true);
+    });
+
+    it("closes one terminal and leaves the rest of the thread running", async () => {
+      const { ptys, second, service } = await openTwoOnOneThread();
+
+      service.close({ sessionId: second.sessionId });
+
+      expect(ptys[0]?.kill).not.toHaveBeenCalled();
+      expect(ptys[1]?.kill).toHaveBeenCalledTimes(1);
+    });
+
+    // The thread view's close button says "put this thread's terminal away",
+    // and a pane whose create has not resolved has no id to name.
+    it("closes every terminal the thread owns when the request names the thread", async () => {
+      const { ptys, service } = await openTwoOnOneThread();
+
+      service.close({ threadKey: "codex:thread-a" });
+
+      expect(ptys[0]?.kill).toHaveBeenCalledTimes(1);
+      expect(ptys[1]?.kill).toHaveBeenCalledTimes(1);
+    });
+
+    // Two shells holding up the quit are two rows. Keyed by thread they
+    // collapsed into one, and the dialog under-reported what it was about to
+    // kill.
+    it("reports each of a thread's terminals as its own quit blocker", async () => {
+      const { first, second, service } = await openTwoOnOneThread({
+        ptyProcess: "sleep",
+      });
+
+      const snapshot = service.getQuitSnapshot();
+
+      expect(snapshot.count).toBe(2);
+      expect(
+        [...snapshot.threads].map((thread) => thread.sessionId).sort(),
+      ).toEqual([first.sessionId, second.sessionId].sort());
+      expect(
+        snapshot.threads.every(
+          (thread) => thread.threadKey === "codex:thread-a",
+        ),
+      ).toBe(true);
+    });
+
+    it("refuses to attach a terminal that belongs to a different thread", async () => {
+      const { second, service } = await openTwoOnOneThread();
+
+      // A pane holding a stale id must not be handed another thread's shell:
+      // it would show one thread's output and send its keystrokes there.
+      await expect(
+        service.createOrAttach(
+          {
+            sessionId: second.sessionId,
+            threadKey: "codex:thread-b",
+            cwd: os.tmpdir(),
+            cols: 80,
+            rows: 24,
+          },
+          fakeWebContents(),
+        ),
+      ).rejects.toThrow(/different thread/);
+    });
+  });
+
+  // Two of a thread's terminals spawning at once, and a close for one of
+  // them. Keyed by thread the queued close could not tell them apart and
+  // killed both — a shell the user never dismissed, dying because a sibling
+  // was dismissed while both were still starting.
+  it("honors a close for the terminal still spawning and spares its sibling", async () => {
+    // Distinct pids so the assertion can correlate a pty back to the terminal
+    // it was spawned for, rather than assuming which spawn won the race.
+    const ptys = [fakePty({ pid: 101 }), fakePty({ pid: 102 })];
+    let spawned = 0;
+    let releaseSpawn: () => void = () => undefined;
+    const spawnGate = new Promise<void>((resolve) => {
+      releaseSpawn = resolve;
+    });
+    const service = new IntegratedTerminalService({
+      loadNodePty: async () => {
+        await spawnGate;
+        return {
+          spawn: vi.fn(() => ptys[spawned++]!) as unknown as typeof import("node-pty").spawn,
+        };
+      },
+    });
+
+    const survivor = service.createOrAttach(
+      {
+        sessionId: "terminal-1",
+        threadKey: "codex:thread-a",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+    const dismissed = service.createOrAttach(
+      {
+        sessionId: "terminal-2",
+        threadKey: "codex:thread-a",
+        cwd: os.tmpdir(),
+        cols: 80,
+        rows: 24,
+      },
+      fakeWebContents(),
+    );
+
+    service.close({ sessionId: "terminal-2" });
+    releaseSpawn();
+    await Promise.all([survivor, dismissed]);
+
+    const sessionIdByPid = new Map(
+      service.listSessions().map((session) => [session.pid, session.sessionId]),
+    );
+    const killedIds = ptys
+      .filter((pty) => vi.mocked(pty.kill).mock.calls.length > 0)
+      .map((pty) => sessionIdByPid.get(pty.pid));
+    expect(killedIds).toEqual(["terminal-2"]);
+  });
+
+  it("refuses to reveal a terminal that is no longer live", async () => {
     const service = new IntegratedTerminalService({
       loadNodePty: async () => ({
         spawn: vi.fn(() => fakePty()) as unknown as typeof import("node-pty").spawn,
@@ -966,7 +1175,7 @@ describe("resolveTerminalShell", () => {
     // The quit dialog can sit open long after its snapshot was taken, so a
     // listed shell may already have exited. Revealing anyway made the renderer
     // open a panel for a session-less thread, which spawned a brand-new shell.
-    expect(service.revealSession("codex:thread-gone")).toBe(false);
+    expect(service.revealSession("terminal-gone")).toBeUndefined();
     expect(service.listSessions()).toEqual([]);
   });
 

--- a/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
+++ b/apps/desktop/src/main/__tests__/integrated-terminal-service.test.ts
@@ -1089,6 +1089,42 @@ describe("resolveTerminalShell", () => {
       ).toBe(true);
     });
 
+    // The one operation an operator triggers by hand from the quit dialog,
+    // and the only one whose scoping was not pinned anywhere.
+    it("reveals the terminal it names and leaves its sibling collapsed", async () => {
+      const { first, second, service } = await openTwoOnOneThread();
+      service.setPanelHidden({ sessionId: first.sessionId, hidden: true });
+      service.setPanelHidden({ sessionId: second.sessionId, hidden: true });
+
+      expect(service.revealSession(second.sessionId)).toEqual({
+        threadKey: "codex:thread-a",
+      });
+
+      const hiddenBySession = new Map(
+        service
+          .listSessions()
+          .map((session) => [session.sessionId, session.panelHidden]),
+      );
+      expect(hiddenBySession.get(second.sessionId)).toBe(false);
+      expect(hiddenBySession.get(first.sessionId)).toBe(true);
+    });
+
+    // An id names one shell. A request whose id has already exited means
+    // "that one is gone" — widening to the thread would take the operator's
+    // other terminals down with a close they never issued.
+    it("closes nothing when the named terminal is already gone", async () => {
+      const { ptys, service } = await openTwoOnOneThread();
+
+      service.close({
+        sessionId: "terminal-that-exited",
+        threadKey: "codex:thread-a",
+      });
+
+      expect(ptys[0]?.kill).not.toHaveBeenCalled();
+      expect(ptys[1]?.kill).not.toHaveBeenCalled();
+      expect(service.listSessions()).toHaveLength(2);
+    });
+
     it("refuses to attach a terminal that belongs to a different thread", async () => {
       const { second, service } = await openTwoOnOneThread();
 

--- a/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-blockers-ipc.test.ts
@@ -61,12 +61,14 @@ describe("quit blocker IPC", () => {
           backend: "codex",
           threadId: "shared",
           threadKey: "codex:shared",
+          sessionId: "term-local",
         },
         {
           kind: "terminal",
           backend: "codex",
           threadId: "shared",
           threadKey: "codex:shared",
+          sessionId: "term-remote",
           target: { scope: "remote", instanceId: "peer-a" },
         },
       ],
@@ -81,12 +83,13 @@ describe("quit blocker IPC", () => {
         {
           kind: "terminal",
           threadKey: "codex:shared",
+          sessionId: "term-remote",
           target: { scope: "remote", instanceId: "peer-a" },
         },
         sender,
       ),
     ).toEqual({ revealed: true });
-    expect(revealIntegratedTerminal).toHaveBeenCalledWith("codex:shared", {
+    expect(revealIntegratedTerminal).toHaveBeenCalledWith("term-remote", {
       instanceId: "peer-a",
     });
     // The owning peer has to ride along: the viewer keys a remote thread by

--- a/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-confirmation-dialog.test.ts
@@ -472,6 +472,7 @@ describe("clicking a quit dialog row", () => {
       backend: "codex",
       threadId: "0f9c2b7a-remote",
       threadKey: "codex:0f9c2b7a-remote",
+      sessionId: "term-remote",
       target: { scope: "remote", instanceId: "peer-a" },
     };
     const pending = showQuitConfirmationDialog({
@@ -485,10 +486,11 @@ describe("clicking a quit dialog row", () => {
 
     clickRow(window, formatQuitItemAction(item));
 
-    expect(revealIntegratedTerminal).toHaveBeenCalledWith(
-      "codex:0f9c2b7a-remote",
-      { instanceId: "peer-a" },
-    );
+    // The terminal, not the thread: the row the operator clicked names one
+    // shell, and the peer can be running several on this thread.
+    expect(revealIntegratedTerminal).toHaveBeenCalledWith("term-remote", {
+      instanceId: "peer-a",
+    });
     // The dialog is what has focus, so requestShowThread would otherwise fall
     // back to whichever window subscribed first — for a peer's terminal that
     // is a window with no such thread.
@@ -517,6 +519,7 @@ describe("clicking a quit dialog row", () => {
       backend: "codex",
       threadId: "local-thread",
       threadKey: "codex:local-thread",
+      sessionId: "term-local",
     };
     const pending = showQuitConfirmationDialog({
       countdownSeconds: 10,
@@ -529,10 +532,9 @@ describe("clicking a quit dialog row", () => {
 
     clickRow(window, formatQuitItemAction(item));
 
-    expect(revealIntegratedTerminal).toHaveBeenCalledWith(
-      "codex:local-thread",
-      {},
-    );
+    // The instance slot is written empty rather than omitted, so this local
+    // terminal's id survives the round trip as an id and not as a peer.
+    expect(revealIntegratedTerminal).toHaveBeenCalledWith("term-local", {});
     expect(requestShowThread).toHaveBeenCalledWith(
       { backend: "codex", threadId: "local-thread" },
       { preferWebContents: undefined },

--- a/apps/desktop/src/main/__tests__/quit-manager.test.ts
+++ b/apps/desktop/src/main/__tests__/quit-manager.test.ts
@@ -356,7 +356,7 @@ describe("createQuitManager", () => {
           inProgressThreads: { count: 0, threadIds: [] },
           terminalSessions: {
             count: 1,
-            threads: [{ threadKey: "codex:thread-1" }],
+            threads: [{ sessionId: "term-1", threadKey: "codex:thread-1" }],
           },
         }),
       resolveThreadTitles: async () =>
@@ -395,6 +395,7 @@ describe("createQuitManager", () => {
             count: 1,
             threads: [
               {
+                sessionId: "term-remote",
                 threadKey: "codex:0f9c2b7a-remote",
                 target,
                 instanceLabel: "Studio Mac",
@@ -443,7 +444,7 @@ describe("createQuitManager", () => {
           inProgressThreads: { count: 0, threadIds: [] },
           terminalSessions: {
             count: 1,
-            threads: [{ threadKey: "codex:thread-1" }],
+            threads: [{ sessionId: "term-1", threadKey: "codex:thread-1" }],
           },
         }),
       resolveThreadTitles: async () => {
@@ -464,6 +465,7 @@ describe("createQuitManager", () => {
             backend: "codex",
             threadId: "thread-1",
             threadKey: "codex:thread-1",
+            sessionId: "term-1",
           },
         ],
       }),
@@ -585,7 +587,7 @@ describe("buildQuitBlockerSnapshot", () => {
       inProgressThreads: { count: 1, threadIds: ["codex:thread-turn"] },
       terminalSessions: {
         count: 1,
-        threads: [{ threadKey: "acp:grok:thread-term" }],
+        threads: [{ sessionId: "term-1", threadKey: "acp:grok:thread-term" }],
       },
       actionRuns: [
         {
@@ -615,6 +617,7 @@ describe("buildQuitBlockerSnapshot", () => {
         backend: "acp:grok",
         threadId: "thread-term",
         threadKey: "acp:grok:thread-term",
+        sessionId: "term-1",
       },
       {
         kind: "action",
@@ -665,8 +668,9 @@ describe("buildQuitBlockerSnapshot", () => {
       terminalSessions: {
         count: 2,
         threads: [
-          { threadKey: "codex:local-thread" },
+          { sessionId: "term-local", threadKey: "codex:local-thread" },
           {
+            sessionId: "term-remote",
             threadKey: "codex:remote-thread",
             target: { scope: "remote", instanceId: "peer-a" },
             instanceLabel: "Studio Mac",
@@ -683,12 +687,14 @@ describe("buildQuitBlockerSnapshot", () => {
         backend: "codex",
         threadId: "local-thread",
         threadKey: "codex:local-thread",
+        sessionId: "term-local",
       },
       {
         kind: "terminal",
         backend: "codex",
         threadId: "remote-thread",
         threadKey: "codex:remote-thread",
+        sessionId: "term-remote",
         target: { scope: "remote", instanceId: "peer-a" },
         // The peer's name is the only thing distinguishing this row from a
         // local shell on a thread with the same key.

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -100,9 +100,17 @@ export class FederationTerminalBridge {
       throw new Error("A thread key is required to start a remote terminal.");
     }
     // Reattach before target resolution so a pane remount never needs to
-    // re-supply the target it created with.
-    const existing = this.sessionForThread(webContents, threadKey);
+    // re-supply the target it created with. A pane that already holds an id
+    // names its own shell; without one, "this thread's terminal" is the
+    // oldest the window owns.
+    const requestedId = request.sessionId?.trim();
+    const existing = requestedId
+      ? this.ownedSession(webContents, requestedId)
+      : this.sessionsForThread(webContents, threadKey)[0];
     if (existing) {
+      if (existing.threadKey !== threadKey) {
+        throw new Error("That terminal belongs to a different thread.");
+      }
       return this.toCreateResponse(existing);
     }
     const target = this.requireTarget(webContents, request);
@@ -205,14 +213,17 @@ export class FederationTerminalBridge {
   }
 
   close(request: IntegratedTerminalCloseRequest, webContents: WebContents): void {
-    const session =
-      (request.sessionId
-        ? this.ownedSession(webContents, request.sessionId)
-        : undefined) ??
-      (request.threadKey
-        ? this.sessionForThread(webContents, request.threadKey)
-        : undefined);
-    if (!session) {
+    const byId = request.sessionId
+      ? this.ownedSession(webContents, request.sessionId)
+      : undefined;
+    // Mirrors the local service: a thread key closes every terminal the
+    // thread owns in this window, an id closes exactly one.
+    const sessions = byId
+      ? [byId]
+      : request.threadKey
+        ? this.sessionsForThread(webContents, request.threadKey.trim())
+        : [];
+    if (sessions.length === 0) {
       // Nothing registered yet. If the open is still in flight, mark it so
       // the session is closed the moment it exists instead of the close
       // being silently lost.
@@ -226,24 +237,28 @@ export class FederationTerminalBridge {
       }
       return;
     }
-    this.dropSession(session);
+    for (const session of sessions) {
+      this.dropSession(session);
+    }
     this.broadcastSessions(webContents);
-    void getDesktopFederationRuntime()
-      .remotePty(session.target)
-      .close({ sessionId: session.sessionId })
-      .catch((error) => {
-        // The owner's disconnect reap covers an undeliverable close.
-        log.warn("remote terminal close failed", {
-          error: error instanceof Error ? error.message : String(error),
+    for (const session of sessions) {
+      void getDesktopFederationRuntime()
+        .remotePty(session.target)
+        .close({ sessionId: session.sessionId })
+        .catch((error) => {
+          // The owner's disconnect reap covers an undeliverable close.
+          log.warn("remote terminal close failed", {
+            error: error instanceof Error ? error.message : String(error),
+          });
         });
-      });
+    }
   }
 
   setPanelHidden(
     request: IntegratedTerminalSetPanelHiddenRequest,
     webContents: WebContents,
   ): void {
-    const session = this.sessionForThread(webContents, request.threadKey);
+    const session = this.ownedSession(webContents, request.sessionId);
     if (!session || session.panelHidden === request.hidden) return;
     session.panelHidden = request.hidden;
     this.broadcastSessions(webContents);
@@ -300,30 +315,35 @@ export class FederationTerminalBridge {
   }
 
   /**
-   * Un-hide a remote thread's terminal panel and report the windows that host
-   * it. The local PTY registry knows nothing about these sessions, so asking
-   * only it — as the quit dialog's row link once did — reports "no such
-   * session" for every shell running on a peer and reveals nothing.
+   * Un-hide one remote terminal's panel and report the window that hosts it.
+   * The local PTY registry knows nothing about these sessions, so asking only
+   * it — as the quit dialog's row link once did — reports "no such session"
+   * for every shell running on a peer and reveals nothing.
+   *
+   * Remote mounts allocate a PTY per viewer window, so one thread open in two
+   * windows is two terminals with two ids. Addressing the id therefore lands
+   * on the shell whose row the operator actually clicked, where addressing
+   * the thread used to reveal both and then guess which window to navigate.
    */
-  revealSession(threadKey: string, instanceId?: string): WebContents[] {
-    const owners: WebContents[] = [];
-    for (const session of this.sessionsById.values()) {
-      if (session.threadKey !== threadKey || session.webContents.isDestroyed()) {
-        continue;
-      }
-      // Two instances can hold the same `backend:threadId`. When the caller
-      // knows which one it means, honor it rather than revealing a shell on
-      // the wrong machine.
-      if (instanceId && session.target.instanceId !== instanceId) {
-        continue;
-      }
-      if (session.panelHidden) {
-        session.panelHidden = false;
-        this.broadcastSessions(session.webContents);
-      }
-      owners.push(session.webContents);
+  revealSession(
+    sessionId: string,
+    instanceId?: string,
+  ): { threadKey: string; owner: WebContents } | undefined {
+    const session = this.sessionsById.get(sessionId);
+    if (!session || session.webContents.isDestroyed()) {
+      return undefined;
     }
-    return owners;
+    // Two instances can hold the same `backend:threadId`. When the caller
+    // knows which one it means, honor it rather than revealing a shell on
+    // the wrong machine.
+    if (instanceId && session.target.instanceId !== instanceId) {
+      return undefined;
+    }
+    if (session.panelHidden) {
+      session.panelHidden = false;
+      this.broadcastSessions(session.webContents);
+    }
+    return { threadKey: session.threadKey, owner: session.webContents };
   }
 
   dispose(): void {
@@ -392,7 +412,7 @@ export class FederationTerminalBridge {
   hasThreadSession(webContents: WebContents, threadKey: string): boolean {
     const trimmed = threadKey.trim();
     return (
-      this.sessionForThread(webContents, trimmed) !== undefined
+      this.sessionsForThread(webContents, trimmed).length > 0
       || this.pendingOpens.has(this.pendingKey(webContents, trimmed))
     );
   }
@@ -496,13 +516,14 @@ export class FederationTerminalBridge {
     return session && session.webContents === webContents ? session : undefined;
   }
 
-  private sessionForThread(
+  /** This window's remote terminals for one thread, oldest first. */
+  private sessionsForThread(
     webContents: WebContents,
     threadKey: string,
-  ): RemoteTerminalSession | undefined {
-    return this.sessionsForWindow(webContents).find(
-      (session) => session.threadKey === threadKey,
-    );
+  ): RemoteTerminalSession[] {
+    return this.sessionsForWindow(webContents)
+      .filter((session) => session.threadKey === threadKey)
+      .sort((left, right) => left.createdAt - right.createdAt);
   }
 
   private sessionsForWindow(webContents: WebContents): RemoteTerminalSession[] {

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -506,6 +506,15 @@ export class FederationTerminalBridge {
     });
   }
 
+  /**
+   * In-flight opens stay THREAD-keyed even though a thread now owns several
+   * terminals: the owner mints the id, so a viewer has nothing else to name a
+   * terminal by until its open resolves. The cost is that two id-less opens on
+   * one thread in one window collapse into a single shell — right for "attach
+   * to this thread's terminal", wrong for "give me another one". No caller can
+   * ask for the second today (a window renders one pane per thread), so a tab
+   * strip that does has to carry its own intent here.
+   */
   private pendingKey(webContents: WebContents, threadKey: string): string {
     return `${webContents.id}:${threadKey}`;
   }

--- a/apps/desktop/src/main/ipc/federation-terminal.ts
+++ b/apps/desktop/src/main/ipc/federation-terminal.ts
@@ -25,6 +25,7 @@ import {
   FEDERATION_PTY_ACK_INTERVAL_BYTES,
   type FederationPtyStreamEvent,
 } from "../federation/federation-pty-service";
+import { terminalsForThread } from "../terminal/integrated-terminal-service";
 import { getDesktopFederationRuntime } from "../federation/federation-runtime";
 import { getMainLogger } from "../log";
 import { federationWindowTargetForWebContents } from "../window";
@@ -213,21 +214,22 @@ export class FederationTerminalBridge {
   }
 
   close(request: IntegratedTerminalCloseRequest, webContents: WebContents): void {
-    const byId = request.sessionId
-      ? this.ownedSession(webContents, request.sessionId)
-      : undefined;
     // Mirrors the local service: a thread key closes every terminal the
-    // thread owns in this window, an id closes exactly one.
-    const sessions = byId
-      ? [byId]
+    // thread owns in this window, an id closes exactly one — and an id that
+    // names nothing live closes nothing, rather than widening to the thread
+    // and dropping shells the caller never named.
+    const sessions = request.sessionId
+      ? toRemoteTargets(this.ownedSession(webContents, request.sessionId))
       : request.threadKey
         ? this.sessionsForThread(webContents, request.threadKey.trim())
         : [];
     if (sessions.length === 0) {
       // Nothing registered yet. If the open is still in flight, mark it so
       // the session is closed the moment it exists instead of the close
-      // being silently lost.
-      if (request.threadKey) {
+      // being silently lost. Only for a close that named no terminal: a
+      // caller holding an id already had its open resolve, so an in-flight
+      // one on the same thread belongs to a different pane.
+      if (request.threadKey && !request.sessionId) {
         const pending = this.pendingOpens.get(
           this.pendingKey(webContents, request.threadKey.trim()),
         );
@@ -521,9 +523,7 @@ export class FederationTerminalBridge {
     webContents: WebContents,
     threadKey: string,
   ): RemoteTerminalSession[] {
-    return this.sessionsForWindow(webContents)
-      .filter((session) => session.threadKey === threadKey)
-      .sort((left, right) => left.createdAt - right.createdAt);
+    return terminalsForThread(this.sessionsForWindow(webContents), threadKey);
   }
 
   private sessionsForWindow(webContents: WebContents): RemoteTerminalSession[] {
@@ -649,6 +649,13 @@ export function sortSessionsByCreatedAt(
   sessions: IntegratedTerminalSessionSummary[],
 ): IntegratedTerminalSessionSummary[] {
   return [...sessions].sort((left, right) => left.createdAt - right.createdAt);
+}
+
+/** `[value]`, or `[]` for a lookup that found nothing. */
+function toRemoteTargets(
+  session: RemoteTerminalSession | undefined,
+): RemoteTerminalSession[] {
+  return session ? [session] : [];
 }
 
 function trimBufferedOutput(value: string): string {

--- a/apps/desktop/src/main/ipc/integrated-terminal.ts
+++ b/apps/desktop/src/main/ipc/integrated-terminal.ts
@@ -20,7 +20,7 @@ import type {
 } from "../../shared/integrated-terminal";
 import { isRemoteFederationTarget } from "@pwragent/shared";
 import {
-  byThreadKey,
+  byQuitTerminal,
   IntegratedTerminalService,
 } from "../terminal/integrated-terminal-service";
 import type { IntegratedTerminalQuitSnapshot } from "../terminal/integrated-terminal-service";
@@ -167,7 +167,7 @@ export function registerIntegratedTerminalIpcHandlers(): void {
     (event, request: IntegratedTerminalSetPanelHiddenRequest): void => {
       if (
         isFederationWindowWebContents(event.sender)
-        || federationBridge?.hasThreadSession(event.sender, request.threadKey)
+        || federationBridge?.hasSession(event.sender, request.sessionId)
       ) {
         federationBridge?.setPanelHidden(request, event.sender);
         return;
@@ -219,13 +219,14 @@ export function getIntegratedTerminalQuitSnapshot(): IntegratedTerminalQuitSnaps
     threads: [
       ...local.threads,
       ...remote.map((session) => ({
+        sessionId: session.sessionId,
         threadKey: session.threadKey,
         target: session.target,
         ...(session.instanceLabel
           ? { instanceLabel: session.instanceLabel }
           : {}),
       })),
-    ].sort(byThreadKey),
+    ].sort(byQuitTerminal),
   };
 }
 
@@ -254,19 +255,25 @@ export type IntegratedTerminalRevealResult = {
  * fresh quit blocker, conjured by trying to look at one.
  */
 export function revealIntegratedTerminal(
-  threadKey: string,
+  sessionId: string,
   options: { instanceId?: string } = {},
 ): IntegratedTerminalRevealResult {
   // A caller naming an instance means a peer's shell, and the local registry
   // can only answer for this machine — checking it first would reveal a local
-  // terminal that happens to share the thread key.
-  if (!options.instanceId && service?.revealSession(threadKey)) {
+  // terminal that happens to share the id.
+  const local = options.instanceId
+    ? undefined
+    : service?.revealSession(sessionId);
+  if (local) {
     // A local session is hosted by whichever windows show the thread, so the
     // broadcast is the routing.
     for (const webContents of subscribersForChannel(
       INTEGRATED_TERMINAL_REVEAL_CHANNEL,
     )) {
-      webContents.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, { threadKey });
+      webContents.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, {
+        sessionId,
+        threadKey: local.threadKey,
+      });
     }
     return { revealed: true };
   }
@@ -274,16 +281,13 @@ export function revealIntegratedTerminal(
   // window, or a main window showing a pinned remote thread. Telling every
   // window to open a terminal panel for it would ask windows that do not have
   // the thread to do something they cannot.
-  const owners =
-    federationBridge?.revealSession(threadKey, options.instanceId) ?? [];
-  if (owners.length === 0) {
+  const remote = federationBridge?.revealSession(sessionId, options.instanceId);
+  if (!remote) {
     return { revealed: false };
   }
-  for (const webContents of owners) {
-    webContents.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, { threadKey });
-  }
-  // Remote mounts allocate a PTY per viewer window, so the same thread can be
-  // open in more than one. Any of them demonstrably has the thread, which is
-  // more than the focused-or-first fallback can promise.
-  return { revealed: true, owner: owners[0] };
+  remote.owner.send(INTEGRATED_TERMINAL_REVEAL_CHANNEL, {
+    sessionId,
+    threadKey: remote.threadKey,
+  });
+  return { revealed: true, owner: remote.owner };
 }

--- a/apps/desktop/src/main/ipc/quit-blockers.ts
+++ b/apps/desktop/src/main/ipc/quit-blockers.ts
@@ -51,8 +51,8 @@ export function revealCurrentQuitBlocker(
   if (!parsed) {
     return { revealed: false };
   }
-  const terminal = item.kind === "terminal"
-    ? revealIntegratedTerminal(item.threadKey, {
+  const terminal = item.kind === "terminal" && item.sessionId
+    ? revealIntegratedTerminal(item.sessionId, {
         ...(item.target
           ? { instanceId: item.target.instanceId }
           : {}),

--- a/apps/desktop/src/main/quit-confirmation-dialog.ts
+++ b/apps/desktop/src/main/quit-confirmation-dialog.ts
@@ -345,8 +345,8 @@ export async function showQuitConfirmationDialog(
           // through to whichever window subscribed first — which for a
           // peer's thread is a window that never mounted it.
           const revealed =
-            target.kind === "terminal"
-              ? revealIntegratedTerminal(target.threadKey, {
+            target.kind === "terminal" && target.sessionId
+              ? revealIntegratedTerminal(target.sessionId, {
                   ...(target.instanceId
                     ? { instanceId: target.instanceId }
                     : {}),
@@ -500,24 +500,36 @@ const QUIT_ITEM_GROUPS: ReadonlyArray<{
  * the same action and the click cannot tell them apart.
  */
 export function formatQuitItemAction(item: QuitBlockerItem): string {
+  // Positional, so the instance slot is written EMPTY rather than omitted
+  // when a terminal id follows it — otherwise a local terminal's id lands in
+  // the instance slot and the click looks for that shell on a peer.
   const segments = [
     "show-thread",
     encodeURIComponent(item.threadKey),
     encodeURIComponent(item.kind),
+    item.target ? encodeURIComponent(item.target.instanceId) : "",
+    item.sessionId ? encodeURIComponent(item.sessionId) : "",
   ];
-  if (item.target) {
-    segments.push(encodeURIComponent(item.target.instanceId));
+  // Trailing empties carry nothing. Dropping them keeps every row that has no
+  // terminal id encoding exactly as it did before terminals grew one.
+  while (segments.length > 3 && segments[segments.length - 1] === "") {
+    segments.pop();
   }
   return segments.join("/");
 }
 
-export function parseQuitItemAction(
-  action: string,
-): { threadKey: string; kind: string; instanceId?: string } | undefined {
+export function parseQuitItemAction(action: string):
+  | {
+      threadKey: string;
+      kind: string;
+      instanceId?: string;
+      sessionId?: string;
+    }
+  | undefined {
   if (!action.startsWith("show-thread/")) {
     return undefined;
   }
-  const [, encodedThreadKey, encodedKind, encodedInstanceId] =
+  const [, encodedThreadKey, encodedKind, encodedInstanceId, encodedSessionId] =
     action.split("/");
   if (!encodedThreadKey) {
     return undefined;
@@ -526,10 +538,14 @@ export function parseQuitItemAction(
     const instanceId = encodedInstanceId
       ? decodeURIComponent(encodedInstanceId)
       : undefined;
+    const sessionId = encodedSessionId
+      ? decodeURIComponent(encodedSessionId)
+      : undefined;
     return {
       threadKey: decodeURIComponent(encodedThreadKey),
       kind: decodeURIComponent(encodedKind ?? ""),
       ...(instanceId ? { instanceId } : {}),
+      ...(sessionId ? { sessionId } : {}),
     };
   } catch {
     return undefined;

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -319,7 +319,12 @@ export function buildQuitBlockerSnapshot(params: {
   const terminalThreads = [...params.terminalSessions.threads].sort(
     byQuitTerminal,
   );
-  const terminalThreadKeys = terminalThreads.map((thread) => thread.threadKey);
+  // One entry per THREAD, as the name promises. A thread blocking quit with
+  // two shells is two rows in `items`, but repeating its key here would read
+  // as a duplicate-key bug in the log line this feeds.
+  const terminalThreadKeys = [
+    ...new Set(terminalThreads.map((thread) => thread.threadKey)),
+  ];
   const actionRuns = params.actionRuns ?? [];
   const automationRuns = params.inProgressThreads.automationRuns ?? [];
   const subAgentThreadKeys = new Set(

--- a/apps/desktop/src/main/quit-manager.ts
+++ b/apps/desktop/src/main/quit-manager.ts
@@ -19,7 +19,7 @@ import { getDesktopFederationRuntime } from "./federation/federation-runtime";
 import { getIntegratedTerminalQuitSnapshot } from "./ipc/integrated-terminal";
 import { getMainLogger } from "./log";
 import {
-  byThreadKey,
+  byQuitTerminal,
   type IntegratedTerminalQuitThread,
 } from "./terminal/integrated-terminal-service";
 import { getDesktopSettingsService } from "./settings/desktop-settings-singleton";
@@ -316,7 +316,9 @@ export function buildQuitBlockerSnapshot(params: {
   actionRuns?: DetachedCommandSummary[];
 }): QuitBlockerSnapshot {
   const threadIds = [...params.inProgressThreads.threadIds].sort();
-  const terminalThreads = [...params.terminalSessions.threads].sort(byThreadKey);
+  const terminalThreads = [...params.terminalSessions.threads].sort(
+    byQuitTerminal,
+  );
   const terminalThreadKeys = terminalThreads.map((thread) => thread.threadKey);
   const actionRuns = params.actionRuns ?? [];
   const automationRuns = params.inProgressThreads.automationRuns ?? [];
@@ -348,6 +350,7 @@ export function buildQuitBlockerSnapshot(params: {
       kind: "terminal" as const,
       ...splitQuitThreadKey(thread.threadKey),
       threadKey: thread.threadKey,
+      sessionId: thread.sessionId,
       ...(thread.target ? { target: thread.target } : {}),
       // The peer's name is what separates this row from a local shell; the
       // title alone reads as though the work is on this machine.

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -215,6 +215,8 @@ type DestroyablePty = IPty & {
  * their own sidebar is already showing.
  */
 export type IntegratedTerminalQuitThread = {
+  /** Which shell. A thread can hold up the quit with more than one. */
+  sessionId: string;
   threadKey: string;
   /** Absent for a shell running on this machine. */
   target?: FederationRemoteTarget;
@@ -233,13 +235,21 @@ export type IntegratedTerminalQuitSnapshot = {
  * became objects. `localeCompare` would reorder around the `:` and `-` that
  * fill thread keys depending on the host locale, which is not something a
  * quit dialog's row order should depend on.
+ *
+ * Ties break on the terminal id. Thread keys stopped being unique when a
+ * thread gained the ability to own several shells, and a comparator that
+ * reports 0 for two distinct rows leaves their order up to whichever sort the
+ * host happens to implement.
  */
-export function byThreadKey(
-  left: { threadKey: string },
-  right: { threadKey: string },
+export function byQuitTerminal(
+  left: IntegratedTerminalQuitThread,
+  right: IntegratedTerminalQuitThread,
 ): number {
-  if (left.threadKey === right.threadKey) return 0;
-  return left.threadKey < right.threadKey ? -1 : 1;
+  if (left.threadKey !== right.threadKey) {
+    return left.threadKey < right.threadKey ? -1 : 1;
+  }
+  if (left.sessionId === right.sessionId) return 0;
+  return left.sessionId < right.sessionId ? -1 : 1;
 }
 
 type IntegratedTerminalServiceOptions = {
@@ -252,7 +262,12 @@ type IntegratedTerminalServiceOptions = {
 
 export class IntegratedTerminalService {
   private readonly logger = getMainLogger("pwragent:integrated-terminal");
-  private readonly sessionsByThread = new Map<string, TerminalSession>();
+  /**
+   * The registry, and the only one. There used to be a parallel
+   * `sessionsByThread` map, which made the thread key the terminal's identity
+   * and capped a thread at one shell as a side effect of how it was stored.
+   * Threads group terminals now; they do not name them.
+   */
   private readonly sessionsById = new Map<string, TerminalSession>();
   private readonly loadNodePty: () => Promise<Pick<NodePtyModule, "spawn">>;
   private readonly now: () => number;
@@ -261,11 +276,12 @@ export class IntegratedTerminalService {
   ) => void;
   private readonly platform: NodeJS.Platform;
   private readonly readLinuxProcessStat?: (pid: number) => string;
-  /** Threads whose PTY is mid-spawn — the window in which a close has nothing
-   *  to act on yet. */
-  private readonly spawningThreadKeys = new Set<string>();
+  /** Terminals mid-spawn, by id, with the thread each belongs to — the window
+   *  in which a close has nothing to act on yet. The thread is kept because a
+   *  close can still only name one when the pane has yet to learn its id. */
+  private readonly spawningThreadKeyBySessionId = new Map<string, string>();
   /** Closes that arrived during that window, to be honored on spawn. */
-  private readonly pendingCloseThreadKeys = new Set<string>();
+  private readonly pendingCloseSessionIds = new Set<string>();
   /** One `destroyed` listener per WebContents, not per session — 10 terminals
    *  in one window used to install 10 and trip Node's max-listeners warning. */
   private readonly subscribedWebContents = new Set<WebContents>();
@@ -289,8 +305,18 @@ export class IntegratedTerminalService {
       throw new Error("A thread key is required to start a terminal.");
     }
 
-    const existing = this.sessionsByThread.get(threadKey);
+    const requestedId = request.sessionId?.trim();
+    const existing = requestedId
+      ? this.sessionsById.get(requestedId)
+      : this.sessionsForThread(threadKey)[0];
     if (existing) {
+      if (existing.threadKey !== threadKey) {
+        // The id outlived the pane that held it and now names some other
+        // thread's shell. Attaching would show one thread's terminal inside
+        // another's pane, and every later write would land in the wrong
+        // shell.
+        throw new Error("That terminal belongs to a different thread.");
+      }
       // Deliberately does NOT touch `panelHidden`. The renderer mounts a pane
       // — and therefore attaches — for every live session, including collapsed
       // ones, so an attach is not evidence that the user wants to see it.
@@ -300,7 +326,11 @@ export class IntegratedTerminalService {
       return this.toCreateResponse(existing);
     }
 
-    this.spawningThreadKeys.add(threadKey);
+    // Settle identity before the spawn, not after it. Everything the spawn
+    // window has to coordinate — a close arriving mid-flight, above all — is
+    // then addressed by the same id the finished terminal answers to.
+    const sessionId = requestedId || randomUUID();
+    this.spawningThreadKeyBySessionId.set(sessionId, threadKey);
     let ptyProcess: IPty;
     let cwd: string;
     let shell: { file: string; args: string[] };
@@ -322,15 +352,15 @@ export class IntegratedTerminalService {
         threadKey,
       });
       // The spawn died, so there is nothing left for a queued close to kill.
-      // Leaving the key behind would shoot down the next terminal on this
-      // thread.
-      this.pendingCloseThreadKeys.delete(threadKey);
+      // Leaving the id behind would shoot down a later terminal that reuses
+      // it.
+      this.pendingCloseSessionIds.delete(sessionId);
       throw new Error(message, { cause: error });
     } finally {
-      this.spawningThreadKeys.delete(threadKey);
+      this.spawningThreadKeyBySessionId.delete(sessionId);
     }
     const session: TerminalSession = {
-      sessionId: randomUUID(),
+      sessionId,
       threadKey,
       pty: ptyProcess,
       cwd,
@@ -341,7 +371,6 @@ export class IntegratedTerminalService {
       subscribers: new Set(),
       disposables: [],
     };
-    this.sessionsByThread.set(threadKey, session);
     this.sessionsById.set(session.sessionId, session);
     this.subscribe(session, webContents);
     session.disposables.push(
@@ -356,12 +385,12 @@ export class IntegratedTerminalService {
     });
 
     // Spawning is slow (login-shell env capture, then the node-pty load), and a
-    // close issued in that window used to find nothing in `sessionsByThread`
-    // and silently no-op — leaving a live shell the user had already dismissed,
+    // close issued in that window used to find nothing in the registry and
+    // silently no-op — leaving a live shell the user had already dismissed,
     // which the renderer then re-adopted from the sessions broadcast. Honor the
     // close now that we finally have something to kill.
-    if (this.pendingCloseThreadKeys.delete(threadKey)) {
-      this.logger.info("closing-on-spawn", { threadKey });
+    if (this.pendingCloseSessionIds.delete(sessionId)) {
+      this.logger.info("closing-on-spawn", { sessionId, threadKey });
       this.killSession(session);
       return this.toCreateResponse(session);
     }
@@ -378,7 +407,7 @@ export class IntegratedTerminalService {
   }
 
   setPanelHidden(request: IntegratedTerminalSetPanelHiddenRequest): void {
-    const session = this.sessionsByThread.get(request.threadKey);
+    const session = this.sessionsById.get(request.sessionId);
     if (!session || session.panelHidden === request.hidden) {
       return;
     }
@@ -386,14 +415,28 @@ export class IntegratedTerminalService {
     this.emitSessionsChanged();
   }
 
-  /** Un-hide a live session's panel. Returns false when there is no session to
-   *  reveal, so callers don't ask the renderer to show a shell that has exited. */
-  revealSession(threadKey: string): boolean {
-    if (!this.sessionsByThread.has(threadKey)) {
-      return false;
+  /**
+   * Un-hide one terminal's panel and report the thread it belongs to, which
+   * the reveal broadcast carries so a renderer knows which thread's chrome to
+   * bring forward.
+   *
+   * Undefined when there is no such terminal, so callers don't ask the
+   * renderer to show a shell that has exited.
+   */
+  revealSession(sessionId: string): { threadKey: string } | undefined {
+    const session = this.sessionsById.get(sessionId);
+    if (!session) {
+      return undefined;
     }
-    this.setPanelHidden({ threadKey, hidden: false });
-    return true;
+    this.setPanelHidden({ sessionId, hidden: false });
+    return { threadKey: session.threadKey };
+  }
+
+  /** A thread's live terminals, oldest first. */
+  private sessionsForThread(threadKey: string): TerminalSession[] {
+    return [...this.sessionsById.values()]
+      .filter((session) => session.threadKey === threadKey)
+      .sort((left, right) => left.createdAt - right.createdAt);
   }
 
   write(request: IntegratedTerminalWriteRequest): void {
@@ -410,21 +453,36 @@ export class IntegratedTerminalService {
   }
 
   close(request: IntegratedTerminalCloseRequest): void {
-    const session =
-      (request.sessionId ? this.sessionsById.get(request.sessionId) : undefined) ??
-      (request.threadKey ? this.sessionsByThread.get(request.threadKey) : undefined);
-    if (session) {
-      this.pendingCloseThreadKeys.delete(session.threadKey);
+    const byId = request.sessionId
+      ? this.sessionsById.get(request.sessionId)
+      : undefined;
+    // A thread key closes every terminal the thread owns. The thread view's
+    // close button means "put this thread's terminal away", and a thread can
+    // now be showing more than one.
+    const targets = byId
+      ? [byId]
+      : request.threadKey
+        ? this.sessionsForThread(request.threadKey)
+        : [];
+    for (const session of targets) {
+      this.pendingCloseSessionIds.delete(session.sessionId);
       this.killSession(session);
+    }
+    if (targets.length > 0) {
       return;
     }
-    // Nothing to kill yet. If a spawn for this thread is still in flight, mark
-    // it so `createOrAttach` kills the session the moment it exists — otherwise
-    // the close is lost and the shell survives the user dismissing it. Gated on
-    // an in-flight spawn so a close for an idle thread can't linger and shoot
-    // down some unrelated terminal the user opens later.
-    if (request.threadKey && this.spawningThreadKeys.has(request.threadKey)) {
-      this.pendingCloseThreadKeys.add(request.threadKey);
+    // Nothing to kill yet. If a spawn this close names is still in flight,
+    // mark it so `createOrAttach` kills the session the moment it exists —
+    // otherwise the close is lost and the shell survives the user dismissing
+    // it. Gated on an in-flight spawn so a close for an idle thread can't
+    // linger and shoot down some unrelated terminal the user opens later.
+    for (const [sessionId, threadKey] of this.spawningThreadKeyBySessionId) {
+      const named = request.sessionId
+        ? sessionId === request.sessionId
+        : threadKey === request.threadKey;
+      if (named) {
+        this.pendingCloseSessionIds.add(sessionId);
+      }
     }
   }
 
@@ -450,8 +508,11 @@ export class IntegratedTerminalService {
       count: sessions.length,
       sessionIds: sessions.map((session) => session.sessionId).sort(),
       threads: sessions
-        .map((session) => ({ threadKey: session.threadKey }))
-        .sort(byThreadKey),
+        .map((session) => ({
+          sessionId: session.sessionId,
+          threadKey: session.threadKey,
+        }))
+        .sort(byQuitTerminal),
     };
   }
 
@@ -576,7 +637,6 @@ export class IntegratedTerminalService {
 
   private deleteSession(session: TerminalSession): void {
     this.disposeSessionListeners(session);
-    this.sessionsByThread.delete(session.threadKey);
     this.sessionsById.delete(session.sessionId);
     session.subscribers.clear();
     this.emitSessionsChanged();

--- a/apps/desktop/src/main/terminal/integrated-terminal-service.ts
+++ b/apps/desktop/src/main/terminal/integrated-terminal-service.ts
@@ -230,6 +230,26 @@ export type IntegratedTerminalQuitSnapshot = {
   threads: IntegratedTerminalQuitThread[];
 };
 
+/** `[value]`, or `[]` for a lookup that found nothing. */
+function toTargets<T>(value: T | undefined): T[] {
+  return value ? [value] : [];
+}
+
+/**
+ * A thread's terminals, oldest first, from any registry that keys terminals
+ * this way. Both this service and the federation bridge group by thread, and
+ * the ordering is load-bearing in both: it decides which terminal a create
+ * request that names none attaches to. One rule, so the local and remote
+ * paths cannot drift on what "the thread's terminal" means.
+ */
+export function terminalsForThread<
+  T extends { threadKey: string; createdAt: number },
+>(sessions: Iterable<T>, threadKey: string): T[] {
+  return [...sessions]
+    .filter((session) => session.threadKey === threadKey)
+    .sort((left, right) => left.createdAt - right.createdAt);
+}
+
 /**
  * Code-unit order, matching the plain `.sort()` these keys used before they
  * became objects. `localeCompare` would reorder around the `:` and `-` that
@@ -434,9 +454,7 @@ export class IntegratedTerminalService {
 
   /** A thread's live terminals, oldest first. */
   private sessionsForThread(threadKey: string): TerminalSession[] {
-    return [...this.sessionsById.values()]
-      .filter((session) => session.threadKey === threadKey)
-      .sort((left, right) => left.createdAt - right.createdAt);
+    return terminalsForThread(this.sessionsById.values(), threadKey);
   }
 
   write(request: IntegratedTerminalWriteRequest): void {
@@ -453,14 +471,12 @@ export class IntegratedTerminalService {
   }
 
   close(request: IntegratedTerminalCloseRequest): void {
-    const byId = request.sessionId
-      ? this.sessionsById.get(request.sessionId)
-      : undefined;
-    // A thread key closes every terminal the thread owns. The thread view's
-    // close button means "put this thread's terminal away", and a thread can
-    // now be showing more than one.
-    const targets = byId
-      ? [byId]
+    // An explicit id NEVER widens to the thread. A request naming a terminal
+    // that has already exited means "that one is gone", not "take the rest of
+    // the thread with it" — and since a thread can now own several, falling
+    // through would kill shells the caller never named.
+    const targets = request.sessionId
+      ? toTargets(this.sessionsById.get(request.sessionId))
       : request.threadKey
         ? this.sessionsForThread(request.threadKey)
         : [];

--- a/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/QuitBlockerQueueToast.tsx
@@ -157,6 +157,9 @@ export function QuitBlockerQueueToast(props: {
                         void props.desktopApi?.revealQuitBlocker?.({
                           kind: selected.kind,
                           threadKey: selected.threadKey,
+                          ...(selected.sessionId
+                            ? { sessionId: selected.sessionId }
+                            : {}),
                           ...(selected.target
                             ? { target: selected.target }
                             : {}),

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/QuitBlockerQueueToast.test.tsx
@@ -91,6 +91,7 @@ describe("QuitBlockerQueueToast", () => {
         backend: "codex",
         threadId: "thread-b",
         threadKey: "codex:thread-b",
+        sessionId: "term-b",
         title: "Terminal B",
         target: { scope: "remote", instanceId: "peer-a" },
         detail: "Build Mac",
@@ -125,6 +126,7 @@ describe("QuitBlockerQueueToast", () => {
     expect(revealQuitBlocker).toHaveBeenCalledWith({
       kind: "terminal",
       threadKey: "codex:thread-b",
+      sessionId: "term-b",
       target: { scope: "remote", instanceId: "peer-a" },
     });
 
@@ -141,6 +143,72 @@ describe("QuitBlockerQueueToast", () => {
       screen.getByText("PwrAgent can quit without interrupting work."),
     ).toBeInTheDocument();
     expect(screen.getByTestId("quit-blocker-queue")).toBeInTheDocument();
+  });
+
+  // A thread can hold up the quit with more than one shell, so the row key
+  // has to carry the terminal id. Without it both rows key the same, and
+  // `retainKnownTitles` — which looks a title up BY that key — hands the
+  // wrong shell's name to whichever row asks first.
+  it("keeps each of a thread's terminals on its own row and title", async () => {
+    vi.useFakeTimers();
+    const revealQuitBlocker = vi.fn(async () => ({ revealed: true }));
+    let showQueue!: (next: QuitBlockerQueueSnapshot) => void;
+    const terminals = [
+      {
+        kind: "terminal" as const,
+        backend: "codex",
+        threadId: "thread-a",
+        threadKey: "codex:thread-a",
+        sessionId: "term-1",
+      },
+      {
+        kind: "terminal" as const,
+        backend: "codex",
+        threadId: "thread-a",
+        threadKey: "codex:thread-a",
+        sessionId: "term-2",
+      },
+    ];
+    const titled = snapshot([
+      { ...terminals[0]!, title: "Build" },
+      { ...terminals[1]!, title: "Tail logs" },
+    ]);
+    // The refresh resolves no titles, which is the case the retention exists
+    // for: both rows have to get their OWN name back.
+    const readQuitBlockerQueue = vi.fn(async () => snapshot(terminals));
+
+    render(
+      <QuitBlockerQueueToast
+        desktopApi={{
+          onShowQuitBlockersRequested: (callback) => {
+            showQueue = callback;
+            return () => undefined;
+          },
+          readQuitBlockerQueue,
+          revealQuitBlocker,
+        }}
+      />,
+    );
+
+    act(() => showQueue(titled));
+    expect(screen.getByText("Build")).toBeInTheDocument();
+    expect(screen.getByText("Tail logs")).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(readQuitBlockerQueue).toHaveBeenCalled();
+    expect(screen.getByText("Build")).toBeInTheDocument();
+    expect(screen.getByText("Tail logs")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Tail logs"));
+
+    expect(revealQuitBlocker).toHaveBeenCalledWith({
+      kind: "terminal",
+      threadKey: "codex:thread-a",
+      sessionId: "term-2",
+    });
   });
 
   it("stays hidden until a quit-dialog row hands the queue to this viewer", () => {

--- a/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
+++ b/apps/desktop/src/renderer/src/features/thread-detail/ThreadView.tsx
@@ -3950,7 +3950,7 @@ export function ThreadView(props: ThreadViewProps) {
                     terminals.setHeight(terminal.threadKey, height);
                   }}
                   onClose={() => {
-                    terminals.closeTerminal(terminal.threadKey);
+                    terminals.closeTerminal(terminal);
                   }}
                   onExit={() => {
                     terminals.handleExit(terminal.threadKey);

--- a/apps/desktop/src/renderer/src/lib/__tests__/useIntegratedTerminals.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useIntegratedTerminals.test.tsx
@@ -64,6 +64,87 @@ describe("useIntegratedTerminals", () => {
     expect(result.current.panes[0]?.remote).toBeUndefined();
   });
 
+  // The quit dialog's row link. Main un-hides exactly the shell the operator
+  // clicked, so the renderer must not reach for the thread: `openPanel`, the
+  // fallback this used to run, un-hides every terminal the thread owns.
+  it("converges on the revealed terminal without touching its siblings", async () => {
+    let emitReveal!: (event: {
+      sessionId: string;
+      threadKey: string;
+    }) => void;
+    const setIntegratedTerminalPanelHidden = vi.fn(async () => undefined);
+    const desktopApi: DesktopApi = {
+      listIntegratedTerminals: vi.fn(async () => [
+        remoteSession({
+          sessionId: "term-1",
+          threadKey: "codex:thread-a",
+          remote: undefined,
+          panelHidden: true,
+          createdAt: 1,
+        }),
+        remoteSession({
+          sessionId: "term-2",
+          threadKey: "codex:thread-a",
+          remote: undefined,
+          panelHidden: true,
+          createdAt: 2,
+        }),
+      ]),
+      onIntegratedTerminalReveal: (callback) => {
+        emitReveal = callback;
+        return () => undefined;
+      },
+      setIntegratedTerminalPanelHidden,
+    };
+    const { result } = renderHook(() => useIntegratedTerminals(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.sessions).toHaveLength(2);
+    });
+    setIntegratedTerminalPanelHidden.mockClear();
+
+    act(() => {
+      emitReveal({ sessionId: "term-2", threadKey: "codex:thread-a" });
+    });
+
+    // Exactly one call, for the terminal the event named. The thread-scoped
+    // fallback fired on this very path — both terminals read as collapsed
+    // until React re-renders, so the "already open?" guard was always false.
+    expect(setIntegratedTerminalPanelHidden.mock.calls).toEqual([
+      [{ sessionId: "term-2", hidden: false }],
+    ]);
+  });
+
+  it("ignores a reveal for a terminal this window has no record of", async () => {
+    let emitReveal!: (event: {
+      sessionId: string;
+      threadKey: string;
+    }) => void;
+    const setIntegratedTerminalPanelHidden = vi.fn(async () => undefined);
+    const desktopApi: DesktopApi = {
+      listIntegratedTerminals: vi.fn(async () => []),
+      onIntegratedTerminalReveal: (callback) => {
+        emitReveal = callback;
+        return () => undefined;
+      },
+      setIntegratedTerminalPanelHidden,
+    };
+    const { result } = renderHook(() => useIntegratedTerminals(desktopApi));
+
+    await waitFor(() => {
+      expect(result.current.sessions).toHaveLength(0);
+    });
+
+    act(() => {
+      emitReveal({ sessionId: "term-gone", threadKey: "codex:thread-a" });
+    });
+
+    // Acting here would open a panel for a thread with no session, which is
+    // what spawns a brand-new shell out of trying to look at one.
+    expect(setIntegratedTerminalPanelHidden).not.toHaveBeenCalled();
+    expect(result.current.panes).toHaveLength(0);
+  });
+
   it("carries the owning instance on a pane opened before its session lands", () => {
     const desktopApi: DesktopApi = {
       listIntegratedTerminals: vi.fn(async () => []),

--- a/apps/desktop/src/renderer/src/lib/useIntegratedTerminals.ts
+++ b/apps/desktop/src/renderer/src/lib/useIntegratedTerminals.ts
@@ -194,30 +194,28 @@ export function useIntegratedTerminals(
       // and main agree on which shell it is. Several panes for one thread is
       // the tab strip's job, and giving them stable React identities across
       // the local-pane hand-off is a design that work has to make.
-      ...[...sessionsByThread.values()].flatMap((group) => {
-        const session = group[0];
-        if (!session) return [];
-        return [
-          {
-            threadKey: session.threadKey,
-            sessionId: session.sessionId,
-            cwd: session.cwd,
-            // A rediscovered remote session (remount, renderer reload) carries
-            // its owning instance in the summary — rebuild the pane's target
-            // from it so re-attaches keep routing to the peer.
-            ...(session.remote
-              ? {
-                  remote: {
-                    ...session.remote,
-                    target: {
-                      scope: "remote" as const,
-                      instanceId: session.remote.instanceId,
-                    },
+      // A group is built around its first element, so it is never empty.
+      ...[...sessionsByThread.values()].map((group) => {
+        const session = group[0]!;
+        return {
+          threadKey: session.threadKey,
+          sessionId: session.sessionId,
+          cwd: session.cwd,
+          // A rediscovered remote session (remount, renderer reload) carries
+          // its owning instance in the summary — rebuild the pane's target
+          // from it so re-attaches keep routing to the peer.
+          ...(session.remote
+            ? {
+                remote: {
+                  ...session.remote,
+                  target: {
+                    scope: "remote" as const,
+                    instanceId: session.remote.instanceId,
                   },
-                }
-              : {}),
-          },
-        ];
+                },
+              }
+            : {}),
+        };
       }),
       ...Object.values(localPanes)
         .filter((pane) => !sessionsByThread.has(pane.threadKey))
@@ -335,10 +333,10 @@ export function useIntegratedTerminals(
     setHeightByThread((current) => ({ ...current, [threadKey]: height }));
   }, []);
 
-  // The quit dialog's terminal links land here: show me the shell, whatever the
-  // remembered panel state was. Only ever for a session main still has — main
-  // already refuses to broadcast otherwise, and `openPanel` on an unknown
-  // thread would create a local pane, which spawns a whole new shell.
+  // The quit dialog's terminal links land here: show me this shell, whatever
+  // the remembered panel state was. Only ever for a session main still has —
+  // acting on an unknown one would reach for a thread this window may not
+  // have, and main already refuses to broadcast for a shell that has exited.
   const liveSessionIds = useMemo(
     () => new Set(sessions.map((session) => session.sessionId)),
     [sessions],
@@ -347,8 +345,16 @@ export function useIntegratedTerminals(
   liveSessionIdsRef.current = liveSessionIds;
   useEffect(() => {
     const unsubscribe = desktopApi?.onIntegratedTerminalReveal?.((event) => {
-      // Keyed on the terminal, not the thread: main un-hid one specific shell
-      // and this converges on that, whatever else the thread is showing.
+      // Terminal-scoped, and ONLY terminal-scoped. This used to fall back to
+      // `openPanel(event.threadKey)`, which un-hides every terminal the
+      // thread owns — and it fired on the ordinary path, not just in a race,
+      // because `isPanelOpenRef` is a render-time ref that still reads
+      // pre-broadcast when the reveal lands. Revealing one shell popped its
+      // siblings open with it.
+      //
+      // Main un-hid this terminal in `revealSession` before sending the
+      // event, so the call below is normally a no-op that just converges a
+      // renderer whose mirror is momentarily behind.
       if (!liveSessionIdsRef.current.has(event.sessionId)) {
         return;
       }
@@ -356,16 +362,11 @@ export function useIntegratedTerminals(
         sessionId: event.sessionId,
         hidden: false,
       });
-      // The pane itself may still be local-only in this window, in which case
-      // main's record is not what is deciding whether it shows.
-      if (!isPanelOpenRef.current(event.threadKey)) {
-        openPanel(event.threadKey);
-      }
     });
     return () => {
       unsubscribe?.();
     };
-  }, [desktopApi, openPanel]);
+  }, [desktopApi]);
 
   return {
     sessions,

--- a/apps/desktop/src/renderer/src/lib/useIntegratedTerminals.ts
+++ b/apps/desktop/src/renderer/src/lib/useIntegratedTerminals.ts
@@ -45,6 +45,14 @@ type LocalPane = {
 
 export type IntegratedTerminalPane = {
   threadKey: string;
+  /**
+   * The terminal this pane is showing, once main has reported one. Panes are
+   * still one-per-thread here — a pane keyed by terminal needs the tab strip
+   * that has yet to be built — but every request main answers is addressed by
+   * terminal, so the pane sends this rather than its thread wherever it has
+   * one.
+   */
+  sessionId?: string;
   cwd?: string;
   remote?: IntegratedTerminalPaneRemote;
 };
@@ -69,7 +77,7 @@ export type IntegratedTerminalsController = {
     cwd?: string,
     remote?: IntegratedTerminalPaneRemote,
   ) => void;
-  closeTerminal: (threadKey: string) => void;
+  closeTerminal: (pane: { threadKey: string; sessionId?: string }) => void;
   handleExit: (threadKey: string) => void;
   setHeight: (threadKey: string, height: number) => void;
 };
@@ -108,10 +116,18 @@ export function useIntegratedTerminals(
     };
   }, [desktopApi]);
 
-  const sessionByThread = useMemo(() => {
-    const next = new Map<string, IntegratedTerminalSessionSummary>();
+  // Grouped, not one-to-one: a thread owns any number of terminals now, and
+  // the thread-level affordances below (the panel toggle, the "running"
+  // indicator) have to answer for all of them.
+  const sessionsByThread = useMemo(() => {
+    const next = new Map<string, IntegratedTerminalSessionSummary[]>();
     for (const session of sessions) {
-      next.set(session.threadKey, session);
+      const group = next.get(session.threadKey);
+      if (group) {
+        group.push(session);
+      } else {
+        next.set(session.threadKey, [session]);
+      }
     }
     return next;
   }, [sessions]);
@@ -125,14 +141,16 @@ export function useIntegratedTerminals(
   // the IPC twice.
   useEffect(() => {
     const settled = Object.values(localPanesRef.current).filter((pane) =>
-      sessionByThread.has(pane.threadKey),
+      sessionsByThread.has(pane.threadKey),
     );
     if (settled.length === 0) return;
 
     for (const pane of settled) {
-      if (pane.hidden && !sessionByThread.get(pane.threadKey)?.panelHidden) {
+      if (!pane.hidden) continue;
+      for (const session of sessionsByThread.get(pane.threadKey) ?? []) {
+        if (session.panelHidden) continue;
         void desktopApi?.setIntegratedTerminalPanelHidden?.({
-          threadKey: pane.threadKey,
+          sessionId: session.sessionId,
           hidden: true,
         });
       }
@@ -150,61 +168,79 @@ export function useIntegratedTerminals(
       }
       return changed ? next : current;
     });
-  }, [desktopApi, sessionByThread]);
+  }, [desktopApi, sessionsByThread]);
 
   const liveThreadKeys = useMemo(
     () => new Set(sessions.map((session) => session.threadKey)),
     [sessions],
   );
-  const hiddenThreadKeys = useMemo(
-    () =>
-      new Set(
-        sessions
-          .filter((session) => session.panelHidden)
-          .map((session) => session.threadKey),
-      ),
-    [sessions],
-  );
+  // "Running behind a collapsed panel" means the thread is showing none of
+  // its terminals. One visible terminal is not a hidden thread, however many
+  // others sit collapsed beside it.
+  const hiddenThreadKeys = useMemo(() => {
+    const next = new Set<string>();
+    for (const [threadKey, group] of sessionsByThread) {
+      if (group.every((session) => session.panelHidden)) {
+        next.add(threadKey);
+      }
+    }
+    return next;
+  }, [sessionsByThread]);
 
   const panes = useMemo<IntegratedTerminalPane[]>(
     () => [
-      ...sessions.map((session) => ({
-        threadKey: session.threadKey,
-        cwd: session.cwd,
-        // A rediscovered remote session (remount, renderer reload) carries
-        // its owning instance in the summary — rebuild the pane's target
-        // from it so re-attaches keep routing to the peer.
-        ...(session.remote
-          ? {
-              remote: {
-                ...session.remote,
-                target: {
-                  scope: "remote" as const,
-                  instanceId: session.remote.instanceId,
-                },
-              },
-            }
-          : {}),
-      })),
+      // One pane per thread, showing the thread's oldest terminal — the same
+      // one `createOrAttach` picks for a request that names none, so the pane
+      // and main agree on which shell it is. Several panes for one thread is
+      // the tab strip's job, and giving them stable React identities across
+      // the local-pane hand-off is a design that work has to make.
+      ...[...sessionsByThread.values()].flatMap((group) => {
+        const session = group[0];
+        if (!session) return [];
+        return [
+          {
+            threadKey: session.threadKey,
+            sessionId: session.sessionId,
+            cwd: session.cwd,
+            // A rediscovered remote session (remount, renderer reload) carries
+            // its owning instance in the summary — rebuild the pane's target
+            // from it so re-attaches keep routing to the peer.
+            ...(session.remote
+              ? {
+                  remote: {
+                    ...session.remote,
+                    target: {
+                      scope: "remote" as const,
+                      instanceId: session.remote.instanceId,
+                    },
+                  },
+                }
+              : {}),
+          },
+        ];
+      }),
       ...Object.values(localPanes)
-        .filter((pane) => !sessionByThread.has(pane.threadKey))
+        .filter((pane) => !sessionsByThread.has(pane.threadKey))
         .map((pane) => ({
           threadKey: pane.threadKey,
           cwd: pane.cwd,
           ...(pane.remote ? { remote: pane.remote } : {}),
         })),
     ],
-    [localPanes, sessionByThread, sessions],
+    [localPanes, sessionsByThread],
   );
 
   const isPanelOpen = useCallback(
     (threadKey: string): boolean => {
-      const session = sessionByThread.get(threadKey);
-      if (session) return !session.panelHidden;
+      const group = sessionsByThread.get(threadKey);
+      // Showing any one of the thread's terminals counts as open: the button
+      // this answers for offers to put them away, and there is something to
+      // put away.
+      if (group) return group.some((session) => !session.panelHidden);
       const local = localPanes[threadKey];
       return local ? !local.hidden : false;
     },
-    [localPanes, sessionByThread],
+    [localPanes, sessionsByThread],
   );
   const isPanelOpenRef = useRef(isPanelOpen);
   isPanelOpenRef.current = isPanelOpen;
@@ -216,13 +252,18 @@ export function useIntegratedTerminals(
       cwd?: string,
       remote?: IntegratedTerminalPaneRemote,
     ) => {
-      if (sessionByThread.has(threadKey)) {
+      const group = sessionsByThread.get(threadKey);
+      if (group) {
         // Collapsing is a preference, not a teardown: the PTY keeps running
-        // and main remembers the choice across remounts.
-        void desktopApi?.setIntegratedTerminalPanelHidden?.({
-          threadKey,
-          hidden,
-        });
+        // and main remembers the choice across remounts. Thread-level, so it
+        // moves every terminal the thread owns — the toggle it serves says
+        // "this thread's terminal", not "this shell".
+        for (const session of group) {
+          void desktopApi?.setIntegratedTerminalPanelHidden?.({
+            sessionId: session.sessionId,
+            hidden,
+          });
+        }
         return;
       }
       setLocalPanes((current) => {
@@ -239,7 +280,7 @@ export function useIntegratedTerminals(
         };
       });
     },
-    [desktopApi, sessionByThread],
+    [desktopApi, sessionsByThread],
   );
 
   const togglePanel = useCallback(
@@ -266,9 +307,17 @@ export function useIntegratedTerminals(
   }, []);
 
   const closeTerminal = useCallback(
-    (threadKey: string) => {
-      dropLocalPane(threadKey);
-      void desktopApi?.closeIntegratedTerminal?.({ threadKey });
+    (pane: { threadKey: string; sessionId?: string }) => {
+      dropLocalPane(pane.threadKey);
+      // Name the terminal when the pane knows it. The thread key is the
+      // fallback for a pane whose create has yet to resolve, and main reads it
+      // as "close this thread's terminals" — which is what a pane with no id
+      // of its own can ask for.
+      void desktopApi?.closeIntegratedTerminal?.(
+        pane.sessionId
+          ? { sessionId: pane.sessionId }
+          : { threadKey: pane.threadKey },
+      );
     },
     [desktopApi, dropLocalPane],
   );
@@ -290,13 +339,25 @@ export function useIntegratedTerminals(
   // remembered panel state was. Only ever for a session main still has — main
   // already refuses to broadcast otherwise, and `openPanel` on an unknown
   // thread would create a local pane, which spawns a whole new shell.
-  const liveThreadKeysRef = useRef(liveThreadKeys);
-  liveThreadKeysRef.current = liveThreadKeys;
+  const liveSessionIds = useMemo(
+    () => new Set(sessions.map((session) => session.sessionId)),
+    [sessions],
+  );
+  const liveSessionIdsRef = useRef(liveSessionIds);
+  liveSessionIdsRef.current = liveSessionIds;
   useEffect(() => {
     const unsubscribe = desktopApi?.onIntegratedTerminalReveal?.((event) => {
-      if (!liveThreadKeysRef.current.has(event.threadKey)) {
+      // Keyed on the terminal, not the thread: main un-hid one specific shell
+      // and this converges on that, whatever else the thread is showing.
+      if (!liveSessionIdsRef.current.has(event.sessionId)) {
         return;
       }
+      void desktopApi?.setIntegratedTerminalPanelHidden?.({
+        sessionId: event.sessionId,
+        hidden: false,
+      });
+      // The pane itself may still be local-only in this window, in which case
+      // main's record is not what is deciding whether it shows.
       if (!isPanelOpenRef.current(event.threadKey)) {
         openPanel(event.threadKey);
       }

--- a/apps/desktop/src/shared/integrated-terminal.ts
+++ b/apps/desktop/src/shared/integrated-terminal.ts
@@ -4,6 +4,20 @@ import type {
 } from "@pwragent/shared";
 
 export type IntegratedTerminalCreateRequest = {
+  /**
+   * The terminal to attach to. A pane that already has one passes it back so
+   * a remount reattaches to its own shell rather than to whichever of the
+   * thread's terminals happens to be oldest. When it names no live terminal
+   * the shell is spawned UNDER this id, so a caller minting one gets a
+   * terminal it can address from the first instant.
+   *
+   * Absent means "this thread's terminal": attach to the oldest live one,
+   * spawn when the thread has none. That is what keeps the Star Map window
+   * and the thread view — separate renderers, each mounting its own pane —
+   * looking at one shell instead of two.
+   */
+  sessionId?: string;
+  /** Grouping attribute, not identity: a thread can own several terminals. */
   threadKey: string;
   cwd?: string;
   cols: number;
@@ -37,7 +51,9 @@ export type IntegratedTerminalRemoteInfo = {
  * every remount would either lose the preference or pop the panel back open.
  */
 export type IntegratedTerminalSessionSummary = {
+  /** Identity. Every operation on a live terminal is addressed by this. */
   sessionId: string;
+  /** Which thread the terminal belongs to. Several may share one. */
   threadKey: string;
   cwd: string;
   shell: string;
@@ -53,12 +69,20 @@ export type IntegratedTerminalSessionsEvent = {
 };
 
 export type IntegratedTerminalSetPanelHiddenRequest = {
-  threadKey: string;
+  sessionId: string;
   hidden: boolean;
 };
 
-/** Main → renderer: force a thread's terminal panel open (quit-dialog link). */
+/**
+ * Main → renderer: force one terminal's panel open (quit-dialog link).
+ *
+ * Addressed by terminal, not by thread: the row the operator clicked names a
+ * specific shell, and a thread can own several. `threadKey` rides along so a
+ * renderer can tell which thread's chrome to bring forward without another
+ * lookup.
+ */
 export type IntegratedTerminalRevealEvent = {
+  sessionId: string;
   threadKey: string;
 };
 
@@ -82,6 +106,11 @@ export type IntegratedTerminalResizeRequest = {
   rows: number;
 };
 
+/**
+ * `sessionId` closes exactly that terminal. `threadKey` closes every terminal
+ * the thread owns — the only address a pane has before its create resolves,
+ * and the one the thread view's close button uses.
+ */
 export type IntegratedTerminalCloseRequest = {
   sessionId?: string;
   threadKey?: string;

--- a/apps/desktop/src/shared/integrated-terminal.ts
+++ b/apps/desktop/src/shared/integrated-terminal.ts
@@ -107,9 +107,12 @@ export type IntegratedTerminalResizeRequest = {
 };
 
 /**
- * `sessionId` closes exactly that terminal. `threadKey` closes every terminal
- * the thread owns — the only address a pane has before its create resolves,
- * and the one the thread view's close button uses.
+ * `sessionId` closes exactly that terminal, and closes nothing when it names
+ * none — it never widens to the thread. `threadKey` closes every terminal the
+ * thread owns; it is the only address a pane has before its create resolves,
+ * which is the one case the thread view's close button still falls back to.
+ *
+ * Pass one or the other. A request carrying both is read as the id.
  */
 export type IntegratedTerminalCloseRequest = {
   sessionId?: string;

--- a/apps/desktop/src/shared/quit-blockers.ts
+++ b/apps/desktop/src/shared/quit-blockers.ts
@@ -7,6 +7,12 @@ export type QuitBlockerItem = {
   backend: string;
   threadId: string;
   threadKey: string;
+  /**
+   * Which terminal. Only `kind: "terminal"` carries one, and it is what makes
+   * two shells on the same thread two rows rather than one: the thread key no
+   * longer identifies a terminal.
+   */
+  sessionId?: string;
   /** Owning peer when the work is mounted from another PwrAgent instance. */
   target?: FederationRemoteTarget;
   /** Resolved before presentation; falls back to the opaque thread id. */
@@ -29,17 +35,28 @@ export type QuitBlockerQueueSnapshot = {
 
 export type RevealQuitBlockerRequest = Pick<
   QuitBlockerItem,
-  "kind" | "threadKey" | "target"
+  "kind" | "threadKey" | "sessionId" | "target"
 >;
 
 export type RevealQuitBlockerResponse = {
   revealed: boolean;
 };
 
+/**
+ * Stable identity for one row, used as the React key, the title-lookup key,
+ * and the handle a reveal request names.
+ *
+ * The terminal id is part of it because a thread can hold up the quit with
+ * more than one shell. Without it both rows key the same, React renders them
+ * as one, and a click reveals whichever the lookup happens to find first.
+ */
 export function quitBlockerItemKey(
-  item: Pick<QuitBlockerItem, "kind" | "threadKey" | "target">,
+  item: Pick<QuitBlockerItem, "kind" | "threadKey" | "sessionId" | "target">,
 ): string {
-  return [item.target?.instanceId ?? "local", item.kind, item.threadKey].join(
-    "::",
-  );
+  return [
+    item.target?.instanceId ?? "local",
+    item.kind,
+    item.threadKey,
+    item.sessionId ?? "",
+  ].join("::");
 }


### PR DESCRIPTION
## What this is

Stage 1 of the cross-instance terminal work, and the prerequisite for the rest of it. [#2092](https://github.com/pwrdrvr/PwrAgent/pull/2092) fixed the two quit-warning symptoms; this changes the model underneath them.

`IntegratedTerminalService` kept two registries, `sessionsByThread` and `sessionsById`. The first made the thread key the terminal's *name*, and capped a thread at one shell as a side effect of how the registry stored it. That map is gone. `sessionsById` is the only registry, `threadKey` is an attribute that groups terminals, and every operation on a live terminal — panel-hidden, reveal, close, the quit-blocker row — addresses the terminal.

The point is to do this **before** `pty.list` / `pty.attach` / `pty.detach`. Building the attach protocol against `threadKey` would mean writing it twice.

## Nothing visible changes

A create request that names no terminal still means "this thread's terminal": attach to the oldest, spawn when the thread has none. That is what keeps the Star Map window and the thread view — separate renderers, each mounting its own pane — looking at one shell rather than two.

A request that *does* name one attaches to it, and spawns **under that id** when it names nothing live. That second branch is how a second shell on a thread becomes reachable at all, and it is what the tab strip and `pty.attach` will use.

## Two bugs fall out of the change

Neither was fixed alongside the refactor — both stop being expressible once the thread key stops being identity:

- **A dismissed terminal took its sibling with it.** The close-during-spawn queue was keyed by thread, so dismissing one of a thread's terminals while both were still starting killed both. It is keyed by terminal now, and identity is settled *before* the spawn, so there is no window where it cannot be.
- **Two terminals on one thread were one quit-blocker row.** They keyed the same, so React drew them as one, `retainKnownTitles` handed the wrong shell's name to whichever row asked first, and a click revealed whichever the main process happened to find first. The row key carries the terminal id.

## What is deliberately not here

The renderer's panes stay thread-shaped. Giving a pane a stable identity across the local-pane → session hand-off is a design the tab strip has to make (today the hand-off works precisely *because* both sides key on the thread), and it is not needed for what this unblocks. The hook learns the terminal id and sends it; the pane list is still one per thread.

## Scope

| Layer | Change |
|---|---|
| `shared/integrated-terminal.ts` | `create` takes an optional `sessionId`; `setPanelHidden` and the reveal event are terminal-addressed |
| `IntegratedTerminalService` | one registry; `sessionsForThread` derives the grouping; spawn/pending-close keyed by terminal |
| `FederationTerminalBridge` | same treatment viewer-side; reveal answers with the one window that owns the terminal instead of guessing among the windows that have the thread |
| `shared/quit-blockers.ts` | `QuitBlockerItem.sessionId`; it is part of `quitBlockerItemKey` |
| `quit-confirmation-dialog.ts` | the row link carries the terminal id (positional, so the instance slot is written empty rather than omitted — otherwise a local terminal's id is read back as a peer) |

## Verification

- Full workspace suite: **805 files / 11,526 passed / 7 skipped**.
- `pnpm typecheck`, `pnpm lint:boundaries` (1970 modules, 6898 dependencies) clean; `pnpm lint:eslint` 0 errors, and no new warnings versus this branch's base.
- **Eight negative controls**, each reverting one gate in isolation and confirming it fails its own test and nothing else: id-addressed attach (local and viewer), thread-close fan-out (local and viewer), the cross-thread attach guard, the id-keyed spawn queue, the terminal id on quit-snapshot rows, and the terminal id in the blocker key.

Two of those controls passed on the first attempt, which meant the tests did not pin what they claimed — the spawn-queue test never had two terminals in flight at once, and the blocker-key test never exercised title retention, which is the path the key actually feeds. Both were rewritten until reverting the gate failed them.

Next: `pty.list` / `pty.attach` / `pty.detach` with owner-held scrollback, then the tabs UI and Star Map tear-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
