### PR TITLE
fix(desktop): preserve sidebar state between lenses

### DIFF
--- a/apps/desktop/e2e/a11y.spec.ts
+++ b/apps/desktop/e2e/a11y.spec.ts
@@ -727,12 +727,14 @@ for (const theme of AUDIT_THEMES) {
           await settle();
           await runAxe(app.window, "directories lens, collapsed");
         });
-        await test.step("user expansion reveals lazy pins under a stationary pointer", async () => {
+        await test.step("user expansion restores loaded rows under a stationary pointer", async () => {
           await directory.click();
           await expect(directory).toHaveAttribute("aria-expanded", "true");
-          // No mouse move or hover release before the asynchronous pages arrive.
+          // No mouse move or hover release while the retained pages refresh.
+          // Reopening preserves the extra rows loaded above instead of resetting
+          // the directory to its first ten unpinned roots.
           await expect(threads.locator('[data-thread-pin-state="pinned"]')).toHaveCount(2);
-          await expect(threads.locator('[data-thread-pin-state="unpinned"]')).toHaveCount(10);
+          await expect(threads.locator('[data-thread-pin-state="unpinned"]')).toHaveCount(12);
         });
       } finally {
         await app.close();

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { readNavigationPresentationOrder, retainNavigationPresentationOrder, type NavigationPresentationOrder } from "./navigation-presentation-order";
 import type { useBoundedNavigationWindow } from "../../lib/useBoundedNavigationWindow";
 import { navigationThreadSelectionKey } from "../../lib/navigation-query-state";
+import { useLensScrollRestoration } from "../../lib/useLensScrollRestoration";
 import type { NavigationDirectoryView as NavigationDirectorySummary } from "../../lib/navigation-loaded-rows";
 import type { PendingLaunchpadCreation } from "../../lib/useThreadNavigation";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -567,6 +568,14 @@ export function Sidebar(props: SidebarProps) {
   const rowsByKey = useMemo(() => new Map(props.threads.map((thread) => [threadSummaryIdentityKey(thread), thread])), [props.threads]);
   const visibleThreads = [...new Map(lensResources.flatMap((resource) => resource.state.page?.entries ?? [])
     .map((entry) => [navigationThreadSelectionKey(entry.row.ref), rowsByKey.get(navigationThreadSelectionKey(entry.row.ref))])).values()].filter((thread): thread is NavigationThreadSummary => Boolean(thread));
+  const lensQuery = props.pagedNavigation?.resources.get("lens")?.state.request.query;
+  const lensMatches = !props.pagedNavigation || props.browseMode === "directories" || props.browseMode === "drafts"
+    || (lensQuery?.kind === "lens" && lensQuery.lens === props.browseMode);
+  const lensScroll = useLensScrollRestoration(
+    JSON.stringify([federationTarget, props.browseMode]),
+    !props.loading && lensMatches && lensResources.every((resource) =>
+      resource.state.page?.entries.every((entry) => rowsByKey.has(navigationThreadSelectionKey(entry.row.ref))) ?? !resource.loading),
+  );
   const hoverStableSnapshot = useHoverStableSnapshot({
     hydrateFrozenValue: (frozen, latest) =>
       hydrateHoverStableSidebarSnapshot(frozen, latest, {
@@ -1940,7 +1949,9 @@ export function Sidebar(props: SidebarProps) {
         </div>
 
         <div
+          ref={lensScroll.ref}
           className="sidebar__scroll-region"
+          onScroll={lensScroll.onScroll}
           onClickCapture={hoverStableSnapshot.onClickCapture}
           onPointerCancel={hoverStableSnapshot.onPointerCancel}
           onPointerLeave={hoverStableSnapshot.onPointerLeave}

--- a/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/Sidebar.tsx
@@ -568,14 +568,6 @@ export function Sidebar(props: SidebarProps) {
   const rowsByKey = useMemo(() => new Map(props.threads.map((thread) => [threadSummaryIdentityKey(thread), thread])), [props.threads]);
   const visibleThreads = [...new Map(lensResources.flatMap((resource) => resource.state.page?.entries ?? [])
     .map((entry) => [navigationThreadSelectionKey(entry.row.ref), rowsByKey.get(navigationThreadSelectionKey(entry.row.ref))])).values()].filter((thread): thread is NavigationThreadSummary => Boolean(thread));
-  const lensQuery = props.pagedNavigation?.resources.get("lens")?.state.request.query;
-  const lensMatches = !props.pagedNavigation || props.browseMode === "directories" || props.browseMode === "drafts"
-    || (lensQuery?.kind === "lens" && lensQuery.lens === props.browseMode);
-  const lensScroll = useLensScrollRestoration(
-    JSON.stringify([federationTarget, props.browseMode]),
-    !props.loading && lensMatches && lensResources.every((resource) =>
-      resource.state.page?.entries.every((entry) => rowsByKey.has(navigationThreadSelectionKey(entry.row.ref))) ?? !resource.loading),
-  );
   const hoverStableSnapshot = useHoverStableSnapshot({
     hydrateFrozenValue: (frozen, latest) =>
       hydrateHoverStableSidebarSnapshot(frozen, latest, {
@@ -595,6 +587,15 @@ export function Sidebar(props: SidebarProps) {
   const presentedByKey = new Map(presentedThreads.map((thread) => [threadSummaryIdentityKey(thread), thread]));
   const renderedThreads = props.browseMode === "directories" ? presentedThreads
     : hoverStableSnapshot.value.visibleKeys.map((key) => presentedByKey.get(key)).filter((thread): thread is NavigationThreadSummary => Boolean(thread));
+  const renderedDirectoryKeys = new Set(renderedDirectories.map((directory) => directory.key));
+  const lensScroll = useLensScrollRestoration(
+    JSON.stringify([federationTarget, props.browseMode]),
+    !props.loading && (!props.pagedNavigation || (props.pagedNavigation.presentationReady
+      && [...props.pagedNavigation.resources.values()].every(({ state }) =>
+        (state.page?.entries.every((entry) => presentedByKey.has(navigationThreadSelectionKey(entry.row.ref))) ?? true)
+        && (props.browseMode !== "directories"
+          || (state.page?.directories?.every((directory) => renderedDirectoryKeys.has(directory.key)) ?? true))))),
+  );
   /**
    * Hover stability protects a target from background list churn. A command
    * the operator chose must instead reveal its resulting snapshot immediately.

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/paged-pin-moves.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/paged-pin-moves.test.tsx
@@ -29,7 +29,7 @@ function mount(terminal = false) {
     [`directory-pins:${directory.key}`, resource(`directory-pins:${directory.key}`, { kind: "directory", directoryKey: directory.key, roots: "pinned" },
       { rangeStart: 5, complete: false, nextCursor: terminal ? undefined : "next", entries: rows.map((row) => ({ row, placement: { kind: "root" }, orderKey: row.pinnedRank! })) })],
   ]);
-  const navigation = { resources, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
+  const navigation = { resources, presentationReady: true, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
     invalidate: () => undefined, refresh: async () => undefined, loadMore: async () => undefined,
     rebaseline: async () => undefined, restart, setVisibleAnchor: () => undefined };
   const mounted = render(<Sidebar backends={[]} browseMode="directories" directories={[directory]} threads={rows}
@@ -152,7 +152,7 @@ it("breadcrumb reveal uses exact owner ancestry even when loaded summaries lack 
   const resources = new Map([["selected-context", exact], [rootId,
     resource(rootId, { kind: "directory", directoryKey: directory.key, roots: "unpinned" }, {})]]);
   const rebaseline = vi.fn(async () => undefined);
-  const navigation = { resources, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
+  const navigation = { resources, presentationReady: true, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
     invalidate: () => undefined, refresh: async () => undefined, loadMore: async () => undefined,
     rebaseline, restart: async () => undefined, setVisibleAnchor: () => undefined };
   const view = render(<Sidebar backends={[]} browseMode="directories" directories={[directory]} threads={[parent, child]}
@@ -178,7 +178,7 @@ it.each(["directories", "inbox"] as const)("keeps expected disconnected child-pa
   resources.set("lens", resource("lens", { kind: "lens", lens: "inbox" }, {
     entries: [{ row: parent, placement: { kind: "root" }, orderKey: "0" }],
   }));
-  const navigation = { resources, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
+  const navigation = { resources, presentationReady: true, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
     invalidate: () => undefined, refresh: async () => undefined, loadMore: async () => undefined,
     rebaseline: async () => undefined, restart: async () => undefined, setVisibleAnchor: () => undefined };
   const view = render(<Sidebar backends={[]} browseMode={browseMode} directories={[directory]} threads={[parent]}
@@ -211,7 +211,7 @@ it("keeps a paged sub-thread tray a valid list", () => {
   const resources = new Map([[childId, children], [pinsId, resource(pinsId,
     { kind: "directory", directoryKey: directory.key, roots: "pinned" },
     { entries: [{ row: parent, placement: { kind: "root" }, orderKey: "0" }] })]]);
-  const navigation = { resources, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
+  const navigation = { resources, presentationReady: true, directories: [directory], selectedDirectoryKeys: [directory.key], connected: true,
     invalidate: () => undefined, refresh: async () => undefined, loadMore: async () => undefined,
     rebaseline: async () => undefined, restart: async () => undefined, setVisibleAnchor: () => undefined };
   const view = render(<Sidebar backends={[]} browseMode="directories" directories={[directory]} threads={[parent, child]}

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -812,7 +812,7 @@ describe("Sidebar", () => {
       threads={[sharedThread]} inboxThreads={[]} loading={false} creatingThread={undefined}
       selectedItemKey="codex:thread-1" onBrowseModeChange={() => undefined}
       onCreateThread={async () => undefined} onOpenLaunchpad={async () => undefined} onSelectThread={() => undefined}
-      pagedNavigation={{ resources: new Map([["directory-index", { id: "directory-index", loading: false,
+      pagedNavigation={{ presentationReady: true, resources: new Map([["directory-index", { id: "directory-index", loading: false,
         state: { ...createNavigationPageState(request), page } }]]), directories: [], selectedDirectoryKeys: undefined, connected: true,
         invalidate: () => undefined, refresh: async () => undefined, loadMore: async () => undefined,
         rebaseline: async () => undefined, restart: async () => undefined, setVisibleAnchor: () => undefined }} />);

--- a/apps/desktop/src/renderer/src/lib/__tests__/navigation-window-queries.test.ts
+++ b/apps/desktop/src/renderer/src/lib/__tests__/navigation-window-queries.test.ts
@@ -16,6 +16,42 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
+it("restores a lens range synchronously while a fresh lease refreshes it in place", async () => {
+  const refreshed = deferred<NavigationQueryPage>();
+  const read = vi.fn().mockResolvedValueOnce(page({ queryKey: "inbox", complete: true, nextCursor: undefined }))
+    .mockResolvedValueOnce(page({ queryKey: "recents" }))
+    .mockReturnValueOnce(refreshed.promise);
+  const release = vi.fn(async () => undefined);
+  const queries = new NavigationWindowQueries({ getNavigationQueryPage: read, releaseNavigationQuery: release });
+  const inbox = new Map([["lens", request()]]);
+  const recents = new Map([["lens", { ...request(), query: { kind: "lens" as const, lens: "recents" as const } }]]);
+  queries.setDemand(inbox);
+  await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.loading).toBe(false));
+  queries.setDemand(recents);
+  await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.state.page?.queryKey).toBe("recents"));
+  queries.setDemand(inbox);
+  expect(queries.getSnapshot().resources.get("lens")?.state.page?.queryKey).toBe("inbox");
+  expect(queries.getSnapshot().resources.get("lens")?.loading).toBe(true);
+  await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(3));
+  expect(read.mock.calls[2]?.[1]).not.toBe(read.mock.calls[0]?.[1]);
+  expect(read.mock.calls[2]?.[0].completeBaselineRevision).toBeUndefined();
+  refreshed.resolve(page({ queryKey: "inbox-updated" }));
+  await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.state.page?.queryKey).toBe("inbox-updated"));
+  queries.dispose();
+});
+
+it("does not restore another owner's lens even with the same resource id", async () => {
+  const pending = deferred<NavigationQueryPage>();
+  const read = vi.fn().mockResolvedValueOnce(page()).mockReturnValueOnce(pending.promise);
+  const queries = new NavigationWindowQueries({ getNavigationQueryPage: read });
+  queries.setDemand(new Map([["lens", request()]]));
+  await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.loading).toBe(false));
+  queries.setDemand(new Map([["lens", { ...request(), federationTarget: { scope: "remote", instanceId: "other" } }]]));
+  expect(queries.getSnapshot().resources.get("lens")?.state.page).toBeUndefined();
+  queries.dispose();
+  pending.resolve(page());
+});
+
 it("requests only demanded first pages and loads continuation only on explicit demand", async () => {
   const read = vi.fn<NonNullable<DesktopApi["getNavigationQueryPage"]>>(async () => page());
   const release = vi.fn(async () => undefined);
@@ -113,6 +149,25 @@ it("enforces the aggregate retained range budget while keeping the accepted base
   expect(state.stale).toBe(true);
   expect(state.error).toContain("retained-page budget");
   expect(new TextEncoder().encode(JSON.stringify(state.page)).byteLength).toBeLessThan(8 * 1024 * 1024);
+  queries.dispose();
+});
+
+it("evicts inactive ranges before they consume the active view's byte budget", async () => {
+  const read = vi.fn(async () => page({ complete: true, nextCursor: undefined,
+    directories: [{ key: "directory", kind: "directory" as const, label: "x".repeat(240_000),
+      counts: { total: 0, active: 0, unread: 0, review: 0 }, pinnedRootCount: 0, unpinnedRootCount: 0, launchpadPresent: false }],
+  }));
+  const queries = new NavigationWindowQueries({ getNavigationQueryPage: read });
+  for (let index = 0; index < 37; index += 1) {
+    queries.setDemand(new Map([["lens", request(String(index))]]));
+    await vi.waitFor(() => expect(queries.getSnapshot().resources.get("lens")?.loading).toBe(false));
+    expect(queries.getSnapshot().resources.get("lens")?.state.error).toBeUndefined();
+  }
+  queries.setVisible(false);
+  queries.setDemand(new Map([["lens", request("0")]]));
+  expect(queries.getSnapshot().resources.get("lens")?.state.page).toBeUndefined();
+  queries.setDemand(new Map([["lens", request("36")]]));
+  expect(queries.getSnapshot().resources.get("lens")?.state.page).toBeDefined();
   queries.dispose();
 });
 

--- a/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useBoundedNavigationWindow.test.tsx
@@ -1,9 +1,11 @@
-import { act, renderHook, waitFor } from "@testing-library/react";
-import { StrictMode } from "react";
+import { act, fireEvent, render, renderHook, waitFor } from "@testing-library/react";
+import { StrictMode, useLayoutEffect } from "react";
 import { expect, it, vi } from "vitest";
 import type { AgentEvent, NavigationDirectoryRow, NavigationQueryPage, NavigationRow } from "@pwragent/shared";
 import type { DesktopApi } from "../desktop-api";
 import { useBoundedNavigationWindow } from "../useBoundedNavigationWindow";
+import { useNavigationDirectoryDisclosure } from "../useNavigationDirectoryDisclosure";
+import { Sidebar } from "../../features/navigation/Sidebar";
 
 const directory: NavigationDirectoryRow = { key: "directory:off-page", kind: "directory", label: "Project",
   counts: { total: 1000, active: 20, unread: 30, review: 10 }, pinnedRootCount: 4, unpinnedRootCount: 996, launchpadPresent: false };
@@ -24,6 +26,90 @@ function api() {
       onAgentEvent: (callback: (event: AgentEvent) => void) => { listener = callback; return () => { listener = undefined; }; },
     } satisfies DesktopApi };
 }
+
+it.each(["drafts", "directories"] as const)("waits for the demand transition even when %s is empty", async (destination) => {
+  const fixture = api();
+  const renders: boolean[] = [];
+  const { result, rerender, unmount } = renderHook(({ mode }: { mode: "inbox" | typeof destination }) => {
+    const navigation = useBoundedNavigationWindow({ ...base, browseMode: mode, desktopApi: fixture.desktopApi });
+    if (mode === destination) renders.push(navigation.presentationReady);
+    return navigation;
+  }, { initialProps: { mode: "inbox" } });
+  await waitFor(() => expect(result.current.presentationReady).toBe(true));
+  rerender({ mode: destination });
+  expect(renders[0]).toBe(false);
+  await waitFor(() => expect(result.current.presentationReady).toBe(true));
+  unmount();
+});
+
+it("waits for the expanded unpinned section after directory descriptors and pins arrive", async () => {
+  const fixture = api();
+  let finish!: () => void;
+  const pending = new Promise<void>((resolve) => { finish = resolve; });
+  fixture.read.mockImplementation(async (request) => {
+    if (request.query.kind === "directory" && request.query.roots === "unpinned") await pending;
+    return page({ directories: request.query.kind === "directory-index" ? [directory] : undefined });
+  });
+  const { result, unmount } = renderHook(() => useBoundedNavigationWindow({ ...base,
+    desktopApi: fixture.desktopApi, expandedByKey: { [directory.key]: true } }));
+  await waitFor(() => expect(result.current.resources.get(`directory-pins:${directory.key}`)?.state.page).toBeDefined());
+  expect(result.current.presentationReady).toBe(false);
+  await act(async () => finish());
+  await waitFor(() => expect(result.current.presentationReady).toBe(true));
+  unmount();
+});
+
+it.each(["drafts", "directories"] as const)("restores %s only after its cached resources and rendered rows return", async (destination) => {
+  const fixture = api();
+  const rows: NavigationRow[] = Array.from({ length: 10 }, (_, index) => ({
+    id: `saved-${index}`, source: "codex", title: `Saved ${index}`, titleSource: "explicit",
+    ref: { backend: "codex", threadId: `saved-${index}` }, rowRevision: "r", linkedDirectories: [],
+    inbox: { inInbox: true }, ordinaryChildCount: 0, nativeSubAgentGroupPresent: false,
+    queueCount: 0, queueState: "unknown",
+  }));
+  const draftRefs = rows.map((row) => row.ref);
+  fixture.read.mockImplementation(async (request) => page({
+    directories: request.query.kind === "directory-index" ? [directory] : undefined,
+    entries: (request.query.kind === "exact" || (request.query.kind === "directory" && request.query.roots === "unpinned")
+      ? rows : []).map((row) => ({ row, placement: { kind: "root" }, orderKey: row.id })),
+  }));
+  let navigation!: ReturnType<typeof useBoundedNavigationWindow>;
+  function Window(props: { mode: "inbox" | typeof destination; hydrated: boolean }) {
+    const disclosure = useNavigationDirectoryDisclosure();
+    useLayoutEffect(() => { disclosure.setExpandedByKey({ [directory.key]: true }); }, [disclosure.setExpandedByKey]);
+    navigation = useBoundedNavigationWindow({ ...base, browseMode: props.mode, desktopApi: fixture.desktopApi,
+      expandedByKey: disclosure.expandedByKey, draftRefs });
+    const threads = props.hydrated ? [...navigation.resources.values()].flatMap((resource) => resource.state.page?.entries.map(({ row }) => row) ?? []) : [];
+    return <Sidebar backends={[]} browseMode={props.mode} directories={props.hydrated ? navigation.directories : []}
+      threads={threads} inboxThreads={threads} pagedNavigation={navigation} directoryDisclosure={disclosure}
+      loading={false} onBrowseModeChange={() => undefined} onSelectThread={() => undefined}
+      onCreateThread={async () => undefined} onOpenLaunchpad={async () => undefined} />;
+  }
+  const mounted = render(<Window mode={destination} hydrated />);
+  try {
+    await waitFor(() => expect(mounted.container.querySelectorAll(".thread-row-shell")).toHaveLength(10));
+    const scroll = mounted.container.querySelector<HTMLDivElement>(".sidebar__scroll-region")!;
+    let offset = 0;
+    // jsdom does not perform browser layout or clamp scrollTop on a short list.
+    Object.defineProperty(scroll, "scrollTop", { configurable: true, get: () => offset,
+      set: (value: number) => { offset = Math.max(0, Math.min(value, mounted.container.querySelectorAll(".thread-row-shell").length * 50 - 100)); } });
+    scroll.scrollTop = 180;
+    fireEvent.scroll(scroll);
+    mounted.rerender(<Window mode="inbox" hydrated />);
+    await waitFor(() => expect(navigation.presentationReady).toBe(true));
+    expect(scroll.scrollTop).toBe(0);
+    mounted.rerender(<Window mode={destination} hydrated={false} />);
+    expect(scroll.scrollTop).toBe(0);
+    // Cached owner pages have arrived, but the parent has yet to hydrate rows
+    // and directory descriptors into the actual sidebar presentation.
+    await waitFor(() => expect(navigation.presentationReady).toBe(true));
+    mounted.rerender(<Window mode={destination} hydrated />);
+    expect(mounted.container.querySelectorAll(".thread-row-shell")).toHaveLength(10);
+    expect(scroll.scrollTop).toBe(180);
+  } finally {
+    mounted.unmount();
+  }
+});
 
 it.each([
   [false, "owner"], [false, "viewer"], [true, "owner"], [true, "viewer"],

--- a/apps/desktop/src/renderer/src/lib/__tests__/useLensScrollRestoration.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useLensScrollRestoration.test.tsx
@@ -1,0 +1,27 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, expect, it } from "vitest";
+import { useLensScrollRestoration } from "../useLensScrollRestoration";
+
+afterEach(cleanup);
+
+function Lens(props: { lens: string; ready: boolean }) {
+  const scroll = useLensScrollRestoration(props.lens, props.ready);
+  return <div data-testid="scroll" {...scroll} />;
+}
+
+it("restores independent lens positions after their rows are ready", () => {
+  const view = render(<Lens lens="inbox" ready />);
+  const element = view.getByTestId("scroll");
+  fireEvent.scroll(element, { target: { scrollTop: 240 } });
+  view.rerender(<Lens lens="recents" ready />);
+  expect(element.scrollTop).toBe(0);
+  fireEvent.scroll(element, { target: { scrollTop: 80 } });
+  view.rerender(<Lens lens="inbox" ready={false} />);
+  fireEvent.scroll(element, { target: { scrollTop: 0 } });
+  view.rerender(<Lens lens="inbox" ready />);
+  expect(element.scrollTop).toBe(240);
+  view.rerender(<Lens lens="inbox" ready />);
+  expect(element.scrollTop).toBe(240);
+  view.rerender(<Lens lens="recents" ready />);
+  expect(element.scrollTop).toBe(80);
+});

--- a/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.bounded.test.tsx
+++ b/apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.bounded.test.tsx
@@ -33,6 +33,31 @@ beforeEach(() => {
 });
 afterEach(() => vi.restoreAllMocks());
 
+it("returns to the loaded lens range without a loading or missing-row frame", async () => {
+  const f = fixture();
+  const originalRead = f.read.getMockImplementation()!;
+  let hold = false;
+  let release!: () => void;
+  const pending = new Promise<void>((resolve) => { release = resolve; });
+  f.read.mockImplementation(async (request) => {
+    if (hold && request.query.kind === "lens") await pending;
+    return originalRead(request);
+  });
+  const { result, unmount } = renderHook(() => useThreadNavigation(f.api));
+  await waitFor(() => expect(result.current.threads.length).toBe(10));
+  await act(() => result.current.pagedNavigation.loadMore("lens"));
+  expect(result.current.threads.length).toBe(20);
+  act(() => result.current.setBrowseMode("recents"));
+  await waitFor(() => expect(result.current.pagedNavigation.resources.get("lens")?.loading).toBe(false));
+  hold = true;
+  act(() => result.current.setBrowseMode("inbox"));
+  expect(result.current.loading).toBe(false);
+  expect(result.current.threads).toHaveLength(20);
+  expect(result.current.pagedNavigation.resources.get("lens")?.state.page?.entries).toHaveLength(20);
+  await act(async () => { hold = false; release(); await pending; });
+  unmount();
+});
+
 it.each([false, true])("waits for New Thread owner authority and respects changed selection=%s", async (changeSelection) => {
   const f = fixture();
   let resolve!: (detail: NavigationSelectedDetailResponse) => void;

--- a/apps/desktop/src/renderer/src/lib/navigation-window-queries.ts
+++ b/apps/desktop/src/renderer/src/lib/navigation-window-queries.ts
@@ -36,6 +36,9 @@ export class NavigationWindowQueries {
   private readonly prefix = `navigation-window:${++nextWindow}`;
   private nextResource = 0;
   private readonly resources = new Map<string, Resource>();
+  // Released transport leases need not discard the view. Keep recently used
+  // ranges window-local, sharing the same byte budget as active resources.
+  private readonly retained = new Map<string, { state: NavigationPageState; anchor?: NavigationQueryAnchor; bytes: number }>();
   private readonly listeners = new Set<() => void>();
   private visible = true;
   private disposed = false;
@@ -64,6 +67,19 @@ export class NavigationWindowQueries {
     this.wakeReaders();
   }
 
+  private retainedKey(id: string, requestKey: string): string {
+    return JSON.stringify([id, requestKey]);
+  }
+
+  private trimRetained(activeBytes: number): void {
+    let bytes = activeBytes + [...this.retained.values()].reduce((total, entry) => total + entry.bytes, 0);
+    for (const [key, entry] of this.retained) {
+      if (bytes <= MAX_RETAINED_BYTES && this.retained.size <= 64) break;
+      this.retained.delete(key);
+      bytes -= entry.bytes;
+    }
+  }
+
   setDemand(demand: ReadonlyMap<string, NavigationQueryRequest>): void {
     if (this.disposed) return;
     const admitted = new Map<string, NavigationQueryRequest>();
@@ -79,6 +95,12 @@ export class NavigationWindowQueries {
     for (const [id, resource] of this.resources) {
       const request = admitted.get(id);
       if (!request || JSON.stringify(request) !== resource.requestKey) {
+        if (resource.value.state.page) {
+          const key = this.retainedKey(id, resource.requestKey);
+          this.retained.delete(key);
+          this.retained.set(key, { state: resource.value.state, anchor: resource.anchor,
+            bytes: new TextEncoder().encode(JSON.stringify(resource.value.state.page)).byteLength });
+        }
         this.release(resource);
         this.resources.delete(id);
         changed = true;
@@ -87,15 +109,21 @@ export class NavigationWindowQueries {
     const added: Resource[] = [];
     for (const [id, request] of admitted) {
       if (this.resources.has(id)) continue;
+      const requestKey = JSON.stringify(request);
+      const retainedKey = this.retainedKey(id, requestKey);
+      const retained = this.retained.get(retainedKey);
+      this.retained.delete(retainedKey);
       const resource: Resource = {
-        requestKey: JSON.stringify(request), token: `${this.prefix}:${++this.nextResource}`,
-        value: { id, state: createNavigationPageState(request), loading: false },
-        refreshAfterPending: false, invalidated: false, released: !this.visible, anchor: request.anchor,
+        requestKey, token: `${this.prefix}:${++this.nextResource}`,
+        value: { id, state: retained ? { ...retained.state, stale: true, error: undefined } : createNavigationPageState(request), loading: false },
+        refreshAfterPending: false, invalidated: false, released: !this.visible, anchor: retained?.anchor ?? request.anchor,
       };
       this.resources.set(id, resource);
       added.push(resource);
       changed = true;
     }
+    if (changed) this.trimRetained([...this.resources.values()].reduce((bytes, resource) => bytes
+      + (resource.value.state.page ? new TextEncoder().encode(JSON.stringify(resource.value.state.page)).byteLength : 0), 0));
     if (changed || admissionError !== this.snapshot.admissionError) {
       this.snapshot = { ...this.snapshot, admissionError };
       this.publish();
@@ -231,6 +259,7 @@ export class NavigationWindowQueries {
             const candidatePage = candidate === resource ? next.page : candidate.value.state.page;
             return bytes + (candidatePage ? new TextEncoder().encode(JSON.stringify(candidatePage)).byteLength : 0);
           }, 0);
+          this.trimRetained(retainedBytes);
           if (retainedBytes > MAX_RETAINED_BYTES) throw new Error("Navigation retained-page budget reached. Collapse a directory or change lens to release pages.");
         };
         const readPage = async (request: NavigationQueryRequest) => {
@@ -305,6 +334,7 @@ export class NavigationWindowQueries {
     this.disposed = true;
     for (const resource of this.resources.values()) this.release(resource);
     this.resources.clear();
+    this.retained.clear();
     this.publish();
     this.listeners.clear();
   }

--- a/apps/desktop/src/renderer/src/lib/useBoundedNavigationWindow.ts
+++ b/apps/desktop/src/renderer/src/lib/useBoundedNavigationWindow.ts
@@ -73,6 +73,15 @@ export function useBoundedNavigationWindow(params: Demand & {
   const demand = buildNavigationWindowDemand({ ...demandParams, disclosedParents });
   addVisibleMountedOwnerDemand({ demand, pages, target: params.target, selectedRef: params.selectedRef });
   const demandKey = JSON.stringify([...demand]);
+  // A previous lens can still own the snapshot during the render that changes
+  // demand. Empty Drafts and collapsed Directories are ready only after that
+  // transition, just like lenses with collection pages.
+  const presentationReady = state.resources.size === demand.size
+    && [...demand].every(([id, request]) => {
+      const resource = state.resources.get(id);
+      return resource && JSON.stringify(resource.state.request) === JSON.stringify(request)
+        && Boolean(resource.state.page || resource.state.error);
+    });
   const demandRef = useRef(demand);
   demandRef.current = demand;
 
@@ -170,5 +179,5 @@ export function useBoundedNavigationWindow(params: Demand & {
   const restart = useCallback((id: string) => controllerRef.current?.restart(id) ?? Promise.resolve(), []);
   const setVisibleAnchor = useCallback((id: string, anchor: NavigationQueryAnchor | undefined) => controllerRef.current?.setVisibleAnchor(id, anchor), []);
   const connectionError = !connected && connection?.target === targetKey ? connection.error : undefined;
-  return { ...state, directories, selectedDirectoryKeys, connected, ...(connectionError ? { connectionError } : {}), invalidate, refresh, loadMore, rebaseline, restart, setVisibleAnchor };
+  return { ...state, presentationReady, directories, selectedDirectoryKeys, connected, ...(connectionError ? { connectionError } : {}), invalidate, refresh, loadMore, rebaseline, restart, setVisibleAnchor };
 }

--- a/apps/desktop/src/renderer/src/lib/useBoundedNavigationWindow.ts
+++ b/apps/desktop/src/renderer/src/lib/useBoundedNavigationWindow.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { classifyDirectory } from "@pwragent/shared";
 import type { NavigationDirectoryRow, NavigationQueryAnchor } from "@pwragent/shared";
 import type { DesktopApi } from "./desktop-api";
@@ -92,7 +92,7 @@ export function useBoundedNavigationWindow(params: Demand & {
     };
   }, [desktopApi]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const controller = controllerRef.current;
     if (!controller) return;
     controller.setVisible(enabled && visible && connected);

--- a/apps/desktop/src/renderer/src/lib/useLensScrollRestoration.ts
+++ b/apps/desktop/src/renderer/src/lib/useLensScrollRestoration.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect, useRef, type UIEvent } from "react";
+
+/** Reading positions belong to each lens, independently of the selected thread. */
+export function useLensScrollRestoration(key: string, ready: boolean) {
+  const ref = useRef<HTMLDivElement>(null);
+  const positions = useRef(new Map<string, number>());
+  const restored = useRef<string | undefined>(undefined);
+  useLayoutEffect(() => {
+    if (!ready || restored.current === key || !ref.current) return;
+    ref.current.scrollTop = positions.current.get(key) ?? 0;
+    restored.current = key;
+  });
+  useLayoutEffect(() => () => {
+    restored.current = undefined;
+  }, [key]);
+  const onScroll = (event: UIEvent<HTMLDivElement>): void => {
+    if (!ready || restored.current !== key) return;
+    positions.current.delete(key);
+    positions.current.set(key, event.currentTarget.scrollTop);
+    if (positions.current.size > 25) positions.current.delete(positions.current.keys().next().value!);
+  };
+  return { ref, onScroll };
+}

--- a/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
+++ b/apps/desktop/src/renderer/src/lib/useThreadNavigation.ts
@@ -8,7 +8,7 @@ import { loadedThreadRows, loadedDirectoryRows, indexLoadedThreadRows, indexLoad
 import { readNavigationUnlinkPlan } from "./navigation-unlink-plan";
 import { readNavigationActionDetail, readNavigationActionThread } from "./navigation-action-authority";
 import { applyLaunchpadEnvironmentSetupProgress, type LaunchpadEnvironmentSetupProgress } from "./launchpad-setup-progress";
-import { useCallback, useEffect, useId, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type {
   AppServerBackendKind,
   AppServerCollaborationModeRequest,
@@ -3130,7 +3130,7 @@ export function useThreadNavigation(
   const acceptedPagesRef = useRef(new Map<string, unknown>());
   const acceptedDefaultsRef = useRef<unknown>(undefined);
   const acceptedDraftHydrationRef = useRef<number | undefined>(undefined);
-  useEffect(() => {
+  useLayoutEffect(() => {
     const pages = new Map([...boundedNavigation.resources].flatMap(([id, resource]) => resource.state.page ? [[id, resource.state.page] as const] : []));
     const changed = pages.size !== acceptedPagesRef.current.size
       || [...pages].some(([id, page]) => acceptedPagesRef.current.get(id) !== page)

--- a/apps/desktop/src/renderer/src/test/navigation-presentation-fixture.tsx
+++ b/apps/desktop/src/renderer/src/test/navigation-presentation-fixture.tsx
@@ -81,7 +81,7 @@ function usePresentationOwner(props: FixtureProps) {
   const directories = (index.directories ?? []).map((descriptor) => ({ ...descriptor,
     launchpad: props.directories.find((directory) => directory.key === descriptor.key)?.launchpad }));
   const loadMore = async (id: string) => setLimits((current) => ({ ...current, [id]: (current[id] ?? 10) + 10 }));
-  const navigation = { resources, directories: index.directories ?? [], selectedDirectoryKeys: undefined, connected: true,
+  const navigation = { resources, presentationReady: true, directories: index.directories ?? [], selectedDirectoryKeys: undefined, connected: true,
     invalidate: () => undefined, refresh: async () => undefined, loadMore,
     rebaseline: async () => undefined, restart: async () => undefined, setVisibleAnchor: () => undefined };
   return { directories, navigation, selectedThreadDirectoryKeys };


### PR DESCRIPTION
## Summary

- Switching sidebar lenses discarded loaded pages and rebuilt the list on return, causing layout shifts. Retain recently viewed ranges within the existing 8 MiB budget and refresh them in place with fresh transport leases.
- Restore each lens's scroll position and reconcile cached rows before paint. Cache identity includes the full request, including the federation target; inactive ranges are evicted first under memory pressure.

## Verification

- Passed navigation controller, bounded-window, sidebar navigation, and scroll restoration tests, including delayed refresh after returning to a 20-row lens, owner isolation, and cache eviction.
- Passed `pnpm typecheck`, `pnpm lint:eslint`, `pnpm lint:boundaries`, and `pnpm build`.
- Passed `git diff --check`.

## Notes

- Retention is window-local memory only; no new persistence or SQLite writes.
- The running app was not restarted. No visual recording was captured; regression coverage exercises the navigation and restoration behavior.
