### PR TITLE
fix(desktop): scope CPU notices to local main windows

### DIFF
--- a/apps/desktop/src/main/window.ts
+++ b/apps/desktop/src/main/window.ts
@@ -7,7 +7,7 @@ import {
   type ContextMenuParams,
   type MenuItemConstructorOptions,
 } from "electron";
-import { homedir } from "node:os";
+import { homedir, hostname } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type {
@@ -563,7 +563,10 @@ export function createMainWindow(options?: {
         for (const subscriber of subscribersForChannel(
           HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL,
         )) {
-          subscriber.send(HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL, event);
+          subscriber.send(HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL, {
+            ...event,
+            sourceHostname: hostname(),
+          });
         }
       },
       session: created.session,
@@ -850,8 +853,9 @@ export function createMainWindow(options?: {
   }
 
   applyWindowSecurityHardening(window);
-  // The main window subscribes to every push-event channel — it
-  // hosts the full app shell. Secondary windows register a narrower
+  // Local main windows receive CPU capture notices. Federation viewers
+  // also host the app shell, but must not receive local CPU notices.
+  // Secondary windows register a narrower
   // set (or none) so broadcasters only deliver to what they actually
   // consume. See `apps/desktop/src/main/window-channels.ts`.
   registerWindowChannels(window, WINDOW_KIND_MAIN, [
@@ -860,7 +864,7 @@ export function createMainWindow(options?: {
     DIAGNOSTICS_HEAP_SNAPSHOT_CAPTURED_EVENT_CHANNEL,
     GITHUB_PR_AUTHENTICATION_FAILURE_EVENT_CHANNEL,
     GITHUB_PR_SAML_ENFORCEMENT_EVENT_CHANNEL,
-    HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL,
+    ...(options?.federationTarget ? [] : [HOT_CPU_PROFILE_CAPTURED_EVENT_CHANNEL]),
     INTEGRATED_TERMINAL_REVEAL_CHANNEL,
     INTEGRATED_TERMINAL_SESSIONS_CHANNEL,
     MANAGED_GROK_SIGNATURE_REJECTED_EVENT_CHANNEL,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -745,7 +745,20 @@ function DesktopAppShell(props: {
       showAppNotice({
         autoDismiss: false,
         copyText: buildHotCpuProfileHandoffMessage(event),
-        detail: `Session: ${event.sessionDirectoryName}`,
+        detail: [
+          `Local app${event.sourceHostname ? ` on ${event.sourceHostname}` : ""}`,
+          `Captured: ${new Date(event.capturedAt).toLocaleString(undefined, {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZoneName: "short",
+          })}`,
+          `Session: ${event.sessionDirectoryName}`,
+        ].join("\n"),
+        dismissGroup: { key: "hot-cpu-profile", label: "CPU profile notices" },
         id: `hot-cpu-profile:${event.capturedAt}:${event.profileFilename}`,
         title: `${event.target === "main" ? "Main" : "Renderer"} CPU profile captured`,
         message: [

--- a/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
+++ b/apps/desktop/src/shared/__tests__/hot-cpu-profile.test.ts
@@ -3,8 +3,9 @@ import { buildHotCpuProfileHandoffMessage } from "../hot-cpu-profile";
 
 describe("hot CPU profile handoff message", () => {
   it("identifies main-process captures", () => {
-    expect(buildHotCpuProfileHandoffMessage({
+    const message = buildHotCpuProfileHandoffMessage({
       target: "main",
+      sourceHostname: "fixture-m5.local",
       capturedAt: "2026-09-05T23:00:00.000Z",
       profileFilename: "main-hot-0001.cpuprofile",
       profilePath: "/tmp/hot-cpu/main-hot-0001.cpuprofile",
@@ -14,7 +15,10 @@ describe("hot CPU profile handoff message", () => {
       triggerCpuPercent: 206,
       triggerMode: "sustained",
       triggerThresholdPercent: 50,
-    })).toContain("PwrAgent captured a main CPU profile.");
+    });
+    expect(message).toContain("PwrAgent captured a main CPU profile.");
+    expect(message).toContain("Source: Local app on fixture-m5.local");
+    expect(message).toContain("Captured at: 2026-09-05T23:00:00.000Z");
   });
 
   it("includes copyable basenames and absolute paths", () => {
@@ -35,6 +39,8 @@ describe("hot CPU profile handoff message", () => {
     ).toBe(
       [
         "PwrAgent captured a renderer CPU profile.",
+        "Source: Local app",
+        "Captured at: 2026-06-10T12:00:00.000Z",
         "Trigger: Slowburn (2 consecutive samples >= 15%; trigger sample 24.3%)",
         "Session basename: 20260610T120000Z",
         "Session directory path: /Users/test/.pwragent/profiles/dev/diagnostics/hot-cpu/20260610T120000Z",
@@ -73,6 +79,8 @@ describe("hot CPU profile handoff message", () => {
     ).toBe(
       [
         "PwrAgent captured a renderer CPU profile.",
+        "Source: Local app",
+        "Captured at: 2026-06-10T12:00:00.000Z",
         "Trigger: Spike (1 sample >= 50%; trigger sample 80%)",
         "Session basename: hot-cpu",
         "Session directory path: /tmp/hot-cpu",

--- a/apps/desktop/src/shared/hot-cpu-profile.ts
+++ b/apps/desktop/src/shared/hot-cpu-profile.ts
@@ -7,6 +7,8 @@ export type HotCpuProfileHeapSnapshotArtifact = {
 };
 
 export type HotCpuProfileCapturedEvent = {
+  /** Host running the local Electron process that produced this capture. */
+  sourceHostname?: string;
   target?: "main" | "renderer";
   capturedAt: string;
   heapSnapshotArtifacts?: HotCpuProfileHeapSnapshotArtifact[];
@@ -74,6 +76,8 @@ export function buildHotCpuProfileHandoffMessage(
 
   return [
     `PwrAgent captured a ${event.target ?? "renderer"} CPU profile.`,
+    `Source: Local app${event.sourceHostname ? ` on ${event.sourceHostname}` : ""}`,
+    `Captured at: ${event.capturedAt}`,
     `Trigger: ${formatHotCpuProfileTriggerSummary(event)}`,
     `Session basename: ${event.sessionDirectoryName}`,
     `Session directory path: ${event.sessionDirectory}`,


### PR DESCRIPTION
## Summary

Local CPU profile notices appeared in Federation viewer windows, making a capture on the viewing machine look like a remote instance warning. Subscribe only local main windows to CPU capture notices.

Show the originating hostname and capture date/time with seconds and timezone. Include hostname and exact capture time in copied handoff text, and enable Dismiss all for accumulated CPU profile notices.

## Verification

- 19 focused tests passed across CPU handoff messages, AppNoticeStack, and AppNoticeToast.
- `pnpm lint:eslint` passed (no errors).
- `git diff --check` passed.

## Notes

CPU profiling behavior is unchanged. No live app restart or visual verification was performed.
