### PR TITLE
fix(desktop): refresh mounted unread counts through current Federation protocol

### DIFF
--- a/apps/desktop/src/main/__tests__/federation-collection-reads.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-collection-reads.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import type { FederationProtocolEnvelope, NavigationSnapshot } from "@pwragent/shared";
 import {
   FEDERATION_BACKEND_METHOD_CAPABILITIES,
+  FederationRemoteBackendClient,
   registerFederationBackendHandlers,
   type FederationBackendOperations,
 } from "../federation/federation-backend-bridge";
+import { NavigationQueryStore } from "../app-server/navigation-query-store";
 import { FederationRouter } from "../federation/federation-router";
 import {
   FEDERATION_COLLECTION_PAGE_BYTES,
@@ -55,6 +57,35 @@ async function request(
 }
 
 describe("bounded Federation collection reads", () => {
+  it("refreshes mounted unread state through the current owner protocol", async () => {
+    const store = new NavigationQueryStore();
+    const getNavigationQueryPage = vi.fn((query) => store.readPage({
+      request: query, scopeKey: "viewer", loadIndex: async () => ({
+        ...snapshot(),
+        threads: [
+          { id: "mounted", source: "codex" as const, titleSource: "explicit" as const, title: "Already read", linkedDirectories: [], inbox: { inInbox: false } },
+          { id: "child", source: "codex" as const, titleSource: "explicit" as const, title: "Unread child", parentThreadId: "mounted",
+            linkedDirectories: [], inbox: { inInbox: true, reason: "updated-since-seen" as const } },
+          { id: "unmounted", source: "codex" as const, titleSource: "explicit" as const, title: "Unrelated unread", linkedDirectories: [],
+            inbox: { inInbox: true, reason: "new-thread" as const } },
+        ],
+      }),
+    }));
+    const owner = { getNavigationQueryPage } as unknown as FederationBackendOperations;
+    // Exercise the registered handlers, including rejection of retired RPCs.
+    const client = new FederationRemoteBackendClient({ request: async (call: { method: string; params: unknown }) => {
+      const reply = await request(owner, call.method, call.params);
+      if (reply?.kind === "error") throw new Error(reply.error.message);
+      if (reply?.kind !== "response") throw new Error("Missing owner response");
+      return reply.result;
+    } } as never);
+    const refreshed = await readFederationPinnedSnapshot(client, ["codex:mounted"]);
+    expect(refreshed.threads.map((thread) => thread.id).sort()).toEqual(["child", "mounted"]);
+    expect(refreshed.threads.find((thread) => thread.id === "mounted")?.inbox.inInbox).toBe(false);
+    expect(refreshed.inboxThreadKeys).toEqual(["codex:child"]);
+    expect(getNavigationQueryPage).toHaveBeenCalled();
+  });
+
   it("rejects local viewer inventory at the Federation boundary", async () => {
     const read = vi.fn();
     const reply = await request({ getNavigationQueryPage: read } as unknown as FederationBackendOperations,
@@ -230,7 +261,7 @@ describe("bounded Federation collection reads", () => {
     const legacy = vi.fn();
     const unavailable = mode === "missing" ? undefined
       : vi.fn().mockRejectedValue(Object.assign(new Error("method_not_found"), { code: "method_not_found" }));
-    const backend = { getProjectPage: unavailable, getNavigationDescendantPage: unavailable, lookupArchivedThreads: unavailable,
+    const backend = { getProjectPage: unavailable, getNavigationQueryPage: unavailable, lookupArchivedThreads: unavailable,
       getNavigationSnapshot: legacy, listThreads: legacy } as unknown as FederationBackendOperations;
     await expect(readFederationPinnedSnapshot(backend, ["codex:one"])).rejects.toThrow("Upgrade");
     await expect(readFederationProjectSnapshot(backend)).rejects.toThrow("Upgrade");

--- a/apps/desktop/src/main/__tests__/federation-navigation-selection.test.ts
+++ b/apps/desktop/src/main/__tests__/federation-navigation-selection.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import type { NavigationSnapshot, NavigationThreadSummary } from "@pwragent/shared";
-import { buildFederatedThreadRef } from "@pwragent/shared";
-import { projectNavigationDescendantPage, type FederationNavigationSelectionRequest } from "../federation/federation-navigation-selection";
+import type { NavigationQueryRequest, NavigationSnapshot, NavigationThreadSummary } from "@pwragent/shared";
+import { buildFederatedThreadRef, NAVIGATION_QUERY_MAX_RESULT_BYTES } from "@pwragent/shared";
+import { projectNavigationDescendantPage } from "../federation/federation-navigation-selection";
+import { NavigationQueryStore } from "../app-server/navigation-query-store";
 import { readFederationPinnedSnapshot } from "../federation/federation-collection-client";
 import type { FederationBackendOperations } from "../federation/federation-backend-bridge";
 
@@ -36,28 +37,53 @@ describe("owner-filtered navigation descendants", () => {
     const value = snapshot([thread("root"), ...Array.from({ length: 205 }, (_, i) =>
       thread(`child-${String(i).padStart(3, "0")}`, { parentThreadId: "root", title: "日".repeat(1200) }))]);
     const getNavigationSnapshot = vi.fn();
-    const getNavigationDescendantPage = vi.fn(async (request: FederationNavigationSelectionRequest) => {
-      const page = projectNavigationDescendantPage(value, "1", request);
-      expect(page.snapshot.threads.length).toBeLessThanOrEqual(100);
-      expect(Buffer.byteLength(JSON.stringify(page))).toBeLessThanOrEqual(256 * 1024);
+    const store = new NavigationQueryStore();
+    const getNavigationQueryPage = vi.fn(async (request: NavigationQueryRequest) => {
+      const page = await store.readPage({ request, scopeKey: "viewer", loadIndex: async () => value });
+      expect(page.entries.length).toBeLessThanOrEqual(100);
+      expect(Buffer.byteLength(JSON.stringify(page))).toBeLessThanOrEqual(NAVIGATION_QUERY_MAX_RESULT_BYTES);
       return page;
     });
-    const result = await readFederationPinnedSnapshot({ getNavigationDescendantPage, getNavigationSnapshot } as unknown as FederationBackendOperations,
+    const getNavigationDescendantPage = vi.fn().mockRejectedValue(new Error("Retired protocol"));
+    const result = await readFederationPinnedSnapshot({ getNavigationQueryPage, getNavigationDescendantPage, getNavigationSnapshot } as unknown as FederationBackendOperations,
       ["codex:root"]);
     expect(result.threads).toHaveLength(206);
     expect(new Set(result.threads.map((row) => row.id)).size).toBe(206);
-    expect(getNavigationDescendantPage.mock.calls.length).toBeGreaterThan(2);
+    expect(getNavigationQueryPage.mock.calls.length).toBeGreaterThan(2);
+    expect(getNavigationDescendantPage).not.toHaveBeenCalled();
     expect(getNavigationSnapshot).not.toHaveBeenCalled();
     expect(() => projectNavigationDescendantPage(value, "2", { threadKeys: ["codex:root"], revision: "1" })).toThrow("changed");
   });
 
+  it("batches more than 100 roots and deduplicates overlapping descendant groups", async () => {
+    const value = snapshot(Array.from({ length: 101 }, (_, i) => thread(`root-${i}`)));
+    value.threads.push(thread("child", { parentThreadId: "root-0" }));
+    const store = new NavigationQueryStore();
+    const getNavigationQueryPage = vi.fn((request: NavigationQueryRequest) =>
+      store.readPage({ request, scopeKey: "viewer", loadIndex: async () => value }));
+    const result = await readFederationPinnedSnapshot({ getNavigationQueryPage } as unknown as FederationBackendOperations,
+      [...value.threads.map((row) => `codex:${row.id}`), "codex:root-0"]);
+    expect(result.threads).toHaveLength(102);
+    expect(getNavigationQueryPage.mock.calls.every(([request]) =>
+      request.query.kind === "group-members" && request.query.roots.length <= 100)).toBe(true);
+  });
+
+  it.each(["generation", "ownerEpoch", "queryKey"] as const)("rejects %s drift between pages", async (field) => {
+    const page = { protocol: 2, ownerEpoch: "owner", generation: "1", queryKey: "pins",
+      entries: [], complete: false, nextCursor: "next" };
+    const getNavigationQueryPage = vi.fn().mockResolvedValueOnce(page)
+      .mockResolvedValueOnce({ ...page, [field]: "changed", complete: true, nextCursor: undefined });
+    await expect(readFederationPinnedSnapshot({ getNavigationQueryPage } as unknown as FederationBackendOperations,
+      ["codex:root"])).rejects.toThrow("inconsistent");
+  });
+
   it("requires an upgrade for a missing bounded method and never falls back after a timeout", async () => {
     const getNavigationSnapshot = vi.fn(async () => snapshot([]));
-    const getNavigationDescendantPage = vi.fn().mockRejectedValue({ code: "method_not_found" });
-    const backend = { getNavigationSnapshot, getNavigationDescendantPage } as unknown as FederationBackendOperations;
+    const getNavigationQueryPage = vi.fn().mockRejectedValue({ code: "method_not_found" });
+    const backend = { getNavigationSnapshot, getNavigationQueryPage } as unknown as FederationBackendOperations;
     await expect(readFederationPinnedSnapshot(backend, ["codex:root"])).rejects.toThrow("Upgrade");
     expect(getNavigationSnapshot).not.toHaveBeenCalled();
-    getNavigationDescendantPage.mockRejectedValue(new Error("timeout"));
+    getNavigationQueryPage.mockRejectedValue(new Error("timeout"));
     await expect(readFederationPinnedSnapshot(backend, ["codex:root"])).rejects.toThrow("timeout");
     expect(getNavigationSnapshot).not.toHaveBeenCalled();
   });
@@ -67,7 +93,8 @@ describe("owner-filtered navigation descendants", () => {
     expect(projectNavigationDescendantPage(value, "1", { threadKeys: ["codex:a"] }).snapshot.threads).toHaveLength(2);
     expect(() => projectNavigationDescendantPage(snapshot([thread("a", { title: "日".repeat(100_000) })]), "1",
       { threadKeys: ["codex:a"] })).toThrow("byte budget");
-    const backend = { getNavigationDescendantPage: async () => ({ revision: "1", snapshot: value, nextAfterKey: "same" }) } as unknown as FederationBackendOperations;
+    const backend = { getNavigationQueryPage: async () => ({ protocol: 2, ownerEpoch: "owner", generation: "1",
+      queryKey: "pins", entries: [], complete: false, nextCursor: "same" }) } as unknown as FederationBackendOperations;
     await expect(readFederationPinnedSnapshot(backend, ["codex:a"])).rejects.toThrow("inconsistent");
   });
 });

--- a/apps/desktop/src/main/federation/federation-collection-client.ts
+++ b/apps/desktop/src/main/federation/federation-collection-client.ts
@@ -1,7 +1,7 @@
 import type { AppServerBackendKind, NavigationSnapshot } from "@pwragent/shared";
-import { buildThreadIdentityKey, federatedThreadIdentityKey, normalizeNavigationSnapshotThreadKeys } from "@pwragent/shared";
+import { buildThreadIdentityKey, federatedThreadIdentityKey, parseThreadIdentityKey, NAVIGATION_QUERY_MAX_PAGE_ROWS, NAVIGATION_QUERY_MAX_RESULT_BYTES } from "@pwragent/shared";
 import type { FederationBackendOperations } from "./federation-backend-bridge";
-import { FEDERATION_COLLECTION_PAGE_BYTES, FEDERATION_COLLECTION_PAGE_ROWS } from "./federation-collection-reads";
+import { FEDERATION_COLLECTION_PAGE_ROWS } from "./federation-collection-reads";
 import { hasFederationErrorCode, type FederationRpcRequestOptions } from "./federation-rpc";
 
 export async function readFederationPinnedSnapshot(
@@ -9,50 +9,64 @@ export async function readFederationPinnedSnapshot(
   threadKeys: string[],
   rpcOptions: FederationRpcRequestOptions = { deadlineAt: Date.now() + 10_000 },
 ): Promise<NavigationSnapshot> {
-  if (backend.getNavigationDescendantPage) {
+  if (backend.getNavigationQueryPage) {
     try {
-      let result: NavigationSnapshot | undefined;
-      let revision: string | undefined;
+      const roots = [...new Set(threadKeys)].map((key) => {
+        const identity = parseThreadIdentityKey(key);
+        if (!identity?.threadId) throw new Error("Pinned navigation requires valid thread identities.");
+        return identity;
+      });
+      if (!roots.length) throw new Error("Pinned navigation requires at least one root.");
+      const result: NavigationSnapshot = {
+        backend: "all", fetchedAt: Date.now(), unchanged: false,
+        threads: [], inboxThreadKeys: [], directories: [],
+        launchpadDefaults: { backend: "codex", executionMode: "default" },
+      };
       let bytes = 0;
       let pages = 0;
-      const selected = [...new Set(threadKeys)];
-      for (let offset = 0; offset < selected.length; offset += FEDERATION_COLLECTION_PAGE_ROWS) {
-        let afterKey: string | undefined;
+      // The pin cache must use the same owner projection as visible rows.
+      // The retired descendant-snapshot RPC leaves persisted unread flags
+      // stuck forever on peers that correctly reject that old protocol.
+      for (let offset = 0; offset < roots.length; offset += NAVIGATION_QUERY_MAX_PAGE_ROWS) {
+        let cursor: string | undefined;
+        let revision: string | undefined;
+        const cursors = new Set<string>();
         do {
+          rpcOptions.signal?.throwIfAborted();
           if (++pages > 256 || (rpcOptions.deadlineAt !== undefined && Date.now() >= rpcOptions.deadlineAt)) {
             throw new Error("Pinned navigation pagination exceeded its page/deadline budget.");
           }
-          const page = await backend.getNavigationDescendantPage({
-            threadKeys: selected.slice(offset, offset + FEDERATION_COLLECTION_PAGE_ROWS),
-            afterKey,
-            revision,
+          const page = await backend.getNavigationQueryPage({
+            protocol: 2, consumer: "main-sidebar", inventory: "owner",
+            query: { kind: "group-members", roots: roots.slice(offset, offset + NAVIGATION_QUERY_MAX_PAGE_ROWS) },
+            pageSize: NAVIGATION_QUERY_MAX_PAGE_ROWS,
+            ...(cursor ? { cursor } : {}),
           }, rpcOptions);
-          const pageBytes = Buffer.byteLength(JSON.stringify(page));
+          rpcOptions.signal?.throwIfAborted();
+          const pageBytes = Buffer.byteLength(JSON.stringify(page), "utf8");
           bytes += pageBytes;
-          if (pageBytes > FEDERATION_COLLECTION_PAGE_BYTES || page.snapshot.threads.length > FEDERATION_COLLECTION_PAGE_ROWS
-            || bytes > 16 * 1024 * 1024 || (revision !== undefined && revision !== page.revision)
-            || (page.nextAfterKey !== undefined && afterKey !== undefined && page.nextAfterKey <= afterKey)) {
+          const pageRevision = JSON.stringify([page.ownerEpoch, page.generation, page.queryKey]);
+          if (page.protocol !== 2 || page.unchanged
+            || pageBytes > NAVIGATION_QUERY_MAX_RESULT_BYTES || page.entries.length > NAVIGATION_QUERY_MAX_PAGE_ROWS
+            || bytes > 16 * 1024 * 1024 || (revision !== undefined && revision !== pageRevision)
+            || (!page.complete && (!page.nextCursor || cursors.has(page.nextCursor)))
+            || (page.complete && page.nextCursor !== undefined)) {
             throw new Error("Pinned navigation returned an oversized or inconsistent collection.");
           }
-          revision = page.revision;
-          const snapshot = normalizeNavigationSnapshotThreadKeys(page.snapshot);
-          result = result ? {
-            ...result,
-            threads: [...result.threads, ...snapshot.threads],
-            inboxThreadKeys: [...result.inboxThreadKeys, ...snapshot.inboxThreadKeys],
-          } : snapshot;
-          afterKey = page.nextAfterKey;
-        } while (afterKey !== undefined);
+          revision = pageRevision;
+          result.threads.push(...page.entries.map(({ row }) => row));
+          cursor = page.complete ? undefined : page.nextCursor;
+          if (cursor) cursors.add(cursor);
+        } while (cursor !== undefined);
       }
-      if (result) return {
-        ...result,
-        threads: [...new Map(result.threads.map((thread) => [
-          thread.federation?.ref ? federatedThreadIdentityKey(thread.federation.ref)
-            : buildThreadIdentityKey(thread.source, thread.id), thread,
-        ])).values()],
-        inboxThreadKeys: [...new Set(result.inboxThreadKeys)],
-      };
-      throw new Error("Pinned navigation requires at least one root.");
+      result.threads = [...new Map(result.threads.map((thread) => [
+        thread.federation?.ref ? federatedThreadIdentityKey(thread.federation.ref)
+          : buildThreadIdentityKey(thread.source, thread.id), thread,
+      ])).values()];
+      result.inboxThreadKeys = result.threads.filter((thread) => thread.inbox.inInbox).map((thread) =>
+        thread.federation?.ref ? federatedThreadIdentityKey(thread.federation.ref)
+          : buildThreadIdentityKey(thread.source, thread.id));
+      return result;
     } catch (error) {
       if (!hasFederationErrorCode(error, "method_not_found")) throw error;
     }


### PR DESCRIPTION
## Summary

- I fixed mounted remote unread counts remaining stale after the row-cookie fix. The remote-pin cache still called `backend.getNavigationDescendantPage`, which current Federation handlers explicitly reject. It therefore kept serving saved unread flags while visible rows independently fetched current owner data, producing counted threads with no unread cookie.
- I migrated pinned-summary refresh to protocol 2 `group-members` queries. Counts and visible rows now obtain unread state from the same owner projection. Refresh remains asynchronous and limited to mounted roots and their owner descendants.
- I preserved root batching, pagination, cancellation, deadlines, row/byte budgets, deduplication, and rejection of inconsistent generations or repeated cursors.

## Verification

- I added a regression through the real Federation client, router, registered handlers, and navigation query store. Before the fix it fails with the retired-protocol error; after the fix it returns the mounted thread's current read state and its unread child, excluding an unrelated unmounted unread thread.
- I ran 84 tests across Federation collection reads, descendant selection, remote summary caching, and navigation projection: all pass.
- I verified typechecking: workspace dependencies passed, and desktop typecheck passed after correcting test fixture types.
- I ran `pnpm lint:eslint`: passed with warnings and no errors.

## Notes

- I started this branch from `origin/main` as requested. This is a separate cause from the new-thread cookie mismatch in #2101.
- I have not verified the operator's live PwrGit counts after this change. The protocol failure and recovery are reproduced in tests.
