### PR TITLE
fix(desktop): keep Add a Project Directory above the federation list

### DIFF
--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -24,9 +24,10 @@ import type { FederationThreadTarget } from "./federation-thread-targets";
  *   3. Add a Project Directory…     → track a repo without starting a chat
  *   4. New chat on → <instance>     → open that owner's launchpad
  *
- * The flyout renders when there's either a meaningful directory choice or an
- * explicit project-registration action. That keeps "Add a Project Directory…"
- * reachable even when the current context is already directory-less.
+ * The flyout renders when any one of those exists — a meaningful directory
+ * choice, a reachable instance, or the project-registration action. That last
+ * disjunct keeps "Add a Project Directory…" reachable even when the current
+ * context is already directory-less and no peer is enrolled.
  *
  * Shared by the sidebar masthead and the relocated thread-header / Windows
  * title-bar placements so every surface reads identically.
@@ -196,13 +197,15 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                 New chat without a directory
               </button>
             )}
-            {/* "Add a Project Directory…" sits above the federation group
-                rather than last: that group grows one row per enrolled
-                machine inside a card capped at 420px with `overflow-y: auto`,
-                so a fixed action placed after it is the first thing to fall
-                below the fold on exactly the federations that are hardest to
-                scroll. Ordering it ahead keeps the menu's one
-                non-thread-creating action at a stable offset from the top. */}
+            {/* Order is load-bearing: every fixed action comes first, and
+                the federation group goes last because it is the only part of
+                this menu whose length is not known here — it grows one row
+                per enrolled machine. A fixed action placed after an
+                unbounded list sits at an offset nobody controls, and
+                `.new-thread-menu__card` scrolls once that offset exceeds its
+                height cap, so the action falls below the fold on exactly the
+                federations that make the card hardest to scroll. Keep any
+                new action above this group for the same reason. */}
             {props.onAddProjectDirectory ? (
               <>
                 <div className="new-thread-menu__separator" role="separator" />
@@ -210,8 +213,19 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                   type="button"
                   role="menuitem"
                   className="new-thread-menu__item"
-                  disabled={props.addingProjectDirectory}
+                  // `aria-disabled`, not `disabled`, for the reason
+                  // `FederationTargetMenuSection` gives: a disabled button
+                  // leaves the tab order, and this menu has no arrow-key
+                  // navigation. The registration keeps running after the
+                  // native picker closes, so the window is interactive while
+                  // this row reads "Adding Project Directory…" — dropping it
+                  // from the tab order there hides the in-progress state from
+                  // exactly the users who cannot see it.
+                  aria-disabled={props.addingProjectDirectory || undefined}
                   onClick={() => {
+                    if (props.addingProjectDirectory) {
+                      return;
+                    }
                     dismissImmediately();
                     void props.onAddProjectDirectory?.();
                   }}

--- a/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/NewThreadButton.tsx
@@ -21,8 +21,8 @@ import type { FederationThreadTarget } from "./federation-thread-targets";
  *
  *   1. New chat in <directory>     → `onCreateThread` (context default)
  *   2. New chat without a directory → `onCreateThreadWithoutDirectory`
- *   3. New chat on → <instance>     → open that owner's launchpad
- *   4. Add a Project Directory…     → track a repo without starting a chat
+ *   3. Add a Project Directory…     → track a repo without starting a chat
+ *   4. New chat on → <instance>     → open that owner's launchpad
  *
  * The flyout renders when there's either a meaningful directory choice or an
  * explicit project-registration action. That keeps "Add a Project Directory…"
@@ -196,18 +196,13 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                 New chat without a directory
               </button>
             )}
-            {hasRemoteTargets && props.remoteTargets ? (
-              <>
-                <div className="new-thread-menu__separator" role="separator" />
-                <FederationTargetMenuSection
-                  targets={props.remoteTargets}
-                  onSelect={(instanceId) => {
-                    dismissImmediately();
-                    void props.onCreateThreadOnTarget?.(instanceId);
-                  }}
-                />
-              </>
-            ) : null}
+            {/* "Add a Project Directory…" sits above the federation group
+                rather than last: that group grows one row per enrolled
+                machine inside a card capped at 420px with `overflow-y: auto`,
+                so a fixed action placed after it is the first thing to fall
+                below the fold on exactly the federations that are hardest to
+                scroll. Ordering it ahead keeps the menu's one
+                non-thread-creating action at a stable offset from the top. */}
             {props.onAddProjectDirectory ? (
               <>
                 <div className="new-thread-menu__separator" role="separator" />
@@ -225,6 +220,18 @@ export function NewThreadButton(props: NewThreadButtonProps): ReactElement {
                     ? "Adding Project Directory…"
                     : "Add a Project Directory…"}
                 </button>
+              </>
+            ) : null}
+            {hasRemoteTargets && props.remoteTargets ? (
+              <>
+                <div className="new-thread-menu__separator" role="separator" />
+                <FederationTargetMenuSection
+                  targets={props.remoteTargets}
+                  onSelect={(instanceId) => {
+                    dismissImmediately();
+                    void props.onCreateThreadOnTarget?.(instanceId);
+                  }}
+                />
               </>
             ) : null}
           </div>

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -180,10 +180,10 @@ describe("NewThreadButton", () => {
         .parentElement as HTMLElement,
     );
 
-    // The federation group grows one row per enrolled machine inside a card
-    // capped at 420px with `overflow-y: auto`. Last place put the menu's one
-    // non-thread-creating action below the fold on exactly the federations
-    // that make the card scroll, so its position is pinned here.
+    // The federation group is the only unbounded part of this menu, so every
+    // fixed action has to precede it — after it, an action sits at an offset
+    // that grows with the machine count and drops below the scrolling card's
+    // fold. Pinned here because nothing about the JSX order enforces it.
     const menu = await screen.findByRole("menu");
     expect(
       within(menu)
@@ -196,6 +196,37 @@ describe("NewThreadButton", () => {
       "Studio Mac / work",
       "Laptop",
     ]);
+  });
+
+  it("keeps the Add row focusable and inert while a registration runs", async () => {
+    const onAddProjectDirectory = vi.fn();
+    render(
+      <NewThreadButton
+        addingProjectDirectory
+        onAddProjectDirectory={onAddProjectDirectory}
+        onCreateThread={vi.fn()}
+      />,
+    );
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "New thread" })
+        .parentElement as HTMLElement,
+    );
+
+    // `registerDirectoryFromDisk` runs after the native picker closes, so the
+    // window is interactive while this row reads "Adding Project Directory…".
+    // A real `disabled` attribute would drop it from the tab order there and
+    // hide the in-progress state from keyboard and screen-reader users — the
+    // same reason the federation rows use `aria-disabled`.
+    const row = await screen.findByRole("menuitem", {
+      name: "Adding Project Directory…",
+    });
+    expect(row).toHaveAttribute("aria-disabled", "true");
+    expect(row).not.toBeDisabled();
+
+    fireEvent.click(row);
+    expect(onAddProjectDirectory).not.toHaveBeenCalled();
+    expect(screen.getByRole("menu")).toBeInTheDocument();
   });
 
   it("carries the verb in the group label instead of repeating it per row", async () => {

--- a/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
+++ b/apps/desktop/src/renderer/src/features/chrome/__tests__/NewThreadButton.test.tsx
@@ -152,6 +152,52 @@ describe("NewThreadButton", () => {
     expect(onCreateThread).not.toHaveBeenCalled();
   });
 
+  it("orders 'Add a Project Directory…' above the federation instances", async () => {
+    render(
+      <NewThreadButton
+        directoryLabel="PwrAgnt"
+        onAddProjectDirectory={vi.fn()}
+        onCreateThread={vi.fn()}
+        onCreateThreadOnTarget={vi.fn()}
+        onCreateThreadWithoutDirectory={vi.fn()}
+        remoteTargets={[
+          {
+            availability: "available",
+            instanceId: "studio-work",
+            label: "Studio Mac / work",
+          },
+          {
+            availability: "available",
+            instanceId: "laptop-default",
+            label: "Laptop",
+          },
+        ]}
+      />,
+    );
+
+    fireEvent.mouseEnter(
+      screen.getByRole("button", { name: "New thread" })
+        .parentElement as HTMLElement,
+    );
+
+    // The federation group grows one row per enrolled machine inside a card
+    // capped at 420px with `overflow-y: auto`. Last place put the menu's one
+    // non-thread-creating action below the fold on exactly the federations
+    // that make the card scroll, so its position is pinned here.
+    const menu = await screen.findByRole("menu");
+    expect(
+      within(menu)
+        .getAllByRole("menuitem")
+        .map((item) => item.textContent),
+    ).toEqual([
+      "New chat in PwrAgnt",
+      "New chat without a directory",
+      "Add a Project Directory…",
+      "Studio Mac / work",
+      "Laptop",
+    ]);
+  });
+
   it("carries the verb in the group label instead of repeating it per row", async () => {
     render(
       <NewThreadButton

--- a/apps/desktop/src/renderer/src/styles/__tests__/new-thread-menu-shrink-contract.test.ts
+++ b/apps/desktop/src/renderer/src/styles/__tests__/new-thread-menu-shrink-contract.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { cssRuleBody } from "./css-rule-body";
+
+/**
+ * Locks the separators in the New Thread flyout against flex shrink.
+ *
+ * The bug this exists for was never a missing declaration, and that is what
+ * made it read as arbitrary. `.new-thread-menu__separator` said `height: 1px`
+ * the whole time. But `.new-thread-menu__card` is a flex column with a
+ * `max-height` and `overflow-y: auto`, and a flex column spends negative free
+ * space on its children FIRST, scrolling only what it cannot squeeze out.
+ * Every row carries `min-height: 36px` and can refuse; the separators had no
+ * floor, so an overflowing card took its entire deficit out of them and
+ * computed both to `height: 0`.
+ *
+ * Measured in Chromium off the real stylesheet: directory-less, the card was
+ * 385px of 385px content and both rules painted. Add a directory context —
+ * one more 36px row, content 421px against the 420px cap — and both computed
+ * to 0px while every row kept its size. The operator saw rules in one menu
+ * and none in the other and could not have guessed why; neither could the
+ * stylesheet, read on its own.
+ *
+ * Not asserted through `getComputedStyle`, even though the computed height is
+ * the real subject: jsdom performs no layout, so it reports the declared 1px
+ * for a stylesheet Chromium — the renderer's actual engine — resolves to 0px.
+ * The declarations that produce the outcome are all this suite can see.
+ */
+describe("new thread menu shrink contract", () => {
+  it("stops the card shrinking any child", () => {
+    // On the children, not the card: the federation group grows one row per
+    // enrolled machine, so what overflows here is unbounded by design and
+    // anything added to this menu later needs the same guarantee.
+    expect(cssRuleBody(".new-thread-menu__card > *")).toMatch(
+      /flex-shrink:\s*0\s*[;}]?/,
+    );
+  });
+
+  it("still has a scrolling, height-capped flex column to guard", () => {
+    // The premise, and every part of it is load-bearing. Drop the cap or the
+    // column and there is no negative free space to spend; drop the scroll
+    // and the overflow stops being deliberate. If any of these go away the
+    // guard above has lost its subject and should be revisited, not deleted.
+    const card = cssRuleBody(".new-thread-menu__card");
+    expect(card).toMatch(/flex-direction:\s*column/);
+    expect(card).toMatch(/max-height:\s*min\(/);
+    expect(card).toMatch(/overflow-y:\s*auto/);
+  });
+
+  it("keeps the separator a hairline with no floor of its own", () => {
+    // Why the separators were what flex took the deficit out of: a 1px box
+    // whose min-content height is 0. Giving them a `min-height` instead of
+    // the shrink guard would also work, but the guard is what is asserted
+    // above — this pins the shape that made them the cheapest thing in the
+    // card, so a future edit cannot quietly recreate the victim elsewhere.
+    const separator = cssRuleBody(".new-thread-menu__separator");
+    expect(separator).toMatch(/height:\s*1px/);
+    expect(separator).not.toMatch(/min-height:/);
+  });
+});

--- a/apps/desktop/src/renderer/src/styles/app.css
+++ b/apps/desktop/src/renderer/src/styles/app.css
@@ -774,6 +774,26 @@ textarea,
   gap: 2px;
 }
 
+/* Nothing in this card may shrink. It is a scrolling container, so negative
+   free space has to become scroll — but a flex column spends that deficit on
+   its children FIRST and only scrolls whatever it could not squeeze out.
+   `min-height: 36px` gives every row a floor to refuse with; the 1px
+   separators have none, so an overflowing card took its whole deficit out of
+   them and computed them to `height: 0` while every row kept its size.
+
+   That is exactly how it presented, and why it read as arbitrary: both rules
+   painted in a directory-less context (card 385px, content 385px), and
+   vanished the moment a directory context added its third row and pushed the
+   content 3px past the 420px cap. The declaration was never missing — the
+   rules were 1px in the stylesheet and 0px on screen.
+
+   On the children rather than the card so anything added here later inherits
+   the guarantee; the federation group already grows without bound, and the
+   whole point of the cap is that this card scrolls. */
+.new-thread-menu__card > * {
+  flex-shrink: 0;
+}
+
 .new-thread-menu__item {
   width: 100%;
   display: block;


### PR DESCRIPTION
The New Thread flyout listed **Add a Project Directory…** last, after the
`New chat on` federation group. That group grows one row per enrolled machine
inside a card capped at `420px` with `overflow-y: auto`, so on a federation
large enough to make the card scroll the menu's one non-thread-creating action
is the first thing pushed below the fold — exactly when the menu is hardest to
navigate.

This orders it ahead of the federation group, so it keeps a stable offset from
the top of the card no matter how many machines are enrolled. The separator pair
swaps with the blocks — each block still emits its own leading separator, so the
count and the grouping are unchanged.

## Before

![New Thread flyout on main: Add a Project Directory last, below the fold, and both separators collapsed](https://github.com/user-attachments/assets/53dc7b88-a279-4371-89cc-52dab4fc2f55)

## After

![New Thread flyout with this PR: Add a Project Directory third, and both separators painting](https://github.com/user-attachments/assets/5b4a9b98-8bf2-4f2e-89ce-8380c60f111b)

Both frames are a directory context with seven invented machines — 100%
contrived fixture data — rendered off the real `NewThreadButton` and `app.css`.
The "before" side imports the component from `origin/main` and restores the one
`app.css` declaration this PR adds, so it is main's actual behavior rather than
an imitation of it.

Note the rules in "After" and their absence in "Before": that is the second fix
below, not a side effect of the reorder. Main's menu really does paint no
separators in a directory context, which is what the card overflowing costs it.

## Review follow-ups

- The Add row used the real `disabled` attribute while a registration was in
  flight. `pickingDirectory` stays true across both `pickDirectoryFromDisk` and
  `registerDirectoryFromDisk`, and the window is interactive for that second
  half — so a keyboard user reopening the flyout mid-registration tabbed past
  the row entirely and never heard "Adding Project Directory…". It now uses
  `aria-disabled` plus a click guard, matching what the federation rows in this
  same menu already document. The state had no test coverage; it does now.
- The doc block's flyout-render condition omitted federation targets, the third
  disjunct of `hasFlyout`.
- Both ordering comments restated app.css's cap as a bare "420px" (the rule is
  `min(420px, calc(100vh - 96px))`) and rested the rule on it. They now lead
  with the durable reason: the federation group is the only unbounded part of
  the menu, so fixed actions precede it.

## Also: the separators were being shrunk to zero

Spotted from the screenshot above, where the rules are missing. They were
missing because of a separate, pre-existing bug this PR now also fixes.

`.new-thread-menu__separator` declares `height: 1px` and always did. But
`.new-thread-menu__card` is a flex column with a `max-height` and
`overflow-y: auto`, and a flex column spends negative free space on its
children before it scrolls anything. Every row carries `min-height: 36px` and
can refuse; the separators had no floor, so an overflowing card took its whole
deficit out of them and computed both to `height: 0` while every row kept its
size.

Measured in Chromium against the real stylesheet:

| menu state | card | content | separators |
|---|---|---|---|
| no directory context | 385px | 385px (fits) | `height: 1px` |
| directory context | 418px (capped) | 421px (**overflows**) | `height: 0px` |

One extra 36px row is the entire difference. That is why the rules appeared in
a directory-less menu and vanished the moment you opened the same menu from a
thread in a directory.

`flex-shrink: 0` goes on the children rather than the card: the federation
group grows one row per enrolled machine, so what overflows here is unbounded
by design and the cap exists precisely so this card scrolls. The deficit now
becomes scroll, as intended (content 421px → 423px).

### Before

![flyout in a directory context with both separators collapsed to zero height](https://github.com/user-attachments/assets/ffed6bc1-759b-462f-a43e-2d8d87e9a10b)

### After

![flyout in a directory context with both separators painting at 1px](https://github.com/user-attachments/assets/12014625-35ad-4cfa-862b-7f88b26328c6)

Both frames are the same contrived fixture in the same directory context; the
only difference is the shrink guard.

A stylesheet contract test pins the guard and its premise, following
`settings-shrink-contract.test.ts` — jsdom does no layout, so it reports the
declared 1px for a stylesheet Chromium resolves to 0px, and the declarations
are all that suite can see.

## Tests

`NewThreadButton.test.tsx` gains an assertion on the full menuitem order, and a
test for the in-flight Add row. Both fail against the pre-change component and
pass after — verified by temporarily reverting each.

- `pnpm test` on `NewThreadButton.test.tsx`, `sidebar.test.tsx`,
  `app-shell.test.tsx` — 215 passed
- `pnpm test` on `styles/` + `features/chrome/` — 195 passed across 19 files
- `pnpm lint:colors` — passed
- `pnpm typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)



