### PR TITLE
fix(desktop): stop the directory disclosure update loop

### DIFF
--- a/apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts
@@ -68,5 +68,93 @@ describe("renderer error ipc", () => {
     disposeRendererErrorIpcHandlers();
     expect(handlers.has(RENDERER_ERROR_REPORT_CHANNEL)).toBe(false);
   });
+
+  it("bounds a stack that exceeds the log limit", async () => {
+    const {
+      registerRendererErrorIpcHandlers,
+      disposeRendererErrorIpcHandlers,
+    } = await import("../ipc/renderer-error");
+    const { RENDERER_ERROR_REPORT_CHANNEL } = await import("../../shared/ipc");
+
+    const stack = `Error: Deep stack${"\n    at frame".repeat(2000)}`;
+    registerRendererErrorIpcHandlers();
+    await handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, {
+      href: "http://localhost:5173/",
+      message: "Deep stack",
+      source: "window-error",
+      stack,
+      timestamp: "2026-04-20T12:28:04.188Z",
+      userAgent: "Vitest",
+    });
+
+    const logged = errorLog.error.mock.calls
+      .map(([first]) => String(first))
+      .find((message) => message.startsWith("report stack"));
+    // The first 8000 characters, then a suffix naming what was dropped so a
+    // truncated frame is never read as the last frame.
+    expect(logged).toBe(
+      `report stack\n${stack.slice(0, 8000)}… (${stack.length - 8000} more characters)`,
+    );
+
+    disposeRendererErrorIpcHandlers();
+  });
+
+  it("logs a repeated fault's stack once per window", async () => {
+    const {
+      registerRendererErrorIpcHandlers,
+      disposeRendererErrorIpcHandlers,
+    } = await import("../ipc/renderer-error");
+    const { RENDERER_ERROR_REPORT_CHANNEL } = await import("../../shared/ipc");
+    const report: RendererErrorReport = {
+      href: "http://localhost:5173/",
+      message: "Repeating rejection",
+      source: "unhandled-rejection",
+      stack: "Error: Repeating rejection\n    at poll",
+      timestamp: "2026-04-20T12:28:04.188Z",
+      userAgent: "Vitest",
+    };
+
+    registerRendererErrorIpcHandlers();
+    await handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, report);
+    await handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, report);
+    await handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, report);
+
+    const stackMessages = errorLog.error.mock.calls
+      .map(([first]) => String(first))
+      .filter((message) => message.startsWith("report stack"));
+    // Every report still logs its summary; only the identical stack is dropped,
+    // because re-logging it adds no signal and rotates the 1 MB main log.
+    expect(errorLog.error.mock.calls.filter(([first]) => first === "report")).toHaveLength(3);
+    expect(stackMessages).toHaveLength(1);
+
+    disposeRendererErrorIpcHandlers();
+  });
+
+  it("does not throw away a report whose stack is not a string", async () => {
+    const {
+      registerRendererErrorIpcHandlers,
+      disposeRendererErrorIpcHandlers,
+    } = await import("../ipc/renderer-error");
+    const { RENDERER_ERROR_REPORT_CHANNEL } = await import("../../shared/ipc");
+
+    registerRendererErrorIpcHandlers();
+    // The channel is not a type system: a renderer whose `Error.prepareStackTrace`
+    // was replaced can report a structured stack, and losing the whole report to
+    // a TypeError is worse than losing the stack.
+    await expect(handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, {
+      componentStack: "   ",
+      href: "http://localhost:5173/",
+      message: "Structured stack",
+      source: "window-error",
+      stack: { frames: [] },
+      timestamp: "2026-04-20T12:28:04.188Z",
+      userAgent: "Vitest",
+    })).resolves.toEqual({ ok: true });
+
+    expect(errorLog.error.mock.calls.map(([first]) => String(first)))
+      .toEqual(["report"]);
+
+    disposeRendererErrorIpcHandlers();
+  });
 });
 

--- a/apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts
@@ -49,7 +49,21 @@ describe("renderer error ipc", () => {
     await expect(handlers.get(RENDERER_ERROR_REPORT_CHANNEL)?.({}, report)).resolves.toEqual({
       ok: true,
     });
-    expect(errorLog.error).toHaveBeenCalledWith("report", report);
+    expect(errorLog.error).toHaveBeenCalledWith("report", {
+      href: "http://localhost:5173/",
+      message: "Should have a queue",
+      name: "Error",
+      source: "error-boundary",
+      timestamp: "2026-04-20T12:28:04.188Z",
+      userAgent: "Vitest",
+    });
+    // The compact field formatter caps a structured value at 320 characters;
+    // the stacks carry the only frames that identify the faulty code, so they
+    // are logged verbatim as their own messages.
+    expect(errorLog.error).toHaveBeenCalledWith(
+      "report stack\nError: Should have a queue",
+    );
+    expect(errorLog.error).toHaveBeenCalledWith("report component stack\nat App");
 
     disposeRendererErrorIpcHandlers();
     expect(handlers.has(RENDERER_ERROR_REPORT_CHANNEL)).toBe(false);

--- a/apps/desktop/src/main/ipc/renderer-error.ts
+++ b/apps/desktop/src/main/ipc/renderer-error.ts
@@ -5,12 +5,38 @@ import { getMainLogger } from "../log";
 
 const rendererErrorLog = getMainLogger("pwragent:renderer:error");
 
+/**
+ * A renderer crash is diagnosed from its stacks, and the compact field
+ * formatter caps every structured value at 320 characters — enough to record
+ * that a stack existed and not enough to name the frame that threw. Log each
+ * stack as its own message instead: the first log argument is written
+ * verbatim. The cap here is per stack rather than per field, generous enough
+ * for a full React component stack and still bounded, because nothing
+ * throttles the global `window-error` handler that shares this channel.
+ */
+const MAX_LOGGED_STACK_LENGTH = 8_000;
+
+function boundStack(stack: string): string {
+  return stack.length > MAX_LOGGED_STACK_LENGTH
+    ? `${stack.slice(0, MAX_LOGGED_STACK_LENGTH)}… (${stack.length - MAX_LOGGED_STACK_LENGTH} more characters)`
+    : stack;
+}
+
 export function registerRendererErrorIpcHandlers(): void {
   ipcMain.removeHandler(RENDERER_ERROR_REPORT_CHANNEL);
   ipcMain.handle(
     RENDERER_ERROR_REPORT_CHANNEL,
     async (_event, report: RendererErrorReport): Promise<{ ok: true }> => {
-      rendererErrorLog.error("report", report);
+      const { componentStack, stack, ...summary } = report;
+      rendererErrorLog.error("report", summary);
+      if (stack) {
+        rendererErrorLog.error(`report stack\n${boundStack(stack.trim())}`);
+      }
+      if (componentStack) {
+        rendererErrorLog.error(
+          `report component stack\n${boundStack(componentStack.trim())}`,
+        );
+      }
       return { ok: true };
     },
   );
@@ -19,4 +45,3 @@ export function registerRendererErrorIpcHandlers(): void {
 export function disposeRendererErrorIpcHandlers(): void {
   ipcMain.removeHandler(RENDERER_ERROR_REPORT_CHANNEL);
 }
-

--- a/apps/desktop/src/main/ipc/renderer-error.ts
+++ b/apps/desktop/src/main/ipc/renderer-error.ts
@@ -11,15 +11,59 @@ const rendererErrorLog = getMainLogger("pwragent:renderer:error");
  * that a stack existed and not enough to name the frame that threw. Log each
  * stack as its own message instead: the first log argument is written
  * verbatim. The cap here is per stack rather than per field, generous enough
- * for a full React component stack and still bounded, because nothing
- * throttles the global `window-error` handler that shares this channel.
+ * for a full React component stack and still bounded.
  */
 const MAX_LOGGED_STACK_LENGTH = 8_000;
 
-function boundStack(stack: string): string {
-  return stack.length > MAX_LOGGED_STACK_LENGTH
-    ? `${stack.slice(0, MAX_LOGGED_STACK_LENGTH)}… (${stack.length - MAX_LOGGED_STACK_LENGTH} more characters)`
-    : stack;
+/**
+ * Nothing throttles the global `window-error` and `unhandled-rejection`
+ * handlers that share this channel, and a fault inside a loop can report many
+ * times a second. Re-logging a stack we just logged adds no signal and would
+ * rotate the 1 MB main log within seconds, discarding the history that makes
+ * the stack worth having. Log a given fault's stacks at most once per window
+ * and report how many repeats were dropped.
+ */
+const STACK_REPEAT_WINDOW_MS = 10_000;
+
+let lastStackFingerprint: string | undefined;
+let lastStackLoggedAt = 0;
+let suppressedStackCount = 0;
+
+/**
+ * The renderer's own reporter sends strings, but an IPC channel is not a type
+ * system: a non-string here must not throw out of the handler and take the
+ * whole report with it.
+ */
+function normalizeStack(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > MAX_LOGGED_STACK_LENGTH
+    ? `${trimmed.slice(0, MAX_LOGGED_STACK_LENGTH)}… (${trimmed.length - MAX_LOGGED_STACK_LENGTH} more characters)`
+    : trimmed;
+}
+
+function shouldLogStacks(fingerprint: string, now: number): boolean {
+  if (
+    fingerprint === lastStackFingerprint
+    && now - lastStackLoggedAt < STACK_REPEAT_WINDOW_MS
+  ) {
+    suppressedStackCount += 1;
+    return false;
+  }
+  if (suppressedStackCount > 0) {
+    rendererErrorLog.error(
+      `report stacks suppressed as repeats count=${suppressedStackCount}`,
+    );
+    suppressedStackCount = 0;
+  }
+  lastStackFingerprint = fingerprint;
+  lastStackLoggedAt = now;
+  return true;
 }
 
 export function registerRendererErrorIpcHandlers(): void {
@@ -29,13 +73,18 @@ export function registerRendererErrorIpcHandlers(): void {
     async (_event, report: RendererErrorReport): Promise<{ ok: true }> => {
       const { componentStack, stack, ...summary } = report;
       rendererErrorLog.error("report", summary);
-      if (stack) {
-        rendererErrorLog.error(`report stack\n${boundStack(stack.trim())}`);
-      }
-      if (componentStack) {
-        rendererErrorLog.error(
-          `report component stack\n${boundStack(componentStack.trim())}`,
-        );
+      const errorStack = normalizeStack(stack);
+      const componentTrace = normalizeStack(componentStack);
+      if (
+        (errorStack || componentTrace)
+        && shouldLogStacks(`${summary.message}\n${errorStack}\n${componentTrace}`, Date.now())
+      ) {
+        if (errorStack) {
+          rendererErrorLog.error(`report stack\n${errorStack}`);
+        }
+        if (componentTrace) {
+          rendererErrorLog.error(`report component stack\n${componentTrace}`);
+        }
       }
       return { ok: true };
     },
@@ -44,4 +93,8 @@ export function registerRendererErrorIpcHandlers(): void {
 
 export function disposeRendererErrorIpcHandlers(): void {
   ipcMain.removeHandler(RENDERER_ERROR_REPORT_CHANNEL);
+  lastStackFingerprint = undefined;
+  lastStackLoggedAt = 0;
+  suppressedStackCount = 0;
 }
+

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -994,6 +994,18 @@ export function DirectoriesList(props: DirectoriesListProps) {
       // selected key as consumed after a matching directory exists;
       // showThread() can set selection before the refreshed
       // directory snapshot includes the thread.
+      //
+      // An already-open directory needs no write at all. Returning a fresh
+      // object for a selection change alone re-renders the whole navigation
+      // tree and recomputes bounded-window demand to reach the same value —
+      // and this effect re-runs on every render whenever `directories`
+      // arrives with a new identity, which is exactly what the hover-stable
+      // sidebar snapshot produces while the pointer rests on a row. That
+      // pair is a self-feeding update loop, and it is the write React named
+      // when the renderer died with "Maximum update depth exceeded".
+      if (current[matchingDirectory.key] === true) {
+        return current;
+      }
       if (
         current[matchingDirectory.key] !== undefined &&
         !selectedItemKeyChanged

--- a/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/DirectoriesList.tsx
@@ -1049,7 +1049,11 @@ export function DirectoriesList(props: DirectoriesListProps) {
     const rootEntry = selectedPage?.entries.find((entry) => entry.placement.kind === "root");
     if (!rootEntry) return;
     handledRevealRequestRef.current = request;
-    setExpandedByKey((current) => ({ ...current, [matchingDirectory.key]: true }));
+    // An already-open directory needs no write here either; see the selection
+    // effect above for what a no-op disclosure write costs.
+    setExpandedByKey((current) => current[matchingDirectory.key] === true
+      ? current
+      : { ...current, [matchingDirectory.key]: true });
     if (rootEntry.row.pinnedRank !== undefined) return;
 
     // The selected child is rendered with its top-level ancestor. Reveal that

--- a/apps/desktop/src/renderer/src/features/navigation/__tests__/directory-disclosure-lifetime.test.tsx
+++ b/apps/desktop/src/renderer/src/features/navigation/__tests__/directory-disclosure-lifetime.test.tsx
@@ -33,3 +33,35 @@ describe("window-owned directory disclosure", () => {
     expect(screen.queryByRole("list", { name: "Threads in Project 1" })).not.toBeNull();
   });
 });
+
+describe("directory disclosure writes", () => {
+  it("does not rewrite disclosure state for a selection inside an open directory", () => {
+    const observed: Record<string, boolean>[] = [];
+    function ObservedWindow({ selected }: { selected: number }) {
+      const disclosure = useNavigationDirectoryDisclosure();
+      observed.push(disclosure.expandedByKey);
+      const thread = fixture.threads[selected]!;
+      return <DirectoriesList
+        directoryDisclosure={disclosure}
+        directories={fixture.directories}
+        threads={fixture.threads}
+        selectedItemKey={buildThreadIdentityKey(thread.source, thread.id)}
+        onOpenLaunchpad={async () => {}}
+        onOpenThreadContextMenu={() => {}}
+        onSelectThread={() => {}}
+      />;
+    }
+
+    const view = render(<ObservedWindow selected={0} />);
+    const opened = observed.at(-1)!;
+    expect(opened["directory:/fixture/project-1"]).toBe(true);
+
+    // Selecting another thread in the same already-open directory must not
+    // allocate a new disclosure map. That write changes nothing, re-renders
+    // the navigation tree, and — because this effect re-runs whenever the
+    // directory array arrives with a new identity — feeds itself.
+    view.rerender(<ObservedWindow selected={1} />);
+    expect(observed.at(-1)).toBe(opened);
+    expect(new Set(observed).size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- A running renderer died with `Maximum update depth exceeded`, leaving the operator on the error-boundary screen while Codex turns kept running in the main process. React named the write: `DirectoriesList`'s selection-reveal effect, the `setExpandedByKey` that reopens the selected thread's directory.
- Two things closed a loop around that write:
  - **The effect re-runs on every render.** It depends on `visibleDirectories`, derived from `props.directories` — and while the pointer rests on a sidebar row, `useHoverStableSnapshot` calls `hydrateFrozenValue` *during render*, so that array arrives with a fresh identity every render. The freeze is doing its job; it is what keeps a row from moving between pointer-down and click.
  - **The updater allocated even when nothing changed.** It returned `{...current, [key]: true}` whenever the selected key had changed, *including* when the directory was already `true`. A new object identity for an identical value re-renders the navigation tree and recomputes bounded-window demand to arrive at the value it already had — which hands the effect a new `directories` identity, which runs the effect again.
- The fix bails when the directory is already open. Both documented behaviors survive: an explicit user collapse (`false`) is still preserved across unrelated snapshot churn, and a newly selected item still reopens a collapsed directory for reveal. The only write removed is the one that could not change anything.
- Second commit: the crash report reached the main process complete and was then truncated to 320 characters by the compact field formatter, so `stack` and `componentStack` both landed in `main.log` as an ellipsis. Stacks now log as their own verbatim messages.

## Verification

- `pnpm test apps/desktop/src/renderer/src/features/navigation/__tests__ apps/desktop/src/renderer/src/lib/__tests__/useThreadNavigation.test.tsx` — 19 files, 478 tests pass.
- `pnpm test apps/desktop/src/main/__tests__/renderer-error-ipc.test.ts` — passes.
- `pnpm lint:eslint` — 0 errors (67 pre-existing warnings, unchanged). `pnpm typecheck` — clean.
- **Negative control on the regression test.** With the new `=== true` guard removed, `directory-disclosure-lifetime.test.tsx` fails with `expected { Object (directory:/fixture/project-1) } to be { Object (directory:/fixture/project-1) }` — identical content, different identity, which is precisely the wasteful write.

## Notes

- **What is proven and what is inferred.** The crash site is certain: the DevTools stack points at `DirectoriesList.tsx:989`, and React reaches its nested-update guard from inside the `setState` dispatch, so that frame is the caller. That the write is unnecessary is also certain, and it is removed. What a single stack cannot establish is whether `selectedItemKey` was *also* flapping upstream. If it was, the churn (repeated demand recomputation) continues at lower volume without the crash. Worth a follow-up if the sidebar is seen doing unexplained work; the logging change means a recurrence names its own line immediately.
- **Why the loop threw instead of just spinning.** React's `nestedUpdateCount` only trips on the sync lane. This cascade re-enters through `useThreadNavigation`'s `useLayoutEffect`, which is sync; a pure passive-effect loop does not trip it. I confirmed the negative in jsdom — an effect-only loop ran 2 000 renders without ever raising the error — which is also why there is no end-to-end test reproducing the crash itself, only a unit test pinning the write that fed it.
- **No behavior change to the disclosure contract.** `directory-disclosure-lifetime.test.tsx`'s existing case (explicit collapse survives a lens unmount, a new selection reopens) still passes unmodified.
- The stack bound in `renderer-error.ts` is per stack rather than per field — generous enough for a full React component stack, and still a bound, because nothing throttles the global `window-error` handler that shares that channel.
- No visible UI change, so no before/after screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
