### PR TITLE
fix(desktop): persist GitHub CLI notice suppression

### DIFF
--- a/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/app-server-ipc.test.ts
@@ -1414,6 +1414,28 @@ describe("app server ipc", () => {
     expect(searchForJump).not.toHaveBeenCalled();
   });
 
+  it("routes notice acknowledgement only from a subscribed renderer", async () => {
+    const { GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL } = await import("../../shared/ipc");
+    const { subscribersForChannel } = await import("../window-channels");
+    const { appServerService } = await import("../ipc/app-server");
+    const sender = subscribersForChannel("test")[0]!;
+    const acknowledge = vi.spyOn(appServerService, "acknowledgeGithubPrAuthenticationNotice")
+      .mockImplementation(() => {});
+    registerAppServerIpcHandlers();
+    const handler = handlers.get(GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL);
+    expect(handler).toBeDefined();
+    try {
+      vi.mocked(subscribersForChannel).mockReturnValueOnce([sender]);
+      await handler?.({ sender });
+      expect(acknowledge).toHaveBeenCalledTimes(1);
+      vi.mocked(subscribersForChannel).mockReturnValueOnce([sender]);
+      await handler?.({ sender: {} });
+      expect(acknowledge).toHaveBeenCalledTimes(1);
+    } finally {
+      acknowledge.mockRestore();
+    }
+  });
+
   it("invalidates the GraphQL token during an auth recheck", async () => {
     const { GithubGraphqlPrClient } = await import(
       "../pr-status/github-graphql-client"

--- a/apps/desktop/src/main/__tests__/github-pr-authentication-notice.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-authentication-notice.test.ts
@@ -22,6 +22,7 @@ describe("GithubPrAuthenticationNotice", () => {
     const secondWindow = vi.fn();
     const notice = new GithubPrAuthenticationNotice(marker);
     notice.publish([firstWindow, secondWindow]);
+    notice.acknowledge();
     for (let poll = 0; poll < 20; poll += 1) {
       notice.publish([firstWindow, secondWindow]);
     }
@@ -46,10 +47,40 @@ describe("GithubPrAuthenticationNotice", () => {
     const second = new GithubPrAuthenticationNotice(marker);
     const deliver = vi.fn();
     first.publish([deliver]);
+    first.acknowledge();
     second.publish([deliver]);
     expect(deliver).toHaveBeenCalledTimes(1);
     new GithubPrAuthenticationNotice(path.join(root, "other", "notice")).publish([deliver]);
     expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries events lost before the renderer listener mounts, including after restart", () => {
+    const loadingWindowSend = vi.fn();
+    const notice = new GithubPrAuthenticationNotice(marker);
+    notice.publish([loadingWindowSend]);
+    expect(loadingWindowSend).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(marker)).toBe(false);
+
+    const restarted = new GithubPrAuthenticationNotice(marker);
+    const receive = vi.fn(() => restarted.acknowledge());
+    restarted.publish([receive]);
+    restarted.publish([receive]);
+    expect(receive).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(marker)).toBe(true);
+  });
+
+  it("retries an unacknowledged delivery on the next poll without restarting", () => {
+    const notice = new GithubPrAuthenticationNotice(marker);
+    notice.publish([vi.fn()]);
+    const receive = vi.fn(() => notice.acknowledge());
+    notice.publish([receive]);
+    notice.publish([receive]);
+    expect(receive).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not consume an acknowledgement before publishing", () => {
+    new GithubPrAuthenticationNotice(marker).acknowledge();
+    expect(fs.existsSync(marker)).toBe(false);
   });
 
   it("logs persistence failures and still limits the notice to once per process", () => {
@@ -58,6 +89,7 @@ describe("GithubPrAuthenticationNotice", () => {
     const deliver = vi.fn();
     const notice = new GithubPrAuthenticationNotice(marker, onError);
     notice.publish([deliver]);
+    notice.acknowledge();
     notice.publish([deliver]);
     expect(onError).toHaveBeenCalledTimes(1);
     expect(deliver).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/main/__tests__/github-pr-authentication-notice.test.ts
+++ b/apps/desktop/src/main/__tests__/github-pr-authentication-notice.test.ts
@@ -1,0 +1,65 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GithubPrAuthenticationNotice } from "../pr-status/github-pr-authentication-notice";
+
+describe("GithubPrAuthenticationNotice", () => {
+  let root: string;
+  let marker: string;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "pwragent-gh-notice-"));
+    marker = path.join(root, "default", "state", "notices", "github-pr-authentication-failure");
+  });
+
+  afterEach(() => {
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  it("delivers once to subscribed windows and stays suppressed across restarts", () => {
+    const firstWindow = vi.fn();
+    const secondWindow = vi.fn();
+    const notice = new GithubPrAuthenticationNotice(marker);
+    notice.publish([firstWindow, secondWindow]);
+    for (let poll = 0; poll < 20; poll += 1) {
+      notice.publish([firstWindow, secondWindow]);
+    }
+    new GithubPrAuthenticationNotice(marker).publish([firstWindow]);
+
+    expect(firstWindow).toHaveBeenCalledTimes(1);
+    expect(secondWindow).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(marker)).toBe(true);
+  });
+
+  it("does not consume the notice before a live window subscribes", () => {
+    const deliver = vi.fn();
+    const notice = new GithubPrAuthenticationNotice(marker);
+    notice.publish([]);
+    expect(fs.existsSync(marker)).toBe(false);
+    notice.publish([deliver]);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates existing instances sharing a profile but keeps profiles independent", () => {
+    const first = new GithubPrAuthenticationNotice(marker);
+    const second = new GithubPrAuthenticationNotice(marker);
+    const deliver = vi.fn();
+    first.publish([deliver]);
+    second.publish([deliver]);
+    expect(deliver).toHaveBeenCalledTimes(1);
+    new GithubPrAuthenticationNotice(path.join(root, "other", "notice")).publish([deliver]);
+    expect(deliver).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs persistence failures and still limits the notice to once per process", () => {
+    fs.writeFileSync(path.join(root, "default"), "blocks directory creation");
+    const onError = vi.fn();
+    const deliver = vi.fn();
+    const notice = new GithubPrAuthenticationNotice(marker, onError);
+    notice.publish([deliver]);
+    notice.publish([deliver]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(deliver).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -1,3 +1,4 @@
+import { GithubPrAuthenticationNotice } from "../pr-status/github-pr-authentication-notice";
 import { expectedNavigationReadFailure, type NavigationReadFailure } from "../../shared/navigation-ipc-result";
 import { NavigationAttentionViewLeases } from "../app-server/navigation-attention-view-leases";
 import type { NavigationAttentionViewReleaseRequest } from "@pwragent/shared";
@@ -1346,7 +1347,10 @@ class DesktopAppServerService {
   private prLookupRegistryLoadPromise: Promise<void> | undefined;
   private prGraphqlClient: GithubGraphqlPrClient | undefined;
   private readonly githubSamlBlockedRepositories = new Set<string>();
-  private githubPrAuthenticationFailureNotified = false;
+  private readonly githubPrAuthenticationNotice = new GithubPrAuthenticationNotice(
+    undefined,
+    (error) => appServerLog.warn("Could not persist GitHub PR authentication notice", { error }),
+  );
   private prPollingScheduler: PrPollingScheduler | undefined;
   private backgroundPrPollingEnabled = false;
   private prAutoDispatchAllowed = false;
@@ -5292,29 +5296,20 @@ class DesktopAppServerService {
         getConfiguredGhCommand: () =>
           getDesktopSettingsService().resolveGhCommandPreference(),
         onAuthenticationFailure: (event) => {
-          if (this.githubPrAuthenticationFailureNotified) {
-            return;
-          }
-          this.githubPrAuthenticationFailureNotified = true;
           const notice = {
             occurredAt: Date.now(),
             ...(event.detail ? { detail: event.detail } : {}),
           };
-          for (const webContents of subscribersForChannel(
-            GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
-          )) {
-            if (!webContents.isDestroyed()) {
-              webContents.send(
+          this.githubPrAuthenticationNotice.publish(
+            subscribersForChannel(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL)
+              .filter((webContents) => !webContents.isDestroyed())
+              .map((webContents) => () => webContents.send(
                 GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
                 notice,
-              );
-            }
-          }
+              )),
+          );
         },
         onRepositoryAccess: (event) => {
-          if (event.status === "available") {
-            this.githubPrAuthenticationFailureNotified = false;
-          }
           const target = {
             kind: "github-repository" as const,
             owner: event.owner,
@@ -7613,7 +7608,6 @@ class DesktopAppServerService {
     this.prPollingSettingsUnsubscribe = undefined;
     this.prGraphqlClient = undefined;
     this.githubSamlBlockedRepositories.clear();
-    this.githubPrAuthenticationFailureNotified = false;
     this.prPollingFocus.clear();
     this.prPollBackendByKey.clear();
     this.prStatusTransitionListeners.clear();

--- a/apps/desktop/src/main/ipc/app-server.ts
+++ b/apps/desktop/src/main/ipc/app-server.ts
@@ -238,6 +238,7 @@ import {
   APP_SERVER_GET_PR_AUTO_DISPATCH_BUDGET_STATUS_CHANNEL,
   APP_SERVER_RESUME_PR_AUTO_DISPATCH_BUDGET_CHANNEL,
   PR_AUTO_DISPATCH_BUDGET_CHANGED_EVENT_CHANNEL,
+  GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL,
   GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
   GITHUB_PR_SAML_ENFORCEMENT_EVENT_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
@@ -5290,6 +5291,10 @@ class DesktopAppServerService {
     await this.prPollingScheduler?.probeAfterNetworkReconnect();
   }
 
+  acknowledgeGithubPrAuthenticationNotice(): void {
+    this.githubPrAuthenticationNotice.acknowledge();
+  }
+
   private getPrGraphqlClient(): GithubGraphqlPrClient {
     if (!this.prGraphqlClient) {
       this.prGraphqlClient = new GithubGraphqlPrClient({
@@ -7922,6 +7927,12 @@ function invalidateNavigationEvent(event: AgentEvent): void {
 }
 
 export function registerAppServerIpcHandlers(): void {
+  ipcMain.removeHandler(GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL);
+  ipcMain.handle(GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL, (event) => {
+    if (subscribersForChannel(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL).includes(event.sender)) {
+      appServerService.acknowledgeGithubPrAuthenticationNotice();
+    }
+  });
   // Refresh a thread's working-state chips when the agent finishes a turn
   // or a git-mutating command in its worktree. Re-registering tears the
   // previous subscription down first so repeated calls don't stack listeners.
@@ -8952,6 +8963,7 @@ export async function disposeAppServerIpcHandlers(): Promise<void> {
     for (const token of consumers) navigationQueryPool.release(token);
   }
   navigationQueryConsumersBySender.clear();
+  ipcMain.removeHandler(GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_SKILLS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_LIST_THREADS_CHANNEL);
   ipcMain.removeHandler(APP_SERVER_READ_THREAD_CHANNEL);

--- a/apps/desktop/src/main/pr-status/github-pr-authentication-notice.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-authentication-notice.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { resolveActiveProfilePath } from "../profile";
+
+/** One advisory per local profile, including across application restarts. */
+export class GithubPrAuthenticationNotice {
+  private notified = false;
+
+  constructor(
+    private readonly markerPath = resolveActiveProfilePath(
+      path.join("state", "notices", "github-pr-authentication-failure"),
+    ),
+    private readonly onPersistenceError: (error: unknown) => void = () => {},
+  ) {}
+
+  publish(deliveries: Array<() => void>): void {
+    // A background lookup before any window subscribes must not consume it.
+    if (this.notified || deliveries.length === 0) return;
+    this.notified = true;
+    try {
+      fs.mkdirSync(path.dirname(this.markerPath), { recursive: true });
+      // Exclusive creation also deduplicates processes sharing a profile.
+      fs.closeSync(fs.openSync(this.markerPath, "wx", 0o600));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") return;
+      // A read-only profile must not break PR polling or repeat every poll.
+      this.onPersistenceError(error);
+    }
+    for (const deliver of deliveries) deliver();
+  }
+}

--- a/apps/desktop/src/main/pr-status/github-pr-authentication-notice.ts
+++ b/apps/desktop/src/main/pr-status/github-pr-authentication-notice.ts
@@ -5,6 +5,7 @@ import { resolveActiveProfilePath } from "../profile";
 /** One advisory per local profile, including across application restarts. */
 export class GithubPrAuthenticationNotice {
   private notified = false;
+  private pending = false;
 
   constructor(
     private readonly markerPath = resolveActiveProfilePath(
@@ -16,6 +17,16 @@ export class GithubPrAuthenticationNotice {
   publish(deliveries: Array<() => void>): void {
     // A background lookup before any window subscribes must not consume it.
     if (this.notified || deliveries.length === 0) return;
+    if (fs.existsSync(this.markerPath)) {
+      this.notified = true;
+      return;
+    }
+    this.pending = true;
+    for (const deliver of deliveries) deliver();
+  }
+
+  acknowledge(): void {
+    if (this.notified || !this.pending) return;
     this.notified = true;
     try {
       fs.mkdirSync(path.dirname(this.markerPath), { recursive: true });
@@ -26,6 +37,5 @@ export class GithubPrAuthenticationNotice {
       // A read-only profile must not break PR polling or repeat every poll.
       this.onPersistenceError(error);
     }
-    for (const deliver of deliveries) deliver();
   }
 }

--- a/apps/desktop/src/preload/__tests__/github-pr-authentication-notice.test.ts
+++ b/apps/desktop/src/preload/__tests__/github-pr-authentication-notice.test.ts
@@ -1,0 +1,39 @@
+import { EventEmitter } from "node:events";
+import type { IpcRenderer } from "electron";
+import { describe, expect, it, vi } from "vitest";
+import { subscribeGithubPrAuthenticationFailure } from "../github-pr-authentication-notice";
+import {
+  GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL,
+  GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
+} from "../../shared/ipc";
+
+describe("GitHub authentication notice acknowledgement", () => {
+  it("acknowledges only after an installed renderer consumer receives the event", () => {
+    const emitter = new EventEmitter();
+    const invoke = vi.fn(async () => {});
+    const ipc = Object.assign(emitter, { invoke }) as unknown as IpcRenderer;
+    const payload = { occurredAt: 123 };
+    const send = () => emitter.emit(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL, {}, payload);
+    send();
+    expect(invoke).not.toHaveBeenCalled();
+    const callback = vi.fn(() => expect(invoke).not.toHaveBeenCalled());
+    const unsubscribe = subscribeGithubPrAuthenticationFailure(ipc, callback);
+    expect(invoke).not.toHaveBeenCalled();
+    send();
+    expect(callback).toHaveBeenCalledExactlyOnceWith(payload);
+    expect(invoke).toHaveBeenCalledExactlyOnceWith(GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL);
+    unsubscribe();
+    send();
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not acknowledge when the renderer consumer throws", () => {
+    const emitter = new EventEmitter();
+    const invoke = vi.fn(async () => {});
+    const ipc = Object.assign(emitter, { invoke }) as unknown as IpcRenderer;
+    subscribeGithubPrAuthenticationFailure(ipc, () => { throw new Error("not received"); });
+    expect(() => emitter.emit(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL, {}, { occurredAt: 123 }))
+      .toThrow("not received");
+    expect(invoke).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/preload/github-pr-authentication-notice.ts
+++ b/apps/desktop/src/preload/github-pr-authentication-notice.ts
@@ -1,0 +1,25 @@
+import type { IpcRenderer } from "electron";
+import type { GithubPrAuthenticationFailureEvent } from "../shared/github-pr-access";
+import {
+  GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL,
+  GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
+} from "../shared/ipc";
+
+export function subscribeGithubPrAuthenticationFailure(
+  ipc: Pick<IpcRenderer, "on" | "off" | "invoke">,
+  callback: (event: GithubPrAuthenticationFailureEvent) => void,
+): () => void {
+  const listener = (
+    _event: Electron.IpcRendererEvent,
+    payload: GithubPrAuthenticationFailureEvent,
+  ) => {
+    callback(payload);
+    // Window registration precedes React mounting. Only acknowledge an event
+    // after the actual consumer receives it, never merely after main sends it.
+    void ipc.invoke(GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL).catch(() => {
+      // Main may be shutting down. An unacknowledged notice can be retried.
+    });
+  };
+  ipc.on(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL, listener);
+  return () => ipc.off(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL, listener);
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -1,3 +1,4 @@
+import { subscribeGithubPrAuthenticationFailure } from "./github-pr-authentication-notice";
 import { unwrapNavigationRead } from "../shared/navigation-ipc-result";
 import type { NavigationAttentionViewReleaseRequest } from "@pwragent/shared";
 import type { MarkNavigationDirectorySeenRequest, MarkNavigationDirectorySeenResponse } from "@pwragent/shared";
@@ -585,7 +586,6 @@ import {
   APP_SERVER_GET_PR_AUTO_DISPATCH_BUDGET_STATUS_CHANNEL,
   APP_SERVER_RESUME_PR_AUTO_DISPATCH_BUDGET_CHANNEL,
   PR_AUTO_DISPATCH_BUDGET_CHANGED_EVENT_CHANNEL,
-  GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
   GITHUB_PR_SAML_ENFORCEMENT_EVENT_CHANNEL,
   MANAGED_GROK_SIGNATURE_REJECTED_EVENT_CHANNEL,
   APP_SERVER_LIST_THREADS_CHANNEL,
@@ -2445,14 +2445,7 @@ const desktopApi = Object.freeze({
   onGithubPrAuthenticationFailure: (
     callback: (event: GithubPrAuthenticationFailureEvent) => void,
   ): (() => void) => {
-    const listener = (
-      _event: Electron.IpcRendererEvent,
-      payload: GithubPrAuthenticationFailureEvent,
-    ) => callback(payload);
-    ipcRenderer.on(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL, listener);
-    return () => {
-      ipcRenderer.off(GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL, listener);
-    };
+    return subscribeGithubPrAuthenticationFailure(ipcRenderer, callback);
   },
   onAppearanceChanged: (
     callback: (appearance: {

--- a/apps/desktop/src/shared/ipc.ts
+++ b/apps/desktop/src/shared/ipc.ts
@@ -71,6 +71,8 @@ export const MANAGED_GROK_SIGNATURE_REJECTED_EVENT_CHANNEL =
   "acp:managed-grok-signature-rejected";
 export const GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL =
   "app-server:github-pr-authentication-failure";
+export const GITHUB_PR_AUTHENTICATION_FAILURE_ACK_CHANNEL =
+  "app-server:github-pr-authentication-failure-ack";
 export const APP_SERVER_ARCHIVE_THREAD_CHANNEL = "app-server:archive-thread";
 export const APP_SERVER_RESOLVE_MISSING_CODEX_THREADS_CHANNEL =
   "app-server:resolve-missing-codex-threads";


### PR DESCRIPTION
## Problem and change

The GitHub CLI authentication toast was deduplicated only in memory, and a successful repository lookup reset that guard. Mixed successful and failed lookups could therefore reopen a dismissed warning every few minutes, and restarting always rearmed it.

Suppress the advisory durably after a renderer receives it. The preload listener acknowledges only after its consumer callback returns; main accepts acknowledgements from registered recipients and writes an exclusive marker under the local profile's `state/notices/` directory. Successful repository checks no longer rearm the warning. PR status and Git settings continue reporting current failures.

Window creation does not prove the renderer listener is mounted. Sending an event therefore never consumes the notice: an event lost during startup remains eligible on the next poll or after restart. Once acknowledged, suppression applies across restarts and processes sharing the profile. If persistence fails, log the error and suppress repeats for the service lifetime.

This adds one empty marker file per profile, with no SQLite writes or polling writes. The existing toast and its controls are unchanged.

## Validation

- 164 focused tests passed across notice persistence, preload delivery, and app-server IPC suites.
- Coverage includes events lost before renderer readiness, retry within a process and after restart, callback-before-acknowledgement ordering, unsubscribe, callback failure, acknowledgement sender validation, repeated polling, shared profiles, and persistence errors.
- `pnpm lint:eslint` passed.
- `pnpm typecheck` passed.
- `git diff --check` passed.
