### PR TITLE
fix(desktop): recover rejected Codex authentication by profile

### DIFF
--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -8185,6 +8185,91 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("reloads provider threads and publishes navigation after login repairs failed startup", async () => {
+    const replace = vi.fn();
+    const codexClient = new MockBackendClient({
+      listThreadsError: new Error("provider unavailable"),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+      discoverLocalAcpAgents: async () => [],
+      providerThreadSnapshotStore: {
+        list: () => [
+          {
+            backend: "codex" as const,
+            observedAt: 100,
+            threads: [
+              {
+                id: "last-good-thread",
+                source: "codex" as const,
+                title: "Last known good",
+                titleSource: "explicit" as const,
+                linkedDirectories: [],
+                updatedAt: 100,
+              },
+            ],
+          },
+        ],
+        replace,
+      },
+    });
+
+    await expect(registry.listThreads({
+      callerReason: "navigation-snapshot",
+    })).resolves.toEqual([
+      expect.objectContaining({ id: "last-good-thread" }),
+    ]);
+    await registry.refreshProvidersAtStartup(
+      issueProviderDiscoveryPermit("startup"),
+    );
+    await vi.waitFor(() => {
+      expect(codexClient.listThreadsCallCount).toBe(1);
+    });
+    await vi.waitFor(() => {
+      expect(registry.getStartupProviderRefreshStatus()).toEqual({
+        state: "degraded",
+        failedProviders: 1,
+      });
+    });
+    expect(replace).not.toHaveBeenCalled();
+    const events: AgentEvent[] = [];
+    registry.onEvent((event) => { events.push(event); });
+    const recoveredThreads: AppServerThreadSummary[] = [{
+      id: "recovered-thread",
+      source: "codex",
+      title: "Recovered after login",
+      titleSource: "explicit",
+      linkedDirectories: [],
+      updatedAt: 200,
+    }];
+    const listing = vi.spyOn(codexClient, "listThreads")
+      .mockRejectedValueOnce(new Error("Temporary recovery failure"))
+      .mockResolvedValue(recoveredThreads);
+    await expect(registry.refreshCodexAfterAuthentication(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    )).rejects.toThrow("Temporary recovery failure");
+    expect(replace).not.toHaveBeenCalled();
+    expect(events.some((event) => event.notification.method === "navigation/providerThreads/refreshed")).toBe(false);
+    await registry.refreshCodexAfterAuthentication(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    );
+    expect(listing).toHaveBeenCalled();
+    expect(replace).toHaveBeenCalledWith(expect.objectContaining({
+      backend: "codex",
+      threads: [expect.objectContaining({ id: "recovered-thread" })],
+    }));
+    expect(registry.getStartupProviderRefreshStatus()).toEqual({ state: "ready" });
+    expect(events.some((event) => event.notification.method === "navigation/providerThreads/refreshed")).toBe(true);
+    listing.mockClear();
+    await expect(registry.listThreads({
+      callerReason: "navigation-snapshot",
+      enrichDirectories: false,
+    })).resolves.toEqual([expect.objectContaining({ id: "recovered-thread" })]);
+    expect(listing).not.toHaveBeenCalled();
+    await registry.close();
+  });
+
   it("marks Gemini ACP thread workspace handoff unavailable after conversation history", async () => {
     const registry = new DesktopBackendRegistry({
       codexClient: new MockBackendClient({ threads: [] }),
@@ -47000,6 +47085,27 @@ script = "printf setup"
     expect(messagingArchiveCleaner.requests).toHaveLength(2);
 
     expect(restoreTokenMiser).toHaveBeenCalledExactlyOnceWith("thread-1");
+    await registry.close();
+  });
+
+  it("skips archive cleanup probes while Codex authentication is blocked", async () => {
+    const codexClient = Object.assign(new MockBackendClient({
+      listThreadsError: new Error("Codex is logged out. Please sign in again."),
+    }), {
+      isAuthenticationRequired: () => true,
+    });
+    const listing = vi.spyOn(codexClient, "listThreads");
+    const messagingStore = createMessagingArchiveCleanupStoreMock({
+      bindings: [{ id: "binding-telegram", threadId: "thread-1" }],
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      messagingStore,
+      overlayStore: createOverlayStoreMock(),
+    });
+    await expect(registry.listThreads({ backend: "codex" })).resolves.toEqual([]);
+    expect(listing.mock.calls.some(([params]) => params?.archived === true)).toBe(false);
+    expect(messagingStore.revokedBindingIds).toEqual([]);
     await registry.close();
   });
 

--- a/apps/desktop/src/main/__tests__/backend-registry.test.ts
+++ b/apps/desktop/src/main/__tests__/backend-registry.test.ts
@@ -6346,6 +6346,31 @@ describe("DesktopBackendRegistry", () => {
     await registry.close();
   });
 
+  it("suspends quota probes while Codex authentication is rejected and resumes after verification", async () => {
+    const codexClient = Object.assign(new MockBackendClient({
+      rateLimits: [{ name: "Weekly limit", remaining: 91 }],
+    }), {
+      isAuthenticationRequired: vi.fn(() => false),
+    });
+    const registry = new DesktopBackendRegistry({
+      codexClient,
+      overlayStore: createOverlayStoreMock(),
+    });
+    await registry.refreshProvidersAtStartup(issueProviderDiscoveryPermit("startup"));
+    const read = vi.spyOn(codexClient, "readRateLimits");
+    codexClient.isAuthenticationRequired.mockReturnValue(true);
+    await registry.listBackends({ refreshRateLimits: true });
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 30_000);
+    await registry.listBackends({ refreshRateLimits: true });
+    expect(read).not.toHaveBeenCalled();
+    codexClient.isAuthenticationRequired.mockReturnValue(false);
+    clock.mockReturnValue(Date.now() + 30_000);
+    await registry.listBackends({ refreshRateLimits: true });
+    expect(read).toHaveBeenCalledOnce();
+    clock.mockRestore();
+    await registry.close();
+  });
+
   it("refreshes idle Codex quotas without rediscovery and coalesces repeated reads", async () => {
     const codexClient = new MockBackendClient({
       rateLimits: [{ name: "Weekly limit", remaining: 91 }],

--- a/apps/desktop/src/main/__tests__/codex-auth-state.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-auth-state.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { CodexAuthState, isCodexAuthenticationFailure } from "../codex-auth-state";
 
@@ -30,6 +31,7 @@ describe("Codex rejected authentication", () => {
     expect(state.isBlocked("/fixture/default")).toBe(true);
     state.verified("/fixture/default");
     expect(() => state.assertAvailable("/fixture/default")).not.toThrow();
-    expect(changes).toEqual(["/fixture/default", "/fixture/default"]);
+    const normalizedHome = path.resolve("/fixture/default");
+    expect(changes).toEqual([normalizedHome, normalizedHome]);
   });
 });

--- a/apps/desktop/src/main/__tests__/codex-auth-state.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-auth-state.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { CodexAuthState, isCodexAuthenticationFailure } from "../codex-auth-state";
+
+describe("Codex rejected authentication", () => {
+  it.each([
+    "Your access token could not be refreshed. Please log out and sign in again.",
+    'Failed to refresh token: 401 Unauthorized: {"code":"invalid_refresh_token"}',
+    "failed to fetch codex rate limits: GET https://chatgpt.com/backend-api/wham/usage failed: 401 Unauthorized",
+    "Could not parse your authentication token. Please try signing in again.",
+  ])("recognizes %s", (message) => {
+    expect(isCodexAuthenticationFailure(message)).toBe(true);
+  });
+
+  it.each(["MCP server returned 401 Unauthorized", "429 Too Many Requests", "Failed to refresh token: connection timed out"])(
+    "does not log out on unrelated failures: %s", (message) => {
+      expect(isCodexAuthenticationFailure(message)).toBe(false);
+    },
+  );
+
+  it("latches rejection per home until verified recovery, notifying only at boundaries", () => {
+    const state = new CodexAuthState();
+    const changes: string[] = [];
+    state.subscribe((home) => changes.push(home));
+    state.reject("/fixture/default");
+    state.reject("/fixture/default");
+    expect(state.isBlocked("/fixture/default")).toBe(true);
+    expect(state.isBlocked("/fixture/work")).toBe(false);
+    expect(() => state.assertAvailable("/fixture/default")).toThrow("sign in");
+    state.verified("/fixture/work");
+    expect(state.isBlocked("/fixture/default")).toBe(true);
+    state.verified("/fixture/default");
+    expect(() => state.assertAvailable("/fixture/default")).not.toThrow();
+    expect(changes).toEqual(["/fixture/default", "/fixture/default"]);
+  });
+});

--- a/apps/desktop/src/main/__tests__/codex-client.test.ts
+++ b/apps/desktop/src/main/__tests__/codex-client.test.ts
@@ -1306,6 +1306,31 @@ async function waitForLatestTransportRequest(
 }
 
 describe("CodexAppServerClient", () => {
+  it("fails active turns and blocks probes until the rejected profile is verified", async () => {
+    const { codexAuthState } = await import("../codex-auth-state");
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const home = "/fixture/client-auth";
+    const client = new CodexAppServerClient();
+    const notifications: AppServerNotification[] = [];
+    client.onNotification((notification) => { notifications.push(notification); });
+    await client.readRateLimits();
+    const transport = MockTransport.instances.at(-1)!;
+    transport.emitInbound({ method: "turn/started", params: {
+      threadId: "auth-thread", turn: { id: "auth-turn", status: "inProgress" },
+    } });
+    await vi.waitFor(() => expect(notifications.some((n) => n.method === "turn/started")).toBe(true));
+    codexAuthState.reject(home);
+    (transport.options as { onAuthenticationRejected: (home: string) => void })
+      .onAuthenticationRejected(home);
+    await vi.waitFor(() => expect(notifications.some((n) => n.method === "turn/failed")).toBe(true));
+    expect(client.isAuthenticationRequired()).toBe(true);
+    await expect(client.readRateLimits()).rejects.toThrow("sign in");
+    codexAuthState.verified(home);
+    await expect(client.readRateLimits()).resolves.toBeDefined();
+    expect(client.isAuthenticationRequired()).toBe(false);
+    await client.close();
+  });
+
   beforeEach(() => {
     codexClientLogError.mockClear();
     codexClientLogInfo.mockClear();

--- a/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-settings-service.test.ts
@@ -43,6 +43,30 @@ function existsOrEmpty(filePath: string): boolean {
 }
 
 describe("DesktopSettingsService", () => {
+  it("projects runtime rejection without changing auth-file discovery", async () => {
+    const { codexAuthState } = await import("../codex-auth-state");
+    const root = createTempRoot();
+    const service = new DesktopSettingsService({
+      configPath: path.join(root, "config.toml"),
+      env: { CODEX_HOME: path.join(root, "codex") },
+      secretStore: new MemoryDesktopSecretStore(),
+    });
+    const initial = service.readCodexProfiles();
+    const profile = initial.profiles[0]!;
+    codexAuthState.reject(profile.codexHome);
+    try {
+      expect(service.readCodexProfiles().profiles[0]).toMatchObject({
+        authenticationRequired: true,
+        hasAuthFile: profile.hasAuthFile,
+      });
+      expect((await service.readSettingsProjection()).models.codex.profiles.profiles[0])
+        .toMatchObject({ authenticationRequired: true });
+    } finally {
+      codexAuthState.verified(profile.codexHome);
+    }
+    expect(service.readCodexProfiles().profiles[0]?.authenticationRequired).toBeUndefined();
+  });
+
   it("persists an explicit federation compression opt-out in the settings snapshot", async () => {
     const service = new DesktopSettingsService({
       configPath: path.join(createTempRoot(), "config.toml"),

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -811,12 +811,17 @@ describe("settings ipc", () => {
     const { registerSettingsIpcHandlers, disposeSettingsIpcHandlers } = await import("../ipc/settings");
     const { SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL } = await import("../../shared/ipc");
     registerSettingsIpcHandlers(service);
+    refreshCodexAfterAuthenticationMock.mockRejectedValueOnce(new Error("Thread refresh failed"));
     try {
       const check = handlers.get(SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL)!;
       await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: false });
       expect(codexAuthState.isBlocked(root)).toBe(true);
-      await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: true });
+      await expect(check({}, { profile: "" })).rejects.toThrow("Thread refresh failed");
       expect(codexAuthState.isBlocked(root)).toBe(false);
+      await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: true });
+      expect(refreshCodexAfterAuthenticationMock).toHaveBeenCalledTimes(2);
+      await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: true });
+      expect(refreshCodexAfterAuthenticationMock).toHaveBeenCalledTimes(2);
       expect(refreshCodexAfterAuthenticationMock).toHaveBeenCalledWith(
         expect.objectContaining({ intent: "settings-user-action" }),
       );

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -11,11 +11,13 @@ const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 const tempRoots: string[] = [];
 const disposeDesktopBackendRegistryMock = vi.fn(async () => undefined);
 const listThreadsMock = vi.fn(async () => [] as unknown[]);
+const refreshCodexAfterAuthenticationMock = vi.fn(async () => undefined);
 const listBackendsMock = vi.fn(async () => ({ backends: [], fetchedAt: 1 }));
 const invalidateAcpBackendDiscoveryMock = vi.fn();
 const getDesktopBackendRegistryMock = vi.fn(() => ({
   invalidateAcpBackendDiscovery: invalidateAcpBackendDiscoveryMock,
   listBackends: listBackendsMock,
+  refreshCodexAfterAuthentication: refreshCodexAfterAuthenticationMock,
   listThreads: listThreadsMock,
 }));
 const desktopConfigStoreMock = vi.hoisted(() => ({
@@ -238,6 +240,7 @@ describe("settings ipc", () => {
     disposeDesktopBackendRegistryMock.mockClear();
     invalidateAcpBackendDiscoveryMock.mockClear();
     listBackendsMock.mockClear();
+    refreshCodexAfterAuthenticationMock.mockClear();
     listThreadsMock.mockClear();
     listThreadsMock.mockResolvedValue([]);
     getDesktopBackendRegistryMock.mockClear();
@@ -814,8 +817,7 @@ describe("settings ipc", () => {
       expect(codexAuthState.isBlocked(root)).toBe(true);
       await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: true });
       expect(codexAuthState.isBlocked(root)).toBe(false);
-      expect(listBackendsMock).toHaveBeenCalledWith(
-        { refreshModels: "codex" },
+      expect(refreshCodexAfterAuthenticationMock).toHaveBeenCalledWith(
         expect.objectContaining({ intent: "settings-user-action" }),
       );
       expect(probe).toHaveBeenCalledTimes(2);

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -781,6 +781,50 @@ describe("settings ipc", () => {
     disposeSettingsIpcHandlers();
   });
 
+  it("keeps a rejected profile blocked until an authenticated API probe succeeds", async () => {
+    const { codexAuthState } = await import("../codex-auth-state");
+    const { CodexAppServerClient } = await import("../codex-app-server/client");
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-auth-recovery-"));
+    tempRoots.push(root);
+    vi.stubEnv("CODEX_HOME", root);
+    codexAuthState.reject(root);
+    childProcessMocks.spawn.mockImplementation(() => createMockSpawnChild((child) => {
+      queueMicrotask(() => {
+        child.stdout.emit("data", "Logged in using ChatGPT");
+        child.emit("close", 0);
+      });
+    }));
+    const probe = vi.spyOn(CodexAppServerClient.prototype, "readRateLimits")
+      .mockRejectedValueOnce(new Error("401 Unauthorized"))
+      .mockResolvedValueOnce([]);
+    const close = vi.spyOn(CodexAppServerClient.prototype, "close").mockResolvedValue();
+    const service = {
+      resolveCodexCommand: vi.fn(async () => ({ command: "codex", source: "config" })),
+      readCodexProfiles: vi.fn(() => ({ effectiveCodexHome: root })),
+    } as unknown as DesktopSettingsService;
+    const { registerSettingsIpcHandlers, disposeSettingsIpcHandlers } = await import("../ipc/settings");
+    const { SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL } = await import("../../shared/ipc");
+    registerSettingsIpcHandlers(service);
+    try {
+      const check = handlers.get(SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL)!;
+      await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: false });
+      expect(codexAuthState.isBlocked(root)).toBe(true);
+      await expect(check({}, { profile: "" })).resolves.toMatchObject({ authenticated: true });
+      expect(codexAuthState.isBlocked(root)).toBe(false);
+      expect(listBackendsMock).toHaveBeenCalledWith(
+        { refreshModels: "codex" },
+        expect.objectContaining({ intent: "settings-user-action" }),
+      );
+      expect(probe).toHaveBeenCalledTimes(2);
+      expect(close).toHaveBeenCalledTimes(2);
+    } finally {
+      probe.mockRestore();
+      close.mockRestore();
+      codexAuthState.verified(root);
+      disposeSettingsIpcHandlers();
+    }
+  });
+
   it("starts named Codex auth profile login with the browser OAuth flow", async () => {
     const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-settings-ipc-"));
     tempRoots.push(tempRoot);

--- a/apps/desktop/src/main/__tests__/settings-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-ipc.test.ts
@@ -781,11 +781,14 @@ describe("settings ipc", () => {
     disposeSettingsIpcHandlers();
   });
 
-  it("keeps a rejected profile blocked until an authenticated API probe succeeds", async () => {
+  it.each(["native", "windows"])("recovers a rejected profile and refreshes its backend with %s paths", async (pathStyle) => {
     const { codexAuthState } = await import("../codex-auth-state");
     const { CodexAppServerClient } = await import("../codex-app-server/client");
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-auth-recovery-"));
-    tempRoots.push(root);
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-auth-recovery-"));
+    tempRoots.push(tempRoot);
+    const root = pathStyle === "windows" ? String.raw`C:\Users\fixture\.codex` : tempRoot;
+    const discovery = await import("@pwrdrvr/codex-discovery");
+    const resolveHome = vi.spyOn(discovery, "resolveDefaultCodexHome").mockReturnValue(root);
     vi.stubEnv("CODEX_HOME", root);
     codexAuthState.reject(root);
     childProcessMocks.spawn.mockImplementation(() => createMockSpawnChild((child) => {
@@ -800,7 +803,7 @@ describe("settings ipc", () => {
     const close = vi.spyOn(CodexAppServerClient.prototype, "close").mockResolvedValue();
     const service = {
       resolveCodexCommand: vi.fn(async () => ({ command: "codex", source: "config" })),
-      readCodexProfiles: vi.fn(() => ({ effectiveCodexHome: root })),
+      readCodexProfiles: vi.fn(() => ({ effectiveCodexHome: root.replace(/\\/g, "/") })),
     } as unknown as DesktopSettingsService;
     const { registerSettingsIpcHandlers, disposeSettingsIpcHandlers } = await import("../ipc/settings");
     const { SETTINGS_CHECK_CODEX_AUTH_PROFILE_STATUS_CHANNEL } = await import("../../shared/ipc");
@@ -818,6 +821,7 @@ describe("settings ipc", () => {
       expect(probe).toHaveBeenCalledTimes(2);
       expect(close).toHaveBeenCalledTimes(2);
     } finally {
+      resolveHome.mockRestore();
       probe.mockRestore();
       close.mockRestore();
       codexAuthState.verified(root);

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -102,7 +102,7 @@ describe("StdioJsonRpcTransport", () => {
       env: { ...process.env, CODEX_HOME: "/fixture/rejected-codex" },
     });
     await transport.connect();
-    child.stderr.write("Your access token could not be refreshed. Please log out and sign in again.\n");
+    child.stderr.write("ERROR codex_login::auth::manager: Your access token could not be refreshed. Please log out and sign in again.\n");
     expect(() => transport.send(JSON.stringify({ id: 1, method: "model/list" })))
       .toThrow("sign in");
     expect(child.writes).toEqual([]);
@@ -135,7 +135,7 @@ describe("StdioJsonRpcTransport", () => {
     expect(() => transport.send(JSON.stringify({ id: 1, method: "turn/start" })))
       .toThrow("Only authentication verification");
     transport.send(JSON.stringify({ id: 2, method: "account/rateLimits/read" }));
-    child.stderr.write("Your access token could not be refreshed. Please log out and sign in again.\n");
+    child.stderr.write("ERROR codex_login::auth::manager: Your access token could not be refreshed. Please log out and sign in again.\n");
     expect(rejected).toHaveBeenCalledWith(home);
     await transport.close();
     codexAuthState.verified(home);
@@ -155,6 +155,8 @@ describe("StdioJsonRpcTransport", () => {
       method: "item/agentMessage/delta",
       params: { delta: "Your access token could not be refreshed" },
     }) + "\n");
+    transport.send(JSON.stringify({ id: 1, method: "mcpServer/oauth/login" }));
+    transport.send(JSON.stringify({ id: 2, method: "account/rateLimits/read" }));
     child.stdout.write(JSON.stringify({ id: 1, error: { message: "MCP server: 401 Unauthorized" } }) + "\n");
     expect(codexAuthState.isBlocked(home)).toBe(false);
     child.stdout.write(JSON.stringify({
@@ -164,6 +166,39 @@ describe("StdioJsonRpcTransport", () => {
     expect(codexAuthState.isBlocked(home)).toBe(true);
     await transport.close();
     codexAuthState.verified(home);
+  });
+
+  it.each(["rpc", "stderr", "turn"])("does not reject the Codex profile for MCP OAuth failures from %s", async (source) => {
+    const home = "/fixture/mcp-auth-" + source;
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const rejected = vi.fn();
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { ...process.env, CODEX_HOME: home },
+      onAuthenticationRejected: rejected,
+    });
+    await transport.connect();
+    try {
+      if (source === "rpc") {
+        transport.send(JSON.stringify({ id: 1, method: "mcpServer/oauth/login", params: { name: "fixture" } }));
+        child.stdout.write(JSON.stringify({ id: 1, error: {
+          code: -32603, message: "invalid_refresh_token: Your access token could not be refreshed.",
+        } }) + "\n");
+      } else if (source === "turn") {
+        transport.send(JSON.stringify({ id: 1, method: "turn/start" }));
+        child.stdout.write(JSON.stringify({ id: 1, error: { message: "invalid_refresh_token" } }) + "\n");
+      } else {
+        child.stderr.write("2026-09-13T00:35:46Z ERROR rmcp::auth: invalid_refresh_token\n");
+        child.stderr.write('"code": "invalid_refresh_token"\n');
+      }
+      expect(codexAuthState.isBlocked(home)).toBe(false);
+      expect(rejected).not.toHaveBeenCalled();
+      expect(() => transport.send(JSON.stringify({ id: 2, method: "model/list" }))).not.toThrow();
+    } finally {
+      await transport.close();
+      codexAuthState.verified(home);
+    }
   });
 
   it("prepends PwrAgent's bundled ripgrep for an external Codex runtime and its shell policy", async () => {

--- a/apps/desktop/src/main/__tests__/stdio-transport.test.ts
+++ b/apps/desktop/src/main/__tests__/stdio-transport.test.ts
@@ -1,3 +1,4 @@
+import { codexAuthState } from "../codex-auth-state";
 import { EventEmitter } from "node:events";
 import {
   chmodSync,
@@ -93,6 +94,78 @@ describe("stdio transport Codex CLI resolution", () => {
 });
 
 describe("StdioJsonRpcTransport", () => {
+  it("stops further requests after a rejected refresh token", async () => {
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { ...process.env, CODEX_HOME: "/fixture/rejected-codex" },
+    });
+    await transport.connect();
+    child.stderr.write("Your access token could not be refreshed. Please log out and sign in again.\n");
+    expect(() => transport.send(JSON.stringify({ id: 1, method: "model/list" })))
+      .toThrow("sign in");
+    expect(child.writes).toEqual([]);
+    await transport.close();
+    await expect(transport.connect()).rejects.toThrow("sign in");
+    codexAuthState.verified("/fixture/rejected-codex");
+    const recovered = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(recovered);
+    await transport.connect();
+    transport.send(JSON.stringify({ id: 2, method: "model/list" }));
+    expect(recovered.writes).toHaveLength(1);
+    await transport.close();
+  });
+
+  it("keeps recovery scoped to its profile and restricts it to authentication probes", async () => {
+    const home = "/fixture/recovery-codex";
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    codexAuthState.reject(home);
+    const rejected = vi.fn();
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { ...process.env, CODEX_HOME: home },
+      authenticationRecovery: true,
+      onAuthenticationRejected: rejected,
+    });
+    await transport.connect();
+    codexAuthState.reject("/fixture/other-codex");
+    expect(rejected).not.toHaveBeenCalled();
+    expect(() => transport.send(JSON.stringify({ id: 1, method: "turn/start" })))
+      .toThrow("Only authentication verification");
+    transport.send(JSON.stringify({ id: 2, method: "account/rateLimits/read" }));
+    child.stderr.write("Your access token could not be refreshed. Please log out and sign in again.\n");
+    expect(rejected).toHaveBeenCalledWith(home);
+    await transport.close();
+    codexAuthState.verified(home);
+    codexAuthState.verified("/fixture/other-codex");
+  });
+
+  it("uses RPC auth errors but ignores transcript text and unrelated MCP errors", async () => {
+    const home = "/fixture/rpc-codex";
+    const child = new MockCodexChildProcess();
+    spawnMock.mockReturnValue(child);
+    const transport = new StdioJsonRpcTransport({
+      command: "codex",
+      env: { ...process.env, CODEX_HOME: home },
+    });
+    await transport.connect();
+    child.stdout.write(JSON.stringify({
+      method: "item/agentMessage/delta",
+      params: { delta: "Your access token could not be refreshed" },
+    }) + "\n");
+    child.stdout.write(JSON.stringify({ id: 1, error: { message: "MCP server: 401 Unauthorized" } }) + "\n");
+    expect(codexAuthState.isBlocked(home)).toBe(false);
+    child.stdout.write(JSON.stringify({
+      id: 2,
+      error: { message: "failed to fetch codex rate limits: GET https://chatgpt.com/backend-api/wham/usage failed: 401 Unauthorized" },
+    }) + "\n");
+    expect(codexAuthState.isBlocked(home)).toBe(true);
+    await transport.close();
+    codexAuthState.verified(home);
+  });
+
   it("prepends PwrAgent's bundled ripgrep for an external Codex runtime and its shell policy", async () => {
     const child = new MockCodexChildProcess();
     const bundledToolsDirectory = createBundledToolsDirectory();

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -8590,6 +8590,7 @@ export class DesktopBackendRegistry {
   private readonly providerThreadSnapshotStore?: ProviderThreadSnapshotStoreLike;
   private durableStartupThreadHydrationAttempted = false;
   private startupProviderRefreshAttempted = false;
+  private startupCodexRefreshFailed = false;
   private startupProviderRefreshPromise?: Promise<void>;
   private startupProviderRefreshStatus?: Readonly<{
     state: "checking" | "degraded" | "ready";
@@ -11079,6 +11080,7 @@ export class DesktopBackendRegistry {
       if (this.closed) {
         return;
       }
+      this.startupCodexRefreshFailed = results[0]?.status === "rejected";
       const failures = results.filter((result) => result.status === "rejected");
       if (failures.length > 0) {
         backendRegistryLog.warn("startup provider thread refresh degraded", {
@@ -11120,6 +11122,40 @@ export class DesktopBackendRegistry {
       this.startupProviderRefreshPromise = undefined;
     });
     return this.startupProviderRefreshPromise;
+  }
+
+  async refreshCodexAfterAuthentication(permit: ProviderDiscoveryPermit): Promise<void> {
+    assertProviderDiscoveryPermit(permit, ["settings-user-action", "setup-user-action"]);
+    // A failed startup refresh must finish publishing before recovery replaces
+    // it. Do not join a thread-list promise admitted under rejected credentials.
+    await this.startupProviderRefreshPromise;
+    if (this.closed) return;
+    this.invalidateThreadListCache();
+    await this.listBackends({ refreshModels: "codex" }, permit);
+    const threads = await this.listThreads({
+      backend: "codex",
+      callerReason: "authentication-recovery",
+      enrichDirectories: false,
+      forceRefresh: true,
+    });
+    if (this.closed) return;
+    this.publishRefreshedProviderThreadsToCache([{ backends: ["codex"], threads }]);
+    const failedProviders = Math.max(
+      0,
+      (this.startupProviderRefreshStatus?.failedProviders ?? 0)
+        - (this.startupCodexRefreshFailed ? 1 : 0),
+    );
+    this.startupCodexRefreshFailed = false;
+    this.startupProviderRefreshStatus = failedProviders > 0
+      ? { state: "degraded", failedProviders }
+      : { state: "ready" };
+    await this.emit({
+      backend: "codex",
+      notification: {
+        method: "navigation/providerThreads/refreshed",
+        params: { failedProviders },
+      },
+    });
   }
 
   private async refreshCodexProviderAtStartup(
@@ -11208,7 +11244,8 @@ export class DesktopBackendRegistry {
     if (
       !this.providerThreadSnapshotStore
       || this.closed
-      || params.callerReason !== "startup-provider-refresh"
+      || (params.callerReason !== "startup-provider-refresh"
+        && params.callerReason !== "authentication-recovery")
       || params.archived === true
       || Boolean(params.filter?.trim())
       || params.limit !== undefined
@@ -24262,6 +24299,8 @@ export class DesktopBackendRegistry {
     filter?: string;
     threads: AppServerThreadSummary[];
   }): Promise<void> {
+    if (params.backend === "codex" && this.codexClient.isAuthenticationRequired?.()) return;
+
     if (params.archived === true) {
       await Promise.all(
         params.threads.map((thread) =>
@@ -24595,6 +24634,7 @@ export class DesktopBackendRegistry {
             if (
               diagnostics?.callerReason === "archive-cleanup"
               || diagnostics?.callerReason === "startup-provider-refresh"
+              || diagnostics?.callerReason === "authentication-recovery"
             ) {
               throw error;
             }

--- a/apps/desktop/src/main/app-server/backend-registry.ts
+++ b/apps/desktop/src/main/app-server/backend-registry.ts
@@ -898,6 +898,7 @@ type BackendClient = {
     callerReason?: string;
     ownerId?: string;
   }): Promise<BackendModelOption[]>;
+  isAuthenticationRequired?(): boolean;
   readAccount?(): Promise<BackendAccountSummary>;
   readRateLimits?(): Promise<BackendRateLimitSummary[]>;
   interruptTurn(params: {
@@ -25419,6 +25420,7 @@ export class DesktopBackendRegistry {
     backendGeneration: number;
     notificationVersion: number;
   }): Promise<boolean> {
+    if (this.codexClient.isAuthenticationRequired?.()) return false;
     let refetchedRateLimits: BackendRateLimitSummary[];
     try {
       refetchedRateLimits = await readClientRateLimits(this.codexClient);

--- a/apps/desktop/src/main/codex-app-server/client.ts
+++ b/apps/desktop/src/main/codex-app-server/client.ts
@@ -1,3 +1,4 @@
+import { CODEX_SIGN_IN_REQUIRED, codexAuthState } from "../codex-auth-state";
 import { mkdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import path from "node:path";
@@ -255,6 +256,7 @@ const MCP_RESOURCE_IMAGE_MIME_TYPES = new Set([
 const BASE64_IMAGE_BLOB_PATTERN = /^[A-Za-z0-9+/]+={0,2}$/;
 
 type CodexClientOptions = {
+  authenticationRecovery?: boolean;
   command?: string;
   args?: string[];
   env?: NodeJS.ProcessEnv;
@@ -7385,6 +7387,8 @@ export class CodexAppServerClient {
   private closeGeneration = 0;
   private pendingCloses = 0;
   private serverGeneration = 0;
+  private readonly authActiveTurns = new Map<string, string>();
+  private rejectedCodexHome?: string;
   private transportClosePromise: Promise<void> | null = null;
   private readonly lastDirectoryEnrichment = new Map<string, ThreadDirectoryEnrichment>();
   private readonly threadDirectoryEnricher: (
@@ -7450,6 +7454,27 @@ export class CodexAppServerClient {
     this.rawConnection = new JsonRpcConnection(
       new StdioJsonRpcTransport({
         command: options.command?.trim() || "codex",
+        authenticationRecovery: options.authenticationRecovery,
+        onAuthenticationRejected: (home) => {
+          this.rejectedCodexHome = home;
+          const activeTurns = [...this.authActiveTurns];
+          this.authActiveTurns.clear();
+          void (async () => {
+            await this.close();
+            for (const [threadId, turnId] of activeTurns) {
+              for (const listener of this.notificationListeners) {
+                await listener({
+                  method: "turn/failed",
+                  params: {
+                    threadId,
+                    turnId,
+                    turn: { id: turnId, status: "failed", error: { message: CODEX_SIGN_IN_REQUIRED } },
+                  },
+                });
+              }
+            }
+          })().catch((error) => codexClientLog.warn("Codex auth shutdown failed", { error: String(error) }));
+        },
         args: options.args ?? [],
         env: options.env,
         resolveArgs: options.resolveArgs,
@@ -7523,6 +7548,17 @@ export class CodexAppServerClient {
       if (helperThreadId && this.helperThreadIds.has(helperThreadId)) {
         this.handleHelperThreadNotification(normalized.method, normalized);
         return;
+      }
+
+      const turnMetadata = extractRequestMetadata(normalized.params);
+      const observedTurnId = turnMetadata.turnId
+        ?? pickString(asRecord(asRecord(normalized.params)?.turn) ?? {}, ["id"]);
+      if (turnMetadata.threadId && observedTurnId) {
+        if (normalized.method === "turn/started") {
+          this.authActiveTurns.set(turnMetadata.threadId, observedTurnId);
+        } else if (normalized.method === "turn/completed" || normalized.method === "turn/failed") {
+          this.authActiveTurns.delete(turnMetadata.threadId);
+        }
       }
 
       if (method === "thread/started") {
@@ -7599,6 +7635,7 @@ export class CodexAppServerClient {
 
   private async closeConnection(): Promise<void> {
     this.initialized = false;
+    this.authActiveTurns.clear();
     this.initializationPromise = null;
     this.initializeResult = null;
     this.rejectHelperTurnWaiters(new Error("codex app server client closed"));
@@ -9794,7 +9831,14 @@ export class CodexAppServerClient {
     }
   }
 
+  isAuthenticationRequired(): boolean {
+    return Boolean(this.rejectedCodexHome && codexAuthState.isBlocked(this.rejectedCodexHome));
+  }
+
   private async ensureInitialized(): Promise<void> {
+    if (this.rejectedCodexHome && !this.options.authenticationRecovery) {
+      codexAuthState.assertAvailable(this.rejectedCodexHome);
+    }
     if (this.pendingCloses > 0) throw new Error("codex app server client closed");
     const generation = this.closeGeneration;
     do {

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -1,3 +1,6 @@
+import path from "node:path";
+import { resolveDefaultCodexHome } from "@pwrdrvr/codex-discovery";
+import { codexAuthState, isCodexAuthenticationFailure } from "../codex-auth-state";
 import {
   spawn,
   type ChildProcessWithoutNullStreams,
@@ -33,6 +36,9 @@ const PROCESS_FORCE_CLOSE_TIMEOUT_MS = 5_000;
 
 export type StdioJsonRpcTransportOptions = {
   command: string;
+  authenticationRecovery?: boolean;
+  onAuthenticationRejected?: (home: string) => void;
+
   args?: string[];
   env?: NodeJS.ProcessEnv;
   resolveArgs?: (env: NodeJS.ProcessEnv) => Promise<string[]> | string[];
@@ -68,6 +74,8 @@ function isJsonRpcResponseEnvelope(message: string): boolean {
 }
 
 export class StdioJsonRpcTransport implements JsonRpcTransport {
+  private codexHome?: string;
+  private unsubscribeAuth?: () => void;
   private childProcess: ChildProcessWithoutNullStreams | null = null;
   private messageHandler: (message: string) => void = () => undefined;
   private closeHandler: (error?: Error) => void = () => undefined;
@@ -120,6 +128,14 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       ? await this.options.resolveEnv()
       : this.options.env ?? process.env;
     this.assertCurrentGeneration(generation);
+    this.codexHome = resolvedEnv.CODEX_HOME || resolveDefaultCodexHome();
+    if (!this.options.authenticationRecovery) codexAuthState.assertAvailable(this.codexHome);
+    this.unsubscribeAuth?.();
+    this.unsubscribeAuth = codexAuthState.subscribe((home) => {
+      if (this.codexHome && path.resolve(this.codexHome) === home && codexAuthState.isBlocked(home)) {
+        this.options.onAuthenticationRejected?.(this.codexHome);
+      }
+    });
     const env = prependBundledToolsToPath(
       buildPwrAgentChildProcessEnv(resolvedEnv),
       {
@@ -185,6 +201,15 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
 
     const stdoutReader = readline.createInterface({ input: child.stdout });
     stdoutReader.on("line", (line: string) => {
+      // Only error envelopes and error notifications are auth evidence;
+      // transcript text and tool output must never invalidate a login.
+      try {
+        const message = JSON.parse(line);
+        const error = message.error
+          ?? (message.method === "error" ? message.params : undefined)
+          ?? (["turn/completed", "turn/failed"].includes(message.method) ? message.params?.turn?.error : undefined);
+        if (error) this.observeAuthenticationError(JSON.stringify(error));
+      } catch { /* JSON-RPC owns malformed-message reporting. */ }
       this.messageHandler(line);
     });
 
@@ -202,6 +227,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     let stderrLinesThisWindow = 0;
     let stderrSuppressedThisWindow = 0;
     stderrReader.on("line", (line: string) => {
+      this.observeAuthenticationError(line);
       const trimmed = line.trim();
       if (trimmed.length === 0) {
         return;
@@ -245,6 +271,8 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
   }
 
   async close(): Promise<void> {
+    this.unsubscribeAuth?.();
+    this.unsubscribeAuth = undefined;
     this.closeRequested = true;
     this.lifecycleGeneration += 1;
     if (this.closePromise) {
@@ -267,7 +295,28 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     return await this.closePromise;
   }
 
+  private observeAuthenticationError(message: string): void {
+    if (!this.closeRequested && this.codexHome && isCodexAuthenticationFailure(message)) {
+      const alreadyBlocked = codexAuthState.isBlocked(this.codexHome);
+      codexAuthState.reject(this.codexHome);
+      // Recovery clients connect while the latch is already set. Their own
+      // rejection must still stop verification; cached model data is not proof
+      // that refreshed credentials work.
+      if (alreadyBlocked) this.options.onAuthenticationRejected?.(this.codexHome);
+    }
+  }
+
   send(message: string): void {
+    if (this.codexHome && !isJsonRpcResponseEnvelope(message)) {
+      if (!this.options.authenticationRecovery) {
+        codexAuthState.assertAvailable(this.codexHome);
+      } else {
+        const method = JSON.parse(message).method;
+        if (!["initialize", "initialized", "account/read", "account/rateLimits/read"].includes(method)) {
+          throw new Error("Only authentication verification is allowed during Codex recovery.");
+        }
+      }
+    }
     const child = this.childProcess;
     if (this.closeRequested) {
       if (isJsonRpcResponseEnvelope(message)) {

--- a/apps/desktop/src/main/codex-app-server/stdio-transport.ts
+++ b/apps/desktop/src/main/codex-app-server/stdio-transport.ts
@@ -75,6 +75,7 @@ function isJsonRpcResponseEnvelope(message: string): boolean {
 
 export class StdioJsonRpcTransport implements JsonRpcTransport {
   private codexHome?: string;
+  private requestMethods = new Map<string | number, string>();
   private unsubscribeAuth?: () => void;
   private childProcess: ChildProcessWithoutNullStreams | null = null;
   private messageHandler: (message: string) => void = () => undefined;
@@ -205,10 +206,18 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
       // transcript text and tool output must never invalidate a login.
       try {
         const message = JSON.parse(line);
+        const requestMethod = message.method === undefined ? this.requestMethods.get(message.id) : undefined;
+        if (message.method === undefined && message.id !== undefined) this.requestMethods.delete(message.id);
         const error = message.error
           ?? (message.method === "error" ? message.params : undefined)
           ?? (["turn/completed", "turn/failed"].includes(message.method) ? message.params?.turn?.error : undefined);
-        if (error) this.observeAuthenticationError(JSON.stringify(error));
+        const source = message.error ? requestMethod : message.method;
+        // MCP OAuth errors describe that server's credentials, never Codex's.
+        if (error && source && /^(?:account|model|thread|turn)\//.test(source)) {
+          this.observeAuthenticationError(JSON.stringify(error), source.startsWith("account/"));
+        } else if (error && source === "error" && message.params?.threadId) {
+          this.observeAuthenticationError(JSON.stringify(error));
+        }
       } catch { /* JSON-RPC owns malformed-message reporting. */ }
       this.messageHandler(line);
     });
@@ -227,7 +236,12 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     let stderrLinesThisWindow = 0;
     let stderrSuppressedThisWindow = 0;
     stderrReader.on("line", (line: string) => {
-      this.observeAuthenticationError(line);
+      // Only a diagnostic attributed to Codex's own auth/API modules is
+      // credential evidence. Multiline JSON and MCP diagnostics have no such
+      // provenance and may describe another OAuth account.
+      const diagnostic = line.replace(/\u001b\[[0-9;]*m/g, "").trim()
+        .match(/^(?:\S+\s+)?(?:ERROR|WARN)\s+(codex_login::auth(?:::[\w]+)*|codex_models_manager::[\w:]+|codex_api::[\w:]+):\s*(.*)$/);
+      if (diagnostic) this.observeAuthenticationError(diagnostic[2], diagnostic[1].startsWith("codex_login::auth"));
       const trimmed = line.trim();
       if (trimmed.length === 0) {
         return;
@@ -274,6 +288,7 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     this.unsubscribeAuth?.();
     this.unsubscribeAuth = undefined;
     this.closeRequested = true;
+    this.requestMethods.clear();
     this.lifecycleGeneration += 1;
     if (this.closePromise) {
       return await this.closePromise;
@@ -295,7 +310,13 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     return await this.closePromise;
   }
 
-  private observeAuthenticationError(message: string): void {
+  private observeAuthenticationError(message: string, credentialSource = false): void {
+    // Generic OAuth codes alone are meaningful only at the Codex account/auth
+    // boundary. A turn or model request can also report an MCP failure.
+    if (!credentialSource) {
+      if (/\bmcp\b|mcpServer|rmcp::/i.test(message)) return;
+      message = message.replace(/invalid_refresh_token|refresh_token_(?:expired|reused|invalidated)/gi, "");
+    }
     if (!this.closeRequested && this.codexHome && isCodexAuthenticationFailure(message)) {
       const alreadyBlocked = codexAuthState.isBlocked(this.codexHome);
       codexAuthState.reject(this.codexHome);
@@ -330,6 +351,15 @@ export class StdioJsonRpcTransport implements JsonRpcTransport {
     }
     if (!child?.stdin) {
       throw new Error("codex app server stdio not connected");
+    }
+    const envelope = JSON.parse(message);
+    if (envelope.id !== undefined && typeof envelope.method === "string") {
+      // Timed-out requests may never receive a response. Eviction fails closed:
+      // an uncorrelated response cannot invalidate profile authentication.
+      if (this.requestMethods.size >= 1024) {
+        this.requestMethods.delete(this.requestMethods.keys().next().value!);
+      }
+      this.requestMethods.set(envelope.id, envelope.method);
     }
     child.stdin.write(`${message}\n`);
   }

--- a/apps/desktop/src/main/codex-auth-state.ts
+++ b/apps/desktop/src/main/codex-auth-state.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+
+export const CODEX_SIGN_IN_REQUIRED =
+  "Codex is logged out. Please sign in again to resume operations.";
+
+export { isCodexAuthenticationFailure } from "@pwragent/shared";
+
+/** Runtime evidence overrides credential-file discovery. No timer or SQLite writes. */
+export class CodexAuthState {
+  private readonly blocked = new Set<string>();
+  private readonly listeners = new Set<(home: string) => void>();
+
+  isBlocked(home: string): boolean {
+    return this.blocked.has(path.resolve(home));
+  }
+
+  assertAvailable(home: string): void {
+    if (this.isBlocked(home)) throw new Error(CODEX_SIGN_IN_REQUIRED);
+  }
+
+  reject(home: string): void {
+    const key = path.resolve(home);
+    if (this.blocked.has(key)) return;
+    this.blocked.add(key);
+    for (const listener of this.listeners) listener(key);
+  }
+
+  verified(home: string): void {
+    const key = path.resolve(home);
+    if (!this.blocked.delete(key)) return;
+    for (const listener of this.listeners) listener(key);
+  }
+
+  subscribe(listener: (home: string) => void): () => void {
+    this.listeners.add(listener);
+    return () => { this.listeners.delete(listener); };
+  }
+}
+
+export const codexAuthState = new CodexAuthState();

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -1005,7 +1005,11 @@ async function checkCodexProfileAuthStatus(
     } finally {
       await client.close();
     }
-    if (authenticated && service.readCodexProfiles().effectiveCodexHome === codexHome) {
+    if (
+      authenticated
+      && service.readCodexProfiles().effectiveCodexHome.replace(/\\/g, "/")
+        === codexHome.replace(/\\/g, "/")
+    ) {
       // Startup may have cached Codex as unavailable. Login is an explicit
       // user action authorizing a fresh model/account discovery.
       await getDesktopBackendRegistry().listBackends(

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -1010,10 +1010,8 @@ async function checkCodexProfileAuthStatus(
       && service.readCodexProfiles().effectiveCodexHome.replace(/\\/g, "/")
         === codexHome.replace(/\\/g, "/")
     ) {
-      // Startup may have cached Codex as unavailable. Login is an explicit
-      // user action authorizing a fresh model/account discovery.
-      await getDesktopBackendRegistry().listBackends(
-        { refreshModels: "codex" },
+      // Recover model/account availability and the provider's navigation data.
+      await getDesktopBackendRegistry().refreshCodexAfterAuthentication(
         issueProviderDiscoveryPermit("settings-user-action"),
       );
     }

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -1,3 +1,5 @@
+import { codexAuthState } from "../codex-auth-state";
+import { CodexAppServerClient } from "../codex-app-server/client";
 import { validateGlabCommand } from "../settings/glab-discovery";
 import { app, BrowserWindow, dialog, ipcMain, shell } from "electron";
 import { mkdir } from "node:fs/promises";
@@ -984,7 +986,34 @@ async function checkCodexProfileAuthStatus(
   const codexHome = resolveRequiredCodexProfileHome(profile);
   const command = await resolveCodexCommandForProfileWorkflow(service);
   const result = await collectCodexStatus(command, codexHome);
-  const authenticated = result.code === 0;
+  let authenticated = result.code === 0;
+  let verificationError: string | undefined;
+  if (authenticated && codexAuthState.isBlocked(codexHome)) {
+    // CLI login status only proves a credential exists. A fresh app-server
+    // must successfully use it before ordinary clients may resume.
+    const client = new CodexAppServerClient({
+      command,
+      env: { ...process.env, CODEX_HOME: codexHome },
+      authenticationRecovery: true,
+    });
+    try {
+      await client.readRateLimits();
+      codexAuthState.verified(codexHome);
+    } catch {
+      authenticated = false;
+      verificationError = "Codex authentication is still rejected. Complete login, then check status again.";
+    } finally {
+      await client.close();
+    }
+    if (authenticated && service.readCodexProfiles().effectiveCodexHome === codexHome) {
+      // Startup may have cached Codex as unavailable. Login is an explicit
+      // user action authorizing a fresh model/account discovery.
+      await getDesktopBackendRegistry().listBackends(
+        { refreshModels: "codex" },
+        issueProviderDiscoveryPermit("settings-user-action"),
+      );
+    }
+  }
   // When the CLI reports authenticated, surface the JWT-derived identity
   // fields too — the onboarding wizard's name+login step renders them
   // inline so the operator can confirm they signed in with the right
@@ -1000,7 +1029,7 @@ async function checkCodexProfileAuthStatus(
         : authenticated
           ? "authenticated"
           : "unauthenticated",
-    ...(result.detail ? { detail: result.detail } : {}),
+    ...(verificationError || result.detail ? { detail: verificationError ?? result.detail } : {}),
     ...(authInfo.email ? { email: authInfo.email } : {}),
     ...(authInfo.planType ? { planType: authInfo.planType } : {}),
   };
@@ -1546,11 +1575,16 @@ export function registerSettingsIpcHandlers(
         getService(service),
       );
       try {
-        return await codexLoginManager.startProfileLogin({
+        const login = await codexLoginManager.startProfileLogin({
           codexHome,
           command,
           profile,
         });
+        if (login.authenticated && codexAuthState.isBlocked(codexHome)) {
+          const status = await checkCodexProfileAuthStatus(getService(service), { profile });
+          return { ...login, authenticated: status.authenticated, detail: status.detail };
+        }
+        return login;
       } catch (error) {
         // The codex-discovery CodexLoginManager rejects when `codex login`
         // exits without emitting a login link (e.g. it printed "Not logged

--- a/apps/desktop/src/main/ipc/settings.ts
+++ b/apps/desktop/src/main/ipc/settings.ts
@@ -972,6 +972,8 @@ function resolveRequiredCodexProfileHome(profile: string): string {
 }
 
 
+const pendingCodexProviderRecovery = new Map<string, { work?: Promise<void> }>();
+
 async function checkCodexProfileAuthStatus(
   service: DesktopSettingsService,
   request: CheckDesktopCodexAuthProfileStatusRequest,
@@ -998,6 +1000,7 @@ async function checkCodexProfileAuthStatus(
     });
     try {
       await client.readRateLimits();
+      pendingCodexProviderRecovery.set(codexHome.replace(/\\/g, "/"), {});
       codexAuthState.verified(codexHome);
     } catch {
       authenticated = false;
@@ -1005,16 +1008,21 @@ async function checkCodexProfileAuthStatus(
     } finally {
       await client.close();
     }
-    if (
-      authenticated
-      && service.readCodexProfiles().effectiveCodexHome.replace(/\\/g, "/")
-        === codexHome.replace(/\\/g, "/")
-    ) {
-      // Recover model/account availability and the provider's navigation data.
-      await getDesktopBackendRegistry().refreshCodexAfterAuthentication(
-        issueProviderDiscoveryPermit("settings-user-action"),
-      );
-    }
+  }
+  const recoveryKey = codexHome.replace(/\\/g, "/");
+  const recovery = pendingCodexProviderRecovery.get(recoveryKey);
+  if (authenticated && recovery
+    && service.readCodexProfiles().effectiveCodexHome.replace(/\\/g, "/") === recoveryKey) {
+    // Authentication can be valid while provider/navigation recovery is still
+    // unfinished. Keep failures retryable through a later explicit status check.
+    recovery.work ??= getDesktopBackendRegistry().refreshCodexAfterAuthentication(
+      issueProviderDiscoveryPermit("settings-user-action"),
+    ).then(() => {
+      if (pendingCodexProviderRecovery.get(recoveryKey) === recovery) {
+        pendingCodexProviderRecovery.delete(recoveryKey);
+      }
+    }).finally(() => { recovery.work = undefined; });
+    await recovery.work;
   }
   // When the CLI reports authenticated, surface the JWT-derived identity
   // fields too — the onboarding wizard's name+login step renders them
@@ -1582,7 +1590,8 @@ export function registerSettingsIpcHandlers(
           command,
           profile,
         });
-        if (login.authenticated && codexAuthState.isBlocked(codexHome)) {
+        if (login.authenticated && (codexAuthState.isBlocked(codexHome)
+          || pendingCodexProviderRecovery.has(codexHome.replace(/\\/g, "/")))) {
           const status = await checkCodexProfileAuthStatus(getService(service), { profile });
           return { ...login, authenticated: status.authenticated, detail: status.detail };
         }
@@ -1967,6 +1976,7 @@ export function registerSettingsIpcHandlers(
 
 export function disposeSettingsIpcHandlers(): void {
   codexLoginManager.dispose();
+  pendingCodexProviderRecovery.clear();
   recentAcpRefreshes.clear();
   ipcMain.removeHandler(ACP_AGENTS_LIST_CHANNEL);
   ipcMain.removeHandler(ACP_AGENT_UPDATE_ACKNOWLEDGE_CHANNEL);

--- a/apps/desktop/src/main/settings/desktop-settings-service.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-service.ts
@@ -1,3 +1,4 @@
+import { codexAuthState } from "../codex-auth-state";
 import type {
   DesktopAppearanceDensity,
   DesktopAppearanceTheme,
@@ -720,7 +721,7 @@ export class DesktopSettingsService {
     const codexDiscovery = this.codexDiscoveryCoordinator.peek?.(
       codexDiscoveryCommand,
     ) ?? codexDiscoveryFromProvider(this.configStore.read("providers").codex);
-    const codexProfiles = this.codexProfiles;
+    const codexProfiles = this.readCodexProfiles();
     // Settle discovery that is ALREADY running before reading its result.
     // Never start it: this must not turn a projection read into a probe,
     // and a caller that arrives before startup discovery simply gets the
@@ -1678,7 +1679,11 @@ export class DesktopSettingsService {
   }
 
   readCodexProfiles(): DesktopCodexAuthProfileDiscoverySnapshot {
-    return structuredClone(this.codexProfiles);
+    const snapshot = structuredClone(this.codexProfiles);
+    for (const profile of snapshot.profiles) {
+      if (codexAuthState.isBlocked(profile.codexHome)) profile.authenticationRequired = true;
+    }
+    return snapshot;
   }
 
   // Applications discovery is config-independent (depends only on this.env

--- a/apps/desktop/src/main/settings/desktop-settings-singleton.ts
+++ b/apps/desktop/src/main/settings/desktop-settings-singleton.ts
@@ -1,3 +1,4 @@
+import { codexAuthState } from "../codex-auth-state";
 import { app, safeStorage } from "electron";
 import { DesktopSettingsService } from "./desktop-settings-service";
 import { DbBackedSafeStorageSecretStore } from "../state/secret-store-sqlite";
@@ -19,6 +20,7 @@ import {
 import { resolveDesktopConfigPath } from "./desktop-config";
 import { setGitCommandResolver } from "../git-command";
 
+let unsubscribeAuth: (() => void) | undefined;
 let desktopSettingsService: DesktopSettingsService | undefined;
 
 export {
@@ -79,6 +81,11 @@ export function getDesktopSettingsService(): DesktopSettingsService {
     // rather than in `index.ts` so the wiring cannot be missed by a code
     // path that reaches settings without going through app startup — and
     // so it is torn down with the service in tests.
+    unsubscribeAuth = codexAuthState.subscribe(() => {
+      for (const webContents of subscribersForChannel(SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL)) {
+        webContents.send(SETTINGS_RUNTIME_CHANGED_EVENT_CHANNEL);
+      }
+    });
     const service = desktopSettingsService;
     setGitCommandResolver(() => service.resolveGitCommandPreference());
     configStore.subscribe(["general"], ({ values }) => {
@@ -103,6 +110,8 @@ export function getDesktopSettingsService(): DesktopSettingsService {
 }
 
 export function resetDesktopSettingsServiceForTests(): void {
+  unsubscribeAuth?.();
+  unsubscribeAuth = undefined;
   desktopSettingsService = undefined;
   setGitCommandResolver(undefined);
   disposeDesktopConfigStore();

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -398,7 +398,7 @@ function DesktopAppShell(props: {
   const showAppNotice = useCallback((notice: AppNoticeToastNotice): void => {
     dispatchAppNotice({ type: "show", notice });
   }, []);
-  const codexProfiles = props.settings.snapshot?.models.codex.profiles;
+  const codexProfiles = props.settings.snapshot?.models?.codex?.profiles;
   const activeCodexProfileRef = useRef(codexProfiles);
   activeCodexProfileRef.current = codexProfiles;
   const openCodexLogin = useCallback(() => {

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -1,3 +1,4 @@
+import { CodexAuthProfileLoginDialog } from "./features/settings/CodexAuthProfileSelect";
 import { navigationIdentityFromThreadKey } from "./lib/navigation-query-state";
 import { classifyDirectory } from "@pwragent/shared";
 import type { NavigationDirectoryView as NavigationDirectorySummary } from "./lib/navigation-loaded-rows";
@@ -389,6 +390,7 @@ function DesktopAppShell(props: {
   // This is intentionally a queue rather than one slot per producer: backend
   // failures can arrive while another safety notice is already visible, and
   // every failure must remain individually reviewable and dismissible.
+  const [codexLoginProfile, setCodexLoginProfile] = useState<{ name: string; displayName: string }>();
   const [appNotices, dispatchAppNotice] = useReducer(
     appNoticeReducer,
     INITIAL_APP_NOTICE_STATE,
@@ -396,6 +398,33 @@ function DesktopAppShell(props: {
   const showAppNotice = useCallback((notice: AppNoticeToastNotice): void => {
     dispatchAppNotice({ type: "show", notice });
   }, []);
+  const codexProfiles = props.settings.snapshot?.models.codex.profiles;
+  const activeCodexProfileRef = useRef(codexProfiles);
+  activeCodexProfileRef.current = codexProfiles;
+  const openCodexLogin = useCallback(() => {
+    const discovery = activeCodexProfileRef.current;
+    const profile = discovery?.profiles.find((entry) => entry.codexHome === discovery.effectiveCodexHome);
+    if (profile) setCodexLoginProfile(profile);
+  }, []);
+  const rejectedCodexHomes = useRef(new Set<string>());
+  useEffect(() => {
+    const rejected = codexProfiles?.profiles.filter((profile) => profile.authenticationRequired) ?? [];
+    const nextHomes = new Set(rejected.map((profile) => profile.codexHome));
+    for (const profile of rejected) {
+      if (rejectedCodexHomes.current.has(profile.codexHome)) continue;
+      showAppNotice({
+        id: `codex-auth:${profile.codexHome}`,
+        title: "Codex login required",
+        message: `${profile.displayName} is logged out. Codex operations are paused until you sign in again.`,
+        autoDismiss: false,
+        actions: [{ label: "Login", onClick: () => setCodexLoginProfile(profile) }],
+      });
+    }
+    for (const home of rejectedCodexHomes.current) {
+      if (!nextHomes.has(home)) dispatchAppNotice({ type: "dismiss", id: `codex-auth:${home}` });
+    }
+    rejectedCodexHomes.current = nextHomes;
+  }, [codexProfiles, showAppNotice]);
   const dismissAppNotice = useCallback((id: string): void => {
     dispatchAppNotice({ type: "dismiss", id });
   }, []);
@@ -1151,6 +1180,7 @@ function DesktopAppShell(props: {
           type: "backend-error",
           signal: {
             kind: "turn-failed",
+            onCodexLogin: openCodexLogin,
             backend: event.backend,
             threadId: params.threadId ?? "unknown",
             turnId: params.turnId ?? "unknown",
@@ -1208,7 +1238,7 @@ function DesktopAppShell(props: {
         return;
       }
     });
-  }, [acknowledgeThreadSpendAlert, desktopApi]);
+  }, [acknowledgeThreadSpendAlert, desktopApi, openCodexLogin]);
   // `instant` is for callers that are about to hide the sidebar (the ⌘K peek):
   // a smooth scroll is animated over several frames, and hiding the sidebar
   // mid-animation abandons it wherever it got to. An instant scroll lands in one
@@ -2623,6 +2653,15 @@ function DesktopAppShell(props: {
       onShowThread={showThreadFromLink}
       threads={navigation.threads}
     >
+      {codexLoginProfile ? (
+        <CodexAuthProfileLoginDialog
+          desktopApi={desktopApi}
+          profile={codexLoginProfile.name}
+          displayName={codexLoginProfile.displayName}
+          onCancel={() => setCodexLoginProfile(undefined)}
+          onAuthenticated={settings.refresh}
+        />
+      ) : null}
       <AppTitleBar
         desktopApi={desktopApi}
         onOpenMessagingActivity={openMessagingActivityWindow}

--- a/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/__tests__/backend-error-notice.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { AppNoticeToastNotice } from "../AppNoticeToast";
 import {
   resolveBackendErrorNotice,
@@ -6,6 +6,25 @@ import {
 } from "../backend-error-notice";
 
 describe("resolveBackendErrorNotice", () => {
+  it("offers local Codex login for a rejected token, without logging in to a peer's profile", () => {
+    const onCodexLogin = vi.fn();
+    const signal = {
+      kind: "turn-failed" as const,
+      backend: "codex" as const,
+      threadId: "thread-1",
+      turnId: "turn-1",
+      threadLabel: "Fixture thread",
+      errorMessage: "Your access token could not be refreshed. Please log out and sign in again.",
+      onCodexLogin,
+    };
+    const notice = resolveBackendErrorNotice(signal, undefined);
+    expect(notice?.actions?.[0]?.label).toBe("Login");
+    notice?.actions?.[0]?.onClick();
+    expect(onCodexLogin).toHaveBeenCalledOnce();
+    expect(resolveBackendErrorNotice({ ...signal, instanceId: "peer-1" }, undefined)?.actions).toBeUndefined();
+    expect(resolveBackendErrorNotice({ ...signal, errorMessage: "Connection timed out" }, undefined)?.actions).toBeUndefined();
+  });
+
   const invalidIdFailure =
     "[ApiIdParam] [input[169].id] [invalid_id_prefix] "
     + "Invalid 'input[169].id': 'review_rollout_user'. "

--- a/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
+++ b/apps/desktop/src/renderer/src/features/notifications/backend-error-notice.ts
@@ -1,3 +1,4 @@
+import { isCodexAuthenticationFailure } from "@pwragent/shared";
 import type {
   AppServerBackendKind,
   FederationInstanceId,
@@ -24,6 +25,7 @@ export type BackendErrorSignal =
     }
   | {
       kind: "turn-failed";
+      onCodexLogin?: () => void;
       backend: AppServerBackendKind;
       threadId: string;
       turnId: string;
@@ -111,6 +113,10 @@ export function resolveBackendErrorNotice(
       autoDismiss: false,
       id: `turn-failed:${signal.backend}:${signal.threadId}:${signal.turnId}`,
       title: "Turn failed",
+      ...(signal.backend === "codex" && !signal.instanceId
+        && signal.onCodexLogin && isCodexAuthenticationFailure(signal.errorMessage)
+        ? { actions: [{ label: "Login", onClick: signal.onCodexLogin }] }
+        : {}),
       message: signal.errorMessage,
       detail: signal.threadLabel,
       threadLink: {

--- a/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/CodexAuthProfileSelect.tsx
@@ -6,6 +6,7 @@ import type {
 import { normalizeProfileName } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { tildifyPath } from "../../lib/tildify-path";
+import { BACKEND_SUMMARIES_REFRESH_EVENT } from "../../lib/useBackendSummaries";
 import { SettingsSplitPath } from "./SettingsSplitPath";
 
 const CREATE_VALUE = "__create_codex_profile__";
@@ -63,13 +64,22 @@ export function CodexAuthProfileSelect(props: {
         {profiles.map((profile) => (
           <option key={profile.name || "default"} value={profile.name}>
             {profile.displayName}
-            {profile.hasAuthFile ? "" : " (no auth)"}
+            {profile.authenticationRequired ? " (logged out)" : profile.hasAuthFile ? "" : " (no auth)"}
           </option>
         ))}
         <option value={CREATE_VALUE}>Create New Codex Profile...</option>
       </select>
 
       {selected ? <CodexAuthProfileStatus profile={selected} /> : null}
+      {selected && (selected.authenticationRequired || !selected.hasAuthFile) ? (
+        <CodexAuthProfileLoginButton
+          desktopApi={props.desktopApi}
+          disabled={props.disabled}
+          displayName={selected.displayName}
+          profile={selected.name}
+          onAuthenticated={props.onAfterProfilesChanged}
+        />
+      ) : null}
 
       {createOpen ? (
         <CodexAuthProfileCreateDialog
@@ -130,7 +140,7 @@ export function CodexAuthProfileLoginButton(props: {
     <>
       <button
         className="button button--secondary"
-        disabled={props.disabled || !props.profile}
+        disabled={props.disabled}
         type="button"
         onClick={() => setLoginOpen(true)}
       >
@@ -175,12 +185,12 @@ function CodexAuthProfileStatus(props: {
         </span>
         <span
           className={`settings-pathrow__chip${
-            profile.hasAuthFile || !profile.name
+            !profile.authenticationRequired && profile.hasAuthFile
               ? ""
               : " settings-pathrow__chip--err"
           }`}
         >
-          {profile.hasAuthFile ? "auth" : "no auth"}
+          {profile.authenticationRequired ? "Logged out" : profile.hasAuthFile ? "auth" : "no auth"}
         </span>
         {profile.hasConfigFile ? (
           <span className="settings-pathrow__chip">config</span>
@@ -433,7 +443,7 @@ function CodexAuthProfileCreateDialog(props: {
   );
 }
 
-function CodexAuthProfileLoginDialog(props: {
+export function CodexAuthProfileLoginDialog(props: {
   desktopApi?: DesktopApi;
   displayName: string;
   profile: string;
@@ -449,8 +459,7 @@ function CodexAuthProfileLoginDialog(props: {
   const authenticatedRef = useRef(false);
   const canLogin = Boolean(
     props.desktopApi?.startCodexAuthProfileLogin
-      && props.desktopApi.checkCodexAuthProfileStatus
-      && props.profile,
+      && props.desktopApi.checkCodexAuthProfileStatus,
   );
 
   const startLogin = async () => {
@@ -497,7 +506,6 @@ function CodexAuthProfileLoginDialog(props: {
     if (
       busy
       || !props.desktopApi?.checkCodexAuthProfileStatus
-      || !props.profile
     ) {
       return;
     }
@@ -593,6 +601,7 @@ function CodexAuthProfileLoginDialog(props: {
               onClick={() => {
                 void (async () => {
                   await props.onAuthenticated?.();
+                  window.dispatchEvent(new Event(BACKEND_SUMMARIES_REFRESH_EVENT));
                   props.onCancel();
                 })();
               }}

--- a/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/ModelsSettings.tsx
@@ -1596,8 +1596,8 @@ function CodexProfileRow(props: {
   const chips: SettingsPathRowChip[] = [
     { label: profile.source === "default" ? "default" : "profile", tone: "muted" },
     {
-      label: profile.hasAuthFile ? "auth" : "no auth",
-      tone: profile.hasAuthFile || !profile.name ? "muted" : "err",
+      label: profile.authenticationRequired ? "Logged out" : profile.hasAuthFile ? "auth" : "no auth",
+      tone: !profile.authenticationRequired && profile.hasAuthFile ? "muted" : "err",
     },
   ];
 
@@ -1624,7 +1624,7 @@ function CodexProfileRow(props: {
       selectedLabel="Next launch"
       disabled={props.disabled || !profile.exists}
       extraAction={
-        profile.name && profile.exists && !profile.hasAuthFile ? (
+        profile.authenticationRequired || !profile.hasAuthFile ? (
           <CodexAuthProfileLoginButton
             desktopApi={props.desktopApi}
             disabled={props.disabled}

--- a/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
+++ b/apps/desktop/src/renderer/src/features/settings/__tests__/settings-screen.test.tsx
@@ -3093,6 +3093,38 @@ describe("SettingsScreen", () => {
     expect(turnOffCodexFastEverywhere).toHaveBeenCalledTimes(2);
   });
 
+  it("offers login for a rejected system-default profile even with an auth file", async () => {
+    const snapshot = createSnapshot();
+    const profile = snapshot.models.codex.profiles.profiles[0]!;
+    profile.authenticationRequired = true;
+    profile.hasAuthFile = true;
+    const startCodexAuthProfileLogin = vi.fn(async () => ({
+      profile: "",
+      codexHome: profile.codexHome,
+      started: true,
+    }));
+    render(
+      <SettingsScreen
+        desktopApi={{
+          startCodexAuthProfileLogin,
+          checkCodexAuthProfileStatus: vi.fn(async () => ({
+            profile: "",
+            codexHome: profile.codexHome,
+            authenticated: false,
+            status: "unauthenticated",
+          })),
+        } as unknown as DesktopApi}
+        initialSection="models"
+        initialSubsection="codex"
+        settings={createSettingsState(snapshot)}
+        onClose={() => undefined}
+      />,
+    );
+    expect(screen.getByText("Logged out")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Login" }));
+    await waitFor(() => expect(startCodexAuthProfileLogin).toHaveBeenCalledWith({ profile: "" }));
+  });
+
   it("can restart login for an existing Codex auth profile", async () => {
     const snapshot = createSnapshot();
     snapshot.models.codex.profiles.profiles[1]!.hasAuthFile = false;

--- a/packages/shared/src/codex-authentication.ts
+++ b/packages/shared/src/codex-authentication.ts
@@ -1,0 +1,6 @@
+export function isCodexAuthenticationFailure(message: string): boolean {
+  return /Codex is logged out\. Please sign in|invalid_refresh_token|refresh_token_(?:expired|reused|invalidated)|access token could not be refreshed|could not (?:parse your authentication|validate your refresh) token/i.test(message)
+    || (/401\s+Unauthorized/i.test(message)
+      && /(?:https?|wss):\/\/chatgpt\.com\/backend-api\/(?:codex|wham)\//i.test(message));
+}
+

--- a/packages/shared/src/contracts/settings.ts
+++ b/packages/shared/src/contracts/settings.ts
@@ -788,6 +788,7 @@ export type DesktopCodexDiscoverySnapshot = {
 export type DesktopCodexAuthProfileSource = "default" | "directory" | "config";
 
 export type DesktopCodexAuthProfileCandidate = {
+  authenticationRequired?: boolean;
   name: string;
   displayName: string;
   codexHome: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -67,3 +67,5 @@ export * from "./thread-incident-summary";
 
 export * from "./thread-tool-display";
 export * from "./subagent-kind";
+
+export { isCodexAuthenticationFailure } from "./codex-authentication";


### PR DESCRIPTION
Codex could reject an expired refresh token while Settings continued to show “auth” because the credential file still existed. Quota probes kept retrying, and the failure toast offered no way to log in.

This change:
- Recognizes Codex authentication failures from RPC errors, turn errors, and app-server stderr, without treating transcript text or unrelated MCP 401s as account failures.
- Blocks requests and restarts for the affected Codex home, stops its clients, fails active turns, and skips quota probes until authentication is verified.
- Shows “Logged out” and Login in both profile surfaces, including the system-default profile, and adds Login to authentication and local turn-failure toasts.
- Verifies recovery through a fresh authenticated API call before releasing the block, then reloads the active backend and provider thread snapshots and publishes navigation updates, so recovery does not require a restart. A successful CLI login-status check alone cannot release it.

The rejection latch is per application runtime and Codex home; it adds no persistence or SQLite writes. Restarting PwrAgent re-evaluates authentication from runtime evidence.

Validation:
- Reproduced a failing transport regression before the fix: a model request was still accepted after the refresh-token rejection.
- Focused transport, client lifecycle, auth-state, Settings service/IPC, Settings rendering, toast, and quota tests pass.
- Recovery coverage includes failed startup, a failed thread reload that must not publish an empty list, navigation cache publication, and skipping archive cleanup while authentication is blocked.
- Typecheck, ESLint (no errors), dependency boundaries, Codex storage boundary, and git diff checks pass.
- Tests use contrived protocol/process fixtures; a live Ubuntu browser login was not exercised.
