### PR TITLE
feat(desktop): run the Star Map intake as an agent turn, not a classifier

### DIFF
--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -10684,6 +10684,279 @@ describe("CodexAppServerClient", () => {
     await probePromise.catch(() => undefined);
   });
 
+  /**
+   * The intake agent turn: the same isolated helper thread as a structured
+   * probe, plus PwrAgent dynamic tools serviced for that turn only.
+   */
+  describe("runHelperToolTurn", () => {
+    const TOOLS = [
+      {
+        type: "namespace" as const,
+        name: "pwragent",
+        description: "PwrAgent tools.",
+        tools: [
+          {
+            type: "function" as const,
+            name: "create_instance_thread",
+            description: "Create a thread.",
+            inputSchema: { type: "object", properties: {} },
+            deferLoading: false,
+          },
+        ],
+      },
+    ];
+
+    function startToolTurn(
+      client: InstanceType<
+        Awaited<typeof import("../codex-app-server/client")>["CodexAppServerClient"]
+      >,
+      onToolCall: (request: {
+        method: string;
+        params: Record<string, unknown>;
+      }) => Promise<{ success: boolean }>,
+    ) {
+      return client.runHelperToolTurn({
+        prompt: "Make a thread in PwrAgent and ask it to make the donuts.",
+        system: "You are the PwrAgent Star Map intake.",
+        dynamicTools: TOOLS,
+        onToolCall: onToolCall as never,
+        timeoutMs: 5_000,
+      });
+    }
+
+    it("advertises the tools on the helper thread and asks for no output schema", async () => {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      MockTransport.threadStartResult = {
+        thread: { id: "tool-helper" },
+        instructionSources: [],
+      };
+      MockTransport.turnStartResult = { turn: { id: "tool-turn" } };
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+      const turnPromise = startToolTurn(client, async () => ({ success: true }));
+      const transport = await waitForLatestTransportRequest("turn/start");
+      const sent = transport.sentMessages.map(
+        (message) => JSON.parse(message) as {
+          method?: string;
+          params?: Record<string, unknown>;
+        },
+      );
+
+      const threadStart = sent.find((entry) => entry.method === "thread/start");
+      expect(JSON.stringify(threadStart?.params?.dynamicTools)).toContain(
+        "create_instance_thread",
+      );
+      expect(threadStart?.params?.ephemeral).toBe(true);
+      // Every configured MCP server stays disabled: the intake's only tools
+      // are the ones it was handed.
+      expect(threadStart?.params?.config).toMatchObject({
+        web_search: "disabled",
+        project_doc_max_bytes: 0,
+      });
+      const turnStart = sent.find((entry) => entry.method === "turn/start");
+      // A tool turn's product is its tool calls; demanding a final JSON record
+      // would fail turns that already did the work.
+      expect(turnStart?.params).not.toHaveProperty("outputSchema");
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "tool-helper",
+          turn: { id: "tool-turn", status: "completed" },
+        },
+      });
+      await expect(turnPromise).resolves.toEqual({ status: "ok" });
+      await client.close();
+    });
+
+    it("routes a tool call on its helper thread to the supplied handler", async () => {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      MockTransport.threadStartResult = {
+        thread: { id: "tool-helper" },
+        instructionSources: [],
+      };
+      MockTransport.turnStartResult = { turn: { id: "tool-turn" } };
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+      const onToolCall = vi.fn(
+        async (_request: { method: string; params: Record<string, unknown> }) => ({
+          success: true,
+        }),
+      );
+      const turnPromise = startToolTurn(client, onToolCall);
+      const transport = await waitForLatestTransportRequest("turn/start");
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        id: "tool-call-1",
+        method: "item/tool/call",
+        params: {
+          threadId: "tool-helper",
+          turnId: "tool-turn",
+          callId: "call-1",
+          namespace: "pwragent",
+          tool: "create_instance_thread",
+          arguments: { projectKey: "dir-agent", input: "Make the donuts." },
+        },
+      });
+
+      await vi.waitFor(() => expect(onToolCall).toHaveBeenCalled());
+      expect(onToolCall.mock.calls[0]?.[0]).toMatchObject({
+        method: "item/tool/call",
+        params: { tool: "create_instance_thread", threadId: "tool-helper" },
+      });
+      await vi.waitFor(() => {
+        const answered = transport.sentMessages.some((message) => {
+          const payload = JSON.parse(message) as { id?: unknown };
+          return payload.id === "tool-call-1";
+        });
+        expect(answered).toBe(true);
+      });
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "tool-helper",
+          turn: { id: "tool-turn", status: "completed" },
+        },
+      });
+      await expect(turnPromise).resolves.toEqual({ status: "ok" });
+      await client.close();
+    });
+
+    /**
+     * The handler is reachable only through the thread that registered it.
+     * That containment is what stands in for the registry's live-turn gate,
+     * which an ephemeral helper turn can never satisfy.
+     */
+    it("does not route a tool call from another thread to the handler", async () => {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      MockTransport.threadStartResult = {
+        thread: { id: "tool-helper" },
+        instructionSources: [],
+      };
+      MockTransport.turnStartResult = { turn: { id: "tool-turn" } };
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+      const onToolCall = vi.fn(async () => ({ success: true }));
+      const turnPromise = startToolTurn(client, onToolCall);
+      const transport = await waitForLatestTransportRequest("turn/start");
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        id: "tool-call-other",
+        method: "item/tool/call",
+        params: {
+          threadId: "somebody-elses-thread",
+          turnId: "their-turn",
+          callId: "call-2",
+          namespace: "pwragent",
+          tool: "create_instance_thread",
+          arguments: {},
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(onToolCall).not.toHaveBeenCalled();
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "tool-helper",
+          turn: { id: "tool-turn", status: "completed" },
+        },
+      });
+      await expect(turnPromise).resolves.toEqual({ status: "ok" });
+      await client.close();
+    });
+
+    it("stops routing tool calls once the turn is over", async () => {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      MockTransport.threadStartResult = {
+        thread: { id: "tool-helper" },
+        instructionSources: [],
+      };
+      MockTransport.turnStartResult = { turn: { id: "tool-turn" } };
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+      const onToolCall = vi.fn(async () => ({ success: true }));
+      const turnPromise = startToolTurn(client, onToolCall);
+      const transport = await waitForLatestTransportRequest("turn/start");
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "tool-helper",
+          turn: { id: "tool-turn", status: "completed" },
+        },
+      });
+      await turnPromise;
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        id: "tool-call-late",
+        method: "item/tool/call",
+        params: {
+          threadId: "tool-helper",
+          turnId: "tool-turn",
+          callId: "call-3",
+          namespace: "pwragent",
+          tool: "create_instance_thread",
+          arguments: {},
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(onToolCall).not.toHaveBeenCalled();
+      await client.close();
+    });
+
+    it("reports a failed turn as failed", async () => {
+      const { CodexAppServerClient } = await import("../codex-app-server/client");
+      MockTransport.threadStartResult = {
+        thread: { id: "tool-helper" },
+        instructionSources: [],
+      };
+      MockTransport.turnStartResult = { turn: { id: "tool-turn" } };
+      const client = new CodexAppServerClient({
+        command: "codex",
+        directoryResolver: async () => [],
+      });
+      const turnPromise = startToolTurn(client, async () => ({ success: true }));
+      const transport = await waitForLatestTransportRequest("turn/start");
+
+      transport.emitInbound({
+        jsonrpc: "2.0",
+        method: "turn/completed",
+        params: {
+          threadId: "tool-helper",
+          turn: {
+            id: "tool-turn",
+            status: "failed",
+            error: { message: "nope" },
+          },
+        },
+      });
+
+      await expect(turnPromise).resolves.toEqual({
+        status: "failed",
+        reason: "codex_title_turn_failed",
+      });
+      await client.close();
+    });
+  });
+
   it("uses a fresh helper thread for every title and unsubscribes each one", async () => {
     const { CodexAppServerClient } = await import("../codex-app-server/client");
     const client = new CodexAppServerClient({

--- a/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-agent-tools-service.test.ts
@@ -613,6 +613,65 @@ describe("federation agent tools service", () => {
     });
   });
 
+  /**
+   * The Star Map intake's calling thread is an ephemeral turn that dissolves
+   * the moment it finishes. Crediting it as `sourceThread` would render a
+   * ThreadChip on the created thread's first turn that links to nothing —
+   * forever, on every thread the intake ever made.
+   */
+  it("lets a caller override how the created thread records who asked for it", async () => {
+    const materializeDirectoryLaunchpad = vi.fn(
+      async (request: MaterializeDirectoryLaunchpadRequest) => ({
+        backend: "codex" as const,
+        threadId: "thread-9",
+        executionMode:
+          request.launchpad?.executionMode ?? ("default" as const),
+        workMode: request.launchpad?.workMode ?? ("local" as const),
+        turnId: "turn-9",
+      }),
+    );
+    const readPopulation = vi.fn(async () =>
+      buildSnapshot({
+        directories: [
+          {
+            key: "dir:/Users/op/pwragent",
+            kind: "directory",
+            label: "PwrAgent",
+            path: "/Users/op/pwragent",
+            threadKeys: [],
+            needsAttentionCount: 0,
+          },
+        ] as NavigationSnapshot["directories"],
+      }),
+    );
+    const handler = createFederationAgentToolsHandler({
+      collectHostInfo: async () => localHostInfo,
+      resolveMessageOrigin: () => ({ kind: "pwragent" }),
+      runtime: buildRuntime({
+        health: async () => buildHealth(),
+        localBackend: (() => ({
+          readPopulation,
+          materializeDirectoryLaunchpad,
+        })) as never,
+      }),
+    });
+
+    await handler({
+      operation: "create_instance_thread",
+      context,
+      args: {
+        instanceId: "pwr_local",
+        projectKey: "dir:/Users/op/pwragent",
+        input: "Make the donuts.",
+      },
+    });
+
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.anything(),
+      { messageOrigin: { kind: "pwragent" } },
+    );
+  });
+
   it("creates a local thread with merged launchpad settings and an initial input", async () => {
     const materializeDirectoryLaunchpad = vi.fn(
       async (request: MaterializeDirectoryLaunchpadRequest) => ({

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -149,6 +149,7 @@ const setMessagingArchiveCleanerMock = vi.fn();
 const setMessagingAgentToolServiceMock = vi.fn();
 const setPwrAgentAppManagementHandlerMock = vi.fn();
 const setPwrAgentFederationHandlerMock = vi.fn();
+const setStarMapIntakeFederationHandlerMock = vi.fn();
 const setFederatedThreadMessageHandlerMock = vi.fn();
 const setFederatedThreadInspectionHandlerMock = vi.fn();
 const setFederatedThreadMutationHandlerMock = vi.fn();
@@ -557,6 +558,7 @@ vi.mock("../app-server/backend-registry", () => ({
     setMessagingAgentToolService: setMessagingAgentToolServiceMock,
     setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
     setPwrAgentFederationHandler: setPwrAgentFederationHandlerMock,
+    setStarMapIntakeFederationHandler: setStarMapIntakeFederationHandlerMock,
     setFederatedThreadMessageHandler: setFederatedThreadMessageHandlerMock,
     setFederatedThreadInspectionHandler:
       setFederatedThreadInspectionHandlerMock,
@@ -770,6 +772,7 @@ describe("bootstrapApp", () => {
     setMessagingAgentToolServiceMock.mockReset();
     setPwrAgentAppManagementHandlerMock.mockReset();
     setPwrAgentFederationHandlerMock.mockReset();
+    setStarMapIntakeFederationHandlerMock.mockReset();
     setFederatedThreadMessageHandlerMock.mockReset();
     setFederatedThreadInspectionHandlerMock.mockReset();
     setFederatedThreadMutationHandlerMock.mockReset();

--- a/apps/desktop/src/main/__tests__/index.test.ts
+++ b/apps/desktop/src/main/__tests__/index.test.ts
@@ -149,7 +149,7 @@ const setMessagingArchiveCleanerMock = vi.fn();
 const setMessagingAgentToolServiceMock = vi.fn();
 const setPwrAgentAppManagementHandlerMock = vi.fn();
 const setPwrAgentFederationHandlerMock = vi.fn();
-const setStarMapIntakeFederationHandlerMock = vi.fn();
+const setStarMapIntakeFederationHandlerFactoryMock = vi.fn();
 const setFederatedThreadMessageHandlerMock = vi.fn();
 const setFederatedThreadInspectionHandlerMock = vi.fn();
 const setFederatedThreadMutationHandlerMock = vi.fn();
@@ -558,7 +558,8 @@ vi.mock("../app-server/backend-registry", () => ({
     setMessagingAgentToolService: setMessagingAgentToolServiceMock,
     setPwrAgentAppManagementHandler: setPwrAgentAppManagementHandlerMock,
     setPwrAgentFederationHandler: setPwrAgentFederationHandlerMock,
-    setStarMapIntakeFederationHandler: setStarMapIntakeFederationHandlerMock,
+    setStarMapIntakeFederationHandlerFactory:
+      setStarMapIntakeFederationHandlerFactoryMock,
     setFederatedThreadMessageHandler: setFederatedThreadMessageHandlerMock,
     setFederatedThreadInspectionHandler:
       setFederatedThreadInspectionHandlerMock,
@@ -772,7 +773,7 @@ describe("bootstrapApp", () => {
     setMessagingAgentToolServiceMock.mockReset();
     setPwrAgentAppManagementHandlerMock.mockReset();
     setPwrAgentFederationHandlerMock.mockReset();
-    setStarMapIntakeFederationHandlerMock.mockReset();
+    setStarMapIntakeFederationHandlerFactoryMock.mockReset();
     setFederatedThreadMessageHandlerMock.mockReset();
     setFederatedThreadInspectionHandlerMock.mockReset();
     setFederatedThreadMutationHandlerMock.mockReset();

--- a/apps/desktop/src/main/__tests__/star-map-intake-agent.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake-agent.test.ts
@@ -207,6 +207,142 @@ describe("star map intake agent tool surface", () => {
     expect(tools.readOutcome()).toMatchObject({ threadId: "thread-new" });
   });
 
+  /**
+   * `outcome` alone cannot hold the cap: it is assigned only after the
+   * creation resolves, so two calls arriving in the same step would both read
+   * it as unset. Codex dispatches inbound tool calls concurrently.
+   */
+  it("refuses a second creation that arrives while the first is still running", async () => {
+    let releaseFirst: () => void = () => {};
+    const federationHandler = vi.fn(async (_request: PwrAgentFederationRequest) => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return {
+        ok: true as const,
+        data: {
+          instanceId: "inst-local",
+          instanceLabel: "This Mac",
+          isLocal: true,
+          backend: "codex" as const,
+          threadId: "thread-new",
+          executionMode: "default" as const,
+          workMode: "local" as const,
+          groupingMode: "none" as const,
+          message: "created",
+        },
+      };
+    });
+    const tools = build({ federationHandler });
+
+    const first = tools.handleToolCall(call("create_instance_thread", DONUT_CREATE));
+    // Second call lands before the first has resolved, so `outcome` is unset.
+    const second = await tools.handleToolCall(
+      call("create_instance_thread", { ...DONUT_CREATE, input: "And again." }),
+    );
+
+    expect(second.success).toBe(false);
+    expect(federationHandler).toHaveBeenCalledTimes(1);
+
+    releaseFirst();
+    expect((await first).success).toBe(true);
+    expect(tools.readOutcome()).toMatchObject({ threadId: "thread-new" });
+  });
+
+  it("reports a creation that has not answered yet as in flight", async () => {
+    let releaseFirst: () => void = () => {};
+    const federationHandler = vi.fn(async (_request: PwrAgentFederationRequest) => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return {
+        ok: true as const,
+        data: {
+          instanceId: "inst-local",
+          instanceLabel: "This Mac",
+          isLocal: true,
+          backend: "codex" as const,
+          threadId: "thread-new",
+          executionMode: "default" as const,
+          workMode: "local" as const,
+          groupingMode: "none" as const,
+          message: "created",
+        },
+      };
+    });
+    const tools = build({ federationHandler });
+
+    expect(tools.isCreationInFlight()).toBe(false);
+    const pending = tools.handleToolCall(
+      call("create_instance_thread", DONUT_CREATE),
+    );
+    expect(tools.isCreationInFlight()).toBe(true);
+
+    releaseFirst();
+    await pending;
+    expect(tools.isCreationInFlight()).toBe(false);
+  });
+
+  /**
+   * A `not_found` on one project is not the end of the intake — the model may
+   * legitimately try another. Only a creation that succeeded is final.
+   */
+  it("lets the agent retry after a creation fails", async () => {
+    const federationHandler = vi.fn(async (request: PwrAgentFederationRequest) => {
+      const args = request.args as { projectKey?: string };
+      return args.projectKey === "dir-agent"
+        ? {
+            ok: false as const,
+            error: { code: "not_found" as const, message: "gone" },
+          }
+        : {
+            ok: true as const,
+            data: {
+              instanceId: "inst-local",
+              instanceLabel: "This Mac",
+              isLocal: true,
+              backend: "codex" as const,
+              threadId: "thread-second",
+              executionMode: "default" as const,
+              workMode: "local" as const,
+              groupingMode: "none" as const,
+              message: "created",
+            },
+          };
+    });
+    const tools = build({ federationHandler });
+
+    const failed = await tools.handleToolCall(
+      call("create_instance_thread", DONUT_CREATE),
+    );
+    const retried = await tools.handleToolCall(
+      call("create_instance_thread", { ...DONUT_CREATE, projectKey: "dir-snap" }),
+    );
+
+    expect(failed.success).toBe(false);
+    expect(retried.success).toBe(true);
+    expect(tools.readOutcome()).toMatchObject({ threadId: "thread-second" });
+  });
+
+  /**
+   * The `creating` line is where the dialog prints a project name, and it is
+   * the operator's last chance to catch a wrong pick. A key this instance
+   * does not have would put a raw directory key there instead.
+   */
+  it("does not announce a project key this instance does not have", async () => {
+    const onCreateStarting = vi.fn();
+    const tools = build({ onCreateStarting });
+
+    await tools.handleToolCall(
+      call("create_instance_thread", {
+        ...DONUT_CREATE,
+        projectKey: "dir-on-some-peer",
+      }),
+    );
+
+    expect(onCreateStarting).not.toHaveBeenCalled();
+  });
+
   it("does not let a creation follow an ask", async () => {
     const federationHandler = vi.fn();
     const tools = build({

--- a/apps/desktop/src/main/__tests__/star-map-intake-agent.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake-agent.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it, vi } from "vitest";
+import { PWRAGENT_TOOL_NAMESPACE } from "@pwragent/shared";
+import type { PwrAgentFederationRequest } from "@pwragent/shared";
+import type { PwrAgentFederationHandler } from "../agent-tools/pwragent-federation-agent-tools";
+import {
+  ASK_OPERATOR_TO_PICK_PROJECT_TOOL,
+  buildStarMapIntakeAgentTools,
+  STAR_MAP_INTAKE_AGENT_SYSTEM,
+} from "../app-server/star-map-intake-agent";
+
+const DIRECTORIES = new Set(["dir-agent", "dir-snap"]);
+
+function build(
+  options: {
+    federationHandler?: PwrAgentFederationHandler;
+    onCreateStarting?: (projectKey: string) => void;
+  } = {},
+) {
+  return buildStarMapIntakeAgentTools({
+    federationHandler:
+      options.federationHandler
+      ?? (async () => ({
+        ok: true,
+        data: {
+          instanceId: "inst-local",
+          instanceLabel: "This Mac",
+          isLocal: true,
+          backend: "codex",
+          threadId: "thread-new",
+          executionMode: "default",
+          workMode: "local",
+          groupingMode: "none",
+          message: "created",
+        },
+      })),
+    resolveDirectoryKey: (projectKey) =>
+      DIRECTORIES.has(projectKey) ? projectKey : undefined,
+    ...(options.onCreateStarting
+      ? { onCreateStarting: options.onCreateStarting }
+      : {}),
+  });
+}
+
+let callSeq = 0;
+function call(tool: string, args: Record<string, unknown>) {
+  callSeq += 1;
+  return {
+    method: "item/tool/call",
+    params: {
+      threadId: "helper-thread",
+      turnId: "helper-turn",
+      callId: `call-${callSeq}`,
+      namespace: PWRAGENT_TOOL_NAMESPACE,
+      tool,
+      arguments: args,
+    },
+  };
+}
+
+/** The arguments a well-behaved intake agent sends for the reported case. */
+const DONUT_CREATE = {
+  instanceId: "inst-local",
+  projectKey: "dir-agent",
+  input: "Make the donuts.",
+};
+
+function toolNames(dynamicTools: ReturnType<typeof build>["dynamicTools"]) {
+  return dynamicTools.flatMap((spec) =>
+    spec.type === "namespace" ? spec.tools.map((tool) => tool.name) : [spec.name],
+  );
+}
+
+describe("star map intake agent tool surface", () => {
+  it("advertises only the tools an intake needs to create one thread", () => {
+    expect(toolNames(build().dynamicTools).sort()).toEqual([
+      ASK_OPERATOR_TO_PICK_PROJECT_TOOL,
+      "create_instance_thread",
+      "list_federation_instances",
+      "list_instance_projects",
+    ]);
+  });
+
+  /**
+   * The bound that keeps a misfire's blast radius equal to the classifier's.
+   * Named individually rather than asserted as a set complement: these are the
+   * tools that would let a confused intake damage work the operator never
+   * mentioned, and a future catalog addition should have to be thought about
+   * rather than silently inherited.
+   */
+  it.each([
+    "steer_thread",
+    "stop_thread",
+    "send_message_to_thread",
+    "start_review",
+    "move_thread_workspace",
+    "detach_thread_directory",
+    "handoff_task",
+    "attach_thread_directory",
+    "search_federation_threads",
+    "create_monitor_delegation",
+  ])("withholds %s", (tool) => {
+    expect(toolNames(build().dynamicTools)).not.toContain(tool);
+  });
+
+  it("refuses a withheld tool at dispatch, not only in the advertisement", async () => {
+    const tools = build();
+    const response = await tools.handleToolCall(
+      call("steer_thread", { threadId: "someone-elses-thread" }),
+    );
+    expect(response.success).toBe(false);
+    expect(tools.readOutcome()).toBeUndefined();
+  });
+
+  it("captures the created thread as the intake's outcome", async () => {
+    const tools = build();
+    const response = await tools.handleToolCall(
+      call("create_instance_thread", DONUT_CREATE),
+    );
+
+    expect(response.success).toBe(true);
+    expect(tools.readOutcome()).toEqual({
+      kind: "created",
+      backend: "codex",
+      threadId: "thread-new",
+    });
+  });
+
+  /**
+   * The reported case, at the seam this change actually owns: whatever the
+   * agent passes as `input` is what the created thread's first turn receives.
+   * The operator's sentence ("Make a thread in the PwrAgnt project and ask it
+   * to make the donuts") never reaches the new thread — that relay is the bug
+   * this replaced. Whether the model separates the two correctly is carried by
+   * the system prompt, asserted below, not by this test.
+   */
+  it("passes the agent's extracted payload through to the creation, not the operator's sentence", async () => {
+    const federationHandler = vi.fn(async (_request: PwrAgentFederationRequest) => ({
+      ok: true as const,
+      data: {
+        instanceId: "inst-local",
+        instanceLabel: "This Mac",
+        isLocal: true,
+        backend: "codex" as const,
+        threadId: "thread-new",
+        executionMode: "default" as const,
+        workMode: "local" as const,
+        groupingMode: "none" as const,
+        message: "created",
+      },
+    }));
+    const tools = build({ federationHandler });
+
+    await tools.handleToolCall(call("create_instance_thread", DONUT_CREATE));
+
+    const request = federationHandler.mock
+      .calls[0]?.[0] as PwrAgentFederationRequest<"create_instance_thread">;
+    expect(request.args.input).toBe("Make the donuts.");
+    expect(request.args.projectKey).toBe("dir-agent");
+  });
+
+  it("names the project before the thread exists, so the dialog can still be caught", async () => {
+    const onCreateStarting = vi.fn();
+    const tools = build({ onCreateStarting });
+
+    await tools.handleToolCall(call("create_instance_thread", DONUT_CREATE));
+
+    expect(onCreateStarting).toHaveBeenCalledWith("dir-agent");
+  });
+
+  /**
+   * The misfire case. A tool-using agent can loop where the classifier could
+   * not, so the second creation is refused rather than left to the model's
+   * judgment, and the first outcome is the one that stands.
+   */
+  it("creates at most one thread per intake", async () => {
+    const federationHandler = vi.fn(async (_request: PwrAgentFederationRequest) => ({
+      ok: true as const,
+      data: {
+        instanceId: "inst-local",
+        instanceLabel: "This Mac",
+        isLocal: true,
+        backend: "codex" as const,
+        threadId: "thread-new",
+        executionMode: "default" as const,
+        workMode: "local" as const,
+        groupingMode: "none" as const,
+        message: "created",
+      },
+    }));
+    const tools = build({ federationHandler });
+
+    const first = await tools.handleToolCall(
+      call("create_instance_thread", DONUT_CREATE),
+    );
+    const second = await tools.handleToolCall(
+      call("create_instance_thread", {
+        ...DONUT_CREATE,
+        projectKey: "dir-snap",
+        input: "And again.",
+      }),
+    );
+
+    expect(first.success).toBe(true);
+    expect(second.success).toBe(false);
+    // The refusal is upstream of the handler: no second thread was started.
+    expect(federationHandler).toHaveBeenCalledTimes(1);
+    expect(tools.readOutcome()).toMatchObject({ threadId: "thread-new" });
+  });
+
+  it("does not let a creation follow an ask", async () => {
+    const federationHandler = vi.fn();
+    const tools = build({
+      federationHandler: federationHandler as unknown as PwrAgentFederationHandler,
+    });
+
+    await tools.handleToolCall(
+      call(ASK_OPERATOR_TO_PICK_PROJECT_TOOL, {
+        candidates: [{ projectKey: "dir-agent", reason: "recent icon work" }],
+      }),
+    );
+    const created = await tools.handleToolCall(
+      call("create_instance_thread", DONUT_CREATE),
+    );
+
+    expect(created.success).toBe(false);
+    expect(federationHandler).not.toHaveBeenCalled();
+  });
+});
+
+describe("ask_operator_to_pick_project", () => {
+  it("carries the ranking and the extracted payload out of the turn", async () => {
+    const tools = build();
+
+    const response = await tools.handleToolCall(
+      call(ASK_OPERATOR_TO_PICK_PROJECT_TOOL, {
+        candidates: [
+          { projectKey: "dir-agent", reason: "recent icon work" },
+          { projectKey: "dir-snap", reason: "owns the screenshot pipeline" },
+        ],
+        input: "Make the donuts.",
+      }),
+    );
+
+    expect(response.success).toBe(true);
+    expect(tools.readOutcome()).toEqual({
+      kind: "needs_disambiguation",
+      candidates: [
+        { directoryKey: "dir-agent", reason: "recent icon work" },
+        { directoryKey: "dir-snap", reason: "owns the screenshot pipeline" },
+      ],
+      input: "Make the donuts.",
+    });
+  });
+
+  /**
+   * The dialog answers an ask with a directoryKey the next dispatch looks up
+   * in this instance's own directory index, so a key naming a peer's project
+   * would be offered and then fail on the pick.
+   */
+  it("drops candidates that are not projects on this instance", async () => {
+    const tools = build();
+
+    await tools.handleToolCall(
+      call(ASK_OPERATOR_TO_PICK_PROJECT_TOOL, {
+        candidates: [
+          { projectKey: "dir-on-some-peer", reason: "sounds right" },
+          { projectKey: "dir-snap", reason: "owns the screenshot pipeline" },
+        ],
+      }),
+    );
+
+    expect(tools.readOutcome()).toMatchObject({
+      candidates: [{ directoryKey: "dir-snap" }],
+    });
+  });
+
+  it("keeps the ask even when nothing it named resolves", async () => {
+    const tools = build();
+
+    await tools.handleToolCall(
+      call(ASK_OPERATOR_TO_PICK_PROJECT_TOOL, { candidates: [] }),
+    );
+
+    expect(tools.readOutcome()).toEqual({
+      kind: "needs_disambiguation",
+      candidates: [],
+    });
+  });
+
+  it("deduplicates a repeated project", async () => {
+    const tools = build();
+
+    await tools.handleToolCall(
+      call(ASK_OPERATOR_TO_PICK_PROJECT_TOOL, {
+        candidates: [
+          { projectKey: "dir-agent", reason: "first" },
+          { projectKey: "dir-agent", reason: "again" },
+        ],
+      }),
+    );
+
+    expect(tools.readOutcome()).toMatchObject({
+      candidates: [{ directoryKey: "dir-agent", reason: "first" }],
+    });
+  });
+
+  it("cuts a long reason at a character boundary", async () => {
+    const tools = build();
+
+    await tools.handleToolCall(
+      call(ASK_OPERATOR_TO_PICK_PROJECT_TOOL, {
+        candidates: [{ projectKey: "dir-agent", reason: "🍩".repeat(200) }],
+      }),
+    );
+
+    const outcome = tools.readOutcome();
+    const reason =
+      outcome?.kind === "needs_disambiguation"
+        ? outcome.candidates[0]?.reason ?? ""
+        : "";
+    expect([...reason]).toHaveLength(120);
+    // A surrogate half here would render as a replacement character in the row.
+    expect(reason.codePointAt(reason.length - 2)).toBe("🍩".codePointAt(0));
+  });
+});
+
+/**
+ * The intake's judgment lives in this prompt, so these assert the two cases
+ * the change exists to separate are actually stated in it. Nothing here can
+ * prove the model obeys — only that the instruction it needs is present and
+ * did not get edited away.
+ */
+describe("star map intake agent system prompt", () => {
+  it("tells the agent the request is addressed to it", () => {
+    expect(STAR_MAP_INTAKE_AGENT_SYSTEM).toContain("addressed to you");
+  });
+
+  it("carries the relay case it exists to prevent", () => {
+    expect(STAR_MAP_INTAKE_AGENT_SYSTEM).toContain(
+      "will create another",
+    );
+  });
+
+  it("carries the negative control: a request that merely mentions threads", () => {
+    expect(STAR_MAP_INTAKE_AGENT_SYSTEM).toContain(
+      "merely mentions threads is not addressed to you",
+    );
+    expect(STAR_MAP_INTAKE_AGENT_SYSTEM).toContain("pass it\nthrough verbatim");
+  });
+
+  it("names the ask tool it must use instead of guessing", () => {
+    expect(STAR_MAP_INTAKE_AGENT_SYSTEM).toContain(
+      ASK_OPERATOR_TO_PICK_PROJECT_TOOL,
+    );
+  });
+
+  it("tells the agent to page the project list rather than read one page", () => {
+    expect(STAR_MAP_INTAKE_AGENT_SYSTEM).toContain("Page the project list");
+  });
+});

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -5,6 +5,13 @@ const generateStructuredObject = vi.fn();
 const ensureDirectoryLaunchpad = vi.fn();
 const materializeDirectoryLaunchpad = vi.fn();
 const publishLocalEvent = vi.fn(async () => undefined);
+/**
+ * Defaults to `undefined` — "no backend here can run an agent turn" — so every
+ * test below that does not set it exercises the deterministic fallback. That
+ * is deliberate: the fallback is still the path for a machine with no Codex
+ * backend, and it is the one the agent tests would otherwise stop covering.
+ */
+const runStarMapIntakeAgentTurn = vi.fn();
 const readLocalNavigationDirectoryIndex = vi.hoisted(() => vi.fn());
 
 vi.mock("../app-server/backend-registry", () => ({
@@ -13,6 +20,7 @@ vi.mock("../app-server/backend-registry", () => ({
     generateStructuredObject,
     materializeDirectoryLaunchpad,
     publishLocalEvent,
+    runStarMapIntakeAgentTurn,
   }),
 }));
 
@@ -61,6 +69,7 @@ function ranked(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  runStarMapIntakeAgentTurn.mockResolvedValue(undefined);
   readLocalNavigationDirectoryIndex.mockResolvedValue([
       directory("dir-snap", "PwrSnap", { latestUpdatedAt: 10 }),
       directory("dir-agent", "PwrAgent", {
@@ -528,5 +537,286 @@ describe("dispatchStarMapIntake", () => {
     });
     expect(response.status).toBe("failed");
     expect(readLocalNavigationDirectoryIndex).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The agent path, which is what an instance with a Codex backend actually
+ * runs. `runStarMapIntakeAgentTurn` stands in for the turn: these assert what
+ * `dispatchStarMapIntake` does with each outcome the turn can produce, not
+ * that a model produces the right one.
+ */
+describe("dispatchStarMapIntake via the intake agent", () => {
+  /** The reported case: one thread, and the relay sentence never reaches it. */
+  it("returns the thread the agent created and never resolves a project itself", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "created", backend: "codex", threadId: "thread-donut" },
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-1",
+      request:
+        "Make a thread in the PwrAgnt project and ask it to make the donuts.",
+    });
+
+    expect(response).toEqual({
+      status: "created",
+      requestId: "req-agent-1",
+      backend: "codex",
+      threadId: "thread-donut",
+    });
+    // Exactly one thread: the agent made it, and nothing here made a second.
+    expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    // The deterministic classifier is a fallback now, not a first step.
+    expect(generateStructuredObject).not.toHaveBeenCalled();
+  });
+
+  it("passes the agent's ranking and extracted payload to the dialog", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: {
+        kind: "needs_disambiguation",
+        candidates: [{ directoryKey: "dir-agent", reason: "recent icon work" }],
+        input: "Make the donuts.",
+      },
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-2",
+      request: "Make a thread and ask it to make the donuts.",
+    });
+
+    expect(response).toMatchObject({
+      status: "needs_disambiguation",
+      candidateSource: "resolver",
+      candidates: [
+        expect.objectContaining({
+          directoryKey: "dir-agent",
+          label: "PwrAgent",
+          reason: "recent icon work",
+        }),
+      ],
+      input: "Make the donuts.",
+    });
+    expect(generateStructuredObject).not.toHaveBeenCalled();
+  });
+
+  /**
+   * An ask naming nothing usable still asked. Recency is the honest source for
+   * the list it gets shown, the same thing the deterministic path says when
+   * its resolver ran and pointed nowhere — "closest match first" over a
+   * recency ordering would claim a judgment nobody made.
+   */
+  it("falls back to recency when the agent asked with no usable candidate", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "needs_disambiguation", candidates: [] },
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-3",
+      request: "Fix the thing",
+    });
+
+    expect(response).toMatchObject({
+      status: "needs_disambiguation",
+      candidateSource: "recent",
+    });
+    expect(
+      response.status === "needs_disambiguation"
+        ? response.candidates.map((candidate) => candidate.directoryKey)
+        : [],
+    ).toEqual(["dir-agent", "dir-snap"]);
+  });
+
+  /**
+   * The operator's answer to "which project?". The agent already separated the
+   * task from the instruction when it asked, so the pick creates the thread
+   * directly — one agent turn per intake, however many times it has to ask.
+   */
+  it("creates with the carried payload when the operator picks a project", async () => {
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-4",
+      request:
+        "Make a thread in the PwrAgnt project and ask it to make the donuts.",
+      directoryKey: "dir-agent",
+      input: "Make the donuts.",
+    });
+
+    expect(response).toMatchObject({ status: "created" });
+    expect(runStarMapIntakeAgentTurn).not.toHaveBeenCalled();
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: "dir-agent",
+        input: [{ type: "text", text: "Make the donuts." }],
+      }),
+      expect.anything(),
+    );
+  });
+
+  /**
+   * The negative control, at the seam this owns. An ordinary work request that
+   * merely mentions threads carries no instruction to strip, so the agent
+   * passes it through and it reaches the thread unchanged. (What keeps the
+   * model from stripping it anyway is the system prompt, asserted in
+   * star-map-intake-agent.test.ts.)
+   */
+  it("sends an ordinary request that merely mentions threads through unchanged", async () => {
+    const request = "Write a feature that creates threads from a template";
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-5",
+      request,
+      directoryKey: "dir-agent",
+      input: request,
+    });
+
+    expect(response).toMatchObject({ status: "created" });
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ input: [{ type: "text", text: request }] }),
+      expect.anything(),
+    );
+  });
+
+  it("ignores a carried payload without a project, so it cannot skip the agent", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "created", backend: "codex", threadId: "thread-donut" },
+    });
+
+    await dispatchStarMapIntake({
+      requestId: "req-agent-6",
+      request: "Make a thread and ask it to make the donuts.",
+      input: "Make the donuts.",
+    });
+
+    expect(runStarMapIntakeAgentTurn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: "Make a thread and ask it to make the donuts.",
+      }),
+    );
+  });
+
+  it("falls back to the deterministic resolver when the agent turn fails", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "failed",
+      reason: "codex_title_turn_timeout",
+    });
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-7",
+      request: "Look into the screenshot issue in PwrSnap",
+    });
+
+    expect(response).toMatchObject({ status: "created" });
+    expect(generateStructuredObject).toHaveBeenCalled();
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({ directoryKey: "dir-snap" }),
+      expect.anything(),
+    );
+  });
+
+  it("falls back when the agent turn throws", async () => {
+    runStarMapIntakeAgentTurn.mockRejectedValue(new Error("client closed"));
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-8",
+      request: "Look into the screenshot issue in PwrSnap",
+    });
+
+    expect(response).toMatchObject({ status: "created" });
+    expect(generateStructuredObject).toHaveBeenCalled();
+  });
+
+  /**
+   * A turn that created the thread and then timed out has still created the
+   * thread. Reporting that as a failure would send the fallback on to create
+   * a second one, which is the one outcome a single intake must never have.
+   */
+  it("keeps a thread the agent created even when the turn reports ok with an outcome after trouble", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "created", backend: "codex", threadId: "thread-late" },
+    });
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-9",
+      request: "Make the donuts in PwrAgent",
+    });
+
+    expect(response).toMatchObject({ threadId: "thread-late" });
+    expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+  });
+
+  it("never runs the agent when no project is registered", async () => {
+    readLocalNavigationDirectoryIndex.mockResolvedValue([]);
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-agent-10",
+      request: "Make the donuts",
+    });
+
+    expect(response).toMatchObject({
+      status: "failed",
+      error: "No projects are registered on this instance. Add a directory first.",
+    });
+    expect(runStarMapIntakeAgentTurn).not.toHaveBeenCalled();
+  });
+});
+
+describe("dispatchStarMapIntake payload carrying", () => {
+  /**
+   * The payload was extracted for the project the operator picked. When that
+   * project is gone by the time they answer, the pick is discarded and the
+   * fallback resolves somewhere else — the payload must not ride along to it.
+   */
+  it("drops a carried payload when the picked project no longer exists", async () => {
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-stale",
+      request: "Make a thread in the gone project and ask it to make the donuts.",
+      directoryKey: "dir-removed",
+      input: "Make the donuts.",
+    });
+
+    expect(response).toMatchObject({ status: "created" });
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        directoryKey: "dir-snap",
+        input: [
+          {
+            type: "text",
+            text: "Make a thread in the gone project and ask it to make the donuts.",
+          },
+        ],
+      }),
+      expect.anything(),
+    );
+  });
+
+  it("keeps the operator's request when the pick carried no payload", async () => {
+    const response = await dispatchStarMapIntake({
+      requestId: "req-no-payload",
+      request: "Fix the recorder crash",
+      directoryKey: "dir-agent",
+    });
+
+    expect(response).toMatchObject({ status: "created" });
+    expect(materializeDirectoryLaunchpad).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: [{ type: "text", text: "Fix the recorder crash" }],
+      }),
+      expect.anything(),
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/star-map-intake.test.ts
+++ b/apps/desktop/src/main/__tests__/star-map-intake.test.ts
@@ -771,6 +771,79 @@ describe("dispatchStarMapIntake via the intake agent", () => {
   });
 });
 
+describe("dispatchStarMapIntake agent-path safety", () => {
+  /**
+   * A creation still running when the turn ended is not "no thread". Falling
+   * through to the deterministic resolver would create a second one for the
+   * same request.
+   */
+  it("never creates a second thread when a creation was still in flight", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "creation_unconfirmed" },
+    });
+    generateStructuredObject.mockResolvedValue(
+      ranked([{ directoryKey: "dir-snap", confidence: 0.9 }]),
+    );
+
+    const response = await dispatchStarMapIntake({
+      requestId: "req-inflight",
+      request: "Make the donuts in PwrAgent",
+    });
+
+    expect(response).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("still being created"),
+    });
+    expect(materializeDirectoryLaunchpad).not.toHaveBeenCalled();
+    expect(generateStructuredObject).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `create_instance_thread` resolves attachments from the calling thread's
+   * turn, and an ephemeral intake turn has none — so the operator's staged
+   * images have to be handed to the agent's federation handler directly.
+   */
+  it("hands the operator's attachments to the agent turn", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "created", backend: "codex", threadId: "thread-donut" },
+    });
+    const attachments = [
+      { type: "localImage" as const, name: "shot.png", path: "/staged/shot.png" },
+    ];
+
+    await dispatchStarMapIntake({
+      requestId: "req-attach",
+      request: "Fix this crash",
+      attachments,
+    });
+
+    expect(runStarMapIntakeAgentTurn).toHaveBeenCalledWith(
+      expect.objectContaining({ attachments }),
+    );
+  });
+
+  it("gives the agent turn a budget that outlives a slow creation", async () => {
+    runStarMapIntakeAgentTurn.mockResolvedValue({
+      status: "ok",
+      outcome: { kind: "created", backend: "codex", threadId: "thread-donut" },
+    });
+
+    await dispatchStarMapIntake({
+      requestId: "req-budget",
+      request: "Make the donuts in PwrAgent",
+    });
+
+    // The federation client alone allows 120s for create_instance_thread, so
+    // a turn budget at or under that expires while the creation runs.
+    const [call] = runStarMapIntakeAgentTurn.mock.calls.at(-1) as [
+      { turnTimeoutMs: number },
+    ];
+    expect(call.turnTimeoutMs).toBeGreaterThan(120_000);
+  });
+});
+
 describe("dispatchStarMapIntake payload carrying", () => {
   /**
    * The payload was extracted for the project the operator picked. When that

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8695,7 +8695,9 @@ export class DesktopBackendRegistry {
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
   private federationHandler: PwrAgentFederationHandler | undefined;
-  private starMapIntakeFederationHandler: PwrAgentFederationHandler | undefined;
+  private starMapIntakeFederationHandlerFactory:
+    | ((attachments: AppServerTurnInputItem[]) => PwrAgentFederationHandler)
+    | undefined;
   private federatedThreadMessageHandler:
     | PwrAgentFederatedThreadMessageHandler
     | undefined;
@@ -9921,15 +9923,19 @@ export class DesktopBackendRegistry {
   }
 
   /**
-   * The federation tools as the Star Map intake agent sees them. A separate
-   * instance rather than a flag on the shared one: it differs only in how a
-   * created thread records who asked for it, and that difference is a
-   * property of the caller, not of the call.
+   * The federation tools as the Star Map intake agent sees them. A factory
+   * rather than a handler: the intake's options depend on the request being
+   * served — who is credited for the created thread, and which staged
+   * attachments belong to it — so one instance built at startup could not
+   * carry either.
    */
-  setStarMapIntakeFederationHandler(
-    handler: PwrAgentFederationHandler | null | undefined,
+  setStarMapIntakeFederationHandlerFactory(
+    factory:
+      | ((attachments: AppServerTurnInputItem[]) => PwrAgentFederationHandler)
+      | null
+      | undefined,
   ): void {
-    this.starMapIntakeFederationHandler = handler ?? undefined;
+    this.starMapIntakeFederationHandlerFactory = factory ?? undefined;
   }
 
   setFederatedThreadMessageHandler(
@@ -22755,6 +22761,7 @@ export class DesktopBackendRegistry {
     prompt: string;
     system: string;
     resolveDirectoryKey: (projectKey: string) => string | undefined;
+    attachments?: AppServerTurnInputItem[];
     onCreateStarting?: (projectKey: string) => void;
     model?: string;
     reasoningEffort?: string;
@@ -22765,13 +22772,21 @@ export class DesktopBackendRegistry {
     | { status: "failed"; reason: string }
     | undefined
   > {
+    // Without the factory every tool the agent could call answers
+    // "unavailable", so the turn is bought and guaranteed to produce nothing.
+    // Declining here sends the caller straight to the deterministic resolver.
+    if (!this.starMapIntakeFederationHandlerFactory) {
+      return undefined;
+    }
     const codex = (await this.listBackends({ includeUnavailable: true })).backends
       .find((summary) => summary.kind === "codex");
     if (!codex?.available || !this.codexClient.runHelperToolTurn) {
       return undefined;
     }
     const tools = buildStarMapIntakeAgentTools({
-      federationHandler: this.starMapIntakeFederationHandler,
+      federationHandler: this.starMapIntakeFederationHandlerFactory(
+        params.attachments ?? [],
+      ),
       resolveDirectoryKey: params.resolveDirectoryKey,
       ...(params.onCreateStarting
         ? { onCreateStarting: params.onCreateStarting }
@@ -22793,7 +22808,14 @@ export class DesktopBackendRegistry {
     // send the fallback on to create a second thread.
     const outcome = tools.readOutcome();
     if (result.status === "failed" && !outcome) {
-      return { status: "failed", reason: result.reason };
+      // A creation that had not answered when the turn ended may still be
+      // running: `create_instance_thread` warns that startup "can take
+      // minutes", and the federation client alone allows two for it. Reported
+      // as a failure this becomes the fallback's cue to create a second
+      // thread for the same request, so say what actually happened instead.
+      return tools.isCreationInFlight()
+        ? { status: "ok", outcome: { kind: "creation_unconfirmed" } }
+        : { status: "failed", reason: result.reason };
     }
     return { status: "ok", outcome };
   }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -391,6 +391,7 @@ import {
   formatRateLimitWindowName,
   type CodexPwrdrvrTokenMiserActivation,
   type CodexServerCapabilities,
+  type HelperThreadToolCallHandler,
 } from "../codex-app-server/client";
 import {
   isCodexInvalidResponseMessageIdError,
@@ -471,6 +472,10 @@ import type { PwrAgentFederationHandler } from "../agent-tools/pwragent-federati
 import type { MessagingAgentToolService } from "../messaging/messaging-agent-tool-service";
 import { resolveAutomationInspectionMcpCommand } from "../automations/automation-inspection-cli";
 import { resolveAgentToolCatalogs } from "../agent-tools/agent-tool-catalog-registry";
+import {
+  buildStarMapIntakeAgentTools,
+  type StarMapIntakeAgentOutcome,
+} from "./star-map-intake-agent";
 import {
   AgentToolRouter,
   readAgentDynamicToolCall,
@@ -808,6 +813,21 @@ type BackendClient = {
     /** Model answering budget, separate from the protocol round-trips. */
     turnTimeoutMs?: number;
   }): ReturnType<ThreadTitleGenerator["generateTitle"]>;
+  /**
+   * One ephemeral helper turn that may call the supplied PwrAgent dynamic
+   * tools. Optional: only Codex advertises dynamic tools, so a backend
+   * without it simply has no agent-driven intake path.
+   */
+  runHelperToolTurn?(params: {
+    model?: string;
+    reasoningEffort?: string;
+    prompt: string;
+    system?: string;
+    dynamicTools: CodexDynamicToolSpec[];
+    onToolCall: HelperThreadToolCallHandler;
+    timeoutMs?: number;
+    turnTimeoutMs?: number;
+  }): Promise<{ status: "ok" } | { status: "failed"; reason: string }>;
   listSkills(params?: {
     cwd?: string;
     cwds?: string[];
@@ -8675,6 +8695,7 @@ export class DesktopBackendRegistry {
   private readonly threadOrchestrationHandler: PwrAgentThreadOrchestrationHandler =
     async (request) => await this.handleThreadOrchestrationRequest(request);
   private federationHandler: PwrAgentFederationHandler | undefined;
+  private starMapIntakeFederationHandler: PwrAgentFederationHandler | undefined;
   private federatedThreadMessageHandler:
     | PwrAgentFederatedThreadMessageHandler
     | undefined;
@@ -9897,6 +9918,18 @@ export class DesktopBackendRegistry {
     handler: PwrAgentFederationHandler | null | undefined,
   ): void {
     this.federationHandler = handler ?? undefined;
+  }
+
+  /**
+   * The federation tools as the Star Map intake agent sees them. A separate
+   * instance rather than a flag on the shared one: it differs only in how a
+   * created thread records who asked for it, and that difference is a
+   * property of the caller, not of the call.
+   */
+  setStarMapIntakeFederationHandler(
+    handler: PwrAgentFederationHandler | null | undefined,
+  ): void {
+    this.starMapIntakeFederationHandler = handler ?? undefined;
   }
 
   setFederatedThreadMessageHandler(
@@ -22705,6 +22738,64 @@ export class DesktopBackendRegistry {
       status: "unavailable",
       reason: `${params.backend ?? backend?.kind ?? "backend"}_structured_generation_unavailable`,
     };
+  }
+
+  /**
+   * Run the Star Map `[+]` intake as one ephemeral agent turn.
+   *
+   * The turn creates the thread itself, through the same
+   * `create_instance_thread` an operator's own agent would use, and then
+   * dissolves. Nothing persists and nothing is shown: the operator sees the
+   * thread they asked for appear, not a relay thread that asked for it.
+   *
+   * Returns `undefined` when no backend here can run a tool-using turn, which
+   * is the caller's signal to fall back to the deterministic resolver.
+   */
+  async runStarMapIntakeAgentTurn(params: {
+    prompt: string;
+    system: string;
+    resolveDirectoryKey: (projectKey: string) => string | undefined;
+    onCreateStarting?: (projectKey: string) => void;
+    model?: string;
+    reasoningEffort?: string;
+    timeoutMs?: number;
+    turnTimeoutMs?: number;
+  }): Promise<
+    | { status: "ok"; outcome: StarMapIntakeAgentOutcome | undefined }
+    | { status: "failed"; reason: string }
+    | undefined
+  > {
+    const codex = (await this.listBackends({ includeUnavailable: true })).backends
+      .find((summary) => summary.kind === "codex");
+    if (!codex?.available || !this.codexClient.runHelperToolTurn) {
+      return undefined;
+    }
+    const tools = buildStarMapIntakeAgentTools({
+      federationHandler: this.starMapIntakeFederationHandler,
+      resolveDirectoryKey: params.resolveDirectoryKey,
+      ...(params.onCreateStarting
+        ? { onCreateStarting: params.onCreateStarting }
+        : {}),
+    });
+    const result = await this.codexClient.runHelperToolTurn({
+      model: params.model,
+      reasoningEffort: params.reasoningEffort,
+      system: params.system,
+      prompt: params.prompt,
+      dynamicTools: tools.dynamicTools,
+      onToolCall: tools.handleToolCall,
+      timeoutMs: params.timeoutMs,
+      turnTimeoutMs: params.turnTimeoutMs,
+    });
+    // A failed turn can still have created the thread — the tool call
+    // succeeds well before the turn ends, and a timeout after that point
+    // would otherwise report an intake that worked as one that did not, and
+    // send the fallback on to create a second thread.
+    const outcome = tools.readOutcome();
+    if (result.status === "failed" && !outcome) {
+      return { status: "failed", reason: result.reason };
+    }
+    return { status: "ok", outcome };
   }
 
   /** Probe once per client; reducer support is immutable for one app-server. */

--- a/apps/desktop/src/main/app-server/star-map-intake-agent.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake-agent.ts
@@ -20,6 +20,10 @@ import {
   type PwrAgentFederationHandler,
 } from "../agent-tools/pwragent-federation-agent-tools";
 import type { HelperThreadToolCallHandler } from "../codex-app-server/client";
+import {
+  MAX_DISAMBIGUATION_CANDIDATES,
+  truncateCandidateReason,
+} from "./star-map-intake-candidates";
 
 /**
  * The tools the Star Map `[+]` intake agent may call.
@@ -51,10 +55,6 @@ const INTAKE_FEDERATION_TOOLS: readonly PwrAgentFederationOperationName[] = [
 
 export const ASK_OPERATOR_TO_PICK_PROJECT_TOOL = "ask_operator_to_pick_project";
 
-/** Mirrors `MAX_DISAMBIGUATION_CANDIDATES` in the dialog's response contract. */
-const MAX_ASK_CANDIDATES = 8;
-const MAX_ASK_REASON_CHARS = 120;
-
 export type StarMapIntakeAgentOutcome =
   | {
       kind: "created";
@@ -71,16 +71,16 @@ export type StarMapIntakeAgentOutcome =
        * second agent turn to re-derive the same sentence.
        */
       input?: string;
+    }
+  | {
+      /**
+       * A creation was still running when the turn ended. The thread is
+       * probably being created and this intake is finished either way: the
+       * one thing that must not happen is the caller treating this as "no
+       * thread" and creating a second one.
+       */
+      kind: "creation_unconfirmed";
     };
-
-/**
- * Cut at a character boundary so a clause ending in an emoji does not leave a
- * lone surrogate in the row. Same rule as the deterministic resolver's.
- */
-function truncateReason(reason: string): string {
-  if (reason.length <= MAX_ASK_REASON_CHARS) return reason;
-  return [...reason].slice(0, MAX_ASK_REASON_CHARS).join("");
-}
 
 function readString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
@@ -110,8 +110,23 @@ export function buildStarMapIntakeAgentTools(params: {
   dynamicTools: DynamicToolSpec[];
   handleToolCall: HelperThreadToolCallHandler;
   readOutcome: () => StarMapIntakeAgentOutcome | undefined;
+  /**
+   * Whether a creation was started and has not answered yet. The caller reads
+   * this when a turn ends without an outcome: a creation still running is not
+   * the same as no thread, and treating it as one is how a single request
+   * ends up with two threads.
+   */
+  isCreationInFlight: () => boolean;
 } {
   let outcome: StarMapIntakeAgentOutcome | undefined;
+  /**
+   * Set synchronously, before the creation is awaited. `outcome` alone cannot
+   * hold the cap: it is only assigned once the creation resolves, so two calls
+   * arriving in the same step would both read it as unset and both proceed.
+   * Codex dispatches inbound tool calls concurrently, so that is a real
+   * interleaving and not a theoretical one.
+   */
+  let creationInFlight = false;
 
   /**
    * The one-thread cap. The classifier this replaces could only ever create a
@@ -119,6 +134,10 @@ export function buildStarMapIntakeAgentTools(params: {
    * the second creation keeps the blast radius of a misfire identical to what
    * it was, and says why, so a model that misread the request stops rather
    * than retrying against a generic error.
+   *
+   * A creation that *failed* releases the flag: the model may legitimately
+   * retry a different project after a `not_found`. Only a creation that
+   * succeeded is final.
    */
   const federationHandler: PwrAgentFederationHandler | undefined =
     params.federationHandler
@@ -126,30 +145,43 @@ export function buildStarMapIntakeAgentTools(params: {
           if (request.operation !== "create_instance_thread") {
             return await params.federationHandler!(request);
           }
-          if (outcome) {
+          if (outcome || creationInFlight) {
             return {
               ok: false,
               error: {
                 code: "forbidden",
-                message:
-                  "This intake has already finished. Exactly one thread is"
-                  + " created per request, so do not call this tool again —"
-                  + " end the turn instead.",
+                message: outcome
+                  ? "This intake has already finished. Exactly one thread is"
+                    + " created per request, so do not call this tool again —"
+                    + " end the turn instead."
+                  : "A thread is already being created for this request. Wait"
+                    + " for that call to return; do not start another.",
               },
             };
           }
-          const projectKey = readString(request.args.projectKey);
-          if (projectKey) params.onCreateStarting?.(projectKey);
-          const response = await params.federationHandler!(request);
-          if (response.ok) {
-            const result = response.data as CreateInstanceThreadResult;
-            outcome = {
-              kind: "created",
-              backend: result.backend,
-              threadId: result.threadId,
-            };
+          creationInFlight = true;
+          try {
+            // Only a key this instance recognizes is announced: the fallback
+            // would put a raw directory key where the dialog prints a project
+            // name, on the one line that exists for the operator to catch a
+            // wrong pick.
+            const projectKey = readString(request.args.projectKey);
+            if (projectKey && params.resolveDirectoryKey(projectKey)) {
+              params.onCreateStarting?.(projectKey);
+            }
+            const response = await params.federationHandler!(request);
+            if (response.ok) {
+              const result = response.data as CreateInstanceThreadResult;
+              outcome = {
+                kind: "created",
+                backend: result.backend,
+                threadId: result.threadId,
+              };
+            }
+            return response;
+          } finally {
+            creationInFlight = false;
           }
-          return response;
         }
       : undefined;
 
@@ -174,7 +206,7 @@ export function buildStarMapIntakeAgentTools(params: {
           type: "array",
           description:
             "Plausible projects, most likely first, at most"
-            + ` ${MAX_ASK_CANDIDATES}. Use projectKey values from`
+            + ` ${MAX_DISAMBIGUATION_CANDIDATES}. Use projectKey values from`
             + " list_instance_projects only. Return an empty array when"
             + " nothing in the request points anywhere: the operator is then"
             + " shown their recent projects, and an invented ranking makes"
@@ -227,9 +259,9 @@ export function buildStarMapIntakeAgentTools(params: {
         const reason = readString(record.reason);
         candidates.push({
           directoryKey,
-          ...(reason ? { reason: truncateReason(reason) } : {}),
+          ...(reason ? { reason: truncateCandidateReason(reason) } : {}),
         });
-        if (candidates.length >= MAX_ASK_CANDIDATES) break;
+        if (candidates.length >= MAX_DISAMBIGUATION_CANDIDATES) break;
       }
       const input = readString(args.input);
       outcome = {
@@ -264,17 +296,20 @@ export function buildStarMapIntakeAgentTools(params: {
     dynamicTools: router.buildDynamicToolSpecs(),
     handleToolCall: async (request) => {
       const call = readAgentDynamicToolCall(request);
-      if (!call || !router.acceptsDynamicToolCall(call)) {
+      if (!call) {
         return toDynamicToolResponse(
           agentToolFailure({
-            code: "unsupported_operation",
-            message: "That tool is not available to the Star Map intake.",
+            code: "invalid_arguments",
+            message: "That is not a PwrAgent tool call.",
           }),
         );
       }
+      // An unknown or withheld tool is refused by the router itself, with the
+      // `unsupportedMessage` it was constructed with.
       return await router.handleDynamicToolCall({ backend: "codex", call });
     },
     readOutcome: () => outcome,
+    isCreationInFlight: () => creationInFlight,
   };
 }
 

--- a/apps/desktop/src/main/app-server/star-map-intake-agent.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake-agent.ts
@@ -1,0 +1,321 @@
+import {
+  PWRAGENT_TOOL_NAMESPACE,
+  type AppServerBackendKind,
+  type CreateInstanceThreadResult,
+  type PwrAgentFederationOperationName,
+} from "@pwragent/shared";
+import type { DynamicToolSpec } from "@pwrdrvr/codex-app-server-protocol/v2";
+import {
+  agentToolFailure,
+  agentToolSuccess,
+  type AgentToolDefinition,
+} from "../agent-tools/agent-tool-definition";
+import {
+  AgentToolRouter,
+  readAgentDynamicToolCall,
+  toDynamicToolResponse,
+} from "../agent-tools/agent-tool-router";
+import {
+  buildPwrAgentFederationToolDefinitions,
+  type PwrAgentFederationHandler,
+} from "../agent-tools/pwragent-federation-agent-tools";
+import type { HelperThreadToolCallHandler } from "../codex-app-server/client";
+
+/**
+ * The tools the Star Map `[+]` intake agent may call.
+ *
+ * Deliberately far narrower than the `federation` catalog it is drawn from,
+ * and narrower still than `thread_orchestration`, which is not here at all.
+ * Two independent reasons:
+ *
+ * 1. Blast radius. The intake exists to create one thread. Every tool that
+ *    mutates an *existing* thread — `steer_thread`, `stop_thread`,
+ *    `send_message_to_thread`, `start_review`, `move_thread_workspace`,
+ *    `detach_thread_directory`, the monitor tools — is a way for a misfire to
+ *    damage work the operator did not mention. `search_federation_threads` is
+ *    withheld for the same reason: it is the tool that would let a confused
+ *    agent *find* something to damage.
+ * 2. They cannot work here. `handoff_task` and `attach_thread_directory` act
+ *    on "the current thread" and gate on `isLiveDynamicToolCall`, which an
+ *    ephemeral intake turn cannot satisfy. Advertising them would spend
+ *    tokens describing tools whose only possible answer is `forbidden`.
+ *
+ * `create_instance_thread` with the default `groupingMode: "none"` — its own
+ * description calls this "independent intake" — is the whole job.
+ */
+const INTAKE_FEDERATION_TOOLS: readonly PwrAgentFederationOperationName[] = [
+  "list_federation_instances",
+  "list_instance_projects",
+  "create_instance_thread",
+];
+
+export const ASK_OPERATOR_TO_PICK_PROJECT_TOOL = "ask_operator_to_pick_project";
+
+/** Mirrors `MAX_DISAMBIGUATION_CANDIDATES` in the dialog's response contract. */
+const MAX_ASK_CANDIDATES = 8;
+const MAX_ASK_REASON_CHARS = 120;
+
+export type StarMapIntakeAgentOutcome =
+  | {
+      kind: "created";
+      backend: AppServerBackendKind;
+      threadId: string;
+    }
+  | {
+      kind: "needs_disambiguation";
+      candidates: { directoryKey: string; reason?: string }[];
+      /**
+       * The task payload the agent extracted before it got stuck. Carrying it
+       * out of the ask is what makes the operator's pick cost nothing: the
+       * second dispatch creates the thread directly instead of paying for a
+       * second agent turn to re-derive the same sentence.
+       */
+      input?: string;
+    };
+
+/**
+ * Cut at a character boundary so a clause ending in an emoji does not leave a
+ * lone surrogate in the row. Same rule as the deterministic resolver's.
+ */
+function truncateReason(reason: string): string {
+  if (reason.length <= MAX_ASK_REASON_CHARS) return reason;
+  return [...reason].slice(0, MAX_ASK_REASON_CHARS).join("");
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+/**
+ * Builds the intake agent's tool surface and captures what it did.
+ *
+ * The outcome is read from the tools rather than from a final structured
+ * message: a turn that created a thread has already produced its result, and
+ * making that result depend on the model also emitting well-formed JSON adds
+ * a second way for a successful intake to be reported as a failure.
+ */
+export function buildStarMapIntakeAgentTools(params: {
+  federationHandler: PwrAgentFederationHandler | undefined;
+  /** Resolves an agent-supplied project key to a registered directory key. */
+  resolveDirectoryKey: (projectKey: string) => string | undefined;
+  /**
+   * Called with the project key the moment a creation is about to happen, so
+   * the dialog can name it while there is still nothing to undo. This is the
+   * last instant the operator can catch a wrong pick — after it returns, the
+   * thread exists — and in the confident path nothing else ever names the
+   * project out loud.
+   */
+  onCreateStarting?: (projectKey: string) => void;
+}): {
+  dynamicTools: DynamicToolSpec[];
+  handleToolCall: HelperThreadToolCallHandler;
+  readOutcome: () => StarMapIntakeAgentOutcome | undefined;
+} {
+  let outcome: StarMapIntakeAgentOutcome | undefined;
+
+  /**
+   * The one-thread cap. The classifier this replaces could only ever create a
+   * single thread in a single project; a tool-using agent can loop. Refusing
+   * the second creation keeps the blast radius of a misfire identical to what
+   * it was, and says why, so a model that misread the request stops rather
+   * than retrying against a generic error.
+   */
+  const federationHandler: PwrAgentFederationHandler | undefined =
+    params.federationHandler
+      ? async (request) => {
+          if (request.operation !== "create_instance_thread") {
+            return await params.federationHandler!(request);
+          }
+          if (outcome) {
+            return {
+              ok: false,
+              error: {
+                code: "forbidden",
+                message:
+                  "This intake has already finished. Exactly one thread is"
+                  + " created per request, so do not call this tool again —"
+                  + " end the turn instead.",
+              },
+            };
+          }
+          const projectKey = readString(request.args.projectKey);
+          if (projectKey) params.onCreateStarting?.(projectKey);
+          const response = await params.federationHandler!(request);
+          if (response.ok) {
+            const result = response.data as CreateInstanceThreadResult;
+            outcome = {
+              kind: "created",
+              backend: result.backend,
+              threadId: result.threadId,
+            };
+          }
+          return response;
+        }
+      : undefined;
+
+  const askTool: AgentToolDefinition = {
+    namespace: PWRAGENT_TOOL_NAMESPACE,
+    name: ASK_OPERATOR_TO_PICK_PROJECT_TOOL,
+    description:
+      "Ask the operator which project the request belongs to, when the"
+      + " request does not say and you cannot tell. This ends your turn: the"
+      + " operator picks from the candidates you rank here and PwrAgent"
+      + " creates the thread, so do not call create_instance_thread"
+      + " afterwards. Prefer this to guessing — a thread created in the wrong"
+      + " project costs the operator more than one question. Pass the task"
+      + " payload in input exactly as you would have passed it to"
+      + " create_instance_thread, so their pick does not cost another turn.",
+    inputSchema: {
+      type: "object",
+      additionalProperties: false,
+      required: ["candidates"],
+      properties: {
+        candidates: {
+          type: "array",
+          description:
+            "Plausible projects, most likely first, at most"
+            + ` ${MAX_ASK_CANDIDATES}. Use projectKey values from`
+            + " list_instance_projects only. Return an empty array when"
+            + " nothing in the request points anywhere: the operator is then"
+            + " shown their recent projects, and an invented ranking makes"
+            + " that harder, not easier.",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: ["projectKey", "reason"],
+            properties: {
+              projectKey: { type: "string" },
+              reason: {
+                type: "string",
+                description:
+                  "One short clause (under 12 words) naming the evidence you"
+                  + " used, addressed to the operator: \"matches the PwrSnap"
+                  + " screenshot work\", not \"the request mentions"
+                  + " screenshots\".",
+              },
+            },
+          },
+        },
+        input: {
+          type: "string",
+          description:
+            "The concrete task for the thread's first turn, with the"
+            + " instruction that addressed you removed. Omit only if the"
+            + " request carries no task at all.",
+        },
+      },
+    },
+    dispatch: (args) => {
+      if (outcome) {
+        return agentToolFailure({
+          code: "forbidden",
+          message:
+            "This intake has already finished. End the turn.",
+        });
+      }
+      const rawCandidates = Array.isArray(args.candidates) ? args.candidates : [];
+      const seen = new Set<string>();
+      const candidates: { directoryKey: string; reason?: string }[] = [];
+      for (const entry of rawCandidates) {
+        if (typeof entry !== "object" || entry === null) continue;
+        const record = entry as { projectKey?: unknown; reason?: unknown };
+        const projectKey = readString(record.projectKey);
+        if (!projectKey) continue;
+        const directoryKey = params.resolveDirectoryKey(projectKey);
+        if (!directoryKey || seen.has(directoryKey)) continue;
+        seen.add(directoryKey);
+        const reason = readString(record.reason);
+        candidates.push({
+          directoryKey,
+          ...(reason ? { reason: truncateReason(reason) } : {}),
+        });
+        if (candidates.length >= MAX_ASK_CANDIDATES) break;
+      }
+      const input = readString(args.input);
+      outcome = {
+        kind: "needs_disambiguation",
+        candidates,
+        ...(input ? { input } : {}),
+      };
+      return agentToolSuccess({
+        asked: true,
+        candidateCount: candidates.length,
+        message:
+          "The operator will pick from these candidates. End the turn now;"
+          + " PwrAgent creates the thread once they choose.",
+      });
+    },
+  };
+
+  const router = new AgentToolRouter(
+    [
+      ...buildPwrAgentFederationToolDefinitions(federationHandler).filter(
+        (definition) =>
+          INTAKE_FEDERATION_TOOLS.includes(
+            definition.name as PwrAgentFederationOperationName,
+          ),
+      ),
+      askTool,
+    ],
+    { unsupportedMessage: "That tool is not available to the Star Map intake." },
+  );
+
+  return {
+    dynamicTools: router.buildDynamicToolSpecs(),
+    handleToolCall: async (request) => {
+      const call = readAgentDynamicToolCall(request);
+      if (!call || !router.acceptsDynamicToolCall(call)) {
+        return toDynamicToolResponse(
+          agentToolFailure({
+            code: "unsupported_operation",
+            message: "That tool is not available to the Star Map intake.",
+          }),
+        );
+      }
+      return await router.handleDynamicToolCall({ backend: "codex", call });
+    },
+    readOutcome: () => outcome,
+  };
+}
+
+/**
+ * What the intake agent is. Kept deliberately short: the tool descriptions
+ * already carry the operational detail (settings inheritance, work modes,
+ * overrides only on request), and repeating it here would give the model two
+ * sources to reconcile.
+ *
+ * The one thing no tool description can say is the thing this whole surface
+ * exists for — that the operator is talking *to* the intake, so the sentence
+ * they typed is an instruction to be carried out, not a prompt to be pasted.
+ */
+export const STAR_MAP_INTAKE_AGENT_SYSTEM = [
+  "You are the PwrAgent Star Map intake. The operator typed one request into",
+  "the [+] card. Your job is to start exactly one thread that does the work",
+  "they described, in the right project, and then stop.",
+  "",
+  "The request is addressed to you. Separate the instruction to you from the",
+  "task for the new thread, and pass only the task as input. \"Make a thread",
+  "in the Foo project and ask it to rebuild the parser\" means: create one",
+  "thread in Foo whose input is \"Rebuild the parser.\" Never pass the",
+  "operator's sentence through unchanged when it addresses you — a thread",
+  "whose first turn is an instruction to create a thread will create another",
+  "one.",
+  "",
+  "A request that merely mentions threads is not addressed to you. \"Write a",
+  "feature that creates threads from a template\" is the task itself; pass it",
+  "through verbatim.",
+  "",
+  "Call list_federation_instances, then list_instance_projects, to find the",
+  "project. Page the project list when it is incomplete rather than deciding",
+  "from the first page. Then call create_instance_thread once.",
+  "",
+  "If the request does not say which project and you cannot tell, call",
+  ASK_OPERATOR_TO_PICK_PROJECT_TOOL + " instead of guessing.",
+  "",
+  "Apply operator startup preferences from ~/.pwragent/AGENTS.md when they",
+  "are supplied below. Set model, execution mode, work mode or branch",
+  "overrides only when the request or those preferences ask for them.",
+  "",
+  "Create one thread, then end the turn. Do not report back in prose; nobody",
+  "reads it.",
+].join("\n");

--- a/apps/desktop/src/main/app-server/star-map-intake-candidates.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake-candidates.ts
@@ -1,0 +1,26 @@
+/**
+ * The shape of a Star Map intake's "which project?" list, shared by the two
+ * things that produce one: the intake agent's `ask_operator_to_pick_project`
+ * tool and the deterministic resolver that stands in for it.
+ *
+ * These live together because both numbers are load-bearing in two places at
+ * once. The cap is sliced by the dispatcher AND interpolated into the tool
+ * schema the model reads, so two copies would let the model be told a
+ * different limit than the one enforced. The truncation length is what keeps
+ * a reason from overflowing its row, and its code-point rule is what keeps a
+ * clause ending in an emoji from leaving a lone surrogate there.
+ */
+
+/** How many projects the operator is ever asked to choose between. */
+export const MAX_DISAMBIGUATION_CANDIDATES = 8;
+
+const MAX_CANDIDATE_REASON_CHARS = 120;
+
+/**
+ * Cut a reason at a character boundary, so a clause ending in an emoji or
+ * other non-BMP character does not leave a lone surrogate in the row.
+ */
+export function truncateCandidateReason(reason: string): string {
+  if (reason.length <= MAX_CANDIDATE_REASON_CHARS) return reason;
+  return [...reason].slice(0, MAX_CANDIDATE_REASON_CHARS).join("");
+}

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type {
+  AppServerTurnInputItem,
   NavigationDirectoryRow,
   StarMapIntakeCandidate,
   StarMapIntakeCandidateSource,
@@ -19,6 +20,10 @@ import {
   STAR_MAP_INTAKE_AGENT_SYSTEM,
   type StarMapIntakeAgentOutcome,
 } from "./star-map-intake-agent";
+import {
+  MAX_DISAMBIGUATION_CANDIDATES,
+  truncateCandidateReason,
+} from "./star-map-intake-candidates";
 
 const log = getMainLogger("pwragent:star-map-intake");
 
@@ -32,7 +37,7 @@ const log = getMainLogger("pwragent:star-map-intake");
  */
 const INTAKE_TIMEOUT_MS = 20_000;
 /**
- * How long the resolver may take to answer.
+ * How long the deterministic resolver may take to answer.
  *
  * This was 20s, inherited from `DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS` by
  * copying the constant rather than by measuring this call. The title helper
@@ -45,6 +50,23 @@ const INTAKE_TIMEOUT_MS = 20_000;
  * they waited and got nothing. Err long.
  */
 const INTAKE_TURN_TIMEOUT_MS = 90_000;
+/**
+ * How long the intake agent's turn may take — a different workload with a
+ * different failure mode, so deliberately not the resolver's number.
+ *
+ * The agent does not answer a question, it does the work: several tool calls,
+ * then a thread creation that `create_instance_thread` itself warns "can take
+ * minutes" (worktree preparation, environment startup), and for which the
+ * federation client alone allows 120s. A budget under that expires *while the
+ * creation runs*, which is the expensive direction here: the intake then has
+ * no confirmed thread. `isCreationInFlight` keeps that from becoming a second
+ * thread, but the operator still waits and then reads an unconfirmed result,
+ * so the budget has to clear a slow creation rather than merely survive one.
+ *
+ * A remote [+] card has its own ceiling regardless: the federation
+ * `starMapIntake` RPC is bounded at 120s by the calling instance.
+ */
+const INTAKE_AGENT_TURN_TIMEOUT_MS = 240_000;
 const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
 /**
  * How many directories the deterministic resolver is shown. Every registered
@@ -60,22 +82,12 @@ const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
  * for the next page.
  */
 const INTAKE_MAX_PROMPT_DIRECTORIES = 80;
-const MAX_DISAMBIGUATION_CANDIDATES = 8;
 /**
  * Create without asking at or above this much confidence in the leading
  * project. Below it the operator picks — but from the resolver's ranking,
  * not from the registry in storage order.
  */
 const AUTO_CREATE_CONFIDENCE = 0.5;
-const MAX_CANDIDATE_REASON_CHARS = 120;
-/**
- * Cut a reason at a character boundary, so a clause ending in an emoji or
- * other non-BMP character does not leave a lone surrogate in the row.
- */
-function truncateReason(reason: string): string {
-  if (reason.length <= MAX_CANDIDATE_REASON_CHARS) return reason;
-  return [...reason].slice(0, MAX_CANDIDATE_REASON_CHARS).join("");
-}
 
 /**
  * The resolver ranks; it does not choose. One pick plus a confidence number
@@ -263,7 +275,7 @@ async function resolveViaConfiguredBackend(params: {
           && Number.isFinite(record.confidence)
             ? record.confidence
             : 0,
-        reason: reason ? truncateReason(reason) : undefined,
+        reason: reason ? truncateCandidateReason(reason) : undefined,
       });
     }
     // Order by the confidence the resolver reported rather than by the
@@ -337,6 +349,7 @@ async function resolveViaIntakeAgent(params: {
   text: string;
   preferences?: string;
   directories: NavigationDirectoryRow[];
+  attachments: AppServerTurnInputItem[];
 }): Promise<StarMapIntakeAgentOutcome | undefined> {
   const directoryKeys = new Set(params.directories.map((entry) => entry.key));
   const labelsByKey = new Map(
@@ -356,8 +369,13 @@ async function resolveViaIntakeAgent(params: {
           : []),
       ].join("\n"),
       prompt: params.text,
+      // The operator's staged images and files. `create_instance_thread`
+      // otherwise resolves attachments from the calling thread's turn, and an
+      // ephemeral intake turn has none — so without this the screenshot the
+      // operator pasted never reaches the thread they pasted it for.
+      attachments: params.attachments,
       timeoutMs: INTAKE_TIMEOUT_MS,
-      turnTimeoutMs: INTAKE_TURN_TIMEOUT_MS,
+      turnTimeoutMs: INTAKE_AGENT_TURN_TIMEOUT_MS,
       // Candidates the operator can act on have to be projects on this
       // instance: the dialog answers with a directoryKey that the next
       // dispatch looks up in this same local index. A key naming a peer's
@@ -483,6 +501,7 @@ export async function dispatchStarMapIntake(
         text,
         preferences,
         directories,
+        attachments: request.attachments ?? [],
       });
       if (agentOutcome?.kind === "created") {
         publishIntakeStatus({
@@ -497,6 +516,16 @@ export async function dispatchStarMapIntake(
           backend: agentOutcome.backend,
           threadId: agentOutcome.threadId,
         };
+      }
+      if (agentOutcome?.kind === "creation_unconfirmed") {
+        // The creation had not answered when the turn ended. Falling through
+        // would create a second thread for the same request, which is the one
+        // outcome a single intake must never have, so stop and say so.
+        const message =
+          "The thread is still being created. It will appear on the map when"
+          + " it is ready — check before asking again.";
+        publishIntakeStatus({ requestId, phase: "failed", message });
+        return { status: "failed", requestId, error: message };
       }
       if (agentOutcome?.kind === "needs_disambiguation") {
         // An agent that asked with no usable candidate still asked. Show the

--- a/apps/desktop/src/main/app-server/star-map-intake.ts
+++ b/apps/desktop/src/main/app-server/star-map-intake.ts
@@ -15,6 +15,10 @@ import {
   getDesktopBackendRegistry,
   type DesktopBackendRegistry,
 } from "./backend-registry";
+import {
+  STAR_MAP_INTAKE_AGENT_SYSTEM,
+  type StarMapIntakeAgentOutcome,
+} from "./star-map-intake-agent";
 
 const log = getMainLogger("pwragent:star-map-intake");
 
@@ -43,12 +47,17 @@ const INTAKE_TIMEOUT_MS = 20_000;
 const INTAKE_TURN_TIMEOUT_MS = 90_000;
 const INTAKE_PREFERENCES_MAX_CHARS = 8_000;
 /**
- * How many directories the resolver is shown. Every registered directory
- * used to go into the prompt, so latency and token cost grew with the
- * registry forever and a large enough one crowds the request itself out of
- * the model's attention — the same unbounded-input problem
+ * How many directories the deterministic resolver is shown. Every registered
+ * directory used to go into the prompt, so latency and token cost grew with
+ * the registry forever and a large enough one crowds the request itself out
+ * of the model's attention — the same unbounded-input problem
  * `INTAKE_PREFERENCES_MAX_CHARS` already solves for AGENTS.md. Most-recently
  * active first, so the ones cut are the ones the operator has not touched.
+ *
+ * This bounds a prompt, so it applies only where a prompt is built. The agent
+ * path calls `list_instance_projects` and pages it, and must NOT inherit this
+ * ceiling: an operator's 81st project is not invisible to a tool that can ask
+ * for the next page.
  */
 const INTAKE_MAX_PROMPT_DIRECTORIES = 80;
 const MAX_DISAMBIGUATION_CANDIDATES = 8;
@@ -314,6 +323,85 @@ function candidateOf(entry: RankedDirectory): StarMapIntakeCandidate {
   };
 }
 
+/**
+ * Run the intake as an agent turn: it reads the project list with tools,
+ * separates the task from the instruction that addressed it, and creates the
+ * thread itself.
+ *
+ * Returns `undefined` when no agent could run — no Codex backend, or the turn
+ * failed without having created anything — which sends the caller to the
+ * deterministic resolver below.
+ */
+async function resolveViaIntakeAgent(params: {
+  requestId: string;
+  text: string;
+  preferences?: string;
+  directories: NavigationDirectoryRow[];
+}): Promise<StarMapIntakeAgentOutcome | undefined> {
+  const directoryKeys = new Set(params.directories.map((entry) => entry.key));
+  const labelsByKey = new Map(
+    params.directories.map((entry) => [entry.key, entry.label]),
+  );
+  const startedAt = Date.now();
+  try {
+    const result = await getDesktopBackendRegistry().runStarMapIntakeAgentTurn({
+      system: [
+        STAR_MAP_INTAKE_AGENT_SYSTEM,
+        ...(params.preferences
+          ? [
+              "",
+              "Operator thread-startup preferences (AGENTS.md):",
+              params.preferences,
+            ]
+          : []),
+      ].join("\n"),
+      prompt: params.text,
+      timeoutMs: INTAKE_TIMEOUT_MS,
+      turnTimeoutMs: INTAKE_TURN_TIMEOUT_MS,
+      // Candidates the operator can act on have to be projects on this
+      // instance: the dialog answers with a directoryKey that the next
+      // dispatch looks up in this same local index. A key naming a peer's
+      // project is dropped rather than offered and then failing on the pick.
+      resolveDirectoryKey: (projectKey) =>
+        directoryKeys.has(projectKey) ? projectKey : undefined,
+      onCreateStarting: (projectKey: string) => {
+        publishIntakeStatus({
+          requestId: params.requestId,
+          phase: "creating",
+          directoryLabel: labelsByKey.get(projectKey) ?? projectKey,
+        });
+      },
+    });
+    if (!result) return undefined;
+    if (result.status === "failed") {
+      log.warn("star map intake agent turn failed", {
+        elapsedMs: Date.now() - startedAt,
+        reason: result.reason,
+      });
+      return undefined;
+    }
+    // The only record of what this turn actually costs. Both budgets above
+    // were last set by reasoning about prompt size, because a successful
+    // intake logged nothing and there was no number to set them from.
+    log.info("star map intake agent resolved", {
+      directoryCount: params.directories.length,
+      elapsedMs: Date.now() - startedAt,
+      outcome: result.outcome?.kind ?? "none",
+      preferencesChars: params.preferences?.length ?? 0,
+      ...(result.outcome?.kind === "needs_disambiguation"
+        ? { candidateCount: result.outcome.candidates.length }
+        : {}),
+    });
+    return result.outcome;
+  } catch (error) {
+    log.warn("star map intake agent unavailable", {
+      elapsedMs: Date.now() - startedAt,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
 export async function ensureStarMapIntakeLaunchpad(
   registry: Pick<DesktopBackendRegistry, "ensureDirectoryLaunchpad">,
   directory: NavigationDirectoryRow,
@@ -329,19 +417,26 @@ export async function ensureStarMapIntakeLaunchpad(
 }
 
 /**
- * The Star Map [+] intake: resolve the operator's natural-language request
- * to a project (structured call over the directory registry + AGENTS.md
- * preferences, deterministic label match as fallback), then materialize the
- * directory's launchpad with the request as the first turn. Runs on the
- * instance that owns the [+] card.
+ * The Star Map [+] intake: carry out the operator's natural-language request
+ * by starting exactly one thread. Runs on the instance that owns the [+] card.
  *
- * The resolver ranks rather than picks, and the ranking survives a low
+ * The request is addressed *to* the intake, and an agent turn is what lets it
+ * act that way. "Make a thread in Foo and ask it to make the donuts" means
+ * create one thread in Foo whose first turn is "Make the donuts" — the
+ * classifier this replaced could only resolve the project and then paste the
+ * whole sentence in as the prompt, so the created thread's agent read the
+ * instruction, obeyed it, and created a second thread. One relay thread whose
+ * only job was to understand a sentence, at $0.48 a time.
+ *
+ * The agent creates the thread itself, through the same
+ * `create_instance_thread` an operator's own agent would use, so every
+ * capability that tool already has — settings inheritance, model and work-mode
+ * overrides, a target instance — arrives without a schema field per feature.
+ *
+ * The deterministic resolver below is the fallback for when no backend can run
+ * an agent turn. It ranks rather than picks, and the ranking survives a low
  * score: below `AUTO_CREATE_CONFIDENCE` the operator chooses, but from the
- * resolver's order with its reasons attached. The previous shape discarded
- * the whole resolution below the threshold and fell through to a substring
- * match on directory labels — so a request that never typed a project name
- * produced the entire registry in storage order, which reads as the intake
- * having thought about nothing.
+ * resolver's order with its reasons attached.
  */
 export async function dispatchStarMapIntake(
   request: StarMapIntakeRequest,
@@ -376,8 +471,69 @@ export async function dispatchStarMapIntake(
     ) {
       directoryKey = undefined;
     }
+    // Whether the operator answered an earlier ask with a project that still
+    // exists. A `directoryKey` this instance no longer has is cleared above,
+    // and the payload that travelled with it was extracted for that project —
+    // so it must not ride along onto whatever the fallback resolves instead.
+    const operatorPickedProject = directoryKey !== undefined;
     if (!directoryKey) {
       const preferences = await readIntakePreferences();
+      const agentOutcome = await resolveViaIntakeAgent({
+        requestId,
+        text,
+        preferences,
+        directories,
+      });
+      if (agentOutcome?.kind === "created") {
+        publishIntakeStatus({
+          requestId,
+          phase: "done",
+          backend: agentOutcome.backend,
+          threadId: agentOutcome.threadId,
+        });
+        return {
+          status: "created",
+          requestId,
+          backend: agentOutcome.backend,
+          threadId: agentOutcome.threadId,
+        };
+      }
+      if (agentOutcome?.kind === "needs_disambiguation") {
+        // An agent that asked with no usable candidate still asked. Show the
+        // registry by recency rather than an empty list under a heading
+        // promising options: `recent` is the honest source for that, and it
+        // is the same thing the deterministic path says when its resolver
+        // ran and pointed nowhere.
+        const asked: RankedDirectory[] = [];
+        for (const candidate of agentOutcome.candidates) {
+          const directory = directories.find(
+            (entry) => entry.key === candidate.directoryKey,
+          );
+          if (!directory) continue;
+          asked.push({
+            directory,
+            confidence: 0,
+            ...(candidate.reason ? { reason: candidate.reason } : {}),
+          });
+        }
+        publishIntakeStatus({ requestId, phase: "needs_disambiguation" });
+        return {
+          status: "needs_disambiguation",
+          requestId,
+          candidateSource: asked.length > 0 ? "resolver" : "recent",
+          candidates: (asked.length > 0
+            ? asked
+            : [...directories]
+                .sort(byRecency)
+                .map<RankedDirectory>((directory) => ({
+                  directory,
+                  confidence: 0,
+                })))
+            .slice(0, MAX_DISAMBIGUATION_CANDIDATES)
+            .map(candidateOf),
+          ...(agentOutcome.input ? { input: agentOutcome.input } : {}),
+        };
+      }
       const resolved = await resolveViaConfiguredBackend({
         text,
         preferences,
@@ -449,12 +605,20 @@ export async function dispatchStarMapIntake(
     });
     const registry = getDesktopBackendRegistry();
     const launchpad = await ensureStarMapIntakeLaunchpad(registry, directory);
+    // `input` is the task the agent already extracted before it asked which
+    // project. Preferring it is what makes the operator's pick cost one
+    // creation instead of a second agent turn re-deriving the same sentence —
+    // and it is the only way the answer to "which project?" still produces
+    // "Make the donuts" rather than the instruction that asked for it.
+    const firstTurnText = operatorPickedProject
+      ? request.input?.trim() || text
+      : text;
     const materialized = await registry.materializeDirectoryLaunchpad(
       {
         directoryKey,
         launchpad,
         input: [
-          { type: "text", text },
+          { type: "text", text: firstTurnText },
           ...(request.attachments ?? []),
         ],
       },

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -95,6 +95,7 @@ import type {
   TurnStartParams as CodexTurnStartParams,
   TurnSteerParams as CodexTurnSteerParams,
   DynamicToolSpec as CodexDynamicToolSpec,
+  DynamicToolCallResponse,
   UserInput as CodexUserInput,
 } from "@pwrdrvr/codex-app-server-protocol/v2";
 import { IterableMapper } from "@shutterstock/p-map-iterable";
@@ -151,6 +152,8 @@ const DEFAULT_CODEX_COLLABORATION_MODEL = "gpt-5.5";
 export const DEFAULT_CODEX_THREAD_TITLE_MODEL = "gpt-5.6-luna";
 const DEFAULT_CODEX_THREAD_TITLE_TIMEOUT_MS = 20_000;
 const CODEX_THREAD_TITLE_CONFIG_READ_REASON = "thread-title-mcp-inventory";
+/** Wire method Codex uses to invoke a dynamic tool the client advertised. */
+const CODEX_DYNAMIC_TOOL_CALL_METHOD = "item/tool/call";
 const CODEX_CONNECTION_MCP_CONFIG_READ_REASON = "connection-mcp-inventory";
 const CODEX_THREAD_TITLE_WORKSPACE_DIR = path.join(
   tmpdir(),
@@ -7359,6 +7362,16 @@ async function requestThreadListPages(params: {
   return mergedThreads;
 }
 
+/**
+ * Services one dynamic tool call made by a helper tool turn. Receives the raw
+ * request so the single `readAgentDynamicToolCall` parser in agent-tool land
+ * stays the only place that decodes the wire shape.
+ */
+export type HelperThreadToolCallHandler = (request: {
+  method: string;
+  params: Record<string, unknown>;
+}) => Promise<DynamicToolCallResponse>;
+
 type HelperTurnResult =
   | {
       status: "ok";
@@ -7441,6 +7454,30 @@ export class CodexAppServerClient {
     string,
     StructuredRecordPredicate
   >();
+  /**
+   * Helper threads that are allowed to call PwrAgent dynamic tools, and the
+   * handler that services those calls.
+   *
+   * Routing them here rather than through the ordinary notification/request
+   * listeners is the point. `BackendRegistry.handleServerRequest` gates every
+   * dynamic tool call on `activeTurnKeys` — proof that the call came from a
+   * live turn on a thread the registry owns. A helper turn is ephemeral and
+   * never enters that map, so it could not pass the gate; registering the
+   * thread here for exactly the lifetime of its turn is the same proof
+   * expressed by ownership instead of by lookup. Nothing outside the caller's
+   * `runHelperToolTurn` frame can reach the handler.
+   */
+  private readonly helperThreadToolHandlers = new Map<
+    string,
+    HelperThreadToolCallHandler
+  >();
+  /**
+   * Helper threads whose turn completes on `turn/completed` alone, with no
+   * structured record required. A tool turn's outcome is whatever its tools
+   * did, so demanding a final JSON object would fail turns that already
+   * succeeded.
+   */
+  private readonly helperToolTurnThreadIds = new Set<string>();
 
   /** Unknown notification methods already warned about on this connection. */
   private readonly reportedUnknownNotificationMethods = new Set<string>();
@@ -7533,6 +7570,13 @@ export class CodexAppServerClient {
       }
     });
     this.rawConnection.setRequestHandler(async (method, params, rpcId) => {
+      const helperToolCallParams = asRecord(params);
+      const helperToolHandler = helperToolCallParams
+        ? this.resolveHelperThreadToolHandler(method, helperToolCallParams)
+        : undefined;
+      if (helperToolHandler && helperToolCallParams) {
+        return await helperToolHandler({ method, params: helperToolCallParams });
+      }
       const wireRequest = isKnownCodexServerRequestMethod(method)
         ? ({
             method,
@@ -7606,6 +7650,8 @@ export class CodexAppServerClient {
     this.pendingFirstTurnShellEnvironments.clear();
     this.recordedThreadNames.clear();
     this.helperThreadIds.clear();
+    this.helperThreadToolHandlers.clear();
+    this.helperToolTurnThreadIds.clear();
     this.completedHelperTurnResults.clear();
     this.mcpStartupStatusByContext.clear();
     this.helperTurnTitleObjects.clear();
@@ -8084,6 +8130,24 @@ export class CodexAppServerClient {
       readHelperTokenUsage(notification.params) ?? this.helperTurnTokenUsage.get(key);
     this.helperTurnTitleObjects.delete(key);
     this.helperTurnTokenUsage.delete(key);
+    if (!object && this.helperToolTurnThreadIds.has(threadId)) {
+      // A tool turn's product is the side effects its tools had, not a final
+      // JSON record. Completion alone is success; the caller reads what its
+      // own tool handler captured.
+      const completion: Extract<HelperTurnResult, { status: "ok" }> = {
+        status: "ok",
+        object: undefined,
+        ...(tokenUsage !== undefined ? { tokenUsage } : {}),
+      };
+      if (!waiter) {
+        this.completedHelperTurnResults.set(key, completion);
+        return;
+      }
+      clearTimeout(waiter.timer);
+      this.helperTurnWaiters.delete(key);
+      waiter.resolve(completion);
+      return;
+    }
     if (!object) {
       const error = new Error("codex_title_turn_completed_without_title");
       if (!waiter) {
@@ -8143,6 +8207,21 @@ export class CodexAppServerClient {
         timer,
       });
     });
+  }
+
+  /**
+   * Returns the tool handler owning this request, or `undefined` to let the
+   * ordinary listeners have it. Keyed on the helper thread, so a registered
+   * intake turn services its own calls and every other thread is untouched.
+   */
+  private resolveHelperThreadToolHandler(
+    method: string,
+    params: Record<string, unknown>,
+  ): HelperThreadToolCallHandler | undefined {
+    if (method !== CODEX_DYNAMIC_TOOL_CALL_METHOD) return undefined;
+    const threadId = readStringFromRecord(params, "threadId");
+    if (!threadId) return undefined;
+    return this.helperThreadToolHandlers.get(threadId);
   }
 
   private rejectHelperTurnWaiters(error: Error): void {
@@ -9077,6 +9156,34 @@ export class CodexAppServerClient {
   }
 
   /**
+   * Run one ephemeral helper turn that may call PwrAgent dynamic tools.
+   *
+   * The same isolation as `generateStructuredObject` — a throwaway thread, a
+   * scratch cwd, no project docs, every configured MCP server disabled and
+   * attested — with exactly one capability added: the tools in
+   * `dynamicTools`, serviced by `onToolCall` for this turn only.
+   *
+   * There is no return value beyond success or failure. The turn's product is
+   * whatever its tools did, so the caller reads the outcome from the handler
+   * it supplied.
+   */
+  async runHelperToolTurn(params: {
+    model?: string;
+    reasoningEffort?: string;
+    prompt: string;
+    system?: string;
+    dynamicTools: CodexDynamicToolSpec[];
+    onToolCall: HelperThreadToolCallHandler;
+    timeoutMs?: number;
+    turnTimeoutMs?: number;
+  }): Promise<{ status: "ok" } | { status: "failed"; reason: string }> {
+    const result = await this.runHelperStructuredTurn(params);
+    return result.status === "ok"
+      ? { status: "ok" }
+      : { status: "failed", reason: result.reason };
+  }
+
+  /**
    * Returns only the effective MCP server names. Connection setup uses this to
    * avoid creating a transport-less disable entry for an alias that Codex did
    * not inherit. The protocol observer redacts the complete config response.
@@ -9150,9 +9257,17 @@ export class CodexAppServerClient {
     model?: string;
     reasoningEffort?: string;
     prompt: string;
-    schema: Record<string, unknown>;
+    /** Omitted by a tool turn, whose product is its tool calls. */
+    schema?: Record<string, unknown>;
     system?: string;
-    isMatch: StructuredRecordPredicate;
+    isMatch?: StructuredRecordPredicate;
+    /**
+     * PwrAgent tools this helper may call. Supplying these also supplies
+     * `onToolCall`; one without the other either advertises tools nothing can
+     * service or registers a handler nothing can reach.
+     */
+    dynamicTools?: CodexDynamicToolSpec[];
+    onToolCall?: HelperThreadToolCallHandler;
     timeoutMs?: number;
     /**
      * How long the model itself may take to answer, separately from the
@@ -9179,6 +9294,12 @@ export class CodexAppServerClient {
     const helperReasoningEffort =
       normalizeCodexReasoningEffort(params.reasoningEffort) ?? "low";
     const helperSystem = params.system?.trim() || "";
+    const isToolTurn = Boolean(params.onToolCall);
+    // A tool turn has no output schema, so nothing it emits should be
+    // mistaken for a result. Never matching keeps `turn/completed` the only
+    // thing that ends it.
+    const helperPredicate: StructuredRecordPredicate =
+      params.isMatch ?? (isToolTurn ? () => false : TITLE_RECORD_PREDICATE);
     const protocolCompatibility = this.getProtocolCompatibility();
     try {
       const mcpServerNames = await this.readHelperMcpServerNames(
@@ -9207,6 +9328,7 @@ export class CodexAppServerClient {
               serviceTier: null,
               ephemeral: true,
               config: helperConfig,
+              ...(params.dynamicTools ? { dynamicTools: params.dynamicTools } : {}),
             },
             protocolCompatibility,
           ),
@@ -9220,6 +9342,7 @@ export class CodexAppServerClient {
               serviceTier: null,
               ephemeral: true,
               config: legacyHelperConfig,
+              ...(params.dynamicTools ? { dynamicTools: params.dynamicTools } : {}),
             },
             protocolCompatibility,
           ),
@@ -9265,7 +9388,14 @@ export class CodexAppServerClient {
         });
       }
       this.helperThreadIds.add(helperThreadId);
-      this.helperThreadPredicates.set(helperThreadId, params.isMatch);
+      this.helperThreadPredicates.set(helperThreadId, helperPredicate);
+      if (params.onToolCall) {
+        // Registered only after the attestation above proves this thread has
+        // no MCP tools, and torn down in `finally`. Between those two points
+        // the thread is the sole holder of this handler.
+        this.helperThreadToolHandlers.set(helperThreadId, params.onToolCall);
+        this.helperToolTurnThreadIds.add(helperThreadId);
+      }
 
       const turnStartResult = await requestWithFallbacks({
         client: this.connection,
@@ -9278,7 +9408,12 @@ export class CodexAppServerClient {
               model: helperModel,
               serviceTier: null,
               reasoningEffort: helperReasoningEffort,
-              outputSchema: params.schema as CodexTurnStartParams["outputSchema"],
+              ...(params.schema
+                ? {
+                    outputSchema:
+                      params.schema as CodexTurnStartParams["outputSchema"],
+                  }
+                : {}),
             },
             protocolCompatibility,
           ),
@@ -9291,7 +9426,7 @@ export class CodexAppServerClient {
         timeoutMs: Math.max(timeoutMs, turnTimeoutMs),
       });
       helperTurnId = extractTurnIdFromValue(turnStartResult);
-      const immediateObject = findStructuredRecord(turnStartResult, params.isMatch);
+      const immediateObject = findStructuredRecord(turnStartResult, helperPredicate);
       if (immediateObject) {
         helperTurnCompleted = true;
         const tokenUsage = readHelperTokenUsage(turnStartResult);
@@ -9370,6 +9505,8 @@ export class CodexAppServerClient {
         }
         this.helperThreadIds.delete(helperThreadId);
         this.helperThreadPredicates.delete(helperThreadId);
+        this.helperThreadToolHandlers.delete(helperThreadId);
+        this.helperToolTurnThreadIds.delete(helperThreadId);
       }
     }
   }

--- a/apps/desktop/src/main/federation/federation-agent-tools-service.ts
+++ b/apps/desktop/src/main/federation/federation-agent-tools-service.ts
@@ -118,6 +118,17 @@ export function createFederationAgentToolsHandler(
     resolveSourceTurnAttachments?: (
       context: PwrAgentFederationContext,
     ) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>;
+    /**
+     * Overrides how a created thread records who asked for it. The default
+     * credits the calling thread, which is right for one agent delegating to
+     * another. A caller whose "calling thread" is an ephemeral turn that
+     * dissolves — the Star Map intake agent — must override it: a
+     * `sourceThread` pointing at a thread that no longer exists renders a
+     * dead ThreadChip on the created thread's first turn forever.
+     */
+    resolveMessageOrigin?: (
+      context: PwrAgentFederationContext,
+    ) => AppServerThreadMessageOrigin;
   } = {},
 ): PwrAgentFederationHandler {
   const runtime = options.runtime ?? getDesktopFederationRuntime;
@@ -148,6 +159,7 @@ export function createFederationAgentToolsHandler(
           options.targetStore,
           options.onRemoteChildMounted,
           options.resolveSourceTurnAttachments,
+          options.resolveMessageOrigin,
         );
       }
       return await searchFederationThreads(
@@ -391,6 +403,9 @@ async function createInstanceThread(
   resolveSourceTurnAttachments: ((
     context: PwrAgentFederationContext,
   ) => AppServerTurnInputItem[] | Promise<AppServerTurnInputItem[]>) | undefined,
+  resolveMessageOrigin: ((
+    context: PwrAgentFederationContext,
+  ) => AppServerThreadMessageOrigin) | undefined,
 ): Promise<PwrAgentFederationResponse> {
   const resolved = await resolveInstance(runtime, args.instanceId, collectHostInfo);
   if (!resolved.ok) {
@@ -447,13 +462,15 @@ async function createInstanceThread(
     ? groupingParent.instanceId
     : undefined;
   const draft = buildLaunchpadDraft({ config, directory, args });
-  const messageOrigin: AppServerThreadMessageOrigin = {
-    kind: "agent",
-    sourceThread: {
-      backend: context.backend,
-      threadId: context.threadId,
-    },
-  };
+  const messageOrigin: AppServerThreadMessageOrigin = resolveMessageOrigin
+    ? resolveMessageOrigin(context)
+    : {
+        kind: "agent",
+        sourceThread: {
+          backend: context.backend,
+          threadId: context.threadId,
+        },
+      };
   const attachmentInput = resolveSourceTurnAttachments
     ? await resolveSourceTurnAttachments(context)
     : [];

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -4,6 +4,10 @@ import { performance } from "node:perf_hooks";
 import { getDesktopBackendRegistry } from "./app-server/backend-registry";
 import { getDesktopOverlayStore } from "./app-server/desktop-overlay-store";
 import { createPwrAgentAppManagementHandler } from "./agent-tools/pwragent-app-management-service";
+import type {
+  CreateInstanceThreadResult,
+  PwrAgentFederationContext,
+} from "@pwragent/shared";
 import { createFederationAgentToolsHandler } from "./federation/federation-agent-tools-service";
 import { createFederatedThreadInspectionHandler } from "./federation/federated-thread-inspection-service";
 import { createFederatedThreadMutationHandler } from "./federation/federated-thread-mutation-service";
@@ -1290,28 +1294,49 @@ export function bootstrapApp(): void {
     );
     // Injected rather than owned by the registry: the federation runtime
     // already imports the registry, so the reverse import would be a cycle.
+    const federationAgentToolOptions = {
+      targetStore: getDesktopOverlayStore(),
+      resolveSourceTurnAttachments: (context: PwrAgentFederationContext) => {
+        const turnId = context.turnId?.trim();
+        return turnId
+          ? getDesktopBackendRegistry().getTurnInputAttachments({
+              backend: context.backend,
+              threadId: context.threadId,
+              turnId,
+            })
+          : [];
+      },
+      onRemoteChildMounted: async ({
+        backend,
+        instanceId,
+        threadId,
+      }: {
+        backend: CreateInstanceThreadResult["backend"];
+        instanceId: string;
+        threadId: string;
+      }) => {
+        await getDesktopBackendRegistry().publishLocalEvent({
+          backend,
+          notification: {
+            method: "navigation/remoteThreadPins/changed",
+            params: { instanceId, threadId, pinned: true },
+          },
+        });
+      },
+    };
     getDesktopBackendRegistry().setPwrAgentFederationHandler(
+      createFederationAgentToolsHandler(federationAgentToolOptions),
+    );
+    // The same tools, for the Star Map [+] intake agent. It differs in one
+    // field: the intake's calling thread is an ephemeral turn that dissolves
+    // the moment it finishes, so crediting it as the created thread's
+    // `sourceThread` would leave a ThreadChip linking to nothing. An intake
+    // thread was asked for by the operator through PwrAgent, which is what
+    // the dialog recorded before there was an agent in the loop.
+    getDesktopBackendRegistry().setStarMapIntakeFederationHandler(
       createFederationAgentToolsHandler({
-        targetStore: getDesktopOverlayStore(),
-        resolveSourceTurnAttachments: (context) => {
-          const turnId = context.turnId?.trim();
-          return turnId
-            ? getDesktopBackendRegistry().getTurnInputAttachments({
-                backend: context.backend,
-                threadId: context.threadId,
-                turnId,
-              })
-            : [];
-        },
-        onRemoteChildMounted: async ({ backend, instanceId, threadId }) => {
-          await getDesktopBackendRegistry().publishLocalEvent({
-            backend,
-            notification: {
-              method: "navigation/remoteThreadPins/changed",
-              params: { instanceId, threadId, pinned: true },
-            },
-          });
-        },
+        ...federationAgentToolOptions,
+        resolveMessageOrigin: () => ({ kind: "pwragent" }),
       }),
     );
     getDesktopBackendRegistry().setFederatedThreadMessageHandler(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1327,17 +1327,28 @@ export function bootstrapApp(): void {
     getDesktopBackendRegistry().setPwrAgentFederationHandler(
       createFederationAgentToolsHandler(federationAgentToolOptions),
     );
-    // The same tools, for the Star Map [+] intake agent. It differs in one
-    // field: the intake's calling thread is an ephemeral turn that dissolves
-    // the moment it finishes, so crediting it as the created thread's
-    // `sourceThread` would leave a ThreadChip linking to nothing. An intake
-    // thread was asked for by the operator through PwrAgent, which is what
-    // the dialog recorded before there was an agent in the loop.
-    getDesktopBackendRegistry().setStarMapIntakeFederationHandler(
-      createFederationAgentToolsHandler({
-        ...federationAgentToolOptions,
-        resolveMessageOrigin: () => ({ kind: "pwragent" }),
-      }),
+    // The same tools, for the Star Map [+] intake agent — built per intake
+    // rather than once, because two of its options are properties of the one
+    // request rather than of the machine:
+    //
+    // - `resolveMessageOrigin`: the intake's calling thread is an ephemeral
+    //   turn that dissolves the moment it finishes, so crediting it as the
+    //   created thread's `sourceThread` would leave a ThreadChip linking to
+    //   nothing. An intake thread was asked for by the operator through
+    //   PwrAgent, which is what the dialog recorded before there was an agent
+    //   in the loop.
+    // - `resolveSourceTurnAttachments`: the shared resolver looks the calling
+    //   thread's turn up in the registry, and an ephemeral helper turn is not
+    //   in it — so it returns nothing and the operator's pasted screenshots
+    //   never reach the thread they described. The intake's staged
+    //   attachments are handed in directly instead.
+    getDesktopBackendRegistry().setStarMapIntakeFederationHandlerFactory(
+      (attachments) =>
+        createFederationAgentToolsHandler({
+          ...federationAgentToolOptions,
+          resolveMessageOrigin: () => ({ kind: "pwragent" }),
+          resolveSourceTurnAttachments: () => attachments,
+        }),
     );
     getDesktopBackendRegistry().setFederatedThreadMessageHandler(
       createFederatedThreadMessageHandler({

--- a/apps/desktop/src/main/ipc/star-map.ts
+++ b/apps/desktop/src/main/ipc/star-map.ts
@@ -110,6 +110,7 @@ async function stageStarMapIntakeRequest(
     ...(request.directoryKey !== undefined
       ? { directoryKey: request.directoryKey }
       : {}),
+    ...(request.input !== undefined ? { input: request.input } : {}),
     ...(attachments.length > 0 ? { attachments } : {}),
   };
 }

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -122,6 +122,13 @@ export function IntakeDialog(props: {
      * than a second resolution of the same sentence.
      */
     input?: string;
+    /**
+     * The request that payload was extracted from. The textarea stays live
+     * while the operator chooses, so an edit made before they pick has to
+     * retire the payload — otherwise their correction is silently replaced by
+     * the sentence they corrected.
+     */
+    requestText?: string;
   }>();
   /**
    * The project the owning instance resolved to, streamed with `creating`.
@@ -405,7 +412,9 @@ export function IntakeDialog(props: {
           setCandidates({
             entries: response.candidates,
             source: response.candidateSource,
-            ...(response.input ? { input: response.input } : {}),
+            ...(response.input
+              ? { input: response.input, requestText: request }
+              : {}),
           });
           return;
         }
@@ -539,7 +548,16 @@ export function IntakeDialog(props: {
                 key={candidate.directoryKey}
                 type="button"
                 className="star-map-intake__candidate"
-                onClick={() => submit(candidate.directoryKey, candidates.input)}
+                onClick={() =>
+                  submit(
+                    candidate.directoryKey,
+                    // Only when the request is still the one it was derived
+                    // from; an edited request has to be read afresh.
+                    candidates.requestText === text.trim()
+                      ? candidates.input
+                      : undefined,
+                  )
+                }
               >
                 <span className="star-map-intake__candidate-label">
                   {candidate.label}

--- a/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/IntakeDialog.tsx
@@ -116,6 +116,12 @@ export function IntakeDialog(props: {
   const [candidates, setCandidates] = useState<{
     entries: StarMapIntakeCandidate[];
     source: StarMapIntakeCandidateSource;
+    /**
+     * The task the intake already extracted before it asked which project.
+     * Sent back with the pick so answering costs a thread creation rather
+     * than a second resolution of the same sentence.
+     */
+    input?: string;
   }>();
   /**
    * The project the owning instance resolved to, streamed with `creating`.
@@ -345,7 +351,7 @@ export function IntakeDialog(props: {
     }
   }, [attachTransferredImages]);
 
-  const submit = (directoryKey?: string) => {
+  const submit = (directoryKey?: string, input?: string) => {
     const request = text.trim();
     if (
       !request
@@ -366,6 +372,7 @@ export function IntakeDialog(props: {
         requestId,
         request,
         directoryKey,
+        ...(directoryKey && input ? { input } : {}),
         federationTarget: props.target.federationTarget,
         ...(imageAttachments.length > 0
           ? {
@@ -398,6 +405,7 @@ export function IntakeDialog(props: {
           setCandidates({
             entries: response.candidates,
             source: response.candidateSource,
+            ...(response.input ? { input: response.input } : {}),
           });
           return;
         }
@@ -531,7 +539,7 @@ export function IntakeDialog(props: {
                 key={candidate.directoryKey}
                 type="button"
                 className="star-map-intake__candidate"
-                onClick={() => submit(candidate.directoryKey)}
+                onClick={() => submit(candidate.directoryKey, candidates.input)}
               >
                 <span className="star-map-intake__candidate-label">
                   {candidate.label}

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -246,6 +246,52 @@ describe("IntakeDialog", () => {
     });
   });
 
+  /**
+   * The textarea stays live while the operator chooses, so a payload derived
+   * from the old wording must not survive an edit — otherwise their
+   * correction is silently replaced by the sentence they corrected.
+   */
+  it("retires the extracted payload when the request is edited before the pick", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    let calls = 0;
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        (calls++ > 0
+          ? {
+              status: "created",
+              requestId: request.requestId,
+              backend: "codex",
+              threadId: "thread-2",
+            }
+          : {
+              status: "needs_disambiguation",
+              requestId: request.requestId,
+              candidateSource: "resolver",
+              candidates: [{ directoryKey: "dir-a", label: "PwrSnap" }],
+              input: "Make the donuts.",
+            }) as never,
+    );
+
+    submitText("Make a thread and ask it to make the donuts.");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /PwrSnap/ })).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByPlaceholderText(/Give me a task/), {
+      target: { value: "Make the donuts, but only the glazed ones." },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /PwrSnap/ }));
+
+    await waitFor(() => {
+      const last = dispatchStarMapIntake.mock.calls.at(-1)?.[0] as unknown as {
+        request: string;
+        input?: string;
+      };
+      expect(last.request).toBe("Make the donuts, but only the glazed ones.");
+      expect(last.input).toBeUndefined();
+    });
+  });
+
   it("omits the payload on a first dispatch, which has nothing to carry", async () => {
     const { dispatchStarMapIntake } = setup(undefined);
     dispatchStarMapIntake.mockImplementation(

--- a/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
+++ b/apps/desktop/src/renderer/src/features/star-map/__tests__/IntakeDialog.test.tsx
@@ -201,6 +201,69 @@ describe("IntakeDialog", () => {
     });
   });
 
+  /**
+   * The intake already separated the task from the instruction that addressed
+   * it before it asked which project. Echoing that payload back with the pick
+   * is what keeps the operator's answer to one thread creation instead of a
+   * second agent turn re-reading the same sentence.
+   */
+  it("sends the extracted payload back with the operator's pick", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    let calls = 0;
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        (calls++ > 0
+          ? {
+              status: "created",
+              requestId: request.requestId,
+              backend: "codex",
+              threadId: "thread-2",
+            }
+          : {
+              status: "needs_disambiguation",
+              requestId: request.requestId,
+              candidateSource: "resolver",
+              candidates: [
+                { directoryKey: "dir-a", label: "PwrSnap" },
+              ],
+              input: "Make the donuts.",
+            }) as never,
+    );
+
+    submitText("Make a thread and ask it to make the donuts.");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /PwrSnap/ })).toBeTruthy();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /PwrSnap/ }));
+
+    await waitFor(() => {
+      expect(dispatchStarMapIntake).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          directoryKey: "dir-a",
+          input: "Make the donuts.",
+        }),
+      );
+    });
+  });
+
+  it("omits the payload on a first dispatch, which has nothing to carry", async () => {
+    const { dispatchStarMapIntake } = setup(undefined);
+    dispatchStarMapIntake.mockImplementation(
+      async (request: { requestId: string }) =>
+        ({
+          status: "created",
+          requestId: request.requestId,
+          backend: "codex",
+          threadId: "thread-2",
+        }) as never,
+    );
+
+    submitText("Make the donuts in PwrSnap");
+
+    await waitFor(() => expect(dispatchStarMapIntake).toHaveBeenCalled());
+    expect(dispatchStarMapIntake.mock.calls[0][0]).not.toHaveProperty("input");
+  });
+
   it("says so when the list is a recency fallback rather than a ranking", async () => {
     const { dispatchStarMapIntake } = setup(undefined);
     dispatchStarMapIntake.mockImplementation(

--- a/packages/shared/src/contracts/star-map.ts
+++ b/packages/shared/src/contracts/star-map.ts
@@ -534,6 +534,14 @@ export type StarMapIntakeRequest = {
   requestId: string;
   request: string;
   directoryKey?: string;
+  /**
+   * The task for the created thread's first turn, when the intake already
+   * worked it out. Sent back with `directoryKey` after the operator picks a
+   * project, so their answer costs a thread creation rather than a second
+   * agent turn to re-read the same sentence. Absent on a first dispatch, and
+   * ignored without `directoryKey`.
+   */
+  input?: string;
   attachments?: StarMapIntakeAttachment[];
 };
 
@@ -551,6 +559,11 @@ export type StarMapIntakeResponse =
       candidates: StarMapIntakeCandidate[];
       /** Whether `candidates` is a real ranking or a recency fallback. */
       candidateSource: StarMapIntakeCandidateSource;
+      /**
+       * The task the intake extracted from the request before it got stuck on
+       * which project. Echo it back as `input` with the operator's pick.
+       */
+      input?: string;
     }
   | {
       status: "failed";


### PR DESCRIPTION
## The problem

`dispatchStarMapIntake` resolved the operator's request to a directory with one structured helper call, then pasted their raw text in as the created thread's first turn. It had no concept of the request being addressed *to it*.

Observed 2026-09-11: the operator typed *"Make a thread in the PwrAgnt project and ask it to make the donuts."* The intake created a thread in PwrAgent with that sentence as its prompt; that thread's agent — which has the orchestration catalog — correctly interpreted it and created a **second** thread with "Make the donuts." One relay thread whose only job was to understand a sentence, at $0.48 on gpt-6-astra.

Messaging never had this problem: there you address an *existing* agent that calls `create_instance_thread`, whose `input` parameter is documented "Include the concrete task, not the parent transcript." The agent authors the payload separately from your instruction.

## The change

An **implicit** agent turn. It runs headless and ephemeral, creates the thread itself, and dissolves — the operator sees one thread appear, not a relay thread that asked for it. No visible orchestrator thread on every intake; that would institutionalize the extra hop this exists to remove.

The classifier was a hand-rolled partial reimplementation of `create_instance_thread`, whose description already covers the intake's whole job. Every gap in it was getting closed by bolting on another JSON schema field; the agent gets settings inheritance, model overrides, worktree-vs-local, base branch and target instance free, because those tool parameters already exist.

`docs/agent-operator-preferences.md` already described this as "the Star Map `[+]` intake sub-agent" deciding "where **and how** to start threads." The docs described the intended design; now the code does both halves.

## The new work

Three building blocks existed; one combination did not. `startThread({ephemeral:true})` + `startTurn`, `dynamicTools` on thread start, and `resolveAgentToolCatalogs` — but the headless path passes no `dynamicTools`, and the helper path *attests* it has none.

`runHelperStructuredTurn` is **generalized rather than copied**, so a tool turn inherits the scratch cwd, the zeroed project-doc budget, the disabled-and-attested MCP servers, the `turnTimeoutMs` split and the cleanup unchanged.

Tool calls route **inside the client**, keyed on the helper thread for exactly the lifetime of its turn. `BackendRegistry.handleServerRequest` gates every dynamic tool call on `activeTurnKeys` — proof the call came from a live turn on a thread the registry owns. An ephemeral helper turn can never enter that map, so ownership expresses the same proof instead of a lookup.

## Bounding the misfire

A tool-using turn can create real threads, so this is deliberately tighter than the catalogs it draws from — **4 tools, not 16**:

| Advertised | Withheld | Why |
|---|---|---|
| `list_federation_instances` | `steer_thread`, `stop_thread`, `send_message_to_thread`, `start_review`, `move_thread_workspace`, `detach_thread_directory`, the 4 monitor tools | Mutate an **existing** thread. A misfire could damage work the operator never mentioned. |
| `list_instance_projects` | `search_federation_threads` | The tool that would let a confused intake *find* something to damage. |
| `create_instance_thread` | `handoff_task`, `attach_thread_directory` | Act on "the current thread" and gate on `isLiveDynamicToolCall`. An ephemeral turn cannot satisfy it, so their only possible answer is `forbidden` — advertising them spends tokens on tools that can only fail. |
| `ask_operator_to_pick_project` | | |

Plus a hard cap: **the first successful creation ends the intake**, so a misfire creates at most one junk thread — the same blast radius the classifier had. And a small model (`gpt-5.6-luna`, the helper default), not gpt-6-astra.

> The last row is narrower than the option approved in planning, which listed `handoff_task` and `attach_thread_directory` as advertised. Verifying the handler showed both hard-fail from a threadless intake, so they are withheld instead.

## Disambiguation

Settled with the operator before building: a dedicated `ask_operator_to_pick_project` tool returning through the existing `needs_disambiguation` response. `IntakeDialog`'s candidate list, the `candidateSource` copy and `e2e/a11y.spec.ts` are untouched.

It also carries the payload the agent already extracted, so the operator's pick creates the thread directly — **one model turn per intake, however many times it asks**. A `directoryKey` this instance no longer has is cleared, and the payload that travelled with it is dropped rather than riding onto whatever the fallback resolves instead.

## The dead ThreadChip

`create_instance_thread` credits the calling thread as `sourceThread`, which `TurnInputContent` renders as a clickable `ThreadChip`. For an intake that would link to a turn that no longer exists — on every thread the intake ever made. The federation handler factory gains a `resolveMessageOrigin` override; the intake's own handler instance stamps `{kind:"pwragent"}`, which is what the dialog recorded before there was an agent in the loop.

## Preserved from #2087

The reveal (`flyToThread` + `openThread`, untouched); the escapable `resolving` wait — `creating` is still published **with the project name, before the thread exists**, via an `onCreateStarting` hook in the create wrapper; the `turnTimeoutMs`/`timeoutMs` split including `Math.max` on `turn/start`; the honest `resolver`/`label`/`recent`/`unresolved` copy; and the latency logging (the agent path logs its own).

The deterministic resolver stays as the fallback for a machine with no Codex backend — `fuzzyMatchDirectories`, the `resolverAgrees` check, recency ordering, `candidateSource: "unresolved"`. Its 80-directory prompt cap deliberately does **not** carry to the agent path: that bounds a prompt, and an operator's 81st project should not be invisible to a tool that can page `list_instance_projects`.

## Testing

`pnpm test` — **807 files, 11,592 tests pass**. Typecheck, eslint (0 errors), `lint:boundaries`, `lint:sql`, `lint:codex-storage`, `lint:colors` all clean. Per repo guidance the Electron/Playwright suite was not run locally; CI runs it here.

44 new tests. What they can and cannot prove is kept explicit:

- **The reported case**, at the seam this change owns: whatever the agent passes as `input` is what the created thread's first turn receives, and exactly one thread is created. The operator's sentence never reaches the new thread.
- **The negative control**: an ordinary request that merely mentions threads ("Write a feature that creates threads from a template") carries no instruction to strip and arrives unchanged.
- The model's *judgment* between those two is carried by the system prompt, not by a unit test — so the prompt is asserted to actually contain both cases, the relay warning, and the paging instruction, and cannot be edited away silently.
- **The misfire**: a second `create_instance_thread` is refused upstream of the handler, and the first outcome stands.
- Every withheld tool is named individually, so a future catalog addition has to be thought about rather than silently inherited.
- Client-level: tools reach the wire, no `outputSchema` is sent, a tool call on the helper thread routes to the handler, one from **another** thread does not, and routing stops when the turn ends.
- The existing `star-map-intake.test.ts` mock now returns `undefined` for the agent turn by default, so all 21 original tests keep covering the fallback rather than quietly ceasing to exercise anything.

## Still open

`IntakeDialog` drops a `needs_disambiguation` response that arrives after the operator closed the dialog — their typed request is gone and they must retype. This redesign did not fix it naturally; recovering it needs `StarMapScreen` state well outside this diff, the same reason it was deferred when first reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
