### PR TITLE
fix(desktop): close the gap above an empty directory's status line

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1930,7 +1930,13 @@ export function DirectoriesList(props: DirectoriesListProps) {
                   <p className="sidebar-empty directory-row__empty">{directory.counts ? "No threads in this directory yet." : "Loading directory counts…"}</p>
                 )}
                 {rootResource?.state.error ? <p className="sidebar-error">{rootResource.state.error}</p> : null}
-                {rootResource?.loading && !rootResource.state.page ? <p className="sidebar-empty">Loading threads…</p> : null}
+                {/* `directory-row__empty` reads as "empty" but means "a status
+                    line in a directory's lane" — the sibling above already
+                    wears it for "Loading directory counts…". Without it this
+                    line keeps the sidebar-level 12px top margin and no lane
+                    inset, so it landed 20px below that sibling and 8px to its
+                    left. Both render together while a directory first opens. */}
+                {rootResource?.loading && !rootResource.state.page ? <p className="sidebar-empty directory-row__empty">Loading threads…</p> : null}
                 {rootResource?.state.rebaselineRequired ? (
                   <SidebarShowMore label="Reload this directory" onClick={() => void props.pagedNavigation?.restart(rootResourceId)} />
                 ) : rootResource?.state.page?.nextCursor ? (

--- a/apps/desktop/src/renderer/src/styles/__tests__/sidebar-empty-spacing-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/sidebar-empty-spacing-contract.test.ts
@@ -3,44 +3,59 @@ import { describe, expect, it } from "vitest";
 import { appCss, cssRuleBody } from "./css-rule-body";
 
 /**
- * Locks the spacing above an expanded-but-empty directory's status line
- * ("No threads in this directory yet." / "Loading directory counts…").
+ * Locks the spacing of a directory's in-lane status line — "No threads in this
+ * directory yet.", "Loading directory counts…", "Loading threads…".
  *
- * The bug this exists for was never a missing declaration. `margin-top: 0`
- * was present and correct; it was written as `.directory-row__empty`, which
- * ties with `.sidebar-empty` on specificity — and `.sidebar-empty` sits
- * further down `app.css` re-asserting the top margin through the `margin`
- * shorthand, so the later rule won. An expanded empty directory carried 16px
- * of air above the message against 6px below it, and the message read as
- * belonging to nothing. A `toContain("margin-top: 0")` assertion would have
- * passed the whole time it was broken, which is why this test asserts the
- * SELECTOR instead: the override only does anything if it out-specifies the
- * rule it has to beat.
+ * The bug this exists for was never a missing declaration. `margin-top: 0` was
+ * present and correct; it was written as `.directory-row__empty`, which ties
+ * with `.sidebar-empty` on specificity — and `.sidebar-empty` sits further
+ * down `app.css` re-asserting the top margin through the `margin` shorthand,
+ * so the later rule won. An expanded empty directory carried 16px of air above
+ * the message against 6px below it, and the message read as belonging to
+ * nothing. A `toContain("margin-top: 0")` assertion would have passed the
+ * whole time it was broken, which is why this file asserts the SELECTOR
+ * instead: the override only does anything if it out-specifies the rule it has
+ * to beat.
  *
  * Not asserted through `getComputedStyle`, even though this suite runs in
  * jsdom and the outcome would be the better thing to check: jsdom resolves a
- * later SHORTHAND over an earlier longhand regardless of specificity (an
- * `#id` rule loses to a later `.class` one), so it reports 12px for a
- * stylesheet Chromium — the renderer's actual engine — resolves to 0px.
+ * later SHORTHAND over an earlier longhand regardless of specificity (an `#id`
+ * rule loses to a later `.class` one), so it reports 12px for a stylesheet
+ * Chromium — the renderer's actual engine — resolves to 0px.
  */
 describe("directory empty-state spacing", () => {
+  // Both classes (0-2-0) beat `.sidebar-empty` (0-1-0) wherever either rule
+  // moves to in the file. Demoting this to the single-class form is the
+  // regression, and the file order that punishes it is not local to either
+  // rule, so nothing at the edit site would show it. Absent entirely, the
+  // helper throws naming the selector it could not find.
+  const override = cssRuleBody(".sidebar-empty.directory-row__empty");
+
   it("out-specifies the sidebar-level rule it has to beat", () => {
-    // Both classes (0-2-0) beat `.sidebar-empty` (0-1-0) wherever either rule
-    // moves to in the file. Demoting this back to the single-class form is
-    // the regression; the file order that punishes it is not local to either
-    // rule, so nothing at the edit site would show it.
-    expect(cssRuleBody(".sidebar-empty.directory-row__empty")).toMatch(
-      /\bmargin-top:\s*0\s*;/,
-    );
-    expect(appCss).not.toMatch(/(?:^|\n)\.directory-row__empty\s*\{/);
+    expect(override).toMatch(/\bmargin-top:\s*0(?:px)?\s*[;}]?/);
+  });
+
+  it("keeps the lane inset that aligns the line with the thread titles", () => {
+    // The override's other half, and the half that never broke — which is
+    // exactly why it needs asserting: it went on working while `margin-top`
+    // silently did not, so nothing about the rule looked wrong.
+    expect(override).toMatch(/\bpadding-left:\s*8px\s*[;}]?/);
   });
 
   it("still has a shorthand to beat", () => {
     // The premise. If `.sidebar-empty` ever stops setting the whole `margin`
     // shorthand, the override above is belt-and-braces rather than
     // load-bearing — worth knowing here rather than rediscovering.
-    expect(cssRuleBody(".sidebar-empty,\n.context-empty,\n.transcript-empty")).toMatch(
-      /\bmargin:\s*12px\s+0\s+0\s*;/,
+    //
+    // Matched out of the raw stylesheet rather than through `cssRuleBody`,
+    // which keys on an exact selector line: `.sidebar-empty` ships inside a
+    // three-selector group, so naming it there means hard-coding that group's
+    // current line breaks and getting a "no such selector" throw the day
+    // someone reflows it or adds a fourth.
+    const sidebarEmptyRule = appCss.match(
+      /\n\.sidebar-empty\s*[,{][\s\S]*?\{(?<body>[\s\S]*?)\n\}/,
     );
+
+    expect(sidebarEmptyRule?.groups?.body).toMatch(/\bmargin:\s*[^;]+;/);
   });
 });

--- a/apps/desktop/src/renderer/src/styles/__tests__/sidebar-empty-spacing-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/sidebar-empty-spacing-contract.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { appCss, cssRuleBody } from "./css-rule-body";
+
+/**
+ * Locks the spacing above an expanded-but-empty directory's status line
+ * ("No threads in this directory yet." / "Loading directory counts…").
+ *
+ * The bug this exists for was never a missing declaration. `margin-top: 0`
+ * was present and correct; it was written as `.directory-row__empty`, which
+ * ties with `.sidebar-empty` on specificity — and `.sidebar-empty` sits
+ * further down `app.css` re-asserting the top margin through the `margin`
+ * shorthand, so the later rule won. An expanded empty directory carried 16px
+ * of air above the message against 6px below it, and the message read as
+ * belonging to nothing. A `toContain("margin-top: 0")` assertion would have
+ * passed the whole time it was broken, which is why this test asserts the
+ * SELECTOR instead: the override only does anything if it out-specifies the
+ * rule it has to beat.
+ *
+ * Not asserted through `getComputedStyle`, even though this suite runs in
+ * jsdom and the outcome would be the better thing to check: jsdom resolves a
+ * later SHORTHAND over an earlier longhand regardless of specificity (an
+ * `#id` rule loses to a later `.class` one), so it reports 12px for a
+ * stylesheet Chromium — the renderer's actual engine — resolves to 0px.
+ */
+describe("directory empty-state spacing", () => {
+  it("out-specifies the sidebar-level rule it has to beat", () => {
+    // Both classes (0-2-0) beat `.sidebar-empty` (0-1-0) wherever either rule
+    // moves to in the file. Demoting this back to the single-class form is
+    // the regression; the file order that punishes it is not local to either
+    // rule, so nothing at the edit site would show it.
+    expect(cssRuleBody(".sidebar-empty.directory-row__empty")).toMatch(
+      /\bmargin-top:\s*0\s*;/,
+    );
+    expect(appCss).not.toMatch(/(?:^|\n)\.directory-row__empty\s*\{/);
+  });
+
+  it("still has a shorthand to beat", () => {
+    // The premise. If `.sidebar-empty` ever stops setting the whole `margin`
+    // shorthand, the override above is belt-and-braces rather than
+    // load-bearing — worth knowing here rather than rediscovering.
+    expect(cssRuleBody(".sidebar-empty,\n.context-empty,\n.transcript-empty")).toMatch(
+      /\bmargin:\s*12px\s+0\s+0\s*;/,
+    );
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -6571,7 +6571,17 @@ a.button {
   width: 100%;
 }
 
-.directory-row__empty {
+/* BOTH classes, and not `.directory-row__empty` alone: the element carries
+   `.sidebar-empty` too, and that rule sets the whole `margin` shorthand
+   (`12px 0 0`) from further DOWN the file. At equal specificity the later
+   rule wins, so the single-class override lost `margin-top` silently and an
+   expanded empty directory sat on 16px of air above the message (4px of
+   `.directory-row__details` top pad + 12px) against 6px below it — a gap the
+   rail reads as a layout break, not as breathing room. The declaration was
+   here the whole time; only its specificity was wrong. Two classes (0-2-0)
+   beat the sidebar-level rule (0-1-0) wherever either one moves to.
+   `padding-left` never noticed, because `.sidebar-empty` sets no padding. */
+.sidebar-empty.directory-row__empty {
   margin-top: 0;
   padding-left: 8px;
 }


### PR DESCRIPTION
Expanding a directory with no threads left **16px of air above** "No threads in this directory yet." against **6px below it**, so the message read as floating between two directories instead of belonging to the one above it.

## Before / After

Light theme:

![empty directory spacing, light theme](https://github.com/user-attachments/assets/a877a6c7-4d71-4bd8-8f5e-1c97ebc9327b)

Dark theme:

![empty directory spacing, dark theme](https://github.com/user-attachments/assets/40d9633f-0aff-4a73-8bb6-28d55faa55d2)

Contrived directory names, rendered off `app.css` at `HEAD` and at this branch side by side.

## Cause

The declaration meant to prevent this was already there, and correct:

```css
.directory-row__empty {
  margin-top: 0;
  padding-left: 8px;
}
```

It just never applied. The element carries `.sidebar-empty` too, and that rule re-asserts the top margin through the `margin` shorthand about 100 lines further down `app.css`:

```css
.sidebar-empty,
.context-empty,
.transcript-empty {
  margin: 12px 0 0;
  ...
}
```

Equal specificity (0-1-0 each), later rule wins. `padding-left` never noticed, because `.sidebar-empty` sets no padding — only the margin was being overwritten, which is why the rule looked like it was working.

The fix writes the override as `.sidebar-empty.directory-row__empty`, so it wins at 0-2-0 wherever either rule moves to in the file. The comment at line 3470 already referred to this element as "the in-lane `.sidebar-empty.directory-row__empty`", so that was the intended shape.

Measured in headless Chromium off a standalone `app.css` harness: the seam under the header goes 16px → 4px (the `.directory-row__details` top pad, which is all it should ever have been), and the 6px below is unchanged.

## On the test

`sidebar-empty-spacing-contract.test.ts` asserts the **selector**, not the computed style. Both of the obvious alternatives are worse:

- `toContain("margin-top: 0")` would have passed for the entire time this was broken. The declaration was never the problem.
- `getComputedStyle` would fail on the *fixed* file. This suite runs in jsdom, and jsdom resolves a later **shorthand** over an earlier longhand regardless of specificity — an `#id` rule loses to a later `.class` one. It reports 12px for a stylesheet Chromium (the renderer's actual engine) resolves to 0px. Verified both directions against a reduced case.

So the test asserts the one thing that makes the override effective in real CSS — that it out-specifies the rule it has to beat — and pins the premise that `.sidebar-empty` still sets the shorthand. Negative control run: demoting the selector back to the single-class form fails it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Follow-up: the same slot's other status line

Code review caught that `.directory-row__details` holds **two** status lines, not one. `<p className="sidebar-empty">Loading threads…</p>` is a sibling of the message above, and it was still a bare `.sidebar-empty` — so it kept the exact 12px margin this PR removes, and never had the 8px lane inset at all. Both render together while a directory first opens.

![directory loading lines, light theme](https://github.com/user-attachments/assets/a09b1236-f2c9-4b94-b4ef-7b3ec75fff09)

![directory loading lines, dark theme](https://github.com/user-attachments/assets/cc083709-7ab8-4fd8-82da-e3544dbe9342)

Measured: 20px below the line above it (12px margin + the container's 8px gap) and 8px to its left → now 8px and aligned. Fixed by giving it the `directory-row__empty` class the sibling already wears, rather than adding a rule — the class reads as "empty" but means "a status line in a directory's lane", and it already carries "Loading directory counts…".

The review also tightened the contract test: it now asserts `padding-left: 8px` survives (the override's other half, and the half that went on silently working while `margin-top` silently did not), finds `.sidebar-empty` by matching the stylesheet instead of hard-coding its three-selector group's current line breaks, and asserts only that the rule still sets the `margin` shorthand rather than pinning `12px 0 0`. The `not.toMatch` guard is gone — a 0-1-0 rule cannot beat a 0-2-0 one wherever it sits, so it guarded nothing. Negative controls run for all three: dropping `padding-left` fails, turning the shorthand into a longhand fails, reflowing the selector group passes.
