### PR TITLE
fix(desktop): align unread cookies with review counts

### DIFF
--- a/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/ThreadRowStatus.tsx
@@ -114,7 +114,9 @@ export function getThreadRowStatus(
     return "thinking";
   }
 
-  if (thread.inbox.reason === "updated-since-seen") {
+  // Counts include newly discovered threads as well as updates. Use the same
+  // membership predicate so every idle thread counted for review has a cookie.
+  if (isThreadAwaitingReview(thread)) {
     return "unread";
   }
 

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/sidebar.test.tsx
@@ -3013,31 +3013,58 @@ describe("Sidebar", () => {
     expect(inputChip).toHaveAttribute("title", "Input needed");
   });
 
-  it("does not duplicate new-thread inbox membership as an attention marker in recents", () => {
-    render(
-      <Sidebar
-        backends={backends}
-        browseMode="recents"
-        directories={directories}
-        inboxThreads={[sharedThread]}
-        loading={false}
-        creatingThread={undefined}
-        selectedItemKey={undefined}
-        threads={[sharedThread]}
-        onBrowseModeChange={() => undefined}
-        onCreateThread={async () => undefined}
-        onOpenLaunchpad={async () => undefined}
-        onSelectThread={() => undefined}
-      />
+  describe.each(["local", "remote"] as const)("%s new-thread unread counts", (owner) => {
+    it.each(["directories", "attention", "inbox", "recents"] as const)(
+      "marks counted new threads in %s and clears the cookie when seen",
+      (browseMode) => {
+        const thread: NavigationThreadSummary = {
+          ...sharedThread,
+          ...(owner === "remote" ? {
+            federation: {
+              instanceLabel: "studio",
+              ref: {
+                backend: "codex",
+                target: { scope: "remote", instanceId: "peer-1" },
+                threadId: sharedThread.id,
+              },
+            },
+          } : {}),
+        };
+        const props = {
+          backends,
+          browseMode,
+          directories,
+          inboxThreads: [thread],
+          loading: false,
+          creatingThread: undefined,
+          selectedItemKey: undefined,
+          threads: [thread],
+          onBrowseModeChange: () => undefined,
+          onCreateThread: async () => undefined,
+          onOpenLaunchpad: async () => undefined,
+          onSelectThread: () => undefined,
+        };
+        const view = render(<Sidebar {...props} />);
+        expect(screen.getByRole("tab", {
+          name: "Attention, 0 active threads, 1 thread to review",
+        })).toBeInTheDocument();
+        if (browseMode === "directories") {
+          fireEvent.click(screen.getByRole("button", {
+            name: "PwrAgent, 1 thread to review",
+          }));
+        }
+        const row = threadCard(screen.getByRole("button", { name: thread.title }));
+        expect(row.querySelector('[data-thread-status="unread"]')).not.toBeNull();
+        expect(row.querySelector('[data-thread-status="thinking"]')).toBeNull();
+
+        const seen = { ...thread, inbox: { inInbox: false } };
+        view.rerender(<Sidebar {...props} threads={[seen]} inboxThreads={[]} />);
+        expect(screen.getByRole("tab", {
+          name: "Attention, 0 active threads, 0 threads to review",
+        })).toBeInTheDocument();
+        expect(view.container.querySelector('[data-thread-status="unread"]')).toBeNull();
+      },
     );
-
-    const browseSection = screen.getByRole("region", { name: "Thread browser" });
-    const threadButton = within(browseSection as HTMLElement).getByRole("button", {
-      name: /Cross-project cleanup/i,
-    });
-
-    expect(threadCard(threadButton).querySelector('[data-thread-status="thinking"]')).toBeNull();
-    expect(threadCard(threadButton).querySelector('[data-thread-status="unread"]')).toBeNull();
   });
 
   it("shows an unread marker in recents for threads updated since they were seen", () => {


### PR DESCRIPTION
## Summary

- I fixed a mismatch where directory and Attention counts included newly discovered threads (`inInbox: true`, `reason: "new-thread"`), but their rows showed no unread cookie. A project could therefore show four threads to review with no visibly unread rows, even without Federation.
- I made the row use the existing review-membership predicate. Newly discovered threads and updates now both show the cookie; active turns retain the thinking indicator.

## Verification

- I reproduced all eight new regression cases failing on the missing cookie before the fix: local and mounted remote threads in Directories, Attention, Inbox, and Recents.
- I verified all 172 sidebar and navigation projection tests pass after the fix. The regressions also verify the count and cookie clear together after the thread is marked seen.
- I ran `pnpm typecheck` and `pnpm lint:eslint` successfully (ESLint reports existing warnings, no errors).

## Notes

- I replaced an older test that explicitly expected newly discovered threads to have no marker, despite their inclusion in the review counts.
- This reproduces the reported symptom without requiring unmounted Federation threads. I have not established whether a separate unmounted-thread issue exists in the reported live instance.
