### PR TITLE
fix(desktop): show steer-when-ready delivery progress

### DIFF
--- a/apps/desktop/src/renderer/src/features/composer/Composer.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/Composer.tsx
@@ -8,7 +8,7 @@ import {
   subscribeLaunchpadAttachmentHandoffs,
 } from "./launchpad-composer-handoff";
 import { QueuedMessageInspector } from "./QueuedMessageInspector";
-import { restoreQueuedMessage } from "./queued-message-content";
+import { notificationIncludesDraftContent, restoreQueuedMessage } from "./queued-message-content";
 import {
   Fragment,
   type ReactNode,
@@ -499,6 +499,7 @@ type QueuedTurnDraft = {
   id: string;
   waitingForScheduledActionId?: string;
   steerWhenReady?: boolean;
+  steerDelivery?: "sending" | "accepted";
   backendQueuePending?: boolean;
   queueEntryId?: string;
   scheduledActionId?: string;
@@ -1296,76 +1297,6 @@ export function EnvActionAnchorEntry(props: {
       run={props.run}
     />
   );
-}
-
-function collectTextFragments(value: unknown): string[] {
-  if (typeof value === "string") {
-    return [value];
-  }
-  if (!value || typeof value !== "object") {
-    return [];
-  }
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => collectTextFragments(entry));
-  }
-
-  const record = value as Record<string, unknown>;
-  const directText = ["text", "content", "message", "input"].flatMap((key) =>
-    typeof record[key] === "string" ? [record[key] as string] : []
-  );
-  const nestedText = ["content", "parts", "input", "item"].flatMap((key) =>
-    typeof record[key] === "string" ? [] : collectTextFragments(record[key])
-  );
-  return [...directText, ...nestedText];
-}
-
-function collectImageUrls(value: unknown): string[] {
-  if (!value || typeof value !== "object") {
-    return [];
-  }
-
-  if (Array.isArray(value)) {
-    return value.flatMap((entry) => collectImageUrls(entry));
-  }
-
-  const record = value as Record<string, unknown>;
-  const directImages = Object.entries(record).flatMap(([key, entry]) =>
-    typeof entry === "string" &&
-    (key === "url" ||
-      key === "image_url" ||
-      key === "imageUrl" ||
-      key === "image" ||
-      key === "src" ||
-      entry.startsWith("data:image/"))
-      ? [entry]
-      : []
-  );
-  const nestedImages = Object.values(record).flatMap((entry) =>
-    typeof entry === "string" ? [] : collectImageUrls(entry)
-  );
-  return [...directImages, ...nestedImages];
-}
-
-function notificationIncludesDraftContent(
-  params: unknown,
-  draft: QueuedTurnDraft,
-): boolean {
-  const preview = draft.text.trim();
-  if (preview) {
-    return collectTextFragments(params).some((fragment) =>
-      fragment.includes(preview)
-    );
-  }
-
-  const attachmentUrls = draft.imageAttachments.map(
-    (attachment) => attachment.url,
-  );
-  if (attachmentUrls.length === 0) {
-    return false;
-  }
-
-  const notificationImageUrls = new Set(collectImageUrls(params));
-  return attachmentUrls.every((url) => notificationImageUrls.has(url));
 }
 
 function parseStaleInterruptError(error: unknown): boolean {
@@ -10477,7 +10408,11 @@ export function Composer(props: ComposerProps) {
           queued.scheduledSendAt,
           scheduleNow,
         );
-        const queuedLabel = queued.waitingForScheduledActionId
+        const queuedLabel = queued.steerDelivery === "sending"
+          ? "Steering…"
+          : queued.steerDelivery === "accepted"
+          ? "Waiting for transcript"
+          : queued.waitingForScheduledActionId
           ? "Waiting for scheduled first message"
           : queued.steerWhenReady
           ? "Steer when ready"
@@ -10519,7 +10454,7 @@ export function Composer(props: ComposerProps) {
             key={queued.id}
           >
             <div className="composer__queued-copy">
-              <span className="composer__queued-label">
+              <span className="composer__queued-label" role="status">
                 {queuedLabel}
               </span>
               <span className="composer__queued-text">
@@ -10545,7 +10480,6 @@ export function Composer(props: ComposerProps) {
                 supportsSteering ? (
                   <button
                     className="composer__secondary-action"
-                    aria-pressed={Boolean(queued.steerWhenReady)}
                     disabled={queued.backendQueuePending}
                     type="button"
                     onClick={() => {
@@ -10555,7 +10489,7 @@ export function Composer(props: ComposerProps) {
                       }));
                     }}
                   >
-                    Steer when ready
+                    {queued.steerWhenReady ? "Queue instead" : "Steer when ready"}
                   </button>
                 ) : null
               ) : queued.manualReleaseRequired && index === 0 ? (
@@ -10597,7 +10531,7 @@ export function Composer(props: ComposerProps) {
                       void steerQueuedTurn(queued);
                     }}
                   >
-                    {steering ? "Steering..." : "Steer"}
+                    {queued.steerDelivery ? "Steering…" : steering ? "Steering..." : "Steer"}
                   </button>
                 ) : null
               ) : !backendOwned && !queued.waitingForScheduledActionId ? (

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/composer.test.tsx
@@ -694,9 +694,60 @@ describe("Composer", () => {
     expect(screen.getByLabelText("New thread")).toHaveValue("Still composing");
     expect(screen.getByLabelText("Queued message")).toHaveTextContent("Correction");
     expect(within(screen.getByLabelText("Queued message")).getByRole("button", {
+      name: "Queue instead",
+    })).toBeEnabled();
+    fireEvent.click(within(screen.getByLabelText("Queued message")).getByRole("button", {
+      name: "Queue instead",
+    }));
+    expect(within(screen.getByLabelText("Queued message")).getByRole("button", {
       name: "Steer when ready",
-    })).toHaveAttribute("aria-pressed", "true");
+    })).toBeEnabled();
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent("Queued next");
     expect(onMaterializeLaunchpad).not.toHaveBeenCalled();
+  });
+
+  it("shows handoff progress until the provider publishes the steered message", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    const store = result.current;
+    const backend = backendSummary("codex");
+    backend.capabilities.steerTurn = true;
+    const thread: NavigationThreadSummary = {
+      id: "materialized", source: "codex", title: "First message", titleSource: "explicit",
+      linkedDirectories: [], inbox: { inInbox: false }, optimisticActiveTurn: { id: "first-turn" },
+    };
+    const response = createDeferred<Awaited<ReturnType<NonNullable<DesktopApi["steerTurn"]>>>>();
+    const listeners = new Set<Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0]>();
+    const desktopApi: DesktopApi = {
+      steerTurn: vi.fn(() => response.promise),
+      onAgentEvent: (callback) => { listeners.add(callback); return () => { listeners.delete(callback); }; },
+    };
+    store.setQueuedTurns("launchpad:project", [{
+      id: "correction", text: "Please add tests", input: [{ type: "text", text: "Please add tests" }],
+      imageAttachments: [], fileAttachments: [], steerWhenReady: true,
+    }]);
+    act(() => handoffLaunchpadComposer(store, "project", thread, desktopApi));
+    const composer = <Composer backends={[backend]} thread={thread} activeTurnId="first-turn"
+      draftStore={store} desktopApi={desktopApi} skills={[]} />;
+    const view = render(composer);
+    const card = screen.getByLabelText("Queued message");
+    expect(within(card).getByRole("status")).toHaveTextContent("Steering…");
+    expect(within(card).getByRole("button", { name: "Steering…" })).toBeDisabled();
+    expect(within(card).getByRole("button", { name: "Edit" })).toBeDisabled();
+    await act(async () => response.resolve({ backend: "codex", threadId: thread.id, turnId: "first-turn", disposition: "steered" }));
+    expect(within(card).getByRole("status")).toHaveTextContent("Waiting for transcript");
+    view.unmount();
+    render(composer);
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent("Please add tests");
+    expect(screen.getByLabelText("Queued message")).toHaveTextContent("Waiting for transcript");
+    await act(async () => {
+      for (const listener of listeners) listener({ backend: "codex", notification: {
+        method: "item/completed", params: { threadId: thread.id, turnId: "first-turn",
+          item: { id: "correction-item", type: "userMessage", content: [{ type: "text", text: "Please add tests" }] },
+        },
+      } });
+    });
+    expect(screen.queryByLabelText("Queued message")).not.toBeInTheDocument();
+    expect(desktopApi.steerTurn).toHaveBeenCalledTimes(1);
   });
 
   it("persists the Auto-fix PR toggle and shows its global polling gate", async () => {

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/launchpad-composer-handoff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/launchpad-composer-handoff.test.tsx
@@ -147,6 +147,75 @@ describe("launchpad composer handoff", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
+  it.each(["turn/failed", "turn/cancelled"] as const)("recovers unconfirmed delivery on %s", async (method) => {
+    const { result } = renderHook(useComposerDraftStore);
+    let emit: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] = () => undefined;
+    const unsubscribe = vi.fn();
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    await act(async () => handoffLaunchpadComposer(result.current, "project", thread, {
+      steerTurn: async () => ({ backend: "codex", threadId: thread.id, turnId: "first-turn", disposition: "steered" }),
+      onAgentEvent: (callback) => { emit = callback; return unsubscribe; },
+    }));
+    act(() => emit({ backend: "codex", notification: method === "turn/failed"
+      ? { method, params: { threadId: thread.id, turnId: "first-turn", turn: { id: "first-turn", status: "failed", error: { message: "Provider failed" } } } }
+      : { method, params: { threadId: thread.id, turnId: "first-turn", turn: { id: "first-turn", status: "cancelled" } } },
+    }));
+    expect(result.current.getQueuedTurns(target)[0]).toMatchObject({ manualReleaseRequired: true, backendQueuePending: false });
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it.each(["before", "after", "delivery-before"])("keeps ACP ownership across the old turn ending %s the response", async (order) => {
+    const { result } = renderHook(useComposerDraftStore);
+    const acpThread = { ...thread, source: "acp:grok" as const };
+    const acpTarget = buildThreadComposerScopeKey(acpThread.source, thread.id);
+    let emit: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] = () => undefined;
+    const unsubscribe = vi.fn();
+    let resolve!: (value: Awaited<ReturnType<NonNullable<DesktopApi["steerTurn"]>>>) => void;
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", acpThread, {
+      steerTurn: () => new Promise((done) => { resolve = done; }),
+      onAgentEvent: (callback) => { emit = callback; return unsubscribe; },
+    }));
+    const end = () => emit({ backend: acpThread.source, notification: {
+      method: "turn/completed", params: { threadId: thread.id, turnId: "first-turn", turn: { id: "first-turn", status: "completed", output: [] } },
+    } });
+    const deliver = () => emit({ backend: acpThread.source, notification: { method: "item/completed", params: {
+      threadId: thread.id, turnId: "next-turn", item: { id: "delivered-message", type: "userMessage", content: [{ type: "text", text: "correction" }] },
+    } } });
+    if (order !== "after") act(end);
+    if (order === "delivery-before") act(deliver);
+    await act(async () => resolve({ backend: acpThread.source, threadId: thread.id, turnId: "first-turn", disposition: "queued" }));
+    if (order === "after") act(end);
+    if (order === "delivery-before") {
+      expect(result.current.getQueuedTurns(acpTarget)).toEqual([]);
+      expect(unsubscribe).toHaveBeenCalledOnce();
+      return;
+    }
+    expect(result.current.getQueuedTurns(acpTarget)[0]).toMatchObject({ backendQueuePending: true, steerDelivery: "accepted" });
+    expect(result.current.getQueuedTurns(acpTarget)[0].manualReleaseRequired).not.toBe(true);
+    expect(unsubscribe).not.toHaveBeenCalled();
+    act(deliver);
+    expect(result.current.getQueuedTurns(acpTarget)).toEqual([]);
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("confirms file-only delivery using the submitted file-reference text", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    let emit: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] = () => undefined;
+    result.current.setQueuedTurns(source, [{ ...queued(""), steerWhenReady: true,
+      input: [{ type: "text", text: "[@notes.txt](/repo/notes.txt)" }],
+      fileAttachments: [{ id: "file", label: "notes.txt", path: "/repo/notes.txt" }],
+    }]);
+    await act(async () => handoffLaunchpadComposer(result.current, "project", thread, {
+      steerTurn: async () => ({ backend: "codex", threadId: thread.id, turnId: "first-turn", disposition: "steered" }),
+      onAgentEvent: (callback) => { emit = callback; return () => undefined; },
+    }));
+    act(() => emit({ backend: "codex", notification: { method: "item/completed", params: {
+      threadId: thread.id, turnId: "first-turn", item: { id: "delivered-message", type: "userMessage", content: [{ type: "text", text: "[@notes.txt](/repo/notes.txt)" }] },
+    } } }));
+    expect(result.current.getQueuedTurns(target)).toEqual([]);
+  });
+
   it("holds a failed steer for explicit recovery without losing its content", async () => {
     const { result } = renderHook(useComposerDraftStore);
     const steerTurn = vi.fn().mockRejectedValue(new Error("Connection lost"));

--- a/apps/desktop/src/renderer/src/features/composer/__tests__/launchpad-composer-handoff.test.tsx
+++ b/apps/desktop/src/renderer/src/features/composer/__tests__/launchpad-composer-handoff.test.tsx
@@ -69,7 +69,82 @@ describe("launchpad composer handoff", () => {
       expectedTurnId: "first-turn",
       input: [{ type: "text", text: "correction" }],
     }));
-    await waitFor(() => expect(result.current.getQueuedTurns(target)).toEqual([]));
+    await waitFor(() => expect(result.current.getQueuedTurns(target)[0]).toMatchObject({ steerDelivery: "accepted", backendQueuePending: true }));
+  });
+
+  it.each(["before", "after"])("keeps the steer visible until its user message arrives %s the response", async (order) => {
+    const { result } = renderHook(useComposerDraftStore);
+    let emit: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] = () => undefined;
+    const unsubscribe = vi.fn();
+    let resolve!: (value: Awaited<ReturnType<NonNullable<DesktopApi["steerTurn"]>>>) => void;
+    const steerTurn = vi.fn(() => new Promise<Awaited<ReturnType<NonNullable<DesktopApi["steerTurn"]>>>>((done) => { resolve = done; }));
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", thread, {
+      steerTurn,
+      onAgentEvent: (callback) => { emit = callback; return unsubscribe; },
+    }));
+    expect(result.current.getQueuedTurns(target)[0]).toMatchObject({ steerDelivery: "sending", backendQueuePending: true });
+    const message = (type = "userMessage", threadId = thread.id, turnId = "first-turn") => emit({
+      backend: "codex", notification: { method: "item/completed", params: {
+        threadId, turnId, item: { id: "user-correction", type, content: [{ type: "text", text: "correction" }] },
+      } },
+    });
+    act(() => { message("agentMessage"); message("userMessage", "other"); message("userMessage", thread.id, "other-turn"); });
+    expect(result.current.getQueuedTurns(target)).toHaveLength(1);
+    if (order === "before") act(() => message());
+    await act(async () => resolve({ backend: "codex", threadId: thread.id, turnId: "first-turn", disposition: "steered" }));
+    if (order === "after") {
+      expect(result.current.getQueuedTurns(target)[0]).toMatchObject({ steerDelivery: "accepted", backendQueuePending: true });
+      expect(getNextReleasableQueuedTurn(result.current.getQueuedTurns(target))).toBeUndefined();
+      act(() => message());
+    }
+    expect(result.current.getQueuedTurns(target)).toEqual([]);
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds unconfirmed delivery when the turn ends and releases its listener", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    let emit: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] = () => undefined;
+    const unsubscribe = vi.fn();
+    const steerTurn = vi.fn<NonNullable<DesktopApi["steerTurn"]>>().mockResolvedValue({
+      backend: "codex", threadId: thread.id, turnId: "first-turn", disposition: "steered",
+    });
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", thread, {
+      steerTurn, onAgentEvent: (callback) => { emit = callback; return unsubscribe; },
+    }));
+    await waitFor(() => expect(result.current.getQueuedTurns(target)[0].steerDelivery).toBe("accepted"));
+    act(() => emit({ backend: "codex", notification: {
+      method: "turn/completed", params: { threadId: thread.id, turnId: "first-turn", turn: { id: "first-turn", status: "completed", output: [] } },
+    } }));
+    expect(result.current.getQueuedTurns(target)[0]).toMatchObject({
+      text: "correction", manualReleaseRequired: true, backendQueuePending: false, steerDelivery: undefined,
+    });
+    expect(getNextReleasableQueuedTurn(result.current.getQueuedTurns(target))).toBeUndefined();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("retains backend recovery ownership when the turn ends before a held response", async () => {
+    const { result } = renderHook(useComposerDraftStore);
+    let emit: Parameters<NonNullable<DesktopApi["onAgentEvent"]>>[0] = () => undefined;
+    const unsubscribe = vi.fn();
+    let resolve!: (value: Awaited<ReturnType<NonNullable<DesktopApi["steerTurn"]>>>) => void;
+    const steerTurn = vi.fn(() => new Promise<Awaited<ReturnType<NonNullable<DesktopApi["steerTurn"]>>>>((done) => { resolve = done; }));
+    result.current.setQueuedTurns(source, [{ ...queued("correction"), steerWhenReady: true }]);
+    act(() => handoffLaunchpadComposer(result.current, "project", thread, {
+      steerTurn, onAgentEvent: (callback) => { emit = callback; return unsubscribe; },
+    }));
+    act(() => emit({ backend: "codex", notification: {
+      method: "turn/completed", params: { threadId: thread.id, turnId: "first-turn", turn: { id: "first-turn", status: "completed", output: [] } },
+    } }));
+    await act(async () => resolve({ backend: "codex", threadId: thread.id, turnId: "first-turn",
+      disposition: "held", queueEntryId: "held-entry", holdReason: "Turn finished",
+    }));
+    expect(result.current.getQueuedTurns(target)[0]).toMatchObject({
+      queueEntryId: "held-entry", text: "correction", manualReleaseRequired: true,
+      backendQueuePending: false, steerDelivery: undefined,
+    });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("holds a failed steer for explicit recovery without losing its content", async () => {
@@ -129,7 +204,7 @@ describe("launchpad composer handoff", () => {
       turnId: "scheduled-turn", displayText: "First message",
     }));
     expect(steerTurn).toHaveBeenCalledWith(expect.objectContaining({ expectedTurnId: "scheduled-turn" }));
-    await waitFor(() => expect(result.current.getQueuedTurns(target)).toEqual([]));
+    await waitFor(() => expect(result.current.getQueuedTurns(target)[0]).toMatchObject({ steerDelivery: "accepted", backendQueuePending: true }));
   });
 
   it("does not release follow-ups ahead of a first message whose setup failed", () => {

--- a/apps/desktop/src/renderer/src/features/composer/launchpad-composer-handoff.ts
+++ b/apps/desktop/src/renderer/src/features/composer/launchpad-composer-handoff.ts
@@ -1,3 +1,5 @@
+import { federationTargetsEqual } from "../../lib/federated-thread-events";
+import { notificationIncludesDraftContent } from "./queued-message-content";
 import type { FederationTarget, NavigationThreadSummary, ScheduledThreadAction } from "@pwragent/shared";
 import type { DesktopApi } from "../../lib/desktop-api";
 import { readRendererFederationTarget } from "../../lib/federation-window";
@@ -96,7 +98,8 @@ export function handoffLaunchpadComposer(
   desktopApi?: DesktopApi,
 ): void {
   const source = `launchpad:${directoryKey}`;
-  const target = buildThreadComposerScopeKey(thread.source, thread.id, thread.federation?.ref.target ?? readRendererFederationTarget() ?? { scope: "local" });
+  const federationTarget = thread.federation?.ref.target ?? readRendererFederationTarget();
+  const target = buildThreadComposerScopeKey(thread.source, thread.id, federationTarget ?? { scope: "local" });
   getLaunchpadComposerDestination(store, source).scopeKey = target;
   const draft = store.get(source);
   if (draft) {
@@ -120,7 +123,7 @@ export function handoffLaunchpadComposer(
     ...(!turnId && thread.scheduledStart ? {
       waitingForScheduledActionId: thread.scheduledStart.actionId,
     } : {}),
-    ...(entry.steerWhenReady && turnId ? { backendQueuePending: true } : {}),
+    ...(entry.steerWhenReady && turnId ? { backendQueuePending: true, steerDelivery: "sending" as const } : {}),
   }));
   store.setQueuedTurns(target, [...store.getQueuedTurns(target), ...queued]);
   store.deleteQueuedTurn(source);
@@ -134,13 +137,56 @@ export function handoffLaunchpadComposer(
         current.id === entry.id ? { ...current, ...patch } : current,
       ));
     };
+    // Subscribe before submission: a user item can precede the RPC response,
+    // and the newly selected Composer may not have mounted yet.
+    let settled = false;
+    let responseReceived = false;
+    let endedTurnId: string | undefined;
+    let deliveredTurnId = expectedTurnId;
+    const holdUnconfirmed = (): void => {
+      settled = true;
+      unsubscribe?.();
+      update({
+        backendQueuePending: false,
+        steerWhenReady: false,
+        steerDelivery: undefined,
+        manualReleaseRequired: true,
+        holdReason: "The turn ended before delivery was confirmed. Check the transcript before sending again.",
+      });
+    };
+    const unsubscribe = desktopApi?.onAgentEvent?.((event) => {
+      const { method } = event.notification;
+      const params = event.notification.params as Record<string, unknown>;
+      if (
+        settled
+        || event.backend !== thread.source
+        || params.threadId !== thread.id
+        || !federationTargetsEqual(event.federationTarget, federationTarget)
+        || (params.turnId ?? (params.turn as { id?: string } | undefined)?.id) !== deliveredTurnId
+      ) return;
+      const item = params.item as { type?: string } | undefined;
+      if (
+        method === "item/completed"
+        && item?.type === "userMessage"
+        && notificationIncludesDraftContent(params, entry)
+      ) {
+        settled = true;
+        unsubscribe?.();
+        store.removeQueuedTurnById(target, entry.id);
+      } else if (method === "turn/completed") {
+        endedTurnId = deliveredTurnId;
+        // The in-flight request may still return a durable fallback. Let
+        // that response establish ownership before converting to recovery.
+        if (responseReceived) holdUnconfirmed();
+      }
+    });
     try {
       if (!desktopApi?.steerTurn || !expectedTurnId || !entry.input?.length) {
         throw new Error("Steering is unavailable. Edit this message to send it again.");
       }
       const response = await desktopApi.steerTurn({
         backend: thread.source,
-        federationTarget: thread.federation?.ref.target ?? readRendererFederationTarget(),
+        federationTarget,
         threadId: thread.id,
         expectedTurnId,
         requestId: entry.id,
@@ -159,23 +205,33 @@ export function handoffLaunchpadComposer(
           },
         },
       });
+      if (settled) return;
+      responseReceived = true;
+      deliveredTurnId = response.turnId ?? expectedTurnId;
       if (response.scheduledAction?.status === "failed") {
         throw new Error(response.scheduledAction.errorMessage ?? "The follow-up could not be dispatched.");
       }
       if (response.disposition === "held" || response.disposition === "scheduled") {
+        unsubscribe?.();
         update({
           backendQueuePending: false,
           steerWhenReady: false,
+          steerDelivery: undefined,
           queueEntryId: response.queueEntryId,
           scheduledActionId: response.scheduledAction?.id,
           manualReleaseRequired: response.disposition === "held",
           holdReason: response.holdReason,
         });
+      } else if (endedTurnId && endedTurnId === deliveredTurnId) {
+        holdUnconfirmed();
       } else {
-        store.removeQueuedTurnById(target, entry.id);
+        update({ steerDelivery: "accepted" });
       }
     } catch (error) {
+      if (settled) return;
+      unsubscribe?.();
       update({
+        steerDelivery: undefined,
         backendQueuePending: false,
         steerWhenReady: false,
         manualReleaseRequired: true,
@@ -196,7 +252,7 @@ export function handoffLaunchpadComposer(
         const next = {
           ...entry,
           waitingForScheduledActionId: undefined,
-          ...(steerReady ? { backendQueuePending: true } : {}),
+          ...(steerReady ? { backendQueuePending: true, steerDelivery: "sending" as const } : {}),
           ...(!admitted ? {
             manualReleaseRequired: true,
             holdReason: action.errorMessage ?? "The scheduled first message did not start. Edit this follow-up to send it.",

--- a/apps/desktop/src/renderer/src/features/composer/launchpad-composer-handoff.ts
+++ b/apps/desktop/src/renderer/src/features/composer/launchpad-composer-handoff.ts
@@ -141,6 +141,8 @@ export function handoffLaunchpadComposer(
     // and the newly selected Composer may not have mounted yet.
     let settled = false;
     let responseReceived = false;
+    let providerQueued = false;
+    const matchingUserTurnIds = new Set<string>();
     let endedTurnId: string | undefined;
     let deliveredTurnId = expectedTurnId;
     const holdUnconfirmed = (): void => {
@@ -162,18 +164,28 @@ export function handoffLaunchpadComposer(
         || event.backend !== thread.source
         || params.threadId !== thread.id
         || !federationTargetsEqual(event.federationTarget, federationTarget)
-        || (params.turnId ?? (params.turn as { id?: string } | undefined)?.id) !== deliveredTurnId
       ) return;
+      const eventTurnId = params.turnId ?? (params.turn as { id?: string } | undefined)?.id;
+      if (typeof eventTurnId !== "string") return;
       const item = params.item as { type?: string } | undefined;
       if (
         method === "item/completed"
         && item?.type === "userMessage"
         && notificationIncludesDraftContent(params, entry)
       ) {
+        // ACP next-turn delivery can arrive before its queued response.
+        // Remember positive evidence, but only accept another turn after
+        // the provider has explicitly claimed next-turn ownership.
+        matchingUserTurnIds.add(eventTurnId);
+        if (eventTurnId !== deliveredTurnId && !providerQueued) return;
         settled = true;
         unsubscribe?.();
         store.removeQueuedTurnById(target, entry.id);
-      } else if (method === "turn/completed") {
+      } else if (
+        (method === "turn/completed" || method === "turn/failed" || method === "turn/cancelled")
+        && eventTurnId === deliveredTurnId
+        && !providerQueued
+      ) {
         endedTurnId = deliveredTurnId;
         // The in-flight request may still return a durable fallback. Let
         // that response establish ownership before converting to recovery.
@@ -207,6 +219,7 @@ export function handoffLaunchpadComposer(
       });
       if (settled) return;
       responseReceived = true;
+      providerQueued = response.disposition === "queued";
       deliveredTurnId = response.turnId ?? expectedTurnId;
       if (response.scheduledAction?.status === "failed") {
         throw new Error(response.scheduledAction.errorMessage ?? "The follow-up could not be dispatched.");
@@ -222,7 +235,11 @@ export function handoffLaunchpadComposer(
           manualReleaseRequired: response.disposition === "held",
           holdReason: response.holdReason,
         });
-      } else if (endedTurnId && endedTurnId === deliveredTurnId) {
+      } else if (providerQueued && matchingUserTurnIds.size > 0) {
+        settled = true;
+        unsubscribe?.();
+        store.removeQueuedTurnById(target, entry.id);
+      } else if (!providerQueued && endedTurnId && endedTurnId === deliveredTurnId) {
         holdUnconfirmed();
       } else {
         update({ steerDelivery: "accepted" });

--- a/apps/desktop/src/renderer/src/features/composer/queued-message-content.ts
+++ b/apps/desktop/src/renderer/src/features/composer/queued-message-content.ts
@@ -37,3 +37,73 @@ export function restoreQueuedMessage(
     ),
   };
 }
+
+function collectTextFragments(value: unknown): string[] {
+  if (typeof value === "string") {
+    return [value];
+  }
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectTextFragments(entry));
+  }
+
+  const record = value as Record<string, unknown>;
+  const directText = ["text", "content", "message", "input"].flatMap((key) =>
+    typeof record[key] === "string" ? [record[key] as string] : []
+  );
+  const nestedText = ["content", "parts", "input", "item"].flatMap((key) =>
+    typeof record[key] === "string" ? [] : collectTextFragments(record[key])
+  );
+  return [...directText, ...nestedText];
+}
+
+function collectImageUrls(value: unknown): string[] {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((entry) => collectImageUrls(entry));
+  }
+
+  const record = value as Record<string, unknown>;
+  const directImages = Object.entries(record).flatMap(([key, entry]) =>
+    typeof entry === "string" &&
+    (key === "url" ||
+      key === "image_url" ||
+      key === "imageUrl" ||
+      key === "image" ||
+      key === "src" ||
+      entry.startsWith("data:image/"))
+      ? [entry]
+      : []
+  );
+  const nestedImages = Object.values(record).flatMap((entry) =>
+    typeof entry === "string" ? [] : collectImageUrls(entry)
+  );
+  return [...directImages, ...nestedImages];
+}
+
+export function notificationIncludesDraftContent(
+  params: unknown,
+  draft: Pick<ComposerQueuedTurnSnapshot, "text" | "imageAttachments">,
+): boolean {
+  const preview = draft.text.trim();
+  if (preview) {
+    return collectTextFragments(params).some((fragment) =>
+      fragment.includes(preview)
+    );
+  }
+
+  const attachmentUrls = draft.imageAttachments.map(
+    (attachment) => attachment.url,
+  );
+  if (attachmentUrls.length === 0) {
+    return false;
+  }
+
+  const notificationImageUrls = new Set(collectImageUrls(params));
+  return attachmentUrls.every((url) => notificationImageUrls.has(url));
+}

--- a/apps/desktop/src/renderer/src/features/composer/queued-message-content.ts
+++ b/apps/desktop/src/renderer/src/features/composer/queued-message-content.ts
@@ -88,13 +88,23 @@ function collectImageUrls(value: unknown): string[] {
 
 export function notificationIncludesDraftContent(
   params: unknown,
-  draft: Pick<ComposerQueuedTurnSnapshot, "text" | "imageAttachments">,
+  draft: Pick<ComposerQueuedTurnSnapshot, "text" | "imageAttachments" | "input">,
 ): boolean {
   const preview = draft.text.trim();
   if (preview) {
     return collectTextFragments(params).some((fragment) =>
       fragment.includes(preview)
     );
+  }
+
+  // File-only drafts have no composer text. Their submitted text includes
+  // the file-reference markdown that the provider echoes in its user item.
+  const submittedText = draft.input?.flatMap((item) =>
+    item.type === "text" && item.text.trim() ? [item.text.trim()] : []
+  ) ?? [];
+  if (submittedText.length > 0) {
+    const fragments = collectTextFragments(params);
+    return submittedText.every((text) => fragments.some((fragment) => fragment.includes(text)));
   }
 
   const attachmentUrls = draft.imageAttachments.map(

--- a/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
+++ b/apps/desktop/src/renderer/src/features/composer/useComposerDraftStore.ts
@@ -32,6 +32,8 @@ export type ComposerQueuedTurnSnapshot = {
   id: string;
   /** Apply this follow-up to the first turn once launchpad setup finishes. */
   steerWhenReady?: boolean;
+  /** Keep the handoff visible until the provider publishes its user message. */
+  steerDelivery?: "sending" | "accepted";
   /** Wait for positive admission of the scheduled first action, not its due time. */
   waitingForScheduledActionId?: string;
   /** Submission is in flight to the main-process FIFO. */


### PR DESCRIPTION
Clicking **Steer when ready** during environment setup previously left the button looking unchanged. After setup, the follow-up disappeared as soon as the steer RPC returned, potentially leaving a long gap before its user message appeared in the transcript.

The button now changes to **Queue instead**, allowing the operator to undo the choice. During handoff, the card stays visible and read-only with **Steering…**, then **Waiting for transcript**. It clears on the matching user-message event from the owning backend, instance, and thread (including ACP delivery in a subsequent turn). Tracking survives navigation and Composer remounts, handles events arriving before the RPC response, and preserves recovery ownership if the turn ends before confirmation. This changes feedback, not backend delivery latency.

Validation:
- Added regressions first: five failures reproduced on the original implementation.
- 335 focused Composer and launchpad-handoff tests pass, including response/event ordering, remounts, unconfirmed completion, and backend-held recovery, failed/cancelled turns, ACP next-turn delivery, and file-only follow-ups.
- `pnpm typecheck` passes.
- `pnpm lint:eslint` passes (existing warnings only).
- `pnpm lint:codex-storage` and `git diff --check` pass.

No new SQLite writes or timers. No live Electron screenshot/E2E run was performed.
